### PR TITLE
MDEV-34761 : Assertion `client_state_.mode() == wsrep::client_state::…

### DIFF
--- a/mysql-test/suite/galera/r/enforce_storage_engine2.result
+++ b/mysql-test/suite/galera/r/enforce_storage_engine2.result
@@ -7,23 +7,15 @@ connection node_1;
 connection node_1;
 CREATE TABLE t1(i INT) ENGINE=INNODB;
 CREATE TABLE t2(i INT) ENGINE=MYISAM;
-Warnings:
-Note	1266	Using storage engine InnoDB for table 't2'
-Note	1266	Using storage engine InnoDB for table 't2'
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
 connection node_2;
 SHOW TABLES;
 Tables_in_test
 t1
-t2
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
   `i` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-SHOW CREATE TABLE t2;
-Table	Create Table
-t2	CREATE TABLE `t2` (
-  `i` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-DROP TABLE t1, t2;
+DROP TABLE t1;
 # End of tests

--- a/mysql-test/suite/galera/r/galera_aria.result
+++ b/mysql-test/suite/galera/r/galera_aria.result
@@ -1,0 +1,25 @@
+connection node_2;
+connection node_1;
+set session sql_mode='';
+SET @@enforce_storage_engine=INNODB;
+CREATE TABLE t1 (c INT ) ENGINE=ARIA;
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+SHOW WARNINGS;
+Level	Code	Message
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+CREATE TABLE t1 (c INT );
+DROP TABLE t1;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+DROP TABLE t1;
+SET @@enforce_storage_engine=ARIA;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+SHOW WARNINGS;
+Level	Code	Message
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set

--- a/mysql-test/suite/galera/t/enforce_storage_engine2.test
+++ b/mysql-test/suite/galera/t/enforce_storage_engine2.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_aria.inc
 
 --echo #
 --echo # MDEV-9312: storage engine not enforced during galera cluster
@@ -7,14 +8,21 @@
 --echo #
 --connection node_1
 CREATE TABLE t1(i INT) ENGINE=INNODB;
+#
+# This is not anymore supported because enforce_storage_engine
+# is local setting and final used storage engine
+# on other members of cluster depend on their configuration.
+# Currently, there is no way to query remote node
+# configuration.
+#
+--error ER_OPTION_PREVENTS_STATEMENT 
 CREATE TABLE t2(i INT) ENGINE=MYISAM;
 
 --connection node_2
 SHOW TABLES;
 SHOW CREATE TABLE t1;
-SHOW CREATE TABLE t2;
 
 # Cleanup
-DROP TABLE t1, t2;
+DROP TABLE t1;
 
 --echo # End of tests

--- a/mysql-test/suite/galera/t/galera_aria.test
+++ b/mysql-test/suite/galera/t/galera_aria.test
@@ -1,0 +1,19 @@
+--source include/galera_cluster.inc
+--source include/have_aria.inc
+--source include/log_bin.inc
+
+set session sql_mode='';
+SET @@enforce_storage_engine=INNODB;
+--error ER_OPTION_PREVENTS_STATEMENT 
+CREATE TABLE t1 (c INT ) ENGINE=ARIA;
+SHOW WARNINGS;
+
+CREATE TABLE t1 (c INT );
+DROP TABLE t1;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+DROP TABLE t1;
+
+SET @@enforce_storage_engine=ARIA;
+--error ER_OPTION_PREVENTS_STATEMENT 
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+SHOW WARNINGS;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12119,6 +12119,23 @@ bool check_engine(THD *thd, const char *db_name,
       my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "NO_ENGINE_SUBSTITUTION");
       DBUG_RETURN(TRUE);
     }
+#ifdef WITH_WSREP
+    /*  @@enforce_storage_engine is local, if user has used
+	ENGINE=XXX we can't allow it in cluster in this
+	case as enf_engine != new _engine. This is because
+        original stmt is replicated including ENGINE=XXX and
+        here */
+    if ((create_info->used_fields & HA_CREATE_USED_ENGINE) &&
+	WSREP(thd))
+    {
+      my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "ENFORCE_STORAGE_ENGINE");
+      push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+			  ER_OPTION_PREVENTS_STATEMENT,
+			  "Do not use ENGINE=x when @@enforce_storage_engine is set");
+
+      DBUG_RETURN(TRUE);
+    }
+#endif
     *new_engine= enf_engine;
   }
 


### PR DESCRIPTION
…m_local' failed in int wsrep::transaction::after_statement(wsrep::unique_lock<wsrep::mutex>&)



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34761*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
@@enforce_storage_engine is local setting and there is no knowledge how other nodes are configured. Statement CREATE TABLE xxx ENGINE=yyy is replicated as it is and if required engine != enforced engine it could lead inconsistent used storage engine in the cluster.

Fix is to return error and a warning if required engine is not same as enforced engine.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
