### PR TITLE
MDEV-36843 : Galera tests fail if wsrep_provider_options is too long …

### DIFF
--- a/mysql-test/suite/galera/r/galera_provider_options_long.result
+++ b/mysql-test/suite/galera/r/galera_provider_options_long.result
@@ -1,0 +1,16 @@
+connection node_2;
+connection node_1;
+#
+# wsrep_provider_options should be already > 2k length
+#
+AS_EXPECT_1
+1
+#
+# Setting single value should pass
+#
+SET GLOBAL wsrep_provider_options='pc.ignore_sb=false;pc.weight=2';
+#
+# This failed before change with ER_WRONG_STRING_LENGTH
+#
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/galera_provider_options_long.cnf
+++ b/mysql-test/suite/galera/t/galera_provider_options_long.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+loose-galera-ssl-upgrade=1
+wsrep-debug=1
+
+[mysqld.1]
+wsrep_provider_options='socket.ssl=yes;socket.ssl_cert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem;socket.ssl_key=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
+
+[mysqld.2]
+wsrep_provider_options='socket.ssl=yes;socket.ssl_cert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem;socket.ssl_key=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'

--- a/mysql-test/suite/galera/t/galera_provider_options_long.test
+++ b/mysql-test/suite/galera/t/galera_provider_options_long.test
@@ -1,0 +1,28 @@
+--source include/galera_cluster.inc
+--source include/have_ssl_communication.inc
+--source include/have_openssl.inc
+
+--let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options`
+
+--echo #
+--echo # wsrep_provider_options should be already > 2k length
+--echo #
+--disable_query_log
+--eval SELECT LENGTH('$wsrep_provider_options_orig') > 2000 AS_EXPECT_1;
+--enable_query_log
+
+--echo #
+--echo # Setting single value should pass
+--echo #
+
+SET GLOBAL wsrep_provider_options='pc.ignore_sb=false;pc.weight=2';
+
+--echo #
+--echo # This failed before change with ER_WRONG_STRING_LENGTH
+--echo #
+
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = "$wsrep_provider_options_orig"
+--enable_query_log
+
+--source include/galera_end.inc

--- a/sql/sys_vars.inl
+++ b/sql/sys_vars.inl
@@ -506,7 +506,7 @@ public:
 */
 class Sys_var_charptr: public sys_var
 {
-  const size_t max_length= 2000;
+  const size_t max_length= 4096;
 public:
   Sys_var_charptr(const char *name_arg,
           const char *comment, int flag_args, ptrdiff_t off, size_t size,


### PR DESCRIPTION
…(> 2k)



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36843*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Galera provider options contains many options and several directory names and file names that could lead situation where wsrep_provider_options string is longer than 2k. Many tests set few new options required by test and then restore wsrep_provider_options to original value. This restoring wsrep_provider_options string to original value then fails because of common limit for all charptr variables (2k).

Fix is to increase common limit for all charptr variables to 4kb.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
