### PR TITLE
MDEV-34388: Stack overflow on Alpine Linux

### DIFF
--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -897,6 +897,9 @@ static int disable_binlog()
 }
 
 
+/* Ok as mysqlcheck is not multi threaded */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 static int handle_request_for_tables(char *tables, size_t length,
                                      my_bool view, my_bool dont_quote)
 {
@@ -1027,9 +1030,6 @@ static void insert_table_name(DYNAMIC_ARRAY *arr, char *in, size_t dblen)
   my_snprintf(buf, sizeof(buf), "%`s.%`s", in, in + dblen + 1);
   insert_dynamic(arr, (uchar*) buf);
 }
-
-/* Ok as mysqlcheck is not multi threaded */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 static void __attribute__((noinline)) print_result()
 {

--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -430,6 +430,8 @@ int main(int argc, char **argv)
   return 0;
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 void concurrency_loop(MYSQL *mysql, uint current, option_string *eptr)
 {
   unsigned int x;
@@ -525,6 +527,7 @@ void concurrency_loop(MYSQL *mysql, uint current, option_string *eptr)
   my_free(head_sptr);
 
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 static struct my_option my_long_options[] =
@@ -2295,6 +2298,7 @@ statement_cleanup(statement *stmt)
   }
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 int 
 slap_connect(MYSQL *mysql)
@@ -2328,3 +2332,4 @@ slap_connect(MYSQL *mysql)
 
   return 0;
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME

--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -41,6 +41,7 @@ SET(MY_WARNING_FLAGS
   -Wvla
   -Wwrite-strings
   -Wcast-function-type-strict
+  -Wframe-larger-than=16384
   )
 
 # Warning flags that are in testing before moving

--- a/extra/mariabackup/fil_cur.cc
+++ b/extra/mariabackup/fil_cur.cc
@@ -217,7 +217,10 @@ xb_fil_cur_open(
 	cursor->buf_size = XB_FIL_CUR_PAGES * cursor->page_size;
 	cursor->buf = static_cast<byte*>(aligned_malloc(cursor->buf_size,
 							srv_page_size));
-
+	cursor->tmp_page = static_cast<byte*>(aligned_malloc(srv_page_size,
+							     srv_page_size));
+	cursor->tmp_frame = static_cast<byte*>(aligned_malloc(srv_page_size,
+							      srv_page_size));
 	cursor->buf_read = 0;
 	cursor->buf_npages = 0;
 	cursor->buf_offset = 0;
@@ -245,15 +248,10 @@ xb_fil_cur_open(
 	return(XB_FIL_CUR_SUCCESS);
 }
 
-/* Stack usage 131224 with clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 static bool page_is_corrupted(const byte *page, ulint page_no,
 			      const xb_fil_cur_t *cursor,
 			      const fil_space_t *space)
 {
-	byte tmp_frame[UNIV_PAGE_SIZE_MAX];
-	byte tmp_page[UNIV_PAGE_SIZE_MAX];
 	const ulint page_size = cursor->page_size;
 	uint16_t page_type = fil_page_get_type(page);
 
@@ -316,42 +314,43 @@ static bool page_is_corrupted(const byte *page, ulint page_no,
 		    && !opt_extended_validation)
 			return false;
 
-		memcpy(tmp_page, page, page_size);
+		memcpy(cursor->tmp_page, page, page_size);
 
 		if (!space->crypt_data
 		    || space->crypt_data->type == CRYPT_SCHEME_UNENCRYPTED
-		    || !fil_space_decrypt(space, tmp_frame, tmp_page)) {
+		    || !fil_space_decrypt(space, cursor->tmp_frame,
+					  cursor->tmp_page)) {
 			return true;
 		}
 
 		if (page_type != FIL_PAGE_PAGE_COMPRESSED_ENCRYPTED) {
-			return buf_page_is_corrupted(false, tmp_page,
+			return buf_page_is_corrupted(false, cursor->tmp_page,
 						     space->flags);
 		}
 	}
 
 	if (page_type == FIL_PAGE_PAGE_COMPRESSED) {
-		memcpy(tmp_page, page, page_size);
+		memcpy(cursor->tmp_page, page, page_size);
 	}
 
 	if (page_type == FIL_PAGE_PAGE_COMPRESSED
 	    || page_type == FIL_PAGE_PAGE_COMPRESSED_ENCRYPTED) {
-		ulint decomp = fil_page_decompress(tmp_frame, tmp_page,
+		ulint decomp = fil_page_decompress(cursor->tmp_frame,
+						   cursor->tmp_page,
 						   space->flags);
-		page_type = fil_page_get_type(tmp_page);
+		page_type = fil_page_get_type(cursor->tmp_page);
 
 		return (!decomp
 			|| (decomp != srv_page_size
 			    && cursor->zip_size)
 			|| page_type == FIL_PAGE_PAGE_COMPRESSED
 			|| page_type == FIL_PAGE_PAGE_COMPRESSED_ENCRYPTED
-			|| buf_page_is_corrupted(false, tmp_page,
+			|| buf_page_is_corrupted(false, cursor->tmp_page,
 						 space->flags));
 	}
 
 	return buf_page_is_corrupted(false, page, space->flags);
 }
-PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 /** Reads and verifies the next block of pages from the source
 file. Positions the cursor after the last read non-corrupted page.
@@ -514,7 +513,11 @@ xb_fil_cur_close(
 	xb_fil_cur_t *cursor)	/*!< in/out: source file cursor */
 {
 	aligned_free(cursor->buf);
+	aligned_free(cursor->tmp_page);
+	aligned_free(cursor->tmp_frame);
 	cursor->buf = NULL;
+	cursor->tmp_page = NULL;
+	cursor->tmp_frame = NULL;
 
 	if (cursor->node != NULL) {
 		xb_fil_node_close_file(cursor->node);

--- a/extra/mariabackup/fil_cur.h
+++ b/extra/mariabackup/fil_cur.h
@@ -45,7 +45,9 @@ struct xb_fil_cur_t {
 	xb_read_filt_t*	read_filter;	/*!< read filter */
 	xb_read_filt_ctxt_t	read_filter_ctxt;
 					/*!< read filter context */
-	byte*		buf;		/*!< read buffer */
+	byte*		buf;		/*!< read buffer of XB_FIL_CUR_PAGES */
+	byte*		tmp_page;	/*!< buffer for decrypting a page */
+	byte*		tmp_frame;	/*!< buffer for decompressing a page */
 	size_t		buf_size;	/*!< buffer size in bytes */
 	size_t		buf_read;	/*!< number of read bytes in buffer
 					after the last cursor read */

--- a/include/my_attribute.h
+++ b/include/my_attribute.h
@@ -83,13 +83,13 @@
 
 /* Define pragmas to disable warnings for stack frame checking */
 
-#if defined(__clang__)
+#ifdef __GNUC__
 #define PRAGMA_DISABLE_CHECK_STACK_FRAME                     \
-_Pragma("clang diagnostic push")                             \
-_Pragma("clang diagnostic ignored \"-Wframe-larger-than=\"")
+_Pragma("GCC diagnostic push")                               \
+_Pragma("GCC diagnostic ignored \"-Wframe-larger-than=\"")
 
 #define PRAGMA_REENABLE_CHECK_STACK_FRAME                    \
-_Pragma("clang diagnostic pop")
+_Pragma("GCC diagnostic pop")
 
 #else
 #define PRAGMA_DISABLE_CHECK_STACK_FRAME

--- a/mysql-test/suite/innodb/r/innodb-wl5522-debug.result
+++ b/mysql-test/suite/innodb/r/innodb-wl5522-debug.result
@@ -81,8 +81,7 @@ SET @saved_debug_dbug = @@SESSION.debug_dbug;
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_1";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -91,8 +90,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_2";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -101,8 +99,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_3";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -111,8 +108,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_4";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -121,8 +117,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_5";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -131,8 +126,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_6";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -141,8 +135,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_7";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -151,8 +144,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_8";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -161,8 +153,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_9";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -171,8 +162,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_10";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -181,8 +171,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_11";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
@@ -191,8 +180,7 @@ INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_12";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
+Warning	1004	Can't create file './test/t1.cfg' (errno: 9 "Bad file descriptor")
 UNLOCK TABLES;
 SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;

--- a/sql/threadpool_generic.cc
+++ b/sql/threadpool_generic.cc
@@ -715,6 +715,10 @@ static void stop_timer(pool_timer_t *timer)
 
   @return a ready connection, or NULL on shutdown
 */
+
+/* ev[MAX_EVENTS] may bloat the stack frame beyond 16 KiB */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 static TP_connection_generic * listener(worker_thread_t *current_thread,
                                thread_group_t *thread_group)
 {
@@ -830,6 +834,7 @@ static TP_connection_generic * listener(worker_thread_t *current_thread,
 
   DBUG_RETURN(retval);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 /**
   Adjust thread counters in group or global
@@ -1157,6 +1162,9 @@ static bool too_many_threads(thread_group_t *thread_group)
   NULL is returned if timeout has expired,or on shutdown.
 */
 
+/* ev[MAX_EVENTS] may bloat the stack frame beyond 16 KiB */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 TP_connection_generic *get_event(worker_thread_t *current_thread,
   thread_group_t *thread_group,  struct timespec *abstime)
 {
@@ -1262,6 +1270,7 @@ TP_connection_generic *get_event(worker_thread_t *current_thread,
 
   DBUG_RETURN(connection);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -2287,6 +2287,8 @@ str_to_offset(const char *str, uint length, long *offset)
     specification or other error.
 
 */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 Time_zone *
 my_tz_find(THD *thd, const String *name)
 {
@@ -2355,6 +2357,7 @@ my_tz_find(THD *thd, const String *name)
 
   DBUG_RETURN(result_tz);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 /**

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -7010,9 +7010,6 @@ PRAGMA_REENABLE_CHECK_STACK_FRAME
   - user has file privilege
 */
 
-/* Stack size 16664 in clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 bool ha_connect::FileExists(const char *fn, bool bf)
 {
   if (!fn || !*fn)
@@ -7048,10 +7045,8 @@ bool ha_connect::FileExists(const char *fn, bool bf)
 
     if (n < 0) {
       if (errno != ENOENT) {
-        char buf[_MAX_PATH + 20];
-
-        snprintf(buf, sizeof(buf),  "Error %d for file %s", errno, filename);
-        push_warning(table->in_use, Sql_condition::WARN_LEVEL_WARN, 0, buf);
+        push_warning_printf(table->in_use, Sql_condition::WARN_LEVEL_WARN, 0,
+                            "Error %d for file %s", errno, filename);
         return true;
       } else
         return false;
@@ -7063,7 +7058,6 @@ bool ha_connect::FileExists(const char *fn, bool bf)
 
   return true;
 } // end of FileExists
-PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 // Called by SameString and NoFieldOptionChange
 bool ha_connect::CheckString(PCSZ str1, PCSZ str2)

--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -3605,9 +3605,6 @@ static my_bool translog_is_LSN_chunk(uchar type)
   @retval 1 Error
 */
 
-/* Stack size 26120 from clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 my_bool translog_init_with_table(const char *directory,
                                  uint32 log_file_max_size,
                                  uint32 server_version,
@@ -3861,6 +3858,7 @@ my_bool translog_init_with_table(const char *directory,
 
   if (logs_found)
   {
+    TRANSLOG_PAGE_SIZE_BUFF psize_buff;
     TRANSLOG_ADDRESS current_page= sure_page;
     my_bool pageok;
 
@@ -3901,7 +3899,6 @@ my_bool translog_init_with_table(const char *directory,
       do
       {
         TRANSLOG_VALIDATOR_DATA data;
-        TRANSLOG_PAGE_SIZE_BUFF psize_buff;
         uchar *page;
         data.addr= &current_page;
         if ((page= translog_get_page(&data, psize_buff.buffer, NULL)) == NULL)
@@ -3950,7 +3947,6 @@ my_bool translog_init_with_table(const char *directory,
     if (logs_found && !old_log_was_recovered && old_flags == flags)
     {
       TRANSLOG_VALIDATOR_DATA data;
-      TRANSLOG_PAGE_SIZE_BUFF psize_buff;
       uchar *page;
       uint16 chunk_offset;
       data.addr= &last_valid_page;
@@ -4241,7 +4237,6 @@ err:
   ma_message_no_user(0, "log initialization failed");
   DBUG_RETURN(1);
 }
-PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 /*

--- a/storage/maria/ma_open.c
+++ b/storage/maria/ma_open.c
@@ -1558,7 +1558,7 @@ uint _ma_state_info_write(MARIA_SHARE *share, uint pWrite)
      @retval 1      Error
 */
 
-/* Stack size 26376 from clang */
+/* MARIA_STATE_INFO_SIZE + MARIA_STATE_EXTRA_SIZE == 25559 */
 PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 uint _ma_state_info_write_sub(File file, MARIA_STATE_INFO *state, uint pWrite)

--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -4913,6 +4913,7 @@ static int flush_cached_blocks(PAGECACHE *pagecache,
    @retval PCFLUSH_PINNED Pinned blocks was met and skipped.
    @retval PCFLUSH_PINNED_AND_ERROR PCFLUSH_ERROR and PCFLUSH_PINNED.
 */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 static int flush_pagecache_blocks_int(PAGECACHE *pagecache,
                                       PAGECACHE_FILE *file,
@@ -5242,6 +5243,7 @@ int flush_pagecache_blocks_with_filter(PAGECACHE *pagecache,
   pagecache_pthread_mutex_unlock(&pagecache->cache_lock);
   DBUG_RETURN(res);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 /*

--- a/storage/maria/ma_recovery.c
+++ b/storage/maria/ma_recovery.c
@@ -277,6 +277,7 @@ int maria_recovery_from_log(void)
      @retval 0      OK
      @retval !=0    Error
 */
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 int maria_apply_log(LSN from_lsn, LSN end_redo_lsn, LSN end_undo_lsn,
                     enum maria_apply_log_way apply,
@@ -562,6 +563,7 @@ end:
   */
   DBUG_RETURN(error);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 
 /* very basic info about the record's header */

--- a/storage/mroonga/CMakeLists.txt
+++ b/storage/mroonga/CMakeLists.txt
@@ -49,6 +49,14 @@ if(MSVC)
       message(FATAL_ERROR ${MRN_OLD_MSVC_MESSAGE})
     endif()
   endif()
+else()
+  STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+         CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+         CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+         CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  MY_CHECK_AND_SET_COMPILER_FLAG(-Wframe-larger-than=49152)
 endif()
 
 if(MRN_BUNDLED)

--- a/storage/mroonga/vendor/groonga/lib/expr.c
+++ b/storage/mroonga/vendor/groonga/lib/expr.c
@@ -2459,6 +2459,10 @@ grn_proc_call(grn_ctx *ctx, grn_obj *proc, int nargs, grn_obj *caller)
   }                                                                     \
 } while (0)
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wframe-larger-than="
+#endif
 inline static void
 grn_expr_exec_get_member_vector(grn_ctx *ctx,
                                 grn_obj *expr,
@@ -3834,6 +3838,9 @@ exit :
   }
   GRN_API_RETURN(val);
 }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 grn_obj *
 grn_expr_get_value(grn_ctx *ctx, grn_obj *expr, int offset)

--- a/storage/perfschema/unittest/pfs_instr-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-t.cc
@@ -86,8 +86,6 @@ void test_no_instruments()
   cleanup_instruments();
 }
 
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 void test_no_instances()
 {
   int rc;
@@ -218,7 +216,7 @@ void test_no_instances()
   ok(file == NULL, "no file");
   ok(global_file_container.m_lost == 4, "lost 4");
 
-  char long_file_name[10000];
+  char long_file_name[5000];
   int size= sizeof(long_file_name);
   memset(long_file_name, 'X', size);
 
@@ -247,7 +245,6 @@ void test_no_instances()
   cleanup_file_hash();
   cleanup_instruments();
 }
-PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 void test_with_instances()
 {

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -9,6 +9,13 @@ SET(CPACK_RPM_rocksdb-engine_PACKAGE_SUMMARY "RocksDB storage engine for MariaDB
 SET(CPACK_RPM_rocksdb-engine_PACKAGE_DESCRIPTION "The RocksDB storage engine is a high performance storage engine, aimed
 at maximising storage efficiency while maintaining InnoDB-like performance." PARENT_SCOPE)
 
+STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+       CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+       CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+STRING(REGEX REPLACE "-Wframe-larger-than=[0-9]*" ""
+       CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+MY_CHECK_AND_SET_COMPILER_FLAG(-Wframe-larger-than=32768)
 MY_CHECK_AND_SET_COMPILER_FLAG(-Wno-range-loop-construct)
 MY_CHECK_AND_SET_COMPILER_FLAG(-Wno-effc++ DEBUG RELWITHDEBINFO)
 

--- a/storage/spider/spd_db_conn.cc
+++ b/storage/spider/spd_db_conn.cc
@@ -10454,6 +10454,7 @@ error:
 }
 
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 bool spider_db_conn_is_network_error(
   int error_num
 ) {
@@ -10470,3 +10471,4 @@ bool spider_db_conn_is_network_error(
   }
   DBUG_RETURN(FALSE);
 }
+PRAGMA_REENABLE_CHECK_STACK_FRAME


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34388*
## Description
`page_is_corrupted()`: Do not allocate the buffers from stack, but from the heap, in `xb_fil_cur_open()`.

`row_quiesce_write_cfg()`: Issue one type of message when we fail to create the `.cfg` file.

`update_statistics_for_table()`, `read_statistics_for_table()`, `delete_statistics_for_table()`, `rename_table_in_stat_tables()`: Use a common stack buffer for `Index_stat`, `Column_stat`, `Table_stat`.

`translog_init_with_table()`: Do not duplicate `TRANSLOG_PAGE_SIZE_BUFF`.

Let us also globally enable the option `-Wframe-larger-than=16384` that was introduced in clang 3.0, to reduce the possibility of introducing such stack overflow in the future. For RocksDB and Mroonga we relax these limits.
## Release Notes
The stack usage of MariaDB was reduced. Most notably, `mariadb-backup` should no longer crash due to stack overflow on Alpine Linux.
## How can this PR be tested?
This is covered by the regression test suite. We have some mandatory clang based targets.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.