### PR TITLE
MDEV-36968 : galera_3nodes.inconsistency_shutdown test occasionally h…

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
+++ b/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
@@ -32,8 +32,8 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 6;
 UPDATE t1 SET f2 = 1 WHERE f1 = 7;
 UPDATE t1 SET f2 = 1 WHERE f1 = 8;
 connection node_2;
-SET wsrep_on=OFF;
-SET wsrep_on=ON;
+# make sure all events landed to slave queue
+set wsrep_sync_wait=0;
 UNLOCK TABLES;
 SET SESSION wsrep_on = ON;
 SET SESSION wsrep_sync_wait = 15;
@@ -56,7 +56,8 @@ f1	f2
 7	1
 8	1
 connection node_2;
-SET GLOBAL wsrep_on=OFF;
+# Gracefully restart the node
+set wsrep_on=OFF;
 # restart
 DROP TABLE t1;
 connection node_1;
@@ -73,11 +74,15 @@ INSERT INTO t1 VALUES (8, 0);
 COMMIT;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 INT);
 connection node_2;
+# Allow 1K slave queue without flow control
 SET GLOBAL wsrep_provider_options='gcs.fc_limit=1K';
+# Introduce inconsistency
 SET wsrep_on=OFF;
 DROP TABLE t2;
 SET wsrep_on=ON;
+# set up sync point to ensure DROP TABLE replication order below
 SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+# Build up slave queue:
 LOCK TABLES t1 READ;
 connection node_1;
 UPDATE t1 SET f2 = 1 WHERE f1 = 1;
@@ -86,18 +91,19 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 3;
 UPDATE t1 SET f2 = 1 WHERE f1 = 4;
 UPDATE t1 SET f2 = 2 WHERE f1 = 4;
 /* dependent applier */;
+# interleave a failing statement
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
 DROP TABLE t2;;
+# make sure DROP TABLE from above has replicated
 connection node_2;
-SET wsrep_on=OFF;
+set wsrep_sync_wait=0;
 "Wait for DROP TABLE to replicate"
 SET SESSION wsrep_on = 0;
-SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 "DROP TABLE replicated"
-SET wsrep_on=ON;
 connection node_1;
 UPDATE t1 SET f2 = 3 WHERE f1 = 4;
 /* dependent applier */
@@ -106,8 +112,7 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 6;
 UPDATE t1 SET f2 = 1 WHERE f1 = 7;
 UPDATE t1 SET f2 = 1 WHERE f1 = 8;
 connection node_2;
-SET wsrep_on=OFF;
-SET wsrep_on=ON;
+# make sure all events landed to slave queue
 UNLOCK TABLES;
 connection node_2a;
 ERROR 42S02: Unknown table 'test.t2'
@@ -128,11 +133,11 @@ f1	f2
 7	1
 8	1
 connection node_2;
-SET SESSION wsrep_on = ON;
+set wsrep_on=OFF;
 SET SESSION wsrep_sync_wait = 15;
-SET SESSION wsrep_on = ON;
+# Wait for the node to shutdown replication
 SET SESSION wsrep_sync_wait = 15;
-SET GLOBAL wsrep_on=OFF;
+# Gracefully restart the node
 # restart
 DROP TABLE t1;
 CALL mtr.add_suppression("Can't find record in 't1'");

--- a/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
+++ b/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
@@ -33,6 +33,7 @@ SET wsrep_on=OFF;
 DELETE FROM t1 WHERE f1 = 2;
 DELETE FROM t1 WHERE f1 = 4;
 SET wsrep_on=ON;
+--source include/galera_wait_ready.inc
 
 # Build up slave queue:
 # - first 8 events will be picked by slave threads
@@ -51,11 +52,11 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 7;
 UPDATE t1 SET f2 = 1 WHERE f1 = 8;
 
 --connection node_2
-# make sure all events landed to slave queue
-SET wsrep_on=OFF;
+--echo # make sure all events landed to slave queue
+set wsrep_sync_wait=0;
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_recv_queue';
 --source include/wait_condition.inc
