### PR TITLE
MDEV-36835 - main.aborted_clients fails after various tests

### DIFF
--- a/mysql-test/main/aborted_clients.result
+++ b/mysql-test/main/aborted_clients.result
@@ -1,4 +1,4 @@
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 connect  con1,localhost,root,,;
 disconnect con1;
 connection default;

--- a/mysql-test/main/aborted_clients.test
+++ b/mysql-test/main/aborted_clients.test
@@ -5,7 +5,7 @@
 -- source include/not_embedded.inc
 -- source include/count_sessions.inc
 
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 # Connect/Disconnect look that aborted_clients stays 0
 connect (con1,localhost,root,,);
 disconnect con1;


### PR DESCRIPTION
Some tests like main.ssl_timeout and main.wait_timeout may abort connections. If main.aborted_clients follows such tests it may observe unstable value of aborted_clients status variable.

FLUSH STATUS was issued to make aborted_clients value reproducible. However after 775cba4d0f0 FLUSH STATUS doesn't reset global status.

Fixed by using FLUSH GLOBAL STATUS.

Regression after "MDEV-33145 - Add FLUSH GLOBAL STATUS".