### PR TITLE
MDEV-30942 MSAN_OPTIONS=poison_in_dtor=1 causes failures in free_root()

### DIFF
--- a/sql/sql_cursor.cc
+++ b/sql/sql_cursor.cc
@@ -202,18 +202,8 @@ Server_side_cursor::~Server_side_cursor() = default;
 
 void Server_side_cursor::operator delete(void *ptr, size_t size)
 {
-  Server_side_cursor *cursor= (Server_side_cursor*) ptr;
-  MEM_ROOT own_root= *cursor->mem_root;
-
   DBUG_ENTER("Server_side_cursor::operator delete");
   TRASH_FREE(ptr, size);
-  /*
-    If this cursor has never been opened mem_root is empty. Otherwise
-    mem_root points to the memory the cursor object was allocated in.
-    In this case it's important to call free_root last, and free a copy
-    instead of *mem_root to avoid writing into freed memory.
-  */
-  free_root(&own_root, MYF(0));
   DBUG_VOID_RETURN;
 }
 

--- a/strings/my_vsnprintf.c
+++ b/strings/my_vsnprintf.c
@@ -739,13 +739,7 @@ size_t my_vsnprintf_ex(CHARSET_INFO *cs, char *to, size_t n,
     else if (*fmt == 'f' || *fmt == 'g')
     {
       double d;
-#if __has_feature(memory_sanitizer)         /* QQ: MSAN has double trouble? */
-      __msan_check_mem_is_initialized(ap, sizeof(double));
-#endif
       d= va_arg(ap, double);
-#if __has_feature(memory_sanitizer)        /* QQ: MSAN has double trouble? */
-      __msan_unpoison(&d, sizeof(double));
-#endif
       to= process_dbl_arg(to, end, width, d, *fmt);
       continue;
     }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30942*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The role of a operator delete is to prepare the object for freeing, but not to actually do the freeing itself.

By removing the freeing aspects the Server_side_cursor can be freed with the the destructor is applied
on the memroot.

## Release Notes

no user impacts.

## How can this PR be tested?

 MSAN_OPTIONS=abort_on_error=1 mysql-test/mtr main.ctype_utf8 in a MSAN environment

(noteably with MSAN_OPTIONS=poison_in_dtor=0 not set)
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] *This is an important bug fix that is trivial in nature. Without this PR applied to 10.6 results in reduced CI coverage for poison_in_dtor=1 for every branch where this fix isn't applied.

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.