-SET wsrep_on=ON;
+
 UNLOCK TABLES;
 --source include/wsrep_wait_disconnect.inc
 # Wait for the node to shutdown replication
@@ -70,8 +71,8 @@ SHOW STATUS LIKE 'wsrep_cluster_size';
 SELECT * FROM t1;
 
 --connection node_2
-#Gracefully restart the node
-SET GLOBAL wsrep_on=OFF;
+--echo # Gracefully restart the node
+set wsrep_on=OFF;
 --source include/shutdown_mysqld.inc
 --source include/start_mysqld.inc
 --source include/galera_wait_ready.inc
@@ -98,20 +99,21 @@ COMMIT;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 INT);
 
 --connection node_2
-# Allow 1K slave queue without flow control
+--echo # Allow 1K slave queue without flow control
 SET GLOBAL wsrep_provider_options='gcs.fc_limit=1K';
-# Introduce inconsistency
-SET wsrep_on=OFF;
 --let $wait_condition = SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
 --source include/wait_condition.inc
+--echo # Introduce inconsistency
+SET wsrep_on=OFF;
 DROP TABLE t2;
 SET wsrep_on=ON;
+--source include/galera_wait_ready.inc
 
-# set up sync point to ensure DROP TABLE replication order below
+--echo # set up sync point to ensure DROP TABLE replication order below
 --let galera_sync_point = after_replicate_sync
 --source include/galera_set_sync_point.inc
 
-# Build up slave queue:
+--echo # Build up slave queue:
 # - first 8 events will be picked by slave threads
 # - one more event will be waiting in slave queue
 LOCK TABLES t1 READ;
@@ -123,20 +125,19 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 3;
 UPDATE t1 SET f2 = 1 WHERE f1 = 4;
 UPDATE t1 SET f2 = 2 WHERE f1 = 4; /* dependent applier */;
 
-# interleave a failing statement
+--echo # interleave a failing statement
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --connection node_2a
 --send DROP TABLE t2;
 
-# make sure DROP TABLE from above has replicated
+--echo # make sure DROP TABLE from above has replicated
 --connection node_2
-SET wsrep_on=OFF;
+set wsrep_sync_wait=0;
 --echo "Wait for DROP TABLE to replicate"
 --source include/galera_wait_sync_point.inc
 --source include/galera_signal_sync_point.inc
 --source include/galera_clear_sync_point.inc
 --echo "DROP TABLE replicated"
-SET wsrep_on=ON;
 
 --connection node_1
 UPDATE t1 SET f2 = 3 WHERE f1 = 4; /* dependent applier */
@@ -146,11 +147,10 @@ UPDATE t1 SET f2 = 1 WHERE f1 = 7;
 UPDATE t1 SET f2 = 1 WHERE f1 = 8;
 
 --connection node_2
-# make sure all events landed to slave queue
-SET wsrep_on=OFF;
+--echo # make sure all events landed to slave queue
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_recv_queue';
 --source include/wait_condition.inc
-SET wsrep_on=ON;
+
 UNLOCK TABLES;
 
 --connection node_2a
@@ -165,12 +165,13 @@ SHOW STATUS LIKE 'wsrep_cluster_size';
 SELECT * FROM t1;
 
 --connection node_2
+set wsrep_on=OFF;
 --source include/wsrep_wait_disconnect.inc
-# Wait for the node to shutdown replication
+--echo # Wait for the node to shutdown replication
 --let $members=0
 --source include/wsrep_wait_membership.inc
-# Gracefully restart the node
-SET GLOBAL wsrep_on=OFF;
+--echo # Gracefully restart the node
+
 --source include/shutdown_mysqld.inc
 --source include/start_mysqld.inc
 --source include/galera_wait_ready.inc


### PR DESCRIPTION
…angs


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36968*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Test changes only. Remove unnecessary wsrep_on=[ON|OFF] and use sync wait instead.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
