### PR TITLE
MDEV-36871 mariadb-backup incremental segfault querying mariadb_backup_history

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -5521,10 +5521,6 @@ fail:
 
 	backup_datasinks.init();
 
-	if (!select_history()) {
-		goto fail;
-	}
-
 	/* open the log file */
 	memset(&stat_info, 0, sizeof(MY_STAT));
 	dst_log_file = ds_open(backup_datasinks.m_redo, LOG_FILE_NAME, &stat_info);
@@ -5539,6 +5535,11 @@ fail:
 	if (innodb_log_checkpoint_now != false) {
 		mysql_read_query_result(mysql_connection);
 	}
+
+	if (!select_history()) {
+		goto fail;
+	}
+
 	/* label it */
 	recv_sys.file_checkpoint = log_sys.next_checkpoint_lsn;
 	log_hdr_init();

--- a/mysql-test/suite/mariabackup/xbstream.result
+++ b/mysql-test/suite/mariabackup/xbstream.result
@@ -1,8 +1,12 @@
 CREATE TABLE t(i INT) ENGINE INNODB;
 INSERT INTO t VALUES(1);
-# xtrabackup backup to stream
+# xtrabackup full backup to stream
+INSERT INTO t VALUES(2), (3), (4);
+# xtrabackup incremental backup to stream
 # xbstream extract
 # xtrabackup prepare
+# xbstream extract for incremental backup
+# xtrabackup incremental prepare
 # shutdown server
 # remove datadir
 # xtrabackup move back
@@ -10,4 +14,8 @@ INSERT INTO t VALUES(1);
 SELECT * FROM t;
 i
 1
+2
+3
+4
 DROP TABLE t;
+DROP TABLE mysql.mariadb_backup_history;

--- a/mysql-test/suite/mariabackup/xbstream.test
+++ b/mysql-test/suite/mariabackup/xbstream.test
@@ -4,11 +4,21 @@ CREATE TABLE t(i INT) ENGINE INNODB;
 INSERT INTO t VALUES(1);
 
 let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
+let $incr_dir=$MYSQLTEST_VARDIR/tmp/backup_incr;
 mkdir $targetdir;
-let $streamfile=$MYSQLTEST_VARDIR/tmp/backup.xb;
+mkdir $incr_dir;
 
-echo # xtrabackup backup to stream;
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10  --databases-exclude=foobar --stream=xbstream > $streamfile 2>$targetdir/backup_stream.log;
+let $streamfile=$MYSQLTEST_VARDIR/tmp/backup.xb;
+let $stream_incr_file=$MYSQLTEST_VARDIR/tmp/backup_incr.xb;
+
+echo # xtrabackup full backup to stream;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10  --databases-exclude=foobar --history=fullback --stream=xbstream > $streamfile 2>$targetdir/backup_stream.log;
+
+INSERT INTO t VALUES(2), (3), (4);
+
+echo # xtrabackup incremental backup to stream;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup  --incremental-history-name=fullback --history=incr_1  --stream=xbstream > $stream_incr_file 2>$targetdir/backup_incr.log;
+
 echo # xbstream extract;
 --disable_result_log
 exec $XBSTREAM -x -C $targetdir  < $streamfile;
@@ -16,9 +26,17 @@ exec $XBSTREAM -x -C $targetdir  < $streamfile;
 echo # xtrabackup prepare;
 exec $XTRABACKUP --prepare --target-dir=$targetdir;
 
+echo # xbstream extract for incremental backup;
+exec $XBSTREAM -x -C $incr_dir  < $stream_incr_file;
+
+echo # xtrabackup incremental prepare;
+exec $XTRABACKUP --prepare --target-dir=$targetdir --incremental-dir=$incr_dir;
+
 -- source include/restart_and_restore.inc
 --enable_result_log
 SELECT * FROM t;
 DROP TABLE t;
+DROP TABLE mysql.mariadb_backup_history;
 rmdir $targetdir;
-
+remove_file $streamfile;
+remove_file $stream_incr_file;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36871*

## Description
Problem:
=========
- Mariabackup tries to read the history data from mysql.mariadb_backup_history and fails with segfault. Reason is that mariabackup does force innodb_log_checkpoint_now from commit 652f33e0a44661d6093993d49d3e83d770904413(MDEV-30000).

- Mariabackup sends the "innodb_log_checkpoint_now=1" query to server and reads the result set for the query later in the code because the query may trigger the page thread to flush the pages. But before reading the query result for innodb_log_checkpoint_now=1, mariabackup does execute the select query for the history table (mysql.mariadb_backup_history) and wrongly reads the query result of innodb_log_checkpoint_now. This leads to assertion in mariabackup

Solution:
=========
- Move the reading of history data from mysql.mariadb_backup_history after reading the result of innodb_log_checkpoint_now=1 query.

## How can this PR be tested?
./mtr mariabackup.xbstream

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.