### PR TITLE
MDEV-35163  InnoDB persistent statistics fail to update after ALTER TABLE...ALGORITHM=COPY

### DIFF
--- a/mysql-test/suite/innodb/r/alter_copy_stats.result
+++ b/mysql-test/suite/innodb/r/alter_copy_stats.result
@@ -1,0 +1,105 @@
+CREATE TABLE t1 (
+c1 INT PRIMARY KEY,
+c2 VARCHAR(50),
+c3 VARCHAR(50),
+c4 VARCHAR(50))ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, 'AAA_2', 'AAA_3', 'AAA_4'),
+(2, 'BBB_2', 'BBB_3', 'BBB_4'),
+(3, 'CCC_2', 'CCC_3', 'CCC_4'),
+(4, 'DDD_2', 'DDD_3', 'DDD_4'),
+(5, 'EEE_2', 'EEE_3', 'EEE_4');
+ALTER TABLE t1 CONVERT TO CHARACTER SET 'utf8mb4',ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (c4), ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (c1), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = INPLACE;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = INPLACE;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+n_rows	database_name	lower(table_name)
+5	test	t1
+CREATE TABLE t2 (
+c1 INT PRIMARY KEY,
+c2 VARCHAR(50),
+c3 VARCHAR(50),
+c4 VARCHAR(50)
+) ENGINE=InnoDB PARTITION BY RANGE (c1) (
+PARTITION p1 VALUES LESS THAN (6),
+PARTITION p2 VALUES LESS THAN (11),
+PARTITION p3 VALUES LESS THAN (16),
+PARTITION p4 VALUES LESS THAN (21)
+);
+INSERT INTO t2 VALUES(1, 'AAA_2', 'AAA_3', 'AAA_4'),
+(2, 'BBB_2', 'BBB_3', 'BBB_4'),
+(3, 'CCC_2', 'CCC_3', 'CCC_4'),
+(4, 'DDD_2', 'DDD_3', 'DDD_4'),
+(5, 'EEE_2', 'EEE_3', 'EEE_4'),
+(6, 'FFF_2', 'DDD_3', 'DDD_4'),
+(7, 'GGG_2', 'DDD_3', 'DDD_4'),
+(8, 'HHH_2', 'DDD_3', 'DDD_4'),
+(9, 'III_2', 'DDD_3', 'DDD_4'),
+(10, 'JJJ_2', 'DDD_3', 'DDD_4'),
+(13, 'KKK_2', 'DDD_3', 'DDD_4'),
+(20, 'LLL_2', 'DDD_3', 'DDD_4');
+ALTER TABLE t2 CONVERT TO CHARACTER SET 'utf8mb4',ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+n_rows	database_name	lower(table_name)
+5	test	t2#p#p1
+5	test	t2#p#p2
+1	test	t2#p#p3
+1	test	t2#p#p4
+ALTER TABLE t2 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+n_rows	database_name	lower(table_name)
+5	test	t2#p#p1
+5	test	t2#p#p2
+1	test	t2#p#p3
+1	test	t2#p#p4
+ALTER TABLE t2 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+n_rows	database_name	lower(table_name)
+5	test	t2#p#p1
+5	test	t2#p#p2
+1	test	t2#p#p3
+1	test	t2#p#p4
+# Test Cleanup.
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/innodb/r/innodb-alter-debug.result
+++ b/mysql-test/suite/innodb/r/innodb-alter-debug.result
@@ -117,8 +117,9 @@ ALTER TABLE t1 FORCE, ALGORITHM=COPY;
 connection default;
 SET DEBUG_SYNC='now WAIT_FOR blocked';
 BEGIN;
-SELECT * FROM mysql.innodb_table_stats FOR UPDATE;
-database_name	table_name	last_update	n_rows	clustered_index_size	sum_of_other_index_sizes
+SELECT database_name, table_name FROM mysql.innodb_table_stats FOR UPDATE;
+database_name	table_name
+test	t1
 SET DEBUG_SYNC='now SIGNAL go';
 connection con1;
 connection default;

