### PR TITLE
MDEV-37107 - Optimise dot_product by loop-unrolling by a factor of 4

### DIFF
--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -241,6 +241,7 @@ struct FVector
     // Round up to process full vector, including padding
     size_t base= ((len + POWER_dims - 1) / POWER_dims) * POWER_dims;
 
+    #pragma GCC unroll 4
     for (size_t i= 0; i < base; i+= POWER_dims)
     {
       vector short x= vec_ld(0, &v1[i]);


### PR DESCRIPTION
This patch introduces loop unrolling by a factor of 4 in the
dot_product() function used in vector-based distance calculations.

The goal is to improve SIMD utilization and overall performance during
high-throughput vector operations, particularly in indexing and search
routines that rely on this function.

Observations from benchmarking (ann-benchmark):
- Query Performance (QPS) improved by 4–10% across datasets.
- Indexation time reduced by 22–28%.
- Loop unrolling factors of 8 or 16 yielded similar performance to
  factor-4 but made the code less readable. Hence, a factor of 4 was
  chosen to maintain a balance between performance and code clarity.

This change is architecture-specific (PowerPC) and should not
introduce any behavioural regressions or side effects in unrelated
parts of the codebase.