### PR TITLE
MDEV-36922 New getter to read Engine Independent JSON histogram buckets directly

### DIFF
--- a/sql/opt_histogram_json.h
+++ b/sql/opt_histogram_json.h
@@ -71,21 +71,7 @@ class Histogram_json_hb final : public Histogram_base
   /* Collection-time only: collected histogram in the JSON form. */
   std::string json_text;
 
-  struct Bucket
-  {
-    // The left endpoint in KeyTupleFormat. The endpoint is inclusive, this
-    // value is in this bucket.
-    std::string start_value;
-
-    // Cumulative fraction: The fraction of table rows that fall into this
-    //  and preceding buckets.
-    double cum_fract;
-
-    // Number of distinct values in the bucket.
-    longlong ndv;
-  };
-
-  std::vector<Bucket> buckets;
+  std::vector<Histogram_bucket> buckets;
 
   std::string last_bucket_end_endp;
 
@@ -128,6 +114,11 @@ public:
                            double avg_sel) override;
   double range_selectivity(Field *field, key_range *min_endp,
                            key_range *max_endp, double avg_sel) override;
+
+  std::vector<Histogram_bucket> get_histogram() override
+  {
+    return buckets;
+  }
 
   void set_json_text(ulonglong sz, const char *json_text_arg,
                      size_t json_text_len)

--- a/sql/sql_statistics.h
+++ b/sql/sql_statistics.h
@@ -152,6 +152,19 @@ bool is_stat_table(const LEX_CSTRING *db, LEX_CSTRING *table);
 bool is_eits_usable(Field* field);
 
 class Histogram_builder;
+struct Histogram_bucket
+{
+  // The left endpoint in KeyTupleFormat. The endpoint is inclusive, this
+  // value is in this bucket.
+  std::string start_value;
+
+  // Cumulative fraction: The fraction of table rows that fall into this
+  //  and preceding buckets.
+  double cum_fract;
+
+  // Number of distinct values in the bucket.
+  longlong ndv;
+};
 
 /*
   Common base for all histograms
@@ -199,6 +212,8 @@ public:
                                    double avg_sel)=0;
   virtual double range_selectivity(Field *field, key_range *min_endp,
                                    key_range *max_endp, double avg_sel)=0;
+  virtual std::vector<Histogram_bucket> get_histogram()=0;
+
   /*
     Legacy: return the size of the histogram on disk.
 
@@ -355,6 +370,11 @@ public:
   */
   double point_selectivity(Field *field, key_range *endpoint,
                            double avg_sel) override;
+
+  std::vector<Histogram_bucket> get_histogram() override
+  {
+    return {};
+  }
 };
 
 


### PR DESCRIPTION
This would allow Columnstore to leverage EI data in its cost-based and rewrite optimizer parts

- [x] *The Jira issue number for this PR is: MDEV-36922*

## Description
This adds an getter to read JSON histogram data within the engines, e.g. Columnstore to leverage Engine Independent statistics by smart engines. 

## Release Notes
Nothing had been changed.

## How can this PR be tested?
This is supposed to be tested by unit tests but there is no reason to add them here.

## Basing the PR against the correct MariaDB version
- [x ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
