### PR TITLE
MDEV-36868: Inconsistency when shrinking innodb_buffer_pool_size

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2011,25 +2011,12 @@ ATTRIBUTE_COLD void buf_pool_t::resize(size_t size, THD *thd) noexcept
     if (ahi_disabled)
       btr_search_enable(true);
 #endif
-    mysql_mutex_lock(&LOCK_global_system_variables);
-    bool resized= n_blocks_removed < 0;
-    if (n_blocks_removed > 0)
-    {
-      mysql_mutex_lock(&mutex);
-      resized= size_in_bytes == old_size;
-      if (resized)
-      {
-        size_in_bytes_requested= size;
-        size_in_bytes= size;
-      }
-      mysql_mutex_unlock(&mutex);
-    }
-
-    if (resized)
+    if (n_blocks_removed)
       sql_print_information("InnoDB: innodb_buffer_pool_size=%zum (%zu pages)"
                             " resized from %zum (%zu pages)",
                             size >> 20, n_blocks_new, old_size >> 20,
                             old_blocks);
+    mysql_mutex_lock(&LOCK_global_system_variables);
   }
   else
   {
@@ -2092,6 +2079,10 @@ ATTRIBUTE_COLD void buf_pool_t::resize(size_t size, THD *thd) noexcept
     mysql_mutex_unlock(&mutex);
     my_printf_error(ER_WRONG_USAGE, "innodb_buffer_pool_size change aborted",
                     MYF(ME_ERROR_LOG));
+#ifdef BTR_CUR_HASH_ADAPT
+    if (ahi_disabled)
+      btr_search_enable(true);
+#endif
     mysql_mutex_lock(&LOCK_global_system_variables);
   }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36868*
## Description
`buf_pool_t::resize()`: After successfully shrinking the buffer pool, announce the success. The size had already been updated in `shrunk()`. After failing to shrink the buffer pool, re-enable the adaptive hash index if it had been enabled.
## Release Notes
When an attempt to reduce the allocation with `SET GLOBAL innodb_buffer_pool_size`  is made, the adaptive hash index would not always be re-enabled afterwards. Also, no message was output about shrinking the buffer pool.
## How can this PR be tested?
```sql
SET GLOBAL innodb_buffer_pool_size=16*1024*1024;
SET GLOBAL innodb_buffer_pool_size=8*1024*1024;
```
and check the server error log.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
This fixes a regression due to #3826.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.