### PR TITLE
Fix building with gcc 16 (evex512 removal)

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -25,7 +25,7 @@
 #else
 # include <cpuid.h>
 # ifdef __APPLE__ /* AVX512 states are not enabled in XCR0 */
-# elif __GNUC__ >= 14 || (defined __clang_major__ && __clang_major__ >= 18)
+# elif (__GNUC__ >= 14 && __GNUC__ < 16) || (defined __clang_major__ && __clang_major__ >= 18)
 #  define TARGET "pclmul,evex512,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
 #  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
 # elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 9)


### PR DESCRIPTION
## Description
Recently, evex512 was removed from gcc trunk [1] which will eventually become gcc 16, and that leads to a build failure
in mariadb, originally reported downstream in a Gentoo bug [2].

```
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:134:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  134 | static inline __m128i xor3_128(__m128i a, __m128i b, __m128i c)
      |                       ^~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:141:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  141 | static inline __m128i xnor3_128(__m128i a, __m128i b, __m128i c)
      |                       ^~~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:148:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  148 | static inline __m512i xor3_512(__m512i a, __m512i b, __m512i c)
      |                       ^~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc: In function ‘__m512i xor3_512(__m512i, __m512i, __m512i)’:
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:148:63: warning: AVX512F vector return without AVX512F enabled changes the ABI [-Wpsabi]
  148 | static inline __m512i xor3_512(__m512i a, __m512i b, __m512i c)
      |                                                               ^
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc: At global scope:
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:155:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  155 | static inline __m128i xor2_and_128(__m128i a, __m128i b, __m128i c)
      |                       ^~~~~~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:162:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  162 | static inline __m512i load512(const char *b) { return _mm512_loadu_epi8(b); }
      |                       ^~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:166:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  166 | static inline __m128i load128(const char *b) { return _mm_loadu_epi64(b); }
      |                       ^~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:170:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  170 | static inline __m512i combine512(__m512i a, __m512i tab, __m512i b)
      |                       ^~~~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:183:23: error: attribute ‘target’ argument ‘evex512’ is unknown
  183 | static inline __m512i extract512_128(__m512i a)
      |                       ^~~~~~~~~~~~~~
/home/kostadin/mariadb-11.4.7/mysys/crc32/crc32c_x86.cc:210:17: error: attribute ‘target’ argument ‘evex512’ is unknown
  210 | static unsigned crc32_avx512(unsigned crc, const char *buf, size_t size,
```

This is reproducible across all versions from 10.6 to current master.

The change is as simple as adding an upper boundary to which gcc versions can use evex512.

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=c052a6f4a1c803cb92147ff98fb91cf3511e0856
[2] https://bugs.gentoo.org/956632

## Release Notes
Fix building with gcc 16 by setting an upper boundary on what gcc versions can use evex512.

## How can this PR be tested?

Build mariadb with gcc 16/trunk before and after the change.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
