### PR TITLE
Make building of the INFO_SRC and INFO_BIN files optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,36 +542,39 @@ IF(SOURCE_REVISION OR
                ${PROJECT_BINARY_DIR}/include/source_revision.h )
 ENDIF()
 
-CONFIGURE_FILE(
-    ${CMAKE_SOURCE_DIR}/cmake/info_macros.cmake.in
-    ${CMAKE_BINARY_DIR}/info_macros.cmake @ONLY)
+OPTION (WITH_INFO_FILES "Control creation of INFO_SRC and INFO_BIN files" ON)
+IF(WITH_INFO_FILES)
+  CONFIGURE_FILE(
+      ${CMAKE_SOURCE_DIR}/cmake/info_macros.cmake.in
+      ${CMAKE_BINARY_DIR}/info_macros.cmake @ONLY)
 
-# Handle the "INFO_*" files.
-INCLUDE(${CMAKE_BINARY_DIR}/info_macros.cmake)
-# Source: This can be done during the cmake phase, all information is
-# available, but should be repeated on each "make" just in case someone
-# does "cmake ; make ; git pull ; make".
-CREATE_INFO_SRC(${CMAKE_BINARY_DIR}/Docs)
-ADD_CUSTOM_TARGET(INFO_SRC ALL
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/info_src.cmake
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
-# Build flags: This must be postponed to the make phase.
-ADD_CUSTOM_TARGET(INFO_BIN ALL
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/info_bin.cmake
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+  # Handle the "INFO_*" files.
+  INCLUDE(${CMAKE_BINARY_DIR}/info_macros.cmake)
+  # Source: This can be done during the cmake phase, all information is
+  # available, but should be repeated on each "make" just in case someone
+  # does "cmake ; make ; git pull ; make".
+  CREATE_INFO_SRC(${CMAKE_BINARY_DIR}/Docs)
+  ADD_CUSTOM_TARGET(INFO_SRC ALL
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/info_src.cmake
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+  # Build flags: This must be postponed to the make phase.
+  ADD_CUSTOM_TARGET(INFO_BIN ALL
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/info_bin.cmake
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
-INSTALL_DOCUMENTATION(README.md CREDITS COPYING THIRDPARTY COMPONENT Readme)
+  INSTALL_DOCUMENTATION(README.md CREDITS COPYING THIRDPARTY COMPONENT Readme)
 
-# MDEV-6526 these files are not installed anymore
-#INSTALL_DOCUMENTATION(${CMAKE_BINARY_DIR}/Docs/INFO_SRC
-#                      ${CMAKE_BINARY_DIR}/Docs/INFO_BIN)
+  # MDEV-6526 these files are not installed anymore
+  #INSTALL_DOCUMENTATION(${CMAKE_BINARY_DIR}/Docs/INFO_SRC
+  #                      ${CMAKE_BINARY_DIR}/Docs/INFO_BIN)
 
-IF(UNIX)
-  INSTALL_DOCUMENTATION(Docs/INSTALL-BINARY COMPONENT Readme)
-  IF(WITH_WSREP)
-    INSTALL_DOCUMENTATION(Docs/README-wsrep COMPONENT Readme)
+  IF(UNIX)
+    INSTALL_DOCUMENTATION(Docs/INSTALL-BINARY COMPONENT Readme)
+    IF(WITH_WSREP)
+      INSTALL_DOCUMENTATION(Docs/README-wsrep COMPONENT Readme)
+    ENDIF()
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
## Description

This is an effort to upstream the Fedora patch introduced in this commit:
  https://src.fedoraproject.org/rpms/mariadb10.11/c/7e36d4?branch=rawhide

MariaDB upstream does not pack it, neither we want to pack it in Fedora.


## Release Notes
None.
This change introduce a conditional the downstream can make a use of. The default value is set to the current behavior.

## How can this PR be tested?
Test build without `-DWITH_INFO_FILES` CMake option.
Test build with `-DWITH_INFO_FILES=ON` CMake option.
Test build with `-DWITH_INFO_FILES=OFF` CMake option.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Discussion
The proposed change is minimum that allows me to cleanly abandon the code in downstream Fedora and RHEL packages.

Bases on an old discussion in the https://jira.mariadb.org/browse/MDEV-7584 you might later want to set the default to OFF, or ditch the whole INFO_{BIN,SRC} code as whole.