--- a/mysql-test/suite/innodb/r/xap_release_locks_on_dict_stats_table.result
+++ b/mysql-test/suite/innodb/r/xap_release_locks_on_dict_stats_table.result
@@ -6,7 +6,7 @@ SET @old_debug_dbug = @@global.debug_dbug;
 XA START 'a';
 INSERT INTO mysql.innodb_index_stats SELECT '','' AS table_name,index_name,LAST_UPDATE,stat_name,0 AS stat_value,sample_size,stat_description FROM mysql.innodb_index_stats WHERE table_name='dummy' FOR UPDATE;
 SET GLOBAL debug_dbug = "+d,dict_stats_save_exit_notify";
-INSERT INTO t VALUES (1);
+INSERT INTO t VALUES (1), (2);
 XA END 'a';
 XA PREPARE 'a';
 SET DEBUG_SYNC="now WAIT_FOR dict_stats_save_finished";

--- a/mysql-test/suite/innodb/t/alter_copy_stats.test
+++ b/mysql-test/suite/innodb/t/alter_copy_stats.test
@@ -1,0 +1,90 @@
+--source include/have_innodb.inc
+--source include/have_partition.inc
+
+CREATE TABLE t1 (
+    c1 INT PRIMARY KEY,
+    c2 VARCHAR(50),
+    c3 VARCHAR(50),
+    c4 VARCHAR(50))ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES(1, 'AAA_2', 'AAA_3', 'AAA_4'),
+                     (2, 'BBB_2', 'BBB_3', 'BBB_4'),
+                     (3, 'CCC_2', 'CCC_3', 'CCC_4'),
+                     (4, 'DDD_2', 'DDD_3', 'DDD_4'),
+                     (5, 'EEE_2', 'EEE_3', 'EEE_4');
+
+ALTER TABLE t1 CONVERT TO CHARACTER SET 'utf8mb4',ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (c4), ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (c1), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 ADD COLUMN c5 VARCHAR(15), ALGORITHM = INPLACE;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+ALTER TABLE t1 DROP COLUMN c5, ALGORITHM = INPLACE;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name IN ('t1');
+
+CREATE TABLE t2 (
+    c1 INT PRIMARY KEY,
+    c2 VARCHAR(50),
+    c3 VARCHAR(50),
+    c4 VARCHAR(50)
+    ) ENGINE=InnoDB PARTITION BY RANGE (c1) (
+    PARTITION p1 VALUES LESS THAN (6),
+    PARTITION p2 VALUES LESS THAN (11),
+    PARTITION p3 VALUES LESS THAN (16),
+    PARTITION p4 VALUES LESS THAN (21)
+);
+INSERT INTO t2 VALUES(1, 'AAA_2', 'AAA_3', 'AAA_4'),
+                     (2, 'BBB_2', 'BBB_3', 'BBB_4'),
+                     (3, 'CCC_2', 'CCC_3', 'CCC_4'),
+                     (4, 'DDD_2', 'DDD_3', 'DDD_4'),
+                     (5, 'EEE_2', 'EEE_3', 'EEE_4'),
+                     (6, 'FFF_2', 'DDD_3', 'DDD_4'),
+                     (7, 'GGG_2', 'DDD_3', 'DDD_4'),
+                     (8, 'HHH_2', 'DDD_3', 'DDD_4'),
+                     (9, 'III_2', 'DDD_3', 'DDD_4'),
+                     (10, 'JJJ_2', 'DDD_3', 'DDD_4'),
+                     (13, 'KKK_2', 'DDD_3', 'DDD_4'),
+                     (20, 'LLL_2', 'DDD_3', 'DDD_4');
+
+ALTER TABLE t2 CONVERT TO CHARACTER SET 'utf8mb4',ALGORITHM=COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+
+ALTER TABLE t2 ADD COLUMN c5 VARCHAR(15), ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+
+ALTER TABLE t2 DROP COLUMN c5, ALGORITHM = COPY;
+SELECT n_rows, database_name, lower(table_name)
+FROM mysql.innodb_table_stats WHERE table_name LIKE '%t2%';
+
+--echo # Test Cleanup.
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/innodb/t/innodb-alter-debug.test
+++ b/mysql-test/suite/innodb/t/innodb-alter-debug.test
@@ -156,7 +156,7 @@ ALTER TABLE t1 FORCE, ALGORITHM=COPY;
 connection default;
 SET DEBUG_SYNC='now WAIT_FOR blocked';
 BEGIN;
