### PR TITLE
MDEV-36997 Assertion failed in ha_tina::delete_row on multi delete

### DIFF
--- a/mysql-test/main/delete_multi_order_by.result
+++ b/mysql-test/main/delete_multi_order_by.result
@@ -391,3 +391,37 @@ id	v
 select * from t3;
 id	v
 drop table t1, t2, t3;
+#
+# Begin 11.8 tests
+#
+#
+# MDEV-36997 Assertion failed in ha_tina::delete_row on multi delete
+#
+SET sql_mode='';
+CREATE TABLE t1 (v INT (1) NOT NULL) ENGINE=CSV;
+INSERT INTO t1 SELECT 1 away;
+SELECT COUNT(*) from t1;
+COUNT(*)
+1
+DELETE FROM a3,a1 USING t1 AS a1 JOIN t1 AS a2 JOIN t1 AS a3;
+SELECT COUNT(*) from t1;
+COUNT(*)
+0
+DROP TABLE t1;
+SET sql_mode='';
+CREATE TABLE t1 (v VECTOR (1) NOT NULL) ENGINE=CSV;
+INSERT INTO t1 SELECT 1 away;
+Warnings:
+Warning	4078	Cannot cast 'int' as 'vector' in assignment of `test`.`t1`.`v`
+Warning	1292	Incorrect vector value: '1' for column `test`.`t1`.`v` at row 1
+SELECT COUNT(*) from t1;
+COUNT(*)
+1
+DELETE FROM a3,a1 USING t1 AS a1 JOIN t1 AS a2 JOIN t1 AS a3;
+SELECT COUNT(*) from t1;
+COUNT(*)
+0
+DROP TABLE t1;
+#
+# End 11.8 tests
+#

--- a/mysql-test/main/delete_multi_order_by.test
+++ b/mysql-test/main/delete_multi_order_by.test
@@ -3,6 +3,7 @@
 #
 
 --source include/have_innodb.inc
+--source include/have_csv.inc
 
 create table t1 (id int primary key, v int);
 create table t2 (id int primary key, v int);
@@ -203,3 +204,30 @@ select * from t2;
 select * from t3;
 
 drop table t1, t2, t3;
+
+--echo #
+--echo # Begin 11.8 tests
+--echo #
+
+--echo #
+--echo # MDEV-36997 Assertion failed in ha_tina::delete_row on multi delete
+--echo #
+SET sql_mode='';
+CREATE TABLE t1 (v INT (1) NOT NULL) ENGINE=CSV;
+INSERT INTO t1 SELECT 1 away;
+SELECT COUNT(*) from t1;
+DELETE FROM a3,a1 USING t1 AS a1 JOIN t1 AS a2 JOIN t1 AS a3;
+SELECT COUNT(*) from t1;
+DROP TABLE t1;
+
+SET sql_mode='';
+CREATE TABLE t1 (v VECTOR (1) NOT NULL) ENGINE=CSV;
+INSERT INTO t1 SELECT 1 away;
+SELECT COUNT(*) from t1;
+DELETE FROM a3,a1 USING t1 AS a1 JOIN t1 AS a2 JOIN t1 AS a3;
+SELECT COUNT(*) from t1;
+DROP TABLE t1;
+
+--echo #
+--echo # End 11.8 tests
+--echo #

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -1647,6 +1647,10 @@ int multi_delete::rowid_table_deletes(TABLE *table, bool ignore)
 err:
   if (err_table)
     err_table->file->print_error(local_error,MYF(ME_FATAL));
+  if (tmp_table->file->inited == handler::init_stat::RND)
+    tmp_table->file->ha_rnd_end();
+  if (table->file->inited == handler::init_stat::RND)
+    table->file->ha_rnd_end();
   DBUG_RETURN(local_error);
 }
 

--- a/storage/csv/ha_tina.cc
+++ b/storage/csv/ha_tina.cc
@@ -1463,6 +1463,7 @@ int ha_tina::rnd_end()
       of the old datafile.
     */
     if (mysql_file_close(data_file, MYF(0)) ||
+        mysql_file_delete(csv_key_file_data, share->data_file_name, MYF(0)) ||
         mysql_file_rename(csv_key_file_data,
                           fn_format(updated_fname, share->table_name,
                                     "", CSN_EXT,


### PR DESCRIPTION
Multi-delete code invokes ha_rnd_end after applying deferred deletes, following the pattern as in multi-update.

The CSV engine batches deletes made via calls to delete_row, then applies them all at once during ha_rnd_end.  For each row batched, the CSV engine decrements an internal counter of the total rows in the table.  The multi-delete code was not calling ha_rnd_end, so this internal counter was not consistent with the total number of rows in the table, triggering the assertion.

In the CSV engine, explicitly delete the destination file before renaming the source file over it.  This avoids a file rename problem on Windows.  This change would have been necessary before the latest multi-delete changes, had this test case existed at that point in time, because the end_read_record call in do_table_deletes swallowed the rename failure on Windows.
