### PR TITLE
MDEV-30363   InnoDB: Failing assertion: trx->error_state == DB_SUCCESS in que_run_threads

### DIFF
--- a/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
+++ b/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
@@ -993,3 +993,15 @@ FTS_DOC_ID	f1	f2
 4294967298	txt	bbb
 100000000000	aaa	bbb
 DROP TABLE t1;
+#
+#  MDEV-30363  Failing assertion: trx->error_state == DB_SUCCESS
+#                    in que_run_threads
+#
+CREATE TABLE server_stopword (value VARCHAR(1))engine=innodb;
+SET GLOBAL innodb_ft_server_stopword_table='test/server_stopword';
+CREATE TABLE t (t VARCHAR(1) COLLATE utf8_unicode_ci,
+FULLTEXT (t))engine=innodb;
+TRUNCATE TABLE t;
+DROP TABLE t;
+DROP TABLE server_stopword;
+SET GLOBAL innodb_ft_server_stopword_table= default;

--- a/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
+++ b/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
@@ -967,3 +967,16 @@ CREATE FULLTEXT INDEX i ON t1 (f2);
 SELECT * FROM t1 WHERE match(f2) against("bbb");
 # Cleanup
 DROP TABLE t1;
+
+--echo #
+--echo #  MDEV-30363  Failing assertion: trx->error_state == DB_SUCCESS
+--echo #                    in que_run_threads
+--echo #
+CREATE TABLE server_stopword (value VARCHAR(1))engine=innodb;
+SET GLOBAL innodb_ft_server_stopword_table='test/server_stopword';
+CREATE TABLE t (t VARCHAR(1) COLLATE utf8_unicode_ci,
+                FULLTEXT (t))engine=innodb;
+TRUNCATE TABLE t;
+DROP TABLE t;
+DROP TABLE server_stopword;
+SET GLOBAL innodb_ft_server_stopword_table= default;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14088,10 +14088,10 @@ int ha_innobase::truncate()
                 trx);
     if (!err)
     {
+      trx->commit(deleted);
       m_prebuilt->table->acquire();
       create_table_info_t::create_table_update_dict(m_prebuilt->table,
                                                     m_user_thd, info, *table);
-      trx->commit(deleted);
     }
     else
     {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30363*

## Description

Problem:
=========
- During truncation of a fulltext table, InnoDB does create the table and does insert the default config fts values in fulltext common config table using create table transaction.

- Before committing the create table transaction, InnoDB does update the dictionary by loading the stopword into fts cache and write the stopword configuration into fulltext common config table by creating a separate transaction. This leads to lock wait timeout error and rollbacks the transaction.

- But truncate table holds dict_sys.lock and rollback also tries to acquire dict_sys.lock. This leads to assertion during rollback.

Solution:
=========
ha_innobase::truncate(): Commit the create table transaction before updating the dictionary after create table.

## How can this PR be tested?
./mtr innodb_fts.innodb_fts_misc_1

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
