### PR TITLE
MDEV-36953 : mysql-wsrep#198 test hangs

### DIFF
--- a/mysql-test/suite/galera/r/mysql-wsrep#198.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#198.result
@@ -7,14 +7,18 @@ SELECT 1 FROM DUAL;
 1
 1
 LOCK TABLE t2 WRITE;
+connect node_2_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2_ctrl;
+SET SESSION wsrep_sync_wait=0;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
 OPTIMIZE TABLE t1,t2;;
+connection node_2_ctrl;
+SET SESSION wsrep_sync_wait = 0;
 connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2b;
 REPAIR TABLE t1,t2;;
-connection node_2;
-SET SESSION wsrep_sync_wait = 0;
+connection node_2_ctrl;
 connection node_1;
 INSERT INTO t2 VALUES (1);
 connection node_2;
@@ -34,3 +38,4 @@ DROP TABLE t2;
 connection node_1;
 disconnect node_2a;
 disconnect node_2b;
+disconnect node_2_ctrl;

--- a/mysql-test/suite/galera/t/mysql-wsrep#198.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#198.test
@@ -10,21 +10,33 @@ SELECT 1 FROM DUAL;
 
 LOCK TABLE t2 WRITE;
 
+--connect node_2_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2_ctrl
+SET SESSION wsrep_sync_wait=0;
+
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --connection node_2a
 --send OPTIMIZE TABLE t1,t2;
+
+--connection node_2_ctrl
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%' OR STATE LIKE 'acquiring total order isolation%';
+--let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_condition_with_debug_and_kill.inc
 
 --connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --connection node_2b
 --send REPAIR TABLE t1,t2;
 
---connection node_2
-SET SESSION wsrep_sync_wait = 0;
---let $wait_condition = SELECT COUNT(*) BETWEEN 1 AND 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%' OR STATE LIKE 'Waiting to execute in isolation%';
+--connection node_2_ctrl
+--let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%' OR STATE LIKE 'acquiring total order isolation%';
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
 --source include/wait_condition_with_debug_and_kill.inc
 
 --connection node_1
+# We have LOCK TABLE in node_2 so this could fail on lock wait
+# or next statement is fast enought and succeed
+--error 0,ER_LOCK_WAIT_TIMEOUT
 INSERT INTO t2 VALUES (1);
 
 --connection node_2
@@ -43,3 +55,5 @@ DROP TABLE t2;
 
 --disconnect node_2a
 --disconnect node_2b
+--disconnect node_2_ctrl
+


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36953*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Test changes only. INSERT may fail for lock wait because in other node we have LOCK TABLE or it may succeed if next statement i.e. UNLOCK TABLES is fast enough.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