-SELECT * FROM mysql.innodb_table_stats FOR UPDATE;
+SELECT database_name, table_name FROM mysql.innodb_table_stats FOR UPDATE;
 SET DEBUG_SYNC='now SIGNAL go';
 
 connection con1;

--- a/mysql-test/suite/innodb/t/xap_release_locks_on_dict_stats_table.test
+++ b/mysql-test/suite/innodb/t/xap_release_locks_on_dict_stats_table.test
@@ -20,7 +20,7 @@ SET @old_debug_dbug = @@global.debug_dbug;
 XA START 'a';
 INSERT INTO mysql.innodb_index_stats SELECT '','' AS table_name,index_name,LAST_UPDATE,stat_name,0 AS stat_value,sample_size,stat_description FROM mysql.innodb_index_stats WHERE table_name='dummy' FOR UPDATE;  # Note the SELECT is empty
 SET GLOBAL debug_dbug = "+d,dict_stats_save_exit_notify";
-INSERT INTO t VALUES (1);
+INSERT INTO t VALUES (1), (2);
 XA END 'a';
 XA PREPARE 'a';
 

--- a/mysql-test/suite/innodb_fts/t/versioning.test
+++ b/mysql-test/suite/innodb_fts/t/versioning.test
@@ -65,6 +65,9 @@ if ($MTR_COMBINATION_UPGRADE)
 {
 --disable_query_log
 call mtr.add_suppression("InnoDB: Table `mysql`.\`innodb_(table|index)_stats`");
+call mtr.add_suppression("InnoDB: Table mysql\\.innodb_table_stats is not readable");
+call mtr.add_suppression("InnoDB: Fetch of persistent statistics requested for table `test`\\.`articles[0-9]*` but the required system tables mysql.innodb_table_stats and mysql.innodb_index_stats are not present or have unexpected structure. Using transient stats instead.");
+call mtr.add_suppression("InnoDB: Recalculation of persistent statistics requested for table `test`\\.`#sql-alter.*` but the required persistent statistics storage is not present or is corrupted. Using transient stats instead.");
 --enable_query_log
   --source include/shutdown_mysqld.inc
   --exec rm -f $datadir/test/*.ibd $datadir/ib*

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -380,7 +380,15 @@ dict_table_schema_check(
 		return DB_TABLE_NOT_FOUND;
 	}
 
-	if (!table->is_readable() && !table->space) {
+	if (!table->is_readable()) {
+		/* table is not readable */
+		snprintf(errstr, errstr_sz,
+			 "Table %s is not readable.",
+			 req_schema->table_name_sql);
+		return DB_ERROR;
+	}
+
+	if (!table->space) {
 		/* missing tablespace */
 		snprintf(errstr, errstr_sz,
 			 "Tablespace for table %s is missing.",
@@ -3921,8 +3929,9 @@ dberr_t dict_stats_rename_table(const char *old_name, const char *new_name,
   dict_fs2utf8(old_name, old_db, sizeof old_db, old_table, sizeof old_table);
   dict_fs2utf8(new_name, new_db, sizeof new_db, new_table, sizeof new_table);
 
-  if (dict_table_t::is_temporary_name(old_name) ||
-      dict_table_t::is_temporary_name(new_name))
+  /* Delete the stats only if renaming the table from old table to
+  intermediate table during COPY algorithm */
+  if (dict_table_t::is_temporary_name(new_name))
   {
     if (dberr_t e= dict_stats_delete_from_table_stats(old_db, old_table, trx))
       return e;

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -942,3 +942,10 @@ ib_push_frm_error(
 @return true if index column length exceeds limit */
 MY_ATTRIBUTE((warn_unused_result))
 bool too_big_key_part_length(size_t max_field_len, const KEY& key);
+
+/** Adjust the persistent statistics after rebuilding ALTER TABLE.
+Remove statistics for dropped indexes, add statistics for created indexes
+and rename statistics for renamed indexes.
+@param table_name Table name in MySQL
+@param thd        alter table thread */
+void alter_stats_rebuild(dict_table_t *table, THD *thd);

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -11176,7 +11176,7 @@ Remove statistics for dropped indexes, add statistics for created indexes
 and rename statistics for renamed indexes.
 @param ha_alter_info Data used during in-place alter
 @param ctx In-place ALTER TABLE context
-@param thd MySQL connection
+@param thd alter table thread
 */
 static
 void
@@ -11201,43 +11201,6 @@ alter_stats_norebuild(
 			dict_stats_init(ctx->new_table);
 			dict_stats_update_for_index(index);
 		}
-	}
-
-	DBUG_VOID_RETURN;
-}
-
-/** Adjust the persistent statistics after rebuilding ALTER TABLE.
-Remove statistics for dropped indexes, add statistics for created indexes
-and rename statistics for renamed indexes.
-@param table InnoDB table that was rebuilt by ALTER TABLE
-@param table_name Table name in MySQL
-@param thd MySQL connection
-*/
-static
-void
-alter_stats_rebuild(
-/*================*/
-	dict_table_t*	table,
-	const char*	table_name,
-	THD*		thd)
-{
-	DBUG_ENTER("alter_stats_rebuild");
-
-	if (!table->space
-	    || !dict_stats_is_persistent_enabled(table)) {
-		DBUG_VOID_RETURN;
-	}
-
-	dberr_t	ret = dict_stats_update(table, DICT_STATS_RECALC_PERSISTENT);
-
-	if (ret != DB_SUCCESS) {
-		push_warning_printf(
-			thd,
-			Sql_condition::WARN_LEVEL_WARN,
-			ER_ALTER_INFO,
-			"Error updating stats for table '%s'"
-			" after table rebuild: %s",
-			table_name, ut_strerr(ret));
 	}
 
 	DBUG_VOID_RETURN;
@@ -11908,9 +11871,7 @@ foreign_fail:
 				(*pctx);
 			DBUG_ASSERT(ctx->need_rebuild());
 
-			alter_stats_rebuild(
-				ctx->new_table, table->s->table_name.str,
-				m_user_thd);
+			alter_stats_rebuild(ctx->new_table, m_user_thd);
 		}
 	} else {
 		for (inplace_alter_handler_ctx** pctx = ctx_array;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35163*

## Description
Problem:
=======
- InnoDB statistics calculation for the table is done after every 10 seconds by default in background thread dict_stats_thread()

- Doing multiple ALTER TABLE..ALGORITHM=COPY causes the dict_stats_thread() to lag behind, therefore calculation of stats for newly created intermediate table gets delayed

Fix:
====
- Stats calculation for newly created intermediate table is made independent of background thread. After copying gets completed, stats for new table is calculated as part of ALTER TABLE ... ALGORITHM=COPY.

dict_stats_rename_table(): Rename the table statistics from temporary table to non-temporary table

This is a cherry-pick fix of mysql commit@cfe5f287ae99d004e8532a30003a7e8e77d379e3

## How can this PR be tested?
./mtr innodb.alter_copy_stats
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.