### PR TITLE
MDEV-34933/MDEV-27964: enable MSAN for crypt and parsec (rpl)

### DIFF
--- a/mysql-test/include/have_crypt.inc
+++ b/mysql-test/include/have_crypt.inc
@@ -1,5 +1,3 @@
-# MDEV-27964 The function ENCRYPT() causes SIGSEGV in WITH_MSAN builds
--- source include/not_msan.inc
 # encrypt('a') is NULL if crypt(3) is not available
 # encrypt('a') is "*0" in fips mode
 if (`select length(encrypt('a')) > 3 IS NOT TRUE`) {

--- a/mysql-test/suite/plugins/t/rpl_auth.test
+++ b/mysql-test/suite/plugins/t/rpl_auth.test
@@ -1,6 +1,3 @@
-# MSAN doesn't like gnutls_rnd
-source include/not_msan.inc;
-
 if ($MTR_COMBINATION_ED25519) {
   let $AUTH_PLUGIN = ed25519;
   let $CLIENT_PLUGIN=client_ed25519;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

With MSAN builder updated, some addition tests can be included in the MSAN testing.

## Release Notes

Not user impacting.

## How can this PR be tested?

Tests run in MSAN builder - check output.
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.