### PR TITLE
MDEV-37197 - Install PAM modules and systemd units from /lib to /usr/lib

### DIFF
--- a/cmake/install_layout.cmake
+++ b/cmake/install_layout.cmake
@@ -196,10 +196,10 @@ SET(INSTALL_MYSQLDATADIR_DEB            "/var/lib/mysql")
 
 SET(INSTALL_RUNDATADIR_DEB              "/run/mysqld")
 SET(INSTALL_UNIX_ADDRDIR_DEB            "${INSTALL_RUNDATADIR_DEB}/mysqld.sock")
-SET(INSTALL_SYSTEMD_UNITDIR_DEB         "/lib/systemd/system")
+SET(INSTALL_SYSTEMD_UNITDIR_DEB         "/usr/lib/systemd/system")
 SET(INSTALL_SYSTEMD_SYSUSERSDIR_DEB     "/usr/lib/sysusers.d")
 SET(INSTALL_SYSTEMD_TMPFILESDIR_DEB     "/usr/lib/tmpfiles.d")
-SET(INSTALL_PAMDIR_DEB                  "/lib/${CMAKE_CXX_LIBRARY_ARCHITECTURE}/security")
+SET(INSTALL_PAMDIR_DEB                  "/usr/lib/${CMAKE_CXX_LIBRARY_ARCHITECTURE}/security")
 SET(INSTALL_PAMDATADIR_DEB              "/etc/security")
 
 #

--- a/cmake/install_layout.cmake
+++ b/cmake/install_layout.cmake
@@ -164,7 +164,12 @@ SET(INSTALL_SYSTEMD_UNITDIR_RPM         "/usr/lib/systemd/system")
 SET(INSTALL_SYSTEMD_SYSUSERSDIR_RPM     "/usr/lib/sysusers.d")
 SET(INSTALL_SYSTEMD_TMPFILESDIR_RPM     "/usr/lib/tmpfiles.d")
 SET(INSTALL_RUNDATADIR_RPM              "/run/mariadb")
-SET(INSTALL_PAMDIR_RPM                  "/${INSTALL_LIBDIR_RPM}/security")
+SET(INSTALL_PAMDIR_RPM                  "/usr/${INSTALL_LIBDIR_RPM}/security")
+IF(RPM MATCHES "^(opensuse|sles)([0-9]+)$")
+  IF(CMAKE_MATCH_2 LESS_EQUAL 1507)
+    SET(INSTALL_PAMDIR_RPM                  "/${INSTALL_LIBDIR_RPM}/security")
+  ENDIF()
+ENDIF()
 SET(INSTALL_PAMDATADIR_RPM              "/etc/security")
 
 #

--- a/debian/mariadb-server-galera.install
+++ b/debian/mariadb-server-galera.install
@@ -1,7 +1,5 @@
 etc/mysql/mariadb.conf.d/wsrep_info.cnf
 debian/additions/mariadb.conf.d/60-galera.cnf etc/mysql/mariadb.conf.d
-lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
-lib/systemd/system/mariadb.service.d/galera.conf
 usr/bin/galera_new_cluster
 usr/bin/galera_recovery
 usr/bin/wsrep_sst_common
@@ -10,6 +8,8 @@ usr/bin/wsrep_sst_mysqldump
 usr/bin/wsrep_sst_rsync
 usr/bin/wsrep_sst_rsync_wan
 usr/lib/mysql/plugin/wsrep_info.so
+usr/lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
+usr/lib/systemd/system/mariadb.service.d/galera.conf
 usr/share/man/man1/galera_new_cluster.1
 usr/share/man/man1/galera_recovery.1
 usr/share/man/man1/wsrep_sst_common.1

--- a/debian/mariadb-server.install
+++ b/debian/mariadb-server.install
@@ -6,13 +6,6 @@ debian/additions/source_mariadb.py usr/share/apport/package-hooks
 etc/apparmor.d/usr.sbin.mariadbd
 etc/logrotate.d/mariadb
 etc/security/user_map.conf
-lib/*/security/pam_user_map.so
-lib/systemd/system/mariadb-extra@.socket
-lib/systemd/system/mariadb.service
-lib/systemd/system/mariadb@.service
-lib/systemd/system/mariadb@.socket
-lib/systemd/system/mysql.service
-lib/systemd/system/mysqld.service
 support-files/rpm/enable_encryption.preset etc/mysql/mariadb.conf.d/99-enable-encryption.cnf.preset
 usr/bin/aria_chk
 usr/bin/aria_dump_log
@@ -27,6 +20,7 @@ usr/bin/myisam_ftdump
 usr/bin/myisamchk
 usr/bin/myisamlog
 usr/bin/myisampack
+usr/lib/*/security/pam_user_map.so
 usr/lib/mysql/plugin/auth_ed25519.so
 usr/lib/mysql/plugin/auth_mysql_sha2.so
 usr/lib/mysql/plugin/auth_pam.so
@@ -50,6 +44,12 @@ usr/lib/mysql/plugin/server_audit.so
 usr/lib/mysql/plugin/simple_password_check.so
 usr/lib/mysql/plugin/sql_errlog.so
 usr/lib/mysql/plugin/type_mysql_json.so
+usr/lib/systemd/system/mariadb-extra@.socket
+usr/lib/systemd/system/mariadb.service
+usr/lib/systemd/system/mariadb@.service
+usr/lib/systemd/system/mariadb@.socket
+usr/lib/systemd/system/mysql.service
+usr/lib/systemd/system/mysqld.service
 usr/lib/tmpfiles.d/mariadb.conf
 usr/share/doc/mariadb-server/mariadbd.sym.gz
 usr/share/man/man1/aria_chk.1

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -4,8 +4,8 @@ etc/mysql/mariadb.conf.d/client.cnf # Debian packaging uses files from debian/ad
 etc/mysql/mariadb.conf.d/enable_encryption.preset # Debian packaging uses files from debian/additions/mariadb.cnf.d/
 etc/mysql/mariadb.conf.d/mysql-clients.cnf # Debian packaging uses files from debian/additions/mariadb.cnf.d/
 etc/mysql/mariadb.conf.d/server.cnf # Debian packaging uses files from debian/additions/mariadb.cnf.d/
-lib/systemd/system/mariadb-extra.socket # Installed by rules file
-lib/systemd/system/mariadb.socket # Installed by rules file
+usr/lib/systemd/system/mariadb-extra.socket # Installed by rules file
+usr/lib/systemd/system/mariadb.socket # Installed by rules file
 usr/bin/mariadb-embedded # Shipping the embedded server in distro packaging does not make sense
 usr/bin/mysql_config # Debian packaging has mysql_config as symlink to mariadb_config
 usr/bin/mysql_embedded # Symlink to mariadb-embedded which is intentionally not included


### PR DESCRIPTION
## Description

Since Fedora 17 and about 2012, the directory /lib has been a symlink to /usr/lib. Debian started a similar migration in 2019. Nowadays all major Linux distributions have a merged /usr, and the canonical location for files should be /usr/lib instead of just /lib.

The location of PAM modules and systemd files is the last remaining part in MariaDB to fully complete the usr merge migration. Stable releases should not move files around, so target MariaDB 11.8 as the first release to have the /usr merge fully completed.

References:
- https://fedoraproject.org/wiki/Features/UsrMove
- https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#a-merged-usr-is-now-required
- https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/

## Release Notes

* Install PAM modules and systemd units from are now installed to /usr/lib instead of /lib

## How can this PR be tested?

CI should continue to be green for builds, installs and upgrades.

## Basing the PR against the correct MariaDB version

- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
