### PR TITLE
MDEV-36771 Assertion 'bulk_insert == TRX_NO_BULK' failed in trx_t::assert_freed

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -580,4 +580,20 @@ WHERE variable_name = 'innodb_bulk_operations';
 bulk_operations
 1
 DROP TABLE t1;
+call mtr.add_suppression("Found 1 prepared XA transactions");
+#
+#  MDEV-36771 Assertion `bulk_insert == TRX_NO_BULK' failed
+#           in trx_t::assert_freed from innodb_shutdown
+#
+CREATE TABLE t1(f1 INT)ENGINE=InnoDB;
+XA START 'a';
+INSERT INTO t1 VALUES(1);
+XA END 'a';
+XA PREPARE 'a';
+# restart
+XA COMMIT 'a';
+SELECT * FROM t1;
+f1
+1
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -638,4 +638,19 @@ SELECT variable_value-@old_bulk_op bulk_operations
 FROM information_schema.global_status
 WHERE variable_name = 'innodb_bulk_operations';
 DROP TABLE t1;
+
+call mtr.add_suppression("Found 1 prepared XA transactions");
+--echo #
+--echo #  MDEV-36771 Assertion `bulk_insert == TRX_NO_BULK' failed
+--echo #           in trx_t::assert_freed from innodb_shutdown
+--echo #
+CREATE TABLE t1(f1 INT)ENGINE=InnoDB;
+XA START 'a';
+INSERT INTO t1 VALUES(1);
+XA END 'a';
+XA PREPARE 'a';
+--source include/restart_mysqld.inc
+XA COMMIT 'a';
+SELECT * FROM t1;
+DROP TABLE t1;
 --echo # End of 10.11 tests

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -515,6 +515,7 @@ TRANSACTIONAL_TARGET void trx_free_at_shutdown(trx_t *trx)
 	ut_a(trx->magic_n == TRX_MAGIC_N);
 
 	ut_d(trx->apply_online_log = false);
+	trx->bulk_insert = 0;
 	trx->commit_state();
 	trx->release_locks();
 	trx->mod_tables.clear();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36771*

## Description
- InnoDB fails to reset bulk_insert of a transaction while freeing the transaction during shutting down of a server.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?
./mtr innodb.insert_into_empty

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
