### PR TITLE
MDEV-24588: Assertion `item->name.str && item->name.str[0]` failed in `TABLE_LIST::create_field_translation`

### DIFF
--- a/mysql-test/main/derived.result
+++ b/mysql-test/main/derived.result
@@ -1356,3 +1356,183 @@ drop table t1,t2,t3;
 #
 # End of 10.3 tests
 #
+#
+# MDEV-24588: Fix crash with unnamed column in derived table.
+# Assertion `item->name.str && item->name.str[0]` in
+# `TABLE_LIST::create_field_translation` fails when a SELECT
+# query includes a derived table containing unnamed column
+# (eg: `SELECT '' from t`).
+#
+# Tests on derived tables
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+SELECT SHA(pk) IN (SELECT * FROM (SELECT '' FROM t) AS a) FROM t;
+SHA(pk) IN (SELECT * FROM (SELECT '' FROM t) AS a)
+0
+0
+0
+SELECT * FROM (SELECT 1, '' FROM t) AS a;
+1	
+1	
+1	
+1	
+SELECT * FROM (SELECT '', 1 FROM t) AS a;
+	1
+	1
+	1
+	1
+SELECT * FROM (SELECT 1, 2, '' FROM t) AS a;
+1	2	
+1	2	
+1	2	
+1	2	
+SELECT * FROM (SELECT pk, '' FROM t) AS a;
+pk	
+1	
+2	
+3	
+SELECT '/', '/';
+/	/
+/	/
+SELECT * FROM (SELECT pk, '', '' as c1 FROM t) AS a;
+pk		c1
+1		
+2		
+3		
+SELECT * FROM (SELECT '', '' from t) AS a;
+ERROR 42S21: Duplicate column name ''
+SELECT * FROM (SELECT '/', '/' FROM t) AS a;
+ERROR 42S21: Duplicate column name '/'
+SELECT * FROM (SELECT '/', '/') AS a;
+ERROR 42S21: Duplicate column name '/'
+DROP TABLE t;
+# Tests on views
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+DROP VIEW IF EXISTS v_t;
+CREATE VIEW v_t AS SELECT * FROM t;
+SHOW CREATE VIEW v_t;
+View	Create View	character_set_client	collation_connection
+v_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_t` AS select `t`.`pk` AS `pk` from `t`	latin1	latin1_swedish_ci
+SELECT SHA(pk) IN (SELECT * FROM (SELECT '' FROM v_t) AS a) FROM v_t;
+SHA(pk) IN (SELECT * FROM (SELECT '' FROM v_t) AS a)
+0
+0
+0
+SELECT * FROM (SELECT 1, '' FROM v_t) AS a;
+1	
+1	
+1	
+1	
+SELECT * FROM (SELECT '', 1 FROM v_t) AS a;
+	1
+	1
+	1
+	1
+SELECT * FROM (SELECT 1, 2, '' FROM v_t) AS a;
+1	2	
+1	2	
+1	2	
+1	2	
+SELECT * FROM (SELECT pk, '' FROM v_t) AS a;
+pk	
+1	
+2	
+3	
+SELECT * FROM (SELECT pk, '', '' as c1 FROM v_t) AS a;
+pk		c1
+1		
+2		
+3		
+SELECT * FROM (SELECT '', '' from v_t) AS a;
+ERROR 42S21: Duplicate column name ''
+SELECT * FROM (SELECT '/', '/' from v_t) AS a;
+ERROR 42S21: Duplicate column name '/'
+DROP VIEW IF EXISTS v1;
+CREATE VIEW v1 AS SELECT '/', '/';
+SHOW CREATE VIEW v1;
+View	Create View	character_set_client	collation_connection
+v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select '/' AS `/`,'/' AS `My_exp_/`	latin1	latin1_swedish_ci
+DROP VIEW v_t;
+DROP VIEW v1;
+DROP TABLE t;
+# Tests on views created using SELECT statements that contain derived columns
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+DROP VIEW IF EXISTS v1_t;
+CREATE VIEW v1_t AS SELECT '' FROM t;
+SHOW CREATE VIEW v1_t;
+View	Create View	character_set_client	collation_connection
+v1_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1_t` AS select '' AS `Name_exp_1` from `t`	latin1	latin1_swedish_ci
+SELECT * FROM v1_t;
+Name_exp_1
+
+
+
+DROP VIEW IF EXISTS v2_t;
+CREATE VIEW v2_t AS SELECT * FROM (SELECT '' FROM t) AS a;
+SHOW CREATE VIEW v2_t;
+View	Create View	character_set_client	collation_connection
+v2_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2_t` AS select `tmp_field` AS `Name_exp_1` from (select '' from `t`) `a`	latin1	latin1_swedish_ci
+Warnings:
+Warning	1356	View 'test.v2_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM v2_t;
+ERROR HY000: View 'test.v2_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+DROP VIEW IF EXISTS v3_t;
+CREATE VIEW v3_t AS SELECT * FROM (SELECT '' as c1 FROM t) AS a;
+SHOW CREATE VIEW v3_t;
+View	Create View	character_set_client	collation_connection
+v3_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3_t` AS select `a`.`c1` AS `c1` from (select '' AS `c1` from `t`) `a`	latin1	latin1_swedish_ci
+SELECT * FROM v3_t;
+c1
+
+
+
+DROP VIEW IF EXISTS v4_t;
+CREATE VIEW v4_t AS SELECT * FROM (SELECT 1, '' FROM t) AS a;
+SHOW CREATE VIEW v4_t;
+View	Create View	character_set_client	collation_connection
+v4_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v4_t` AS select `a`.`1` AS `1`,`tmp_field` AS `Name_exp_2` from (select 1 AS `1`,'' from `t`) `a`	latin1	latin1_swedish_ci
+Warnings:
+Warning	1356	View 'test.v4_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * from v4_t;
+ERROR HY000: View 'test.v4_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+DROP VIEW IF EXISTS v5_t;
+CREATE VIEW v5_t AS SELECT '';
+SHOW CREATE VIEW v5_t;
+View	Create View	character_set_client	collation_connection
+v5_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v5_t` AS select '' AS `Name_exp_1`	latin1	latin1_swedish_ci
+SELECT * FROM v5_t;
+Name_exp_1
+
+DROP VIEW IF EXISTS v6_t;
+CREATE VIEW v6_t AS SELECT * FROM (SELECT '') AS a;
+SHOW CREATE VIEW v6_t;
+View	Create View	character_set_client	collation_connection
+v6_t	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v6_t` AS select `tmp_field` AS `Name_exp_1` from (select '') `a`	latin1	latin1_swedish_ci
+Warnings:
+Warning	1356	View 'test.v6_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM v6_t;
+ERROR HY000: View 'test.v6_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+DROP VIEW v1_t;
+DROP VIEW v2_t;
+DROP VIEW v3_t;
+DROP VIEW v4_t;
+DROP VIEW v5_t;
+DROP VIEW v6_t;
+DROP TABLE t;
+# Test on Prepared statements
+SET sql_mode='';
+DROP TABLE IF EXISTS t;
+Warnings:
+Note	1051	Unknown table 'test.t'
+CREATE TABLE t (id INT);
+PREPARE p FROM 'SELECT SHA(id) IN (SELECT * FROM (SELECT \'\' FROM t) AS a) FROM t;';
+EXECUTE p;
+SHA(id) IN (SELECT * FROM (SELECT '' FROM t) AS a)
+DEALLOCATE PREPARE p;
+DROP TABLE t;
+# End of 10.11 tests

--- a/mysql-test/main/derived.test
+++ b/mysql-test/main/derived.test
@@ -1183,3 +1183,160 @@ drop table t1,t2,t3;
 --echo #
 --echo # End of 10.3 tests
 --echo #
+
+--echo #
+--echo # MDEV-24588: Fix crash with unnamed column in derived table.
+--echo # Assertion `item->name.str && item->name.str[0]` in
+--echo # `TABLE_LIST::create_field_translation` fails when a SELECT
+--echo # query includes a derived table containing unnamed column
+--echo # (eg: `SELECT '' from t`).
+--echo #
+
+--echo # Tests on derived tables
+--disable_warnings
+DROP TABLE IF EXISTS t;
+--enable_warnings
+
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+
+# this should pass withiout assertion fail in dbg or should not crash mariadb server
+SELECT SHA(pk) IN (SELECT * FROM (SELECT '' FROM t) AS a) FROM t;
+
+SELECT * FROM (SELECT 1, '' FROM t) AS a;
+SELECT * FROM (SELECT '', 1 FROM t) AS a;
+SELECT * FROM (SELECT 1, 2, '' FROM t) AS a;
+SELECT * FROM (SELECT pk, '' FROM t) AS a;
+SELECT '/', '/';
+
+SELECT * FROM (SELECT pk, '', '' as c1 FROM t) AS a;
+--error ER_DUP_FIELDNAME
+SELECT * FROM (SELECT '', '' from t) AS a;
+--error ER_DUP_FIELDNAME
+SELECT * FROM (SELECT '/', '/' FROM t) AS a;
+--error ER_DUP_FIELDNAME
+SELECT * FROM (SELECT '/', '/') AS a;
+
+DROP TABLE t;
+
+--echo # Tests on views
+
+--disable_warnings
+DROP TABLE IF EXISTS t;
+--enable_warnings
+
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+
+--disable_warnings
+DROP VIEW IF EXISTS v_t;
+--enable_warnings
+CREATE VIEW v_t AS SELECT * FROM t;
+SHOW CREATE VIEW v_t;
+
+SELECT SHA(pk) IN (SELECT * FROM (SELECT '' FROM v_t) AS a) FROM v_t;
+
+SELECT * FROM (SELECT 1, '' FROM v_t) AS a;
+SELECT * FROM (SELECT '', 1 FROM v_t) AS a;
+SELECT * FROM (SELECT 1, 2, '' FROM v_t) AS a;
+SELECT * FROM (SELECT pk, '' FROM v_t) AS a;
+
+SELECT * FROM (SELECT pk, '', '' as c1 FROM v_t) AS a;
+--error ER_DUP_FIELDNAME
+SELECT * FROM (SELECT '', '' from v_t) AS a;
+--error ER_DUP_FIELDNAME
+SELECT * FROM (SELECT '/', '/' from v_t) AS a;
+
+--disable_warnings
+DROP VIEW IF EXISTS v1;
+--enable_warnings
+CREATE VIEW v1 AS SELECT '/', '/';
+SHOW CREATE VIEW v1;
+
+DROP VIEW v_t;
+DROP VIEW v1;
+DROP TABLE t;
+
+--echo # Tests on views created using SELECT statements that contain derived columns
+
+--disable_warnings
+DROP TABLE IF EXISTS t;
+--enable_warnings
+
+CREATE TABLE t (pk INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3);
+
+--disable_warnings
+DROP VIEW IF EXISTS v1_t;
+--enable_warnings
+CREATE VIEW v1_t AS SELECT '' FROM t;
+SHOW CREATE VIEW v1_t;
+
+SELECT * FROM v1_t;
+
+--disable_warnings
+DROP VIEW IF EXISTS v2_t;
+--enable_warnings
+CREATE VIEW v2_t AS SELECT * FROM (SELECT '' FROM t) AS a;
+SHOW CREATE VIEW v2_t;
+
+--error ER_VIEW_INVALID
+SELECT * FROM v2_t;
+
+--disable_warnings
+DROP VIEW IF EXISTS v3_t;
+--enable_warnings
+CREATE VIEW v3_t AS SELECT * FROM (SELECT '' as c1 FROM t) AS a;
+SHOW CREATE VIEW v3_t;
+
+SELECT * FROM v3_t;
+
+--disable_warnings
+DROP VIEW IF EXISTS v4_t;
+--enable_warnings
+CREATE VIEW v4_t AS SELECT * FROM (SELECT 1, '' FROM t) AS a;
+SHOW CREATE VIEW v4_t;
+
+--error ER_VIEW_INVALID
+SELECT * from v4_t;
+
+--disable_warnings
+DROP VIEW IF EXISTS v5_t;
+--enable_warnings
+CREATE VIEW v5_t AS SELECT '';
+SHOW CREATE VIEW v5_t;
+
+SELECT * FROM v5_t;
+
+--disable_warnings
+DROP VIEW IF EXISTS v6_t;
+--enable_warnings
+CREATE VIEW v6_t AS SELECT * FROM (SELECT '') AS a;
+SHOW CREATE VIEW v6_t;
+
+--error ER_VIEW_INVALID
+SELECT * FROM v6_t;
+
+DROP VIEW v1_t;
+DROP VIEW v2_t;
+DROP VIEW v3_t;
+DROP VIEW v4_t;
+DROP VIEW v5_t;
+DROP VIEW v6_t;
+DROP TABLE t;
+
+--echo # Test on Prepared statements
+
+SET sql_mode='';
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (id INT);
+
+# The PREPARE command itself should succeed without crashing
+PREPARE p FROM 'SELECT SHA(id) IN (SELECT * FROM (SELECT \'\' FROM t) AS a) FROM t;';
+
+EXECUTE p;
+DEALLOCATE PREPARE p;
+
+DROP TABLE t;
+
+--echo # End of 10.11 tests

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -6054,7 +6054,6 @@ allocate:
 
   while ((item= it++))
   {
-    DBUG_ASSERT(item->name.str && item->name.str[0]);
     transl[field_count].name.str=    thd->strmake(item->name.str, item->name.length);
     transl[field_count].name.length= item->name.length;
     transl[field_count++].item= item;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-24588*

## Description
MariaDB server crashes when a query includes a derived table containing unnamed column (eg: `SELECT '' from t`). When `Item` object representing such unnamed column was checked for valid, non-empty name in `TABLE_LIST::create_field_translation`, the server crahsed (assertion `item->name.str && item->name.str[0]` failed).

This fix ensures, unnamed column in a derived table's select list have valid, non-empty names. If an item lacks a name, a temporary name is assigned and made unique within the dervied table's scope using `make_unique_view_field_name()`.

## Release Notes
~

## How can this PR be tested?
`mysql-test/main/mdev_24588_unnamed_column_crash.test` to verify the fix



<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
