### PR TITLE
MDEV-35739 ST_INTERSECTION precise self-intersection

### DIFF
--- a/mysql-test/main/gis.result
+++ b/mysql-test/main/gis.result
@@ -5507,3 +5507,24 @@ ST_SRID(g1)	ST_SRID(ST_GeomFromWKB(g1, 4326))	ST_SRID(ST_GeomFromWKB(g1))	ST_AsT
 SELECT ST_DISTANCE_SPHERE(st_geomfromtext('linestring( 2 2, 2 8) '), ST_GeomFromText('POINT(18.413076 43.856258)')) ;
 ERROR HY000: Calling geometry function st_distance_sphere with unsupported types of arguments.
 # End of 10.5 tests
+#
+# Start of 10.11 tests
+#
+#
+# MDEV-35739 Linestring self-intersection equality
+#
+CREATE TABLE t1(geom geometry NOT NULL);
+INSERT INTO t1 (geom) VALUES(ST_GeomFromText('LINESTRING(2 2,4 4,6 2,3 2,2 4)'));
+SELECT ST_ASTEXT(geom) FROM t1;
+ST_ASTEXT(geom)
+LINESTRING(2 2,4 4,6 2,3 2,2 4)
+SELECT ST_EQUALS(geom, ST_INTERSECTION(geom, geom)) AS isequal, ST_ASTEXT(ST_INTERSECTION(geom, geom)) AS intersection FROM t1;
+isequal	intersection
+1	LINESTRING(2 2,4 4,6 2,3 2,2 4)
+SELECT ST_AsText(ST_SYMDIFFERENCE(geom, ST_Intersection(geom, geom))) FROM t1;
+ST_AsText(ST_SYMDIFFERENCE(geom, ST_Intersection(geom, geom)))
+GEOMETRYCOLLECTION EMPTY
+DROP TABLE t1;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/gis.test
+++ b/mysql-test/main/gis.test
@@ -3515,3 +3515,21 @@ FROM (
 SELECT ST_DISTANCE_SPHERE(st_geomfromtext('linestring( 2 2, 2 8) '), ST_GeomFromText('POINT(18.413076 43.856258)')) ;
 
 --echo # End of 10.5 tests
+
+--echo #
+--echo # Start of 10.11 tests
+--echo #
+
+--echo #
+--echo # MDEV-35739 Linestring self-intersection equality
+--echo #
+CREATE TABLE t1(geom geometry NOT NULL);
+INSERT INTO t1 (geom) VALUES(ST_GeomFromText('LINESTRING(2 2,4 4,6 2,3 2,2 4)'));
+SELECT ST_ASTEXT(geom) FROM t1;
+SELECT ST_EQUALS(geom, ST_INTERSECTION(geom, geom)) AS isequal, ST_ASTEXT(ST_INTERSECTION(geom, geom)) AS intersection FROM t1;
+SELECT ST_AsText(ST_SYMDIFFERENCE(geom, ST_Intersection(geom, geom))) FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -424,6 +424,28 @@ int Geometry::bbox_as_json(String *wkt)
 }
 
 
+/**
+ * Geometry::operator==
+ *
+ * @param rhs   a Geometry instance to compare to *this
+ * @return true when *this is the same Geometry as rhs, false otherwise.  If
+ *              either *this or rhs have no Geometry associated (because, for
+ *              example, they are built with the default constructor) then the
+ *              comparison will always be false.
+ */
+bool Geometry::operator==(Geometry &rhs) const
+{
+  if (!m_data || !rhs.m_data)
+    return false;
+
+  const ptrdiff_t len= m_data_end - m_data;
+  if (len != rhs.m_data_end - rhs.m_data)
+    return false;
+
+  return memcmp(m_data, rhs.m_data, len) == 0;
+}
+
+
 static double wkb_get_double(const char *ptr, Geometry::wkbByteOrder bo)
 {
   double res;

--- a/sql/spatial.h
+++ b/sql/spatial.h
@@ -384,6 +384,8 @@ public:
             (expected_points > ((m_data_end - data) /
                                 (POINT_DATA_SIZE + extra_point_space))));
   }
+
+  bool operator==(Geometry &rhs) const;
 protected:
   const char *m_data;
   const char *m_data_end;


### PR DESCRIPTION
ST_INTERSECTION(geom_1, geom_1) returns geom_1 exactly.

Replaces 'goto exit;' in Item_func_spatial_operation::val_str with SCOPE_EXIT. This was done to leverage existing geometry construction calls without incurring compiler errors caused by skipping initialization on goto.
