### PR TITLE
MDEV-36995: ifunc is not supported by musl

### DIFF
--- a/sql/bloom_filters.h
+++ b/sql/bloom_filters.h
@@ -35,7 +35,7 @@ SOFTWARE.
   implementation for now.
 */
 #define DEFAULT_IMPLEMENTATION
-#if __GNUC__ > 7
+#if __GNUC__ > 7 && defined(__GLIBC__)
 #ifdef __x86_64__
 #ifdef HAVE_IMMINTRIN_H
 #include <immintrin.h>


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36995*

## Description

Only glibc and not musl currently supports the mechanisms of IFUNC. This fixes 11.8 branch build on Alpine Linux.

Build error was:
```console
mariadb-11.8.2/sql/vector_mhnsw.cc: In static member function 'static const FVector* FVector::create(metric_type, void*, const void*, size_t)': mariadb-11.8.2/sql/vector_mhnsw.cc:299:19: error: multiversioning needs 'ifunc' which is not supported on this target
  299 |   static FVector *align_ptr(void *ptr) { return (FVector*)ptr; }
      |                   ^~~~~~~~~
mariadb-11.8.2/sql/vector_mhnsw.cc:113:3: error: use of multiversioned function without a default
```

## Release Notes

Fix build problem on musl (Alpine Linux)

## How can this PR be tested?

Build MariaDB server 11.8.2 on Alpine Linux, see https://gitlab.alpinelinux.org/alpine/aports/-/tree/master/main/mariadb

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
