### PR TITLE
MDEV-32570: Fragment ROW replication events larger than slave_max_allowed_packet

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1173,12 +1173,24 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
       break;
     case TABLE_MAP_EVENT:
     {
+      /*
+        Always keep the Table_map_log_event around in case a group of
+        Partial_rows_log_events is seen, where we will write the content of
+        the Table_map_log_event for the last fragment so it can be re-applied.
+
+        TODO: Refactor the existing logic now that the Tmle is always
+              persistent
+      */
       Table_map_log_event *map= ((Table_map_log_event *)ev);
+      if (print_event_info->table_map_event)
+        delete print_event_info->table_map_event;
+      print_event_info->table_map_event= map;
+      destroy_evt= FALSE;
+
       if (shall_skip_database(map->get_db_name()) ||
           shall_skip_table(map->get_table_name()))
       {
         print_event_info->m_table_map_ignored.set_table(map->get_table_id(), map);
-        destroy_evt= FALSE;
         goto end;
       }
 #ifdef WHEN_FLASHBACK_REVIEW_READY
@@ -2429,9 +2441,16 @@ static Exit_status dump_log_entries(const char* logname)
   print_event_info.short_form= short_form;
   print_event_info.print_row_count= print_row_count;
   print_event_info.file= result_file;
+  print_event_info.table_map_event= NULL;
   fflush(result_file);
   rc= (remote_opt ? dump_remote_log_entries(&print_event_info, logname) :
        dump_local_log_entries(&print_event_info, logname));
+
+  /*
+    TODO Is there a better place to delete this?
+  */
+  if (print_event_info.table_map_event)
+    delete print_event_info.table_map_event;
 
   if (rc == ERROR_STOP)
     return rc;

--- a/mysql-test/include/binlog_start_pos.inc
+++ b/mysql-test/include/binlog_start_pos.inc
@@ -22,7 +22,7 @@
 ##############################################################################
 
 --disable_query_log
-set @binlog_start_pos=256 + @@encrypt_binlog * (36 + (@@binlog_checksum != 'NONE') * 4);
+set @binlog_start_pos=257 + @@encrypt_binlog * (36 + (@@binlog_checksum != 'NONE') * 4);
 --enable_query_log
 let $binlog_start_pos=`select @binlog_start_pos`;
 

--- a/mysql-test/include/show_binlog_events2.inc
+++ b/mysql-test/include/show_binlog_events2.inc
@@ -26,7 +26,7 @@ if ($binlog_start)
 }
 if (!$binlog_start)
 {
-  --let $_binlog_start=256
+  --let $_binlog_start=257
 }
 if ($binlog_file)
 {

--- a/mysql-test/suite/binlog_encryption/rpl_checksum.result
+++ b/mysql-test/suite/binlog_encryption/rpl_checksum.result
@@ -85,7 +85,7 @@ set @saved_dbug = @@global.debug_dbug;
 set @@global.debug_dbug='d,simulate_slave_unaware_checksum';
 start slave;
 include/wait_for_slave_io_error.inc [errno=1236]
-Last_IO_Error = 'Got fatal error 1236 from master when reading data from binary log: 'Slave can not handle replication events with the checksum that master is configured to log; the first event 'master-bin.000009' at 411, the last event read from 'master-bin.000010' at 4, the last byte read from 'master-bin.000010' at 256.''
+Last_IO_Error = 'Got fatal error 1236 from master when reading data from binary log: 'Slave can not handle replication events with the checksum that master is configured to log; the first event 'master-bin.000009' at 412, the last event read from 'master-bin.000010' at 4, the last byte read from 'master-bin.000010' at 257.''
 select count(*) as zero from t1;
 zero
 0

--- a/mysql-test/suite/rpl/r/rpl_checksum.result
+++ b/mysql-test/suite/rpl/r/rpl_checksum.result
@@ -85,7 +85,7 @@ set @saved_dbug = @@global.debug_dbug;
 set @@global.debug_dbug='d,simulate_slave_unaware_checksum';
 start slave;
 include/wait_for_slave_io_error.inc [errno=1236]
-Last_IO_Error = 'Got fatal error 1236 from master when reading data from binary log: 'Slave can not handle replication events with the checksum that master is configured to log; the first event 'master-bin.000009' at 375, the last event read from 'master-bin.000010' at 4, the last byte read from 'master-bin.000010' at 256.''
+Last_IO_Error = 'Got fatal error 1236 from master when reading data from binary log: 'Slave can not handle replication events with the checksum that master is configured to log; the first event 'master-bin.000009' at 376, the last event read from 'master-bin.000010' at 4, the last byte read from 'master-bin.000010' at 257.''
 select count(*) as zero from t1;
 zero
 0

--- a/mysql-test/suite/rpl/r/rpl_fragment_row_event.result
+++ b/mysql-test/suite/rpl/r/rpl_fragment_row_event.result
@@ -1,0 +1,1153 @@
+include/rpl_init.inc [topology=1->2, 2->3]
+# Setup Defaults for rpl_fragment_row_event.inc
+#
+#
+# Test case ) Boundary Testing
+#
+# A rows event at its maximum unfragmented length (i.e. the length of
+# slave_max_allowed_packet minus the Rows_log event metadata (e.g.
+# headers)) should not fragment, and replication replay should work both
+# via traditional replication as well as mysqlbinlog.
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000001 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+NOT FOUND matches in binlog_insert_frags.out
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000001 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+NOT FOUND matches in binlog_insert_frags.out
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000001 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+NOT FOUND matches in binlog_insert_frags.out
+# Reset data state on server_2 for mysqlbinlog replay
+connection server_2;
+set statement sql_log_bin=0 for drop table t1;
+# MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# Ensuring mysqlbinlog event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1]
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+#
+# If rows event surpasses its maximum unfragmented length by 1, it
+# should fragment into 2 pieces, and replication replay should work
+# both via traditional replication as well as mysqlbinlog.
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000003 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 2 matches in binlog_insert_frags.out
+Partial_rows (1 / 2)
+Partial_rows (2 / 2)
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000003 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 2 matches in binlog_insert_frags.out
+Partial_rows (1 / 2)
+Partial_rows (2 / 2)
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000003 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 2 matches in binlog_insert_frags.out
+Partial_rows (1 / 2)
+Partial_rows (2 / 2)
+# Reset data state on server_2 for mysqlbinlog replay
+connection server_2;
+set statement sql_log_bin=0 for drop table t1;
+# MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# Ensuring mysqlbinlog event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1]
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+#
+#
+# Test case ) Regular row events that surpass
+# slave_max_allowed_packet should be fragmented
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000005 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000005 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000005 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+#
+# Test Update_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Update_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Update_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Update_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000006 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_2 binlogs for Update_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000006 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_3 binlogs for Update_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000006 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+#
+# Test Delete_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Delete_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Delete_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Delete_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Delete_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Delete_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Reset data state on server_2 for mysqlbinlog replay
+connection server_2;
+set statement sql_log_bin=0 for drop table t1;
+# MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_update_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_delete_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# Ensuring mysqlbinlog event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1]
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+#
+#
+# Test case ) Compressed row events that surpass
+# slave_max_allowed_packet should be fragmented
+connection server_1;
+set @@global.log_bin_compress= 1;
+connection server_2;
+set @@global.log_bin_compress= 1;
+connection server_3;
+set @@global.log_bin_compress= 1;
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000009 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000009 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000009 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+#
+# Test Update_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Update_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Update_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Update_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000010 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_2 binlogs for Update_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000010 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_3 binlogs for Update_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000010 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+#
+# Test Delete_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Delete_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Delete_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Delete_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Delete_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Delete_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Reset data state on server_2 for mysqlbinlog replay
+connection server_2;
+set statement sql_log_bin=0 for drop table t1;
+# MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_update_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_delete_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# Ensuring mysqlbinlog event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1]
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_1;
+set @@global.log_bin_compress= 0;
+connection server_2;
+set @@global.log_bin_compress= 0;
+connection server_3;
+set @@global.log_bin_compress= 0;
+#
+#
+# Test case ) Parallel replication
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_parallel_threads= 4;
+include/start_slave.inc
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_parallel_threads= 4;
+include/start_slave.inc
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000013 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000013 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000013 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+#
+# Test Update_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Update_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Update_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Update_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000014 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_2 binlogs for Update_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000014 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_3 binlogs for Update_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000014 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+#
+# Test Delete_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Delete_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Delete_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Delete_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Delete_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_3 binlogs for Delete_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Reset data state on server_2 for mysqlbinlog replay
+connection server_2;
+set statement sql_log_bin=0 for drop table t1;
+# MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_update_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# MYSQL_BINLOG mysqld_datadir/binlog_delete_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+# Ensuring mysqlbinlog event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1]
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_parallel_threads= 0;;
+include/start_slave.inc
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_parallel_threads= 0;;
+include/start_slave.inc
+#
+#
+# Test case ) Chain replication with different slave_max_allowed_packet
+# configurations
+connection server_1;
+set @@global.slave_max_allowed_packet= 1024;
+set @@global.net_buffer_length= 1024;
+disconnect server_1;
+connect  server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,;
+connection server_2;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 16384;
+set @@global.net_buffer_length= 16384;
+disconnect server_2;
+connect  server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,;
+connection server_3;
+include/stop_slave.inc
+set @@global.slave_max_allowed_packet= 16384;
+set @@global.net_buffer_length= 16384;
+disconnect server_3;
+connect  server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,;
+#
+# Initialize test data
+connection server_1;
+create table t1 (a int, b longblob) engine=innodb;
+#
+# Test Write_rows_log_event fragmentation
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Write_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Write_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Write_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000017 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+FOUND 13 matches in binlog_insert_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Write_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000017 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+NOT FOUND matches in binlog_insert_frags.out
+# Server_3 binlogs for Write_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000017 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_insert_frags.out --base64-output=never
+NOT FOUND matches in binlog_insert_frags.out
+#
+# Test Update_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Update_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Update_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Update_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.1/data//master-bin.000018 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+FOUND 12 matches in binlog_update_frags.out
+Partial_rows (1 / 12)
+Partial_rows (2 / 12)
+Partial_rows (3 / 12)
+Partial_rows (4 / 12)
+Partial_rows (5 / 12)
+Partial_rows (6 / 12)
+Partial_rows (7 / 12)
+Partial_rows (8 / 12)
+Partial_rows (9 / 12)
+Partial_rows (10 / 12)
+Partial_rows (11 / 12)
+Partial_rows (12 / 12)
+# Server_2 binlogs for Update_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.2/data//slave-bin.000018 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+NOT FOUND matches in binlog_update_frags.out
+# Server_3 binlogs for Update_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG /home/brandon/workspace/server/build/mysql-test/var/mysqld.3/data//master-bin.000018 --result-file=/home/brandon/workspace/server/build/mysql-test/var/binlog_update_frags.out --base64-output=never
+NOT FOUND matches in binlog_update_frags.out
+#
+# Test Delete_rows_log_event fragmentation
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection server_3;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+# Ensuring Delete_rows replication event replay is consistent..
+include/diff_tables.inc [server_1:test.t1, server_2:test.t1, server_3:test.t1]
+# Ensuring Delete_rows data was fragmented into Partial_rows_log_events
+# Server_1 binlogs for Delete_rows event
+connection server_1;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+FOUND 13 matches in binlog_delete_frags.out
+Partial_rows (1 / 7)
+Partial_rows (2 / 7)
+Partial_rows (3 / 7)
+Partial_rows (4 / 7)
+Partial_rows (5 / 7)
+Partial_rows (6 / 7)
+Partial_rows (7 / 7)
+Partial_rows (1 / 6)
+Partial_rows (2 / 6)
+Partial_rows (3 / 6)
+Partial_rows (4 / 6)
+Partial_rows (5 / 6)
+Partial_rows (6 / 6)
+# Server_2 binlogs for Delete_rows event
+connection server_2;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+NOT FOUND matches in binlog_delete_frags.out
+# Server_3 binlogs for Delete_rows event
+connection server_3;
+flush logs;
+# MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+NOT FOUND matches in binlog_delete_frags.out
+#
+# Cleanup test case
+connection server_1;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+connection server_2;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_3;
+set @@global.slave_max_allowed_packet= 1073741824;
+set @@global.net_buffer_length= 16384;
+include/start_slave.inc
+connection server_1;
+drop table t1;
+flush logs;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+flush logs;
+connection server_3;
+include/sync_with_master_gtid.inc
+flush logs;
+include/rpl_end.inc
+# End of rpl_fragment_row_event.test

--- a/mysql-test/suite/rpl/t/rpl_fragment_row_event.cnf
+++ b/mysql-test/suite/rpl/t/rpl_fragment_row_event.cnf
@@ -1,0 +1,22 @@
+!include ../my.cnf
+
+[mysqlbinlog]
+debug_binlog_row_event_max_encoded_size=1KB
+
+[mysqld.1]
+gtid_domain_id=0
+server_id=1
+
+[mysqld.2]
+gtid_domain_id=1
+server_id=2
+log_slave_updates
+
+[mysqld.3]
+gtid_domain_id=2
+server_id=3
+log_slave_updates
+
+[ENV]
+SERVER_MYPORT_3=		@mysqld.3.port
+SERVER_MYSOCK_3=		@mysqld.3.socket

--- a/mysql-test/suite/rpl/t/rpl_fragment_row_event.inc
+++ b/mysql-test/suite/rpl/t/rpl_fragment_row_event.inc
@@ -1,0 +1,256 @@
+#
+#
+#
+# Parameters:
+#   $insert_size             : (uint)
+#   $test_mysqlbinlog_replay : (bool)
+#   $test_update             : (bool)
+#   $test_delete             : (bool)
+#   $server_1_max_packet     : (uint)
+#   $server_2_max_packet     : (uint)
+#   $server_3_max_packet     : (uint)
+#
+
+--connection server_1
+--let $server_1_old_slave_max_packet= `SELECT @@global.slave_max_allowed_packet`
+--let $server_1_old_net_buf= `SELECT @@global.net_buffer_length`
+--eval set @@global.slave_max_allowed_packet= $server_1_max_packet
+--eval set @@global.net_buffer_length= $server_1_max_packet
+--disconnect server_1
+--source include/wait_until_disconnected.inc
+--connect (server_1,127.0.0.1,root,,test,$SERVER_MYPORT_1,)
+
+--connection server_2
+--source include/stop_slave.inc
+--let $server_2_old_slave_max_packet= `SELECT @@global.slave_max_allowed_packet`
+--let $server_2_old_net_buf= `SELECT @@global.net_buffer_length`
+--eval set @@global.slave_max_allowed_packet= $server_2_max_packet
+--eval set @@global.net_buffer_length= $server_2_max_packet
+--disconnect server_2
+--source include/wait_until_disconnected.inc
+--connect (server_2,127.0.0.1,root,,test,$SERVER_MYPORT_2,)
+
+--connection server_3
+--source include/stop_slave.inc
+--let $server_3_old_slave_max_packet= `SELECT @@global.slave_max_allowed_packet`
+--let $server_3_old_net_buf= `SELECT @@global.net_buffer_length`
+--eval set @@global.slave_max_allowed_packet= $server_3_max_packet
+--eval set @@global.net_buffer_length= $server_3_max_packet
+--disconnect server_3
+--source include/wait_until_disconnected.inc
+--connect (server_3,127.0.0.1,root,,test,$SERVER_MYPORT_3,)
+
+--echo #
+--echo # Initialize test data
+--connection server_1
+create table t1 (a int, b longblob) engine=innodb;
+
+--echo #
+--echo # Test Write_rows_log_event fragmentation
+--disable_query_log
+if ($insert_size)
+{
+  # subtract 8 from the insert for the first column
+  --let $insert_text_len= `SELECT $insert_size - 9`
+  --eval insert into t1 values (1, repeat("a", $insert_text_len))
+}
+if (!$insert_size)
+{
+  insert into t1 select seq,repeat(seq,512) from seq_1_to_10;
+  insert into t1 select 11 as a, group_concat(b) as b from t1;
+}
+--enable_query_log
+
+--connection server_2
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+
+--connection server_3
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+
+--echo # Ensuring Write_rows replication event replay is consistent..
+--let $diff_tables= server_1:test.t1, server_2:test.t1, server_3:test.t1
+--source include/diff_tables.inc
+
+--echo # Ensuring Write_rows data was fragmented into Partial_rows_log_events
+--let $n_servers= 3
+--let $i= 1
+while (`SELECT $i <= $n_servers`)
+{
+  --echo # Server_$i binlogs for Write_rows event
+  --connection server_$i
+  --let $mysqld_datadir=`select @@datadir`
+  --let $binlog_insert_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+  --let $binlog_file_param= $mysqld_datadir/$binlog_insert_filename
+  --let $binlog_analysis_file= $MYSQLTEST_VARDIR/binlog_insert_frags.out
+  flush logs;
+  --echo # MYSQL_BINLOG $binlog_file_param --result-file=$binlog_analysis_file --base64-output=never
+  --exec $MYSQL_BINLOG $binlog_file_param --result-file=$binlog_analysis_file --base64-output=never
+
+  --let SEARCH_PATTERN= Partial_rows \([0-9]+ / [0-9]+\)
+  --let SEARCH_FILE= $binlog_analysis_file
+  --let SEARCH_OUTPUT= count
+  --source include/search_pattern_in_file.inc
+  --let SEARCH_OUTPUT= matches
+  --source include/search_pattern_in_file.inc
+  --inc $i
+}
+
+
+if ($test_update)
+{
+  --echo #
+  --echo # Test Update_rows_log_event fragmentation
+  --connection server_1
+  --disable_query_log
+  update t1 set a=a+1 where a=11;
+  --enable_query_log
+  --source include/save_master_gtid.inc
+
+  --connection server_2
+  --source include/start_slave.inc
+  --source include/sync_with_master_gtid.inc
+  --source include/stop_slave.inc
+
+  --connection server_3
+  --source include/start_slave.inc
+  --source include/sync_with_master_gtid.inc
+  --source include/stop_slave.inc
+
+  --echo # Ensuring Update_rows replication event replay is consistent..
+  --let $diff_tables= server_1:test.t1, server_2:test.t1, server_3:test.t1
+  --source include/diff_tables.inc
+
+  --echo # Ensuring Update_rows data was fragmented into Partial_rows_log_events
+  --let $n_servers= 3
+  --let $i= 1
+  while (`SELECT $i <= $n_servers`)
+  {
+    --echo # Server_$i binlogs for Update_rows event
+    --connection server_$i
+    --let $mysqld_datadir=`select @@datadir`
+    --let $binlog_update_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+    --let $binlog_file_param= $mysqld_datadir/$binlog_update_filename
+    --let $binlog_analysis_file= $MYSQLTEST_VARDIR/binlog_update_frags.out
+    flush logs;
+    --echo # MYSQL_BINLOG $binlog_file_param --result-file=$binlog_analysis_file --base64-output=never
+    --exec $MYSQL_BINLOG $binlog_file_param --result-file=$binlog_analysis_file --base64-output=never
+
+    --let SEARCH_PATTERN= Partial_rows \([0-9]+ / [0-9]+\)
+    --let SEARCH_FILE= $binlog_analysis_file
+    --let SEARCH_OUTPUT= count
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_OUTPUT= matches
+    --source include/search_pattern_in_file.inc
+
+    --inc $i
+  }
+}
+
+if ($test_delete)
+{
+  --echo #
+  --echo # Test Delete_rows_log_event fragmentation
+  --connection server_1
+  --disable_query_log
+  delete from t1;
+  --enable_query_log
+  --source include/save_master_gtid.inc
+
+  --connection server_2
+  --source include/start_slave.inc
+  --source include/sync_with_master_gtid.inc
+  --source include/stop_slave.inc
+
+  --connection server_3
+  --source include/start_slave.inc
+  --source include/sync_with_master_gtid.inc
+  --source include/stop_slave.inc
+
+  --echo # Ensuring Delete_rows replication event replay is consistent..
+  --let $diff_tables= server_1:test.t1, server_2:test.t1, server_3:test.t1
+  --source include/diff_tables.inc
+
+  --echo # Ensuring Delete_rows data was fragmented into Partial_rows_log_events
+  --let $n_servers= 3
+  --let $i= 1
+  while (`SELECT $i <= $n_servers`)
+  {
+    --echo # Server_$i binlogs for Delete_rows event
+    --connection server_$i
+    --let $mysqld_datadir=`select @@datadir`
+    --let $binlog_delete_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+    --let $binlog_file_param= $mysqld_datadir/$binlog_delete_filename
+    --let $binlog_analysis_file= $MYSQLTEST_VARDIR/binlog_delete_frags.out
+    flush logs;
+    --echo # MYSQL_BINLOG binlog_file_param --result-file=binlog_analysis_file --base64-output=never
+    --exec $MYSQL_BINLOG $binlog_file_param --result-file=$binlog_analysis_file --base64-output=never
+
+    --let SEARCH_PATTERN= Partial_rows \([0-9]+ / [0-9]+\)
+    --let SEARCH_FILE= $binlog_analysis_file
+    --let SEARCH_OUTPUT= count
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_OUTPUT= matches
+    --source include/search_pattern_in_file.inc
+    --inc $i
+  }
+}
+
+if ($test_mysqlbinlog_replay)
+{
+  --echo # Reset data state on server_2 for mysqlbinlog replay
+  --connection server_2
+  set statement sql_log_bin=0 for drop table t1;
+
+  --echo # MYSQL_BINLOG mysqld_datadir/binlog_insert_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+  --exec $MYSQL_BINLOG $mysqld_datadir/$binlog_insert_filename | $MYSQL_SLAVE --init-command="set sql_log_bin=0"
+
+  if ($test_update)
+  {
+    --echo # MYSQL_BINLOG mysqld_datadir/binlog_update_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+    --exec $MYSQL_BINLOG $mysqld_datadir/$binlog_update_filename | $MYSQL_SLAVE --init-command="set sql_log_bin=0"
+  }
+
+  if ($test_delete)
+  {
+    --echo # MYSQL_BINLOG mysqld_datadir/binlog_delete_filename | MYSQL_SLAVE --init-command="set sql_log_bin=0"
+    --exec $MYSQL_BINLOG $mysqld_datadir/$binlog_delete_filename | $MYSQL_SLAVE --init-command="set sql_log_bin=0"
+  }
+
+  --echo # Ensuring mysqlbinlog event replay is consistent..
+  --let $diff_tables= server_1:test.t1, server_2:test.t1
+  --source include/diff_tables.inc
+}
+
+
+--echo #
+--echo # Cleanup test case
+--connection server_1
+--eval set @@global.slave_max_allowed_packet= $server_1_old_slave_max_packet
+--eval set @@global.net_buffer_length= $server_1_old_net_buf
+
+--connection server_2
+--eval set @@global.slave_max_allowed_packet= $server_2_old_slave_max_packet
+--eval set @@global.net_buffer_length= $server_2_old_net_buf
+--source include/start_slave.inc
+
+--connection server_3
+--eval set @@global.slave_max_allowed_packet= $server_3_old_slave_max_packet
+--eval set @@global.net_buffer_length= $server_3_old_net_buf
+--source include/start_slave.inc
+
+--connection server_1
+drop table t1;
+flush logs;
+--source include/save_master_gtid.inc
+
+--connection server_2
+--source include/sync_with_master_gtid.inc
+flush logs;
+
+--connection server_3
+--source include/sync_with_master_gtid.inc
+flush logs;

--- a/mysql-test/suite/rpl/t/rpl_fragment_row_event.test
+++ b/mysql-test/suite/rpl/t/rpl_fragment_row_event.test
@@ -1,0 +1,179 @@
+#
+#   This file tests that row events which are larger than a server's configured
+# slave_max_allowed_packet will be fragmented into Partial_rows_log_event, that
+# the slave re-assembles to execute the event.
+#
+#   The following use cases are tested when replaying transactions via
+# traditional replication, as well as mysqlbinlog when applicable.
+#
+#   Test cases done:
+#   : Any Rows event type that surpasses slave_max_allowed_packet should be
+#     fragmented:
+#     a) Write_rows
+#     b) Update_rows
+#     c) Delete_rows
+#     d) Write_rows_compressed
+#     e) Update_rows_compressed
+#     f) Delete_rows_compressed
+#   : Boundary testing of event size vs slave_max_allowed_packet
+#     a) If full rows_log_event (ev metadta incl) <= slave_max_allowed_packet,
+#        no fragmentation
+#     b) If rows_data size is less than slave_max_allowed_packet, but adding
+#        the metadata of the Rows_event would result in surpassing
+#        slave_max_allowed_packet (by one byte), fragmentation should occur
+#   : Parallel replication applier
+#   : Using chain-replication, servers configured with different
+#     slave_max_allowed_packet should binlog according to the configured policy
+#     of that specific server
+#
+#   Test cases still TODO
+#   : Multi-statement transaction w/ multiple tables
+#   : Explicitly test mysqlbinlog fragmentation @1, @2 style 
+#   : Multi-row-event transactions
+#   : Replication delay
+#   : Replication filters
+#   : Skip replication should be honored
+#   : Change slave_max_allowed_packet in a transaction
+#   : Mariadb capability testing (probably in a different test file though)
+#
+#
+#   The following error cases are checked when replaying transactions both via
+# traditional replication and mysqlbinlog (TODO):
+#   : Missing fragments
+#   : Data corruption
+#   : Out-of-memory
+#
+#
+#   Note this test users MTR variables to save old variables rather than user
+# variables because slave_max_allowed_packet is reset dynamically, and
+# connections are disconnected and reconnected to reset the value, as
+# FLUSH STATUS doesn't reset this value.
+#
+#
+# References:
+#   MDEV-32570: Fragment ROW replication events larger than max_packet_size
+#
+
+--source include/have_sequence.inc
+--source include/have_innodb.inc
+--source include/have_binlog_format_row.inc
+--let $rpl_topology=1->2, 2->3
+--source include/rpl_init.inc
+
+--echo # Setup Defaults for rpl_fragment_row_event.inc
+--let $server_1_max_packet=1024
+--let $server_2_max_packet=1024
+--let $server_3_max_packet=1024
+--let $test_update= 1
+--let $test_delete= 1
+
+
+--echo #
+--echo #
+--echo # Test case ) Boundary Testing
+--let $log_ev_header_len= 19
+--let $rows_header_len= 8
+--let $binlog_checksum_len= 4
+--let $ev_metadata_size=  `SELECT ($log_ev_header_len + $rows_header_len + $binlog_checksum_len)`
+--let $max_unfragged_ev= `SELECT ($server_1_max_packet - $ev_metadata_size)`
+
+--echo #
+--echo # A rows event at its maximum unfragmented length (i.e. the length of
+--echo # slave_max_allowed_packet minus the Rows_log event metadata (e.g.
+--echo # headers)) should not fragment, and replication replay should work both
+--echo # via traditional replication as well as mysqlbinlog.
+--let $test_mysqlbinlog_replay= 1
+--let $test_update=0
+--let $test_delete=0
+--let $insert_size=$max_unfragged_ev
+--source rpl_fragment_row_event.inc
+
+--echo #
+--echo # If rows event surpasses its maximum unfragmented length by 1, it
+--echo # should fragment into 2 pieces, and replication replay should work
+--echo # both via traditional replication as well as mysqlbinlog.
+
+--let $insert_size= `SELECT ($max_unfragged_ev + 1)`
+--source rpl_fragment_row_event.inc
+
+# Clear insert_size for future transactions to use default insertion logic
+--let $insert_size=
+--let $test_update=1
+--let $test_delete=1
+
+
+--echo #
+--echo #
+--echo # Test case ) Regular row events that surpass
+--echo # slave_max_allowed_packet should be fragmented
+
+--let $test_mysqlbinlog_replay= 1
+--source rpl_fragment_row_event.inc
+
+
+--echo #
+--echo #
+--echo # Test case ) Compressed row events that surpass
+--echo # slave_max_allowed_packet should be fragmented
+--connection server_1
+--let $old_s1_compress= `SELECT @@global.log_bin_compress`
+set @@global.log_bin_compress= 1;
+--connection server_2
+--let $old_s2_compress= `SELECT @@global.log_bin_compress`
+set @@global.log_bin_compress= 1;
+--connection server_3
+--let $old_s3_compress= `SELECT @@global.log_bin_compress`
+set @@global.log_bin_compress= 1;
+
+--let $test_mysqlbinlog_replay= 1
+--source rpl_fragment_row_event.inc
+
+--connection server_1
+--eval set @@global.log_bin_compress= $old_s1_compress
+--connection server_2
+--eval set @@global.log_bin_compress= $old_s2_compress
+--connection server_3
+--eval set @@global.log_bin_compress= $old_s3_compress
+
+
+--echo #
+--echo #
+--echo # Test case ) Parallel replication
+--connection server_2
+--source include/stop_slave.inc
+--let $old_s2_threads= `SELECT @@global.slave_parallel_threads`
+set @@global.slave_parallel_threads= 4;
+--source include/start_slave.inc
+--connection server_3
+--source include/stop_slave.inc
+--let $old_s3_threads= `SELECT @@global.slave_parallel_threads`
+set @@global.slave_parallel_threads= 4;
+--source include/start_slave.inc
+
+--let $test_mysqlbinlog_replay= 1
+--source rpl_fragment_row_event.inc
+
+--connection server_2
+--source include/stop_slave.inc
+--eval set @@global.slave_parallel_threads= $old_s2_threads;
+--source include/start_slave.inc
+--connection server_3
+--source include/stop_slave.inc
+--eval set @@global.slave_parallel_threads= $old_s3_threads;
+--source include/start_slave.inc
+
+
+--echo #
+--echo #
+--echo # Test case ) Chain replication with different slave_max_allowed_packet
+--echo # configurations
+
+--let $server_1_max_packet=1024
+--let $server_2_max_packet=16384
+--let $server_3_max_packet=16384
+--let $test_mysqlbinlog_replay= 0
+--source rpl_fragment_row_event.inc
+
+
+--source include/rpl_end.inc
+--echo # End of rpl_fragment_row_event.test

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -6930,6 +6930,7 @@ Event_log::flush_and_set_pending_rows_event(THD *thd, Rows_log_event* event,
   {
     Log_event_writer writer(&cache_data->cache_log, cache_data,
                             pending->select_checksum_alg(cache_data), NULL);
+    Log_event *ev_to_write= NULL;
 
     /*
       Write pending event to the cache.
@@ -6945,14 +6946,55 @@ Event_log::flush_and_set_pending_rows_event(THD *thd, Rows_log_event* event,
                         clear_dbug= true;
                       }
                     });
-    if (writer.write(pending))
+
+    ulong rows_ev_metadata_len=
+        LOG_EVENT_HEADER_LEN + ROWS_HEADER_LEN_V1 + BINLOG_CHECKSUM_LEN;
+    ulong max_rows_ev_len= slave_max_allowed_packet - rows_ev_metadata_len;
+    if (pending->rows_data_size_exceeds(max_rows_ev_len))
+    {
+      ulong partial_ev_metadata_len=
+          LOG_EVENT_HEADER_LEN + ROWS_HEADER_LEN_V1 + PARTIAL_ROWS_HEADER_LEN +
+          BINLOG_CHECKSUM_LEN;
+      ulong max_partial_ev_len=
+          slave_max_allowed_packet - partial_ev_metadata_len;
+      Rows_log_event_fragmenter fragmenter= Rows_log_event_fragmenter(
+          max_partial_ev_len, pending); // 0.5 GB?
+      Rows_log_event_fragmenter::Fragmented_rows_log_event *frag_ev=
+          fragmenter.fragment();
+      if (!frag_ev->is_valid())
+      {
+        /*
+          TODO: Error handling
+        */
+        DBUG_RETURN(1);
+      }
+      ev_to_write= frag_ev;
+    }
+    else
+    {
+      ev_to_write= pending;
+    }
+
+    if (!ev_to_write)
+    {
+      /*
+        TODO: Error handling
+      */
+      DBUG_RETURN(1);
+    }
+
+    if (writer.write(ev_to_write))
     {
       set_write_error(thd, is_transactional);
       if (check_cache_error(thd, cache_data) &&
           (stmt_has_updated_non_trans_table(thd) ||
            !is_transactional))
         cache_data->set_incident();
+
+      if (ev_to_write && ev_to_write != pending)
+        delete ev_to_write;
       delete pending;
+
       cache_data->set_pending(NULL);
       DBUG_EXECUTE_IF("simulate_disk_full_at_flush_pending",
                       {
@@ -6967,6 +7009,8 @@ Event_log::flush_and_set_pending_rows_event(THD *thd, Rows_log_event* event,
                         DBUG_SET("-d,simulate_file_write_error");
                     });
 
+    if (ev_to_write && ev_to_write != pending)
+      delete ev_to_write;
     delete pending;
   }
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1253,6 +1253,9 @@ Log_event *Log_event::read_log_event_no_checksum(
       ev= new Table_map_log_event(buf, event_len, fdle);
       break;
 #endif
+  case PARTIAL_ROW_DATA_EVENT:
+    ev= new Partial_rows_log_event(buf, event_len, fdle);
+    break;
     case BEGIN_LOAD_QUERY_EVENT:
       ev= new Begin_load_query_log_event(buf, event_len, fdle);
       break;
@@ -2184,6 +2187,7 @@ Format_description_log_event(uint8 binlog_ver, const char* server_ver,
       post_header_len[WRITE_ROWS_COMPRESSED_EVENT_V1-1]=   ROWS_HEADER_LEN_V1;
       post_header_len[UPDATE_ROWS_COMPRESSED_EVENT_V1-1]=  ROWS_HEADER_LEN_V1;
       post_header_len[DELETE_ROWS_COMPRESSED_EVENT_V1-1]=  ROWS_HEADER_LEN_V1;
+      post_header_len[PARTIAL_ROW_DATA_EVENT-1]=  PARTIAL_ROWS_HEADER_LEN;
 
       // Sanity-check that all post header lengths are initialized.
       int i;
@@ -3980,6 +3984,48 @@ Incident_log_event::Incident_log_event(const uchar *buf, uint event_len,
   DBUG_PRINT("info", ("m_incident: %d", m_incident));
   DBUG_VOID_RETURN;
 }
+
+
+#ifdef HAVE_REPLICATION
+Partial_rows_log_event::Partial_rows_log_event(
+    const uchar *buf, uint event_len,
+    const Format_description_log_event *description_event)
+    : Log_event(buf, description_event), metadata_written(0), rows_event(NULL)
+{
+  DBUG_ENTER("Partial_rows_log_event::Partial_rows_log_even(const uchar*,uint,...)");
+
+  uint8 common_header_len= description_event->common_header_len;
+  uint8 post_header_len= description_event->post_header_len[PARTIAL_ROW_DATA_EVENT-1];
+  DBUG_PRINT("info",("event_len: %u  common_header_len: %d  post_header_len: %d",
+                     event_len, common_header_len, post_header_len));
+  DBUG_ASSERT(post_header_len == PARTIAL_ROWS_HEADER_LEN);
+
+	if (event_len < (uint)(common_header_len + post_header_len))
+		DBUG_VOID_RETURN;
+
+  /* Read the post-header */
+  const uchar *post_start= buf + common_header_len;
+  VALIDATE_BYTES_READ(post_start, buf, event_len);
+
+  total_fragments= uint4korr(post_start);
+  post_start+= 4;
+  VALIDATE_BYTES_READ(post_start, buf, event_len);
+
+  seq_no= uint4korr((post_start));
+  post_start+= 4;
+  VALIDATE_BYTES_READ(post_start, buf, event_len);
+  DBUG_ASSERT(seq_no <= total_fragments);
+
+  flags2= *(post_start++);
+  VALIDATE_BYTES_READ(post_start, buf, event_len);
+
+  ev_buffer_base= buf;
+  start_offset= common_header_len + PARTIAL_ROWS_HEADER_LEN;
+  end_offset= event_len;
+
+  DBUG_VOID_RETURN;
+}
+#endif
 
 
 Incident_log_event::~Incident_log_event()

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -974,7 +974,7 @@ err:
   constructors.
 */
 
-Log_event* Log_event::read_log_event(const uchar *buf, uint event_len,
+Log_event* Log_event::read_log_event(const uchar *buf, size_t event_len,
                                      const char **error,
                                      const Format_description_log_event *fdle,
                                      my_bool crc_check,
@@ -1251,7 +1251,7 @@ exit:
 #endif
   }
 
-  DBUG_PRINT("read_event", ("%s(type_code: %u; event_len: %u)",
+  DBUG_PRINT("read_event", ("%s(type_code: %u; event_len: %zu)",
                             ev ? ev->get_type_str() : "<unknown>",
                             (uchar)buf[EVENT_TYPE_OFFSET],
                             event_len));
@@ -3074,7 +3074,7 @@ const uchar *sql_ex_info::init(const uchar *buf, const uchar *buf_end,
 **************************************************************************/
 
 
-Rows_log_event::Rows_log_event(const uchar *buf, uint event_len,
+Rows_log_event::Rows_log_event(const uchar *buf, size_t event_len,
                                const Format_description_log_event
                                *description_event)
   : Log_event(buf, description_event),
@@ -3101,7 +3101,7 @@ Rows_log_event::Rows_log_event(const uchar *buf, uint event_len,
   if (event_len < (uint)(common_header_len + post_header_len))
     DBUG_VOID_RETURN;
 
-  DBUG_PRINT("enter",("event_len: %u  common_header_len: %d  "
+  DBUG_PRINT("enter",("event_len: %zu  common_header_len: %d  "
 		      "post_header_len: %d",
 		      event_len, common_header_len,
 		      post_header_len));
@@ -3812,7 +3812,7 @@ Optional_metadata_fields(unsigned char* optional_metadata,
   Constructor used by slave to read the event from the binary log.
  */
 #ifdef HAVE_REPLICATION
-Write_rows_log_event::Write_rows_log_event(const uchar *buf, uint event_len,
+Write_rows_log_event::Write_rows_log_event(const uchar *buf, size_t event_len,
                                            const Format_description_log_event
                                            *description_event)
 : Rows_log_event(buf, event_len, description_event)
@@ -3820,7 +3820,7 @@ Write_rows_log_event::Write_rows_log_event(const uchar *buf, uint event_len,
 }
 
 Write_rows_compressed_log_event::Write_rows_compressed_log_event(
-                                           const uchar *buf, uint event_len,
+                                           const uchar *buf, size_t event_len,
                                            const Format_description_log_event
                                            *description_event)
 : Write_rows_log_event(buf, event_len, description_event)
@@ -3838,7 +3838,7 @@ Write_rows_compressed_log_event::Write_rows_compressed_log_event(
   Constructor used by slave to read the event from the binary log.
  */
 #ifdef HAVE_REPLICATION
-Delete_rows_log_event::Delete_rows_log_event(const uchar *buf, uint event_len,
+Delete_rows_log_event::Delete_rows_log_event(const uchar *buf, size_t event_len,
                                              const Format_description_log_event
                                              *description_event)
   : Rows_log_event(buf, event_len, description_event)
@@ -3846,7 +3846,7 @@ Delete_rows_log_event::Delete_rows_log_event(const uchar *buf, uint event_len,
 }
 
 Delete_rows_compressed_log_event::Delete_rows_compressed_log_event(
-                                           const uchar *buf, uint event_len,
+                                           const uchar *buf, size_t event_len,
                                            const Format_description_log_event
                                            *description_event)
   : Delete_rows_log_event(buf, event_len, description_event)
@@ -3869,19 +3869,17 @@ Update_rows_log_event::~Update_rows_log_event()
   Constructor used by slave to read the event from the binary log.
  */
 #ifdef HAVE_REPLICATION
-Update_rows_log_event::Update_rows_log_event(const uchar *buf, uint event_len,
-                                             const
-                                             Format_description_log_event
-                                             *description_event)
-  : Rows_log_event(buf, event_len, description_event)
+Update_rows_log_event::Update_rows_log_event(
+    const uchar *buf, size_t event_len,
+    const Format_description_log_event *description_event)
+    : Rows_log_event(buf, event_len, description_event)
 {
 }
 
 Update_rows_compressed_log_event::Update_rows_compressed_log_event(
-                                             const uchar *buf, uint event_len,
-                                             const Format_description_log_event
-                                             *description_event)
-  : Update_rows_log_event(buf, event_len, description_event)
+    const uchar *buf, size_t event_len,
+    const Format_description_log_event *description_event)
+    : Update_rows_log_event(buf, event_len, description_event)
 {
   uncompress_buf();
 }

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1093,6 +1093,64 @@ Log_event* Log_event::read_log_event(const uchar *buf, size_t event_len,
          alg != BINLOG_CHECKSUM_ALG_OFF))
       event_len= event_len - BINLOG_CHECKSUM_LEN;
 
+    ev= Log_event::read_log_event_no_checksum(buf, event_len, error, fdle);
+  }
+
+  if (ev)
+  {
+#ifdef MYSQL_CLIENT
+    ev->read_checksum_alg= alg;
+    if (alg != BINLOG_CHECKSUM_ALG_OFF && alg != BINLOG_CHECKSUM_ALG_UNDEF)
+      ev->read_checksum_value= uint4korr(buf + (event_len));
+#endif
+  }
+
+  DBUG_RETURN(ev);
+}
+
+Log_event *Log_event::read_log_event_no_checksum(
+    const uchar *buf, size_t event_len, const char **error,
+    const Format_description_log_event *fdle)
+{
+  Log_event* ev;
+  DBUG_ENTER("Log_event::read_log_event_no_checksum(char*,...)");
+  DBUG_ASSERT(fdle != 0);
+  DBUG_PRINT("info", ("binlog_version: %d", fdle->binlog_version));
+  DBUG_DUMP_EVENT_BUF(buf, event_len);
+
+  *error= 0;
+  /*
+    Check the integrity; This is needed because handle_slave_io() doesn't
+    check if packet is of proper length.
+ */
+  if (event_len < EVENT_LEN_OFFSET)
+  {
+    *error="Sanity check failed";		// Needed to free buffer
+    DBUG_RETURN(NULL); // general sanity check - will fail on a partial read
+  }
+
+  uint event_type= buf[EVENT_TYPE_OFFSET];
+
+  /*
+    In some previuos versions (see comment in
+    Format_description_log_event::Format_description_log_event(char*,...)),
+    event types were assigned different id numbers than in the
+    present version. In order to replicate from such versions to the
+    present version, we must map those event type id's to our event
+    type id's.  The mapping is done with the event_type_permutation
+    array, which was set up when the Format_description_log_event
+    was read.
+  */
+  if (fdle->event_type_permutation)
+  {
+    int new_event_type= fdle->event_type_permutation[event_type];
+    DBUG_PRINT("info", ("converting event type %d to %d (%s)",
+                 event_type, new_event_type,
+                 get_type_str((Log_event_type)new_event_type)));
+    event_type= new_event_type;
+  }
+
+
     /*
       Create an object of Ignorable_log_event for unrecognized sub-class.
       So that SLAVE SQL THREAD will only update the position and continue.
@@ -1238,18 +1296,8 @@ Log_event* Log_event::read_log_event(const uchar *buf, size_t event_len,
                           (uchar) buf[EVENT_TYPE_OFFSET]));
       ev= NULL;
       break;
-    }
   }
 exit:
-
-  if (ev)
-  {
-#ifdef MYSQL_CLIENT
-    ev->read_checksum_alg= alg;
-    if (alg != BINLOG_CHECKSUM_ALG_OFF && alg != BINLOG_CHECKSUM_ALG_UNDEF)
-      ev->read_checksum_value= uint4korr(buf + (event_len));
-#endif
-  }
 
   DBUG_PRINT("read_event", ("%s(type_code: %u; event_len: %zu)",
                             ev ? ev->get_type_str() : "<unknown>",

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -4787,8 +4787,28 @@ public:
 #endif
 
 #ifdef MYSQL_SERVER
+  /*
+    Writes the table_id and flags
+  */
   bool write_data_header(Log_event_writer *writer) override;
+
+  /*
+    Writes both the metadata (width, cols, and cols_ai) and the entirety of the
+    rows data
+  */
   bool write_data_body(Log_event_writer *writer) override;
+
+  /*
+    Writes the context of the rows data, i.e. the width, cols, and cols_ai
+  */
+  bool write_data_body_metadata(Log_event_writer *writer);
+
+  /*
+    Writes the rows data itself
+  */
+  bool write_data_body_rows(Log_event_writer *writer, uint64_t from_offset= 0,
+                            uint64_t len_to_write= 0);
+
   virtual bool write_compressed(Log_event_writer *writer);
   const char *get_db() override { return m_table->s->db.str; }
 #ifdef HAVE_REPLICATION

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1583,11 +1583,26 @@ public:
     is calculated during write()
   */
   virtual int get_data_size() { return 0;}
+
+  /*
+    Creates a Log_event from a memory buffer that is representative of the raw
+    event data, and assumes that there is a checksum at the end of the event
+    data, even if crc_check is false.
+  */
   static Log_event* read_log_event(const uchar *buf, size_t event_len,
 				   const char **error,
                                    const Format_description_log_event
                                    *description_event, my_bool crc_check,
                                    my_bool print_errors= 1);
+  /*
+    Creates a Log_event from a memory buffer that is representative of the raw
+    event data, and assumes that there is no checksum at the end of the raw
+    data (at least within the provided event_len offset of buf).
+  */
+  static Log_event *read_log_event_no_checksum(
+      const uchar *buf, size_t event_len, const char **error,
+      const Format_description_log_event *description_event);
+
   /**
     Returns the human readable name of the given event type.
   */

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -226,6 +226,7 @@ class String;
 #define GTID_LIST_HEADER_LEN   4
 #define START_ENCRYPTION_HEADER_LEN 0
 #define XA_PREPARE_HEADER_LEN 0
+#define PARTIAL_ROWS_HEADER_LEN  (4 + 4 + 1)
 
 /* 
   Max number of possible extra bytes in a replication event compared to a
@@ -406,6 +407,11 @@ class String;
 #define ELQ_FN_POS_START_OFFSET ELQ_FILE_ID_OFFSET + 4
 #define ELQ_FN_POS_END_OFFSET ELQ_FILE_ID_OFFSET + 8
 #define ELQ_DUP_HANDLING_OFFSET ELQ_FILE_ID_OFFSET + 12
+
+/* PRW = "Partial RoWs" */
+#define PRW_TOTAL_SEQS_OFFSET 0
+#define PRW_SELF_SEQ_OFFSET 4
+#define PRW_FLAGS_OFFSET 8
 
 /* 4 bytes which all binlogs should begin with */
 #define BINLOG_MAGIC        (const uchar*) "\xfe\x62\x69\x6e"
@@ -589,7 +595,12 @@ class String;
 /* MariaDB >= 10.0.1, which knows about global transaction id events. */
 #define MARIA_SLAVE_CAPABILITY_GTID 4
 
+/* MariaDB >= 12.1.0, which know about container log events. */
+#define MARIA_SLAVE_CAPABILITY_PARTIAL_ROW_DATA 5
+
 /* Our capability. */
+// TODO
+//#define MARIA_SLAVE_CAPABILITY_MINE MARIA_SLAVE_CAPABILITY_PARTIAL_ROW_DATA
 #define MARIA_SLAVE_CAPABILITY_MINE MARIA_SLAVE_CAPABILITY_GTID
 
 
@@ -745,6 +756,11 @@ enum Log_event_type
   WRITE_ROWS_COMPRESSED_EVENT = 169,
   UPDATE_ROWS_COMPRESSED_EVENT = 170,
   DELETE_ROWS_COMPRESSED_EVENT = 171,
+
+  /*
+    Partial Row Data Event
+  */
+  PARTIAL_ROW_DATA_EVENT = 172,
 
   /* Add new MariaDB events here - right above this comment!  */
 
@@ -1047,7 +1063,7 @@ public:
     checksum_len(( checksum_alg != BINLOG_CHECKSUM_ALG_OFF &&
                    checksum_alg != BINLOG_CHECKSUM_ALG_UNDEF) ?
                  BINLOG_CHECKSUM_LEN : 0),
-    file(file_arg), cache_data(cache_data_arg), crypto(cr) { }
+    file(file_arg), cache_data(cache_data_arg), crc(0), crypto(cr) { }
 
 private:
   IO_CACHE *file;
@@ -4686,6 +4702,19 @@ public:
 
   virtual ~Rows_log_event();
 
+  /*
+    Check if the length of the rows data exceeds a given limit. This is used to
+    decide whether or not to fragment the event into multiple partial row log
+    events when binlogging.
+
+    TODO Rename this function
+  */
+  my_bool rows_data_size_exceeds(uint size_limit)
+  {
+    my_ptrdiff_t const data_size= m_rows_cur - m_rows_buf;
+    return data_size > size_limit;
+  }
+
   void set_flags(flag_set flags_arg) { m_flags |= flags_arg; }
   void clear_flags(flag_set flags_arg) { m_flags &= ~flags_arg; }
   flag_set get_flags(flag_set flags_arg) const { return m_flags & flags_arg; }
@@ -5058,6 +5087,8 @@ private:
   */
   virtual int do_exec_row(rpl_group_info *rli) = 0;
 #endif /* defined(MYSQL_SERVER) && defined(HAVE_REPLICATION) */
+
+  friend class Rows_log_event_fragmenter;
 };
 
 /**
@@ -5499,6 +5530,234 @@ bool copy_cache_to_file_wrapped(IO_CACHE *body,
                                 bool is_verbose);
 #endif
 
+/**
+  @class Partial_rows_log_event
+
+  When any given instantiation of a Rows_log_event (e.g. Write_rows_log_event,
+  etc) is too large to be sent to a replica (i.e. larger than
+  the value slave_max_allowed_packet, as configured on a replica), then the
+  rows event must be fragmented into sub-events (i.e. Partial_rows_log_events),
+  each of size slave_max_allowed_packet, so the event can be transmitted to the
+  replica. The replica will then take the content of each of these
+  Partial_rows_log_events, and join them together into a large
+  Rows_log_event to be executed as normal.
+
+  Partial_rows_log_events are written to the binary log sequentially, and
+  the replica assembles the events in the order they are binlogged. Each
+  Partial_rows_log_event stores its sequence number (seq_no) in the overall
+  series of fragments, the total number of fragments needed to re-assemble the
+  Rows_log_event (total_fragments), and a uchar for flags for embedding extra
+  data. For the debut of this event, there are no flags set and no extra data
+  embedded in the event; however, it is kept for future extensibility.
+
+  The cached Rows_log_event data is fragmented into Partial_rows_log_events as
+  follows. The primary will still generate a Rows_log_event to write to the
+  binlog; however, during the actual writing process, the raw data of the
+  rows event is split into fragments, each covering some continuous section of
+  the rows data. A Partial_rows_log_event is created for each continuous
+  section, and the Partial_rows_log_events are written sequentially in-place of
+  the too-large Rows_log_event. The original data to be fragmented will include
+  a header and data header; however, will not include a checksum, as each
+  Partial_rows_log_event will have a checksum for validation, as well as a
+  sequence_number and total number of fragments to ensure all fragments are
+  present.
+
+  @note This class behaves slightly different depending on if it is being used
+  for fragmentation (writing) or assembly (reading). During fragmentation, each
+  Partial_rows_log_event uses its member variables start_offset and end_offset
+  to refer to the boundaries of the original Rows_log_event that this
+  particular class is responsible for writing (specifically, it references only
+  the rows data; it is implied that the first event of the group should also
+  write the header and data header). During assembly, the start_offset and
+  end_offset refer to the start and end of the rows_event data within the
+  context of the full Partial_rows_log_event data.
+
+  @note Where slave_max_allowed_packet has a maximum of 1GB at the time of
+  creating this class (MariaDB 12.1), even if that one day grows larger, the
+  current binlog format only supports row events of maximum size 4GB anyway.
+  If/when this max_allowed_packet restriction is ever lifted, the size of any
+  given Partial_rows_log_event should then be 4GB.
+*/
+class Partial_rows_log_event : public Log_event
+{
+public:
+  /*
+    Flags for future extensibility, currently unused
+  */
+  uchar flags2;
+
+  /*
+    Within the context of a fragmented Rows_log_event, the sequence number for
+    _this_ particular fragment. Starts at 1.
+  */
+  uint32_t seq_no;
+
+  /*
+    The total number of fragments to store the content of a Rows_log_event that
+    is written in fragments.
+  */
+  uint32_t total_fragments;
+
+  /*
+    The size of the header and data_header that is written for the first
+    Partial_rows_log_event in a group. This is needed to calculate the
+    start_offset and end_offset to still fit within the desired size of a
+    fragment. That is, because events are written as (pseudo-code)
+
+      if (is_first_in_group(partial_ev))
+      {
+        Log_event_writer::write_header()
+        Log_event_writer::write_data_header()
+        Log_event_writer::write_data_body_metadata()
+      }
+      Log_event_writer::write_data_body_rows(start_offset, end_offset)
+
+    for the first Partial_rows_log_event written, we need to track the size
+    of data written by the header, data_header, and data_body_metadata to
+    make sure that the start_offset and end_offset account for this to not
+    write too large of an event.
+  */
+  uint32_t metadata_written;
+
+  /*
+    Functions differently depending if fragmenting (writing to binlog) or
+    assembling (reading from binlog).
+
+    During fragmentation, this refers to the offset in the rows_data of the
+    Rows_log_event where this object is responsible for writing.
+
+    During assembly, this refers to the offset in the memory buffer of the
+    Partial_rows_log_event where the Rows_log_event content starts.
+  */
+  uint64_t start_offset;
+
+  /*
+    Functions differently depending if fragmenting (writing to binlog) or
+    assembling (reading from binlog).
+
+    During fragmentation, this refers to the end offset in the rows_data of the
+    Rows_log_event where this object is responsible for writing.
+
+    During assembly, this is the _length_ of the Rows_log_event data in the
+    scope of the overall Partial_rows_log_event data buffer.
+  */
+  uint64_t end_offset;
+
+  /*
+    During assembly, this refers to the start of the memory buffer of the
+    overall Partial_rows_log_event.
+
+    Unused for fragmentation.
+  */
+  const uchar *ev_buffer_base;
+
+private:
+  /*
+    During fragmentation, references the original Rows_log_event that is to
+    be fragmented.
+
+    Unused for assembly.
+  */
+  Rows_log_event *rows_event;
+
+public:
+  Partial_rows_log_event(uint32 seq_no, uint32 total_fragments,
+                         uint32 metadata_written, uint64_t start_offset,
+                         uint64_t end_offset, Rows_log_event *rows_event)
+      : flags2(0), seq_no(seq_no), total_fragments(total_fragments),
+        metadata_written(metadata_written), start_offset(start_offset),
+        end_offset(end_offset), ev_buffer_base(NULL), rows_event(rows_event){};
+
+  Partial_rows_log_event(
+      const uchar *buf, uint event_len,
+      const Format_description_log_event *description_event);
+
+  ~Partial_rows_log_event() {}
+
+  /*
+    TODO: Move to .cc
+
+    For the event to be valid, it must hold true to some general principles for
+    both fragmentation and assembly; though be set up specifically for the
+    fragmentation or assembly use case (and not both).
+  */
+  bool is_valid() const override {
+    /*
+      There should be at least 2 fragments for the group, and the sequence
+      number of this instance should fall between 1 and the total number of
+      fragments. Flags2 is also unused right now, so ensure it is always 0.
+    */
+    bool general_validity= seq_no >= 1 && total_fragments >= 2 &&
+                           seq_no <= total_fragments && !flags2;
+
+    bool is_first= seq_no == 1;
+
+    /*
+      To be valid from a fragmentation context, the following should hold true:
+        1) There should be a _valid_ Rows_log_event that is referenced
+        2) Start_offset and end_offset should be representative of the
+           fragment. If it is the first fragment, then start_offset should be
+           0. The end_offset should be after the start_offset.
+        3) If it is the first event, we should have metadata to write;
+           otherwise we should not.
+        4) ev_buffer_base should not be used
+    */
+    bool is_valid_for_fragmentation=
+        (rows_event && rows_event->is_valid()) &&
+        (((start_offset || is_first) && end_offset) &&
+         (end_offset > start_offset)) &&
+        ((is_first && metadata_written) || !metadata_written) &&
+        !ev_buffer_base;
+
+    /*
+      To be valid from an assembly context, the following should hold true:
+        1) ev_buffer_base should be set (referencing the read-in buffer)
+        2) start_offset should point beyond the Partial_rows_log_event header,
+           as it points to the start of the Rows_log_event content
+        3) end_offset should be non-zero (there should always be some content)
+        4) Neither rows_event nor metadata_written should be set
+    */
+    bool is_valid_for_assembly=
+        ev_buffer_base && start_offset > PARTIAL_ROWS_HEADER_LEN &&
+        end_offset && (!rows_event && !metadata_written);
+
+    bool is_valid= general_validity &&
+                   (is_valid_for_fragmentation ^ is_valid_for_assembly);
+
+    return is_valid;
+  }
+
+  Log_event_type get_type_code() override {
+    return PARTIAL_ROW_DATA_EVENT;
+  }
+
+  int get_data_size() override
+  {
+    return (int) get_rows_size() + metadata_written +
+           PARTIAL_ROWS_HEADER_LEN;
+  }
+
+  size_t get_rows_size()
+  {
+    return end_offset - start_offset;
+  }
+
+#ifdef MYSQL_SERVER
+  bool write_data_header(Log_event_writer *writer) override;
+  bool write_data_body(Log_event_writer *writer) override;
+  int do_apply_event(rpl_group_info *rgi) override;
+#ifdef HAVE_REPLICATION
+  /*
+    TODO Implement & test
+  */
+  //void pack_info(Protocol* protocol) override;
+#endif /* HAVE_REPLICATION */
+#else
+  bool print(FILE* file, PRINT_EVENT_INFO* print_event_info) override;
+#endif
+};
+
+
 #ifdef MYSQL_SERVER
 /*****************************************************************************
 
@@ -5541,6 +5800,304 @@ inline int Log_event_writer::write(Log_event *ev)
   add_status(ev->logged_status());
   return res;
 }
+
+/*
+  Helper class which fragments the content of a large Rows_log_event into
+  multiple Partial_rows_log_events, which can be written to the binary log.
+  Writing these Partial_rows_log_events is abstracted by a special Log_event
+  implementation, a Fragmented_rows_log_event, which contains and writes a
+  complete group of multiple Partial_rows_log_events (i.e. all these partial
+  events can be assembled to recreate the original Rows_log_event). That way,
+  it is easy to pass a single Fragmented_rows_log_event to
+  Log_event_writer::write(), and it will write all Partial_rows_log_events to
+  the binary log.
+*/
+class Rows_log_event_fragmenter
+{
+public:
+  /*
+    Helper class for writing a complete group of Partial_row_log_events that
+    store the full content of a large Rows_log_event. It really only
+    implements Log_event::write(), such that it will write all
+    Partial_rows_log_events into the binary log. It also implements
+    Log_event::is_valid() to ensure the fragmentation was done correctly.
+  */
+  class Fragmented_rows_log_event : public Log_event
+  {
+  private:
+    Partial_rows_log_event *fragments;
+    uint32_t n_fragments;
+  public:
+    Fragmented_rows_log_event(Partial_rows_log_event *fragments,
+                              uint32_t n_fragments)
+        : fragments(fragments), n_fragments(n_fragments){};
+
+    ~Fragmented_rows_log_event()
+    {
+      DBUG_ASSERT(n_fragments);
+      my_free(fragments);
+    }
+
+    /*
+      Write all Partial_rows_log_event fragments
+    */
+    bool write(Log_event_writer *writer) override {
+      for (uint32_t i= 0; i < n_fragments; i++)
+      {
+        bool res= writer->write(&fragments[i]);
+        if (res)
+          return res;
+      }
+      return 0;
+    }
+
+    /*
+      Valid if all fragments are correctly ordered, and each fragment itself
+      is valid
+    */
+    bool is_valid() const override
+    {
+      uint32_t last_fragment_seen= 0;
+      for (uint32_t i= 0; i < n_fragments; i++)
+      {
+        Partial_rows_log_event *frag= &fragments[i];
+        bool is_valid= (frag->total_fragments == n_fragments) &&
+                       (frag->seq_no == last_fragment_seen + 1) &&
+                       frag->is_valid();
+        if (!is_valid)
+          return false;
+        last_fragment_seen= frag->seq_no;
+      }
+      return true;
+    }
+
+    /* Not applicable */
+    Log_event_type get_type_code() override {
+      DBUG_ASSERT(0);
+      return UNKNOWN_EVENT;
+    }
+
+    /* Not applicable */
+    int get_data_size() override
+    {
+      DBUG_ASSERT(0);
+      return 0;
+    }
+
+#ifdef MYSQL_SERVER
+    /* Not applicable */
+    bool write_data_header(Log_event_writer *writer) override
+    {
+      DBUG_ASSERT(0);
+      return 1;
+    }
+
+    /* Not applicable */
+    bool write_data_body(Log_event_writer *writer) override
+    {
+      DBUG_ASSERT(0);
+      return 1;
+    }
+#endif
+  };
+
+public:
+  /*
+    The amount of Rows_log_event content that each Partial_rows_log_event may hold
+  */
+  uint32_t fragment_size;
+
+  /*
+    The Rows_log_event to fragment
+  */
+  Rows_log_event *rows_event;
+
+  /*
+    Length of metadata to write for the first Partial_rows_log_event.
+  */
+  uint32_t metadata_size;
+
+  /*
+    Total number of Partial_rows_log_events to create to encompass the content
+    of the Rows_log_event to fragment.
+  */
+  uint32_t num_chunks;
+
+  /*
+    Size of the last Partial_rows_log_event. The prior ones will all have a
+    fixed size, and the last chunk is whatever remains.
+  */
+  uint32_t last_chunk_size;
+
+  /*
+    The amount of Rows_log_event content to be held by each
+    Partial_rows_log_event
+  */
+  uint64_t data_size_per_chunk;
+
+  /*
+    {{num_chunks}} Partial_rows_log_events that altogether hold the entire
+    content of a Rows_log_event.
+  */
+  Partial_rows_log_event *fragments;
+
+public:
+  /*
+    TODO: Move to .cc
+  */
+  Rows_log_event_fragmenter(uint32_t fragment_size, Rows_log_event *rows_event)
+      : fragment_size(fragment_size), rows_event(rows_event)
+  {
+    uchar width_tmp_buf[MAX_INT_WIDTH];
+    uchar *const width_tmp_buf_end= net_store_length(width_tmp_buf, (size_t) rows_event->m_width);
+    uint32_t width_size= (width_tmp_buf_end - width_tmp_buf);
+
+    /*
+      Update row events write another bitmap
+    */
+    uint32_t cols_size=
+        no_bytes_in_export_map(&rows_event->m_cols) *
+        ((rows_event->get_general_type_code() == UPDATE_ROWS_EVENT) ? 2 : 1);
+
+    metadata_size=
+        LOG_EVENT_HEADER_LEN + ROWS_HEADER_LEN_V1 + width_size + cols_size;
+
+    uint32_t data_size=
+        static_cast<uint64_t>(rows_event->m_rows_cur - rows_event->m_rows_buf);
+
+    uint32_t total_size= metadata_size + data_size;
+
+    data_size_per_chunk= get_payload_size_per_chunk();
+
+    last_chunk_size= (total_size % data_size_per_chunk); /* TODO Should last_chunk_size be uint64? */
+    uint8_t last_chunk= last_chunk_size ? 1 : 0;
+    num_chunks= (total_size / data_size_per_chunk) + last_chunk;
+
+    fragments= (Partial_rows_log_event *)
+        my_malloc(
+            PSI_INSTRUMENT_ME,
+            sizeof(
+                Partial_rows_log_event) *
+                num_chunks,
+            MYF(MY_WME));
+    if (!fragments)
+    {
+      /*
+        TODO Error handling
+      */
+    }
+  }
+
+  /*
+    Note that our variable fragments which we allocate is freed by
+    Fragmented_rows_log_event::~Fragmented_rows_log_event()
+  */
+  ~Rows_log_event_fragmenter() {}
+
+  /*
+    TODO: Move to .cc
+    Fragments our Rows_log_event (provided in the constructor) into num_chunks
+    Partial_rows_log_events, housed by a Fragmented_rows_log_event.
+  */
+  Fragmented_rows_log_event* fragment()
+  {
+    Fragmented_rows_log_event *ev;
+
+    for (uint32 i= 0; i < num_chunks; i++)
+    {
+      my_bool is_first_chunk= (i == 0);
+      my_bool is_last_chunk= (i == (num_chunks - 1));
+      uint64_t chunk_start=
+          is_first_chunk ? 0 : ((i * data_size_per_chunk) - metadata_size) + 1;
+      uint64_t chunk_end= (is_last_chunk)
+                              ? chunk_start + last_chunk_size - 1 // Why -1 again
+                              : ((chunk_start + data_size_per_chunk) -
+                                 (is_first_chunk ? metadata_size - 1 : 0)); // TODO Why - 1??
+      new (&fragments[i]) Partial_rows_log_event(
+          i + 1, num_chunks, is_first_chunk ? metadata_size : 0, chunk_start,
+          chunk_end, rows_event);
+    }
+
+    ev= new Fragmented_rows_log_event(fragments, num_chunks);
+    return ev;
+  }
+
+  /*
+    The amount of Rows_log_event content to be held by each
+    Partial_rows_log_event
+  */
+  uint64_t get_payload_size_per_chunk()
+  {
+    DBUG_ASSERT(fragment_size > LOG_EVENT_HEADER_LEN +
+                                    PARTIAL_ROWS_HEADER_LEN +
+                                    BINLOG_CHECKSUM_LEN);
+    return fragment_size - LOG_EVENT_HEADER_LEN - PARTIAL_ROWS_HEADER_LEN -
+           BINLOG_CHECKSUM_LEN;
+  }
+
+  Partial_rows_log_event *get_fragment(size_t i)
+  {
+    return &fragments[i];
+  }
+};
+
+/*
+  Class which assembles a Rows_log_event from a group of
+  Partial_rows_log_events
+*/
+class Rows_log_event_assembler
+{
+private:
+  /*
+    Internal state tracker to ensure that Partial_rows_log_events are being
+    ingested in-order
+  */
+  uint32_t last_fragment_seen;
+
+public:
+
+  /*
+    Memory buffer, initialized to the maximum size of the Rows_log_event
+    (i.e. total_fragments * event_size), where each Partial_rows_log_event
+    will append its Rows_log_event content to.
+  */
+  char *rows_ev_buf_builder_ptr;
+
+  /*
+    Total length of the Rows_log_event to construct
+  */
+  uint64_t ev_len;
+
+  /*
+    Total number of Partial_rows_log_events in the group.
+  */
+  uint32_t total_fragments;
+
+  Rows_log_event_assembler(uint32_t total_fragments)
+      : last_fragment_seen(0), total_fragments(total_fragments){};
+
+  ~Rows_log_event_assembler() {};
+
+  bool all_fragments_assembled()
+  {
+    return last_fragment_seen == total_fragments;
+  }
+
+  /*
+    Append the Rows_log_event content from a Partial_rows_log_event into our
+    builder to re-create the original Rows_log_event.
+  */
+  bool append(Partial_rows_log_event *partial_ev);
+
+  /*
+    Build the original Rows_log_event once all Partial_rows_log_event
+    fragments have been appended.
+  */
+  Log_event *create_rows_event(const Format_description_log_event *fdle,
+                                    my_bool crc_check, my_bool print_errors
+
+  );
+};
 
 /**
    The function is called by slave applier in case there are

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -938,6 +938,13 @@ typedef struct st_print_event_info
   bool print_table_metadata;
 
   /*
+    The Table_map_log_event for the current event group.  We always need it
+    around in case we are printing a group of Partial_rows_log_events, where we
+    will write a Table_map_log_event for the last fragment.
+  */
+  Table_map_log_event *table_map_event;
+
+  /*
      These two caches are used by the row-based replication events to
      collect the header information and the main body of the events
      making up a statement.
@@ -4549,6 +4556,12 @@ public:
 
 #ifdef MYSQL_CLIENT
   bool print(FILE *file, PRINT_EVENT_INFO *print_event_info) override;
+
+  /*
+    Only print the content of the Table_map_log_event which is actually used to
+    re-construct the event
+  */
+  bool print_body(PRINT_EVENT_INFO *print_event_info);
 #endif
 
   table_def get_table_def();

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1583,7 +1583,7 @@ public:
     is calculated during write()
   */
   virtual int get_data_size() { return 0;}
-  static Log_event* read_log_event(const uchar *buf, uint event_len,
+  static Log_event* read_log_event(const uchar *buf, size_t event_len,
 				   const char **error,
                                    const Format_description_log_event
                                    *description_event, my_bool crc_check,
@@ -4815,7 +4815,7 @@ protected:
 		 MY_BITMAP const *cols, bool is_transactional,
 		 Log_event_type event_type);
 #endif
-  Rows_log_event(const uchar *row_data, uint event_len,
+  Rows_log_event(const uchar *row_data, size_t event_len,
 		 const Format_description_log_event *description_event);
   void uncompress_buf();
 
@@ -5045,7 +5045,7 @@ public:
                        bool is_transactional);
 #endif
 #ifdef HAVE_REPLICATION
-  Write_rows_log_event(const uchar *buf, uint event_len,
+  Write_rows_log_event(const uchar *buf, size_t event_len,
                        const Format_description_log_event *description_event);
 #endif
 #if defined(MYSQL_SERVER) 
@@ -5095,7 +5095,7 @@ public:
   bool write(Log_event_writer *writer) override;
 #endif
 #ifdef HAVE_REPLICATION
-  Write_rows_compressed_log_event(const uchar *buf, uint event_len,
+  Write_rows_compressed_log_event(const uchar *buf, size_t event_len,
                        const Format_description_log_event *description_event);
 #endif
 private:
@@ -5132,7 +5132,7 @@ public:
   ~Update_rows_log_event() override;
 
 #ifdef HAVE_REPLICATION
-  Update_rows_log_event(const uchar *buf, uint event_len,
+  Update_rows_log_event(const uchar *buf, size_t event_len,
 			const Format_description_log_event *description_event);
 #endif
 
@@ -5184,7 +5184,7 @@ public:
   bool write(Log_event_writer *writer) override;
 #endif
 #ifdef HAVE_REPLICATION
-  Update_rows_compressed_log_event(const uchar *buf, uint event_len,
+  Update_rows_compressed_log_event(const uchar *buf, size_t event_len,
                        const Format_description_log_event *description_event);
 #endif
 private:
@@ -5223,7 +5223,7 @@ public:
   Delete_rows_log_event(THD*, TABLE*, ulonglong, bool is_transactional);
 #endif
 #ifdef HAVE_REPLICATION
-  Delete_rows_log_event(const uchar *buf, uint event_len,
+  Delete_rows_log_event(const uchar *buf, size_t event_len,
 			const Format_description_log_event *description_event);
 #endif
 #ifdef MYSQL_SERVER
@@ -5275,7 +5275,7 @@ public:
   bool write(Log_event_writer *writer) override;
 #endif
 #ifdef HAVE_REPLICATION
-  Delete_rows_compressed_log_event(const uchar *buf, uint event_len,
+  Delete_rows_compressed_log_event(const uchar *buf, size_t event_len,
                        const Format_description_log_event *description_event);
 #endif
 private:

--- a/sql/log_event_client.cc
+++ b/sql/log_event_client.cc
@@ -3180,13 +3180,8 @@ bool Table_map_log_event::print(FILE *file, PRINT_EVENT_INFO *print_event_info)
       print_columns(&print_event_info->head_cache, fields);
       print_primary_key(&print_event_info->head_cache, fields);
     }
-    bool do_print_encoded=
-      print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
-      print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS &&
-      !print_event_info->short_form;
 
-    if (print_base64(&print_event_info->body_cache, print_event_info,
-                     do_print_encoded) ||
+    if (print_body(print_event_info) ||
         copy_event_cache_to_file_and_reinit(&print_event_info->head_cache,
                                             file))
       goto err;
@@ -3195,6 +3190,22 @@ bool Table_map_log_event::print(FILE *file, PRINT_EVENT_INFO *print_event_info)
   return 0;
 err:
   return 1;
+}
+
+bool Table_map_log_event::print_body(PRINT_EVENT_INFO *print_event_info)
+{
+  if (!print_event_info->short_form || print_event_info->print_row_count)
+  {
+    bool do_print_encoded=
+        print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
+        print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS &&
+        !print_event_info->short_form;
+
+    if (print_base64(&print_event_info->body_cache, print_event_info,
+                     do_print_encoded))
+      return 1;
+  }
+  return 0;
 }
 
 /**
@@ -3587,6 +3598,57 @@ void Table_map_log_event::print_primary_key
 
     my_b_printf(file, ")\n");
   }
+}
+
+bool Partial_rows_log_event::print(FILE *file,
+                                   PRINT_EVENT_INFO *print_event_info)
+{
+  IO_CACHE *const head= &print_event_info->head_cache;
+  IO_CACHE *const body= &print_event_info->body_cache;
+  IO_CACHE *const tail= &print_event_info->tail_cache;
+  bool do_print_encoded=
+      print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
+      print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS &&
+      !print_event_info->short_form;
+
+  if (!print_event_info->short_form)
+    if (print_header(head, print_event_info, 0) ||
+        my_b_printf(head, "\tPartial_rows (%u / %u):\n", seq_no,
+                    total_fragments))
+      goto err;
+
+  if (!print_event_info->short_form || print_event_info->print_row_count)
+  {
+    DBUG_ASSERT(print_event_info->table_map_event);
+    /*
+      For the last fragment, re-write the Table_map_log_event into the start of
+      the BINLOG base64 statement. This is necessary, as the server logic
+      treats BINLOG statements as standalone, and automatically cleans up
+      and closes tables after each one. The last Partial_rows_log_event is
+      what re-creates and executes the original Rows_log_event, so the
+      Table_map_log_event is needed to run beforehand to set up the context
+      to execute the Rows_log_event.
+
+      TODO: Probably re-document the above in the .h
+    */
+    if (seq_no == total_fragments)
+      if (print_event_info->table_map_event->print_body(print_event_info))
+        goto err;
+
+    if (print_base64(body, print_event_info, do_print_encoded))
+      goto err;
+  }
+
+  if (copy_event_cache_to_file_and_reinit(head, file) ||
+      copy_cache_to_file_wrapped(body, file, do_print_encoded,
+                                 print_event_info->delimiter,
+                                 print_event_info->verbose) ||
+      copy_event_cache_to_file_and_reinit(tail, file))
+    goto err;
+
+  return 0;
+err:
+  return 1;
 }
 
 

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2173,7 +2173,8 @@ rpl_group_info::rpl_group_info(Relay_log_info *rli)
     deferred_events(NULL), m_annotate_event(0), is_parallel_exec(false),
     gtid_ev_flags2(0), gtid_ev_flags_extra(0), gtid_ev_sa_seq_no(0),
     reserved_start_alter_thread(0), finish_event_group_called(0), rpt(NULL),
-    start_alter_ev(NULL), direct_commit_alter(false), sa_info(NULL)
+    start_alter_ev(NULL), direct_commit_alter(false), sa_info(NULL),
+    assembler(NULL)
 {
   reinit(rli);
   bzero(&current_gtid, sizeof(current_gtid));

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -912,6 +912,15 @@ struct rpl_group_info
   bool direct_commit_alter;
   start_alter_info *sa_info;
 
+  /*
+    Use the scope of an RGI to re-assemble partial row log events into the
+    original rows log event. That is, the re-assembly and execution of a row
+    event happens happens in Partial_rows_log_event::do_apply_event(), so then
+    regardless of if the slave is running on parallel or serial mode, the
+    logic remains the same.
+  */
+  Rows_log_event_assembler *assembler;
+
   rpl_group_info(Relay_log_info *rli_);
   ~rpl_group_info();
   void reinit(Relay_log_info *rli);

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -3550,7 +3550,7 @@ sql_delay_event(Log_event *ev, THD *thd, rpl_group_info *rgi)
   Split out so that it can run with rli->data_lock held in non-parallel
   replication, but without the mutex held in the parallel case.
 */
-static int
+int
 apply_event_and_update_pos_setup(Log_event* ev, THD* thd, rpl_group_info *rgi)
 {
   DBUG_ENTER("apply_event_and_update_pos_setup");

--- a/sql/slave.h
+++ b/sql/slave.h
@@ -260,6 +260,8 @@ void set_slave_thread_default_charset(THD *thd, rpl_group_info *rgi);
 int rotate_relay_log(Master_info* mi);
 int has_temporary_error(THD *thd);
 int sql_delay_event(Log_event *ev, THD *thd, rpl_group_info *rgi);
+int apply_event_and_update_pos_setup(Log_event *ev, THD *thd,
+                                            struct rpl_group_info *rgi);
 int apply_event_and_update_pos(Log_event* ev, THD* thd,
                                struct rpl_group_info *rgi);
 int apply_event_and_update_pos_for_parallel(Log_event* ev, THD* thd,

--- a/sql/sql_binlog.cc
+++ b/sql/sql_binlog.cc
@@ -83,6 +83,7 @@ static int check_event_type(int type, Relay_log_info *rli)
   case PRE_GA_WRITE_ROWS_EVENT:
   case PRE_GA_UPDATE_ROWS_EVENT:
   case PRE_GA_DELETE_ROWS_EVENT:
+  case PARTIAL_ROW_DATA_EVENT:
     /*
       Row events are only allowed if a Format_description_event has
       already been seen.
@@ -273,6 +274,7 @@ void mysql_client_binlog_statement(THD* thd)
   const char *error= 0;
   Log_event *ev = 0;
   my_bool is_fragmented= FALSE;
+  my_bool keep_rgi= false;
   /*
     Out of memory check
   */
@@ -424,6 +426,16 @@ void mysql_client_binlog_statement(THD* thd)
         */
         LEX *backup_lex;
 
+        /*
+          If we are re-assembling a Rows_log_event from a group of
+          Partial_rows_log_events, the rgi houses the assembler, so we need
+          it around while we are re-constructing the event.
+        */
+        if (ev->get_type_code() == PARTIAL_ROW_DATA_EVENT &&
+            (((Partial_rows_log_event *) ev)->seq_no <
+             ((Partial_rows_log_event *) ev)->total_fragments))
+          keep_rgi= true;
+
         thd->backup_and_reset_current_lex(&backup_lex);
         err= save_restore_context_apply_event(ev, rgi);
         thd->restore_current_lex(backup_lex);
@@ -466,7 +478,11 @@ end:
   thd->variables.option_bits= thd_options;
   rgi->slave_close_thread_tables(thd);
   my_free(buf);
-  delete rgi;
-  rgi= thd->rgi_fake= NULL;
+
+  if (!keep_rgi)
+  {
+    delete rgi;
+    rgi= thd->rgi_fake= NULL;
+  }
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
This PR is currently a draft.

This PR solves two problems:
  1. Rows log events cannot be transmitted to the slave if their
     size exceeds slave_max_packet_size (max 1GB at the time of
     writing this patch, i.e. MariaDB 12.1)
  2. Rows log events cannot be binlogged if they are larger than
     4GB because the common binlog event header field event_len is
     32-bits.

This PR adds support for fragmenting large Rows_log_events
through a new event type, Partial_rows_log_event. When any given
instantiation of a Rows_log_event (e.g. Write_rows_log_event, etc)
is too large to be sent to a replica (i.e. larger than the value
slave_max_allowed_packet, as configured on a replica), then the rows
event must be fragmented into sub-events (i.e.
Partial_rows_log_events), each of size slave_max_allowed_packet, so
the event can be transmitted to the replica. The replica will then
take the content of each of these Partial_rows_log_events, and join
them together into a large Rows_log_event to be executed as normal.
Partial_rows_log_events are written to the binary log sequentially,
and the replica assembles the events in the order they are 
binlogged.


Remaining things to be done to remove draft status of the PR:
  1. Implement error handling
  2. Implementing Partial_rows_log_event::pack_info()
  3. Extend MTR testing

This PR is organized as follows:
* Commits 1 - 3 commits add code preparations to make the actual
   feature commits easier to read
* Commit 4 adds the Partial_rows_log_event type and the server logic
   to support fragmenting and re-assembling/applying large
   Rows_log_events.
* Commit 5 adds client (mysqlbinlog) logic to support output and
   replay of Partial_rows_log_events through piping to the
    mariadb client
 * Commit 6 adds the MTR test (still working on this) for the feature
 * Commit 7 adjusts existing MTR tests to pass