### PR TITLE
MDEV-36134 : Mariadb server crashed during insert

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
@@ -1,0 +1,137 @@
+connection node_2;
+connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_2;
+START SLAVE;
+connection node_3;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+connection node_2;
+connection node_1;
+#
+# Set up replication filtering this should work for slave
+#
+connection node_2;
+STOP SLAVE;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+@@replicate_ignore_table
+mysql.gtid_slave_pos,test.t2
+START SLAVE;
+#
+# Set up replication filtering, this should not have any effect
+#
+connection node_1;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+@@replicate_ignore_table
+mysql.gtid_slave_pos,test.t2
+#
+# Insert data to MariaDB master, inserts to t2 should not be on slave
+#
+connection node_3;
+INSERT INTO t1 SELECT * FROM seq_1_to_100;
+INSERT INTO t2 SELECT * FROM seq_1_to_100;
+INSERT INTO t3 SELECT * FROM seq_1_to_100;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+100
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+100
+SELECT COUNT(*) FROM t3;
+COUNT(*)
+100
+connection node_2;
+SELECT COUNT(*) AS EXPECT_100 FROM t1;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_100 FROM t3;
+EXPECT_100
+100
+#
+# Insert data to Galera node_2, all these should be replicated
+#
+INSERT INTO t1 SELECT * FROM seq_101_to_200;
+INSERT INTO t2 SELECT * FROM seq_101_to_200;
+INSERT INTO t3 SELECT * FROM seq_101_to_200;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+EXPECT_200
+200
+connection node_1;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+EXPECT_200
+200
+#
+# Insert data to Galera node_1, all these should be replicated
+#
+INSERT INTO t1 SELECT * FROM seq_201_to_300;
+INSERT INTO t2 SELECT * FROM seq_201_to_300;
+INSERT INTO t3 SELECT * FROM seq_201_to_300;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+connection node_3;
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+
+connection node_1;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+0-3-6
+connection node_2;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+0-3-6
+connection node_2;
+STOP SLAVE;
+RESET SLAVE ALL;
+SET GLOBAL replicate_ignore_table='';
+connection node_1;
+SET GLOBAL replicate_ignore_table='';
+connection node_3;
+DROP TABLE t1,t2,t3;
+connection node_2;
+DROP TABLE t1,t2,t3;
+connection node_3;
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_with_filtering.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_with_filtering.cnf
@@ -1,0 +1,12 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mariadbd.1]
+wsrep-gtid-mode=ON
+log-bin
+log-slave-updates
+
+[mariadbd.2]
+wsrep-gtid-mode=ON
+log-bin
+log-slave-updates
+

--- a/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
@@ -1,0 +1,146 @@
+#
+# Test Galera as a slave to a MySQL master
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+# mariadb master (node_3) ----async replication--->galera node_2 <---galera replication-->node_1
+#
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+# As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
+# we open the node_3 connection here
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_2
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_SSL_VERIFY_SERVER_CERT=0, MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE;
+
+--connection node_3
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3';
+--source include/wait_condition.inc
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3';
+--source include/wait_condition.inc
+
+--echo #
+--echo # Set up replication filtering this should work for slave
+--echo #
+--connection node_2
+STOP SLAVE;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_SSL_VERIFY_SERVER_CERT=0, MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE;
+
+--echo #
+--echo # Set up replication filtering, this should not have any effect
+--echo #
+--connection node_1
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+
+--echo #
+--echo # Insert data to MariaDB master, inserts to t2 should not be on slave
+--echo #
+--connection node_3
+INSERT INTO t1 SELECT * FROM seq_1_to_100;
+INSERT INTO t2 SELECT * FROM seq_1_to_100;
+INSERT INTO t3 SELECT * FROM seq_1_to_100;
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+SELECT COUNT(*) FROM t3;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 100 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 100 FROM t3;
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS EXPECT_100 FROM t1;
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+SELECT COUNT(*) AS EXPECT_100 FROM t3;
+
+--echo #
+--echo # Insert data to Galera node_2, all these should be replicated
+--echo #
+INSERT INTO t1 SELECT * FROM seq_101_to_200;
+INSERT INTO t2 SELECT * FROM seq_101_to_200;
+INSERT INTO t3 SELECT * FROM seq_101_to_200;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 200 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+
+--echo #
+--echo # Insert data to Galera node_1, all these should be replicated
+--echo #
+INSERT INTO t1 SELECT * FROM seq_201_to_300;
+INSERT INTO t2 SELECT * FROM seq_201_to_300;
+INSERT INTO t3 SELECT * FROM seq_201_to_300;
+
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+
+--connection node_3
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 300 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 300 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+SET GLOBAL replicate_ignore_table='';
+
+--connection node_1
+SET GLOBAL replicate_ignore_table='';
+
+--connection node_3
+DROP TABLE t1,t2,t3;
+
+--connection node_2
+DROP TABLE t1,t2,t3;
+
+--connection node_3
+RESET MASTER;

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -6522,8 +6522,8 @@ check_table_map(rpl_group_info *rgi, RPL_TABLE_LIST *table_list)
   DBUG_ENTER("check_table_map");
   enum_tbl_map_status res= OK_TO_PROCESS;
   Relay_log_info *rli= rgi->rli;
-  if ((rgi->thd->slave_thread /* filtering is for slave only */ ||
-        IF_WSREP((WSREP(rgi->thd) && rgi->thd->wsrep_applier), 0)) &&
+
+  if (rgi->thd->slave_thread /* filtering is for slave only */ &&
       (!rli->mi->rpl_filter->db_ok(table_list->db.str) ||
        (rli->mi->rpl_filter->is_on() && !rli->mi->rpl_filter->tables_ok("", table_list))))
     res= FILTERED_OUT;


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36134*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Replication filtering is not safe for cluster consistency. There is problem when two or more filtering rules are provided by user. Here, we disable replication filtering inside a Galera cluster for now. To support safe replication filereing in the Galera cluster it should also effect SST/IST.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
