### PR TITLE
MDEV-36107: Add expression support to mysqltest

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -666,6 +666,16 @@ int multi_reg_replace(struct st_replace_regex* r,char* val);
 void free_win_path_patterns();
 #endif
 
+/* For expression parsing */
+static long long expr(const char**);
+static long long logical_or(const char**);
+static long long logical_and(const char**);
+static long long equality(const char**);
+static long long comparison(const char**);
+static long long term(const char**);
+static long long factor(const char**);
+static long long unary(const char**);
+static long long primary(const char**);
 
 /* For replace_column */
 static char *replace_column[MAX_COLUMNS];
@@ -5022,6 +5032,165 @@ int do_save_master_pos()
 }
 
 
+static void skip_whitespace(const char **s)
+{
+  while (isspace(**s)) (*s)++;
+}
+
+
+static int match(const char **s, const char *op)
+{
+  skip_whitespace(s);
+  size_t len= strlen(op);
+  if (strncmp(*s, op, len) == 0)
+  {
+    *s += len;
+    return 1;
+  }
+  return 0;
+}
+
+
+static long long primary(const char **s)
+{
+  skip_whitespace(s);
+  if (match(s, "("))
+  {
+    long long result= expr(s);
+    if (!match(s, ")"))
+      die("Syntax error: Expected ')' in expression");
+    return result;
+  }
+
+  long long result= 0;
+  const char *start= *s;
+  while (isdigit(**s))
+  {
+    result= result * 10 + (**s - '0');
+    (*s)++;
+  }
+
+  if (*s == start)
+    die("Syntax error: Expected a number or a '(' in expression");
+  
+  return result;
+}
+
+
+static long long unary(const char **s)
+{
+  if (match(s, "!"))
+    return !unary(s);
+  return primary(s);
+}
+
+
+static long long factor(const char **s)
+{
+  long long result= unary(s);
+  while (true) {
+    if (match(s, "*")) result *= unary(s);
+    else if (match(s, "/"))
+    {
+      long long divisor= unary(s);
+      if (divisor == 0)
+        die("Evaluation error: Division by zero");
+      result /= divisor;
+    }
+    else if (match(s, "%")) {
+        long long divisor= unary(s);
+        if (divisor == 0)
+          die("Evaluation error: Modulo by zero");
+        result %= divisor;
+    }
+    else break;
+  }
+  return result;
+}
+
+
+static long long term(const char **s)
+{
+  long long result= factor(s);
+  while (true) {
+    if (match(s, "+")) result += factor(s);
+    else if (match(s, "-")) result -= factor(s);
+    else break;
+  }
+  return result;
+}
+
+
+static long long comparison(const char **s)
+{
+  long long result= term(s);
+  while (true)
+  {
+    if (match(s, "<=")) result= result <= term(s);
+    else if (match(s, ">=")) result= result >= term(s);
+    else if (match(s, "<")) result= result < term(s);
+    else if (match(s, ">")) result= result > term(s);
+    else break;
+  }
+  return result;
+}
+
+
+static long long equality(const char **s)
+{
+  long long result= comparison(s);
+  while (true)
+  {
+    if (match(s, "==")) result= result == comparison(s);
+    else if (match(s, "!=")) result= result != comparison(s);
+    else break;
+  }
+  return result;
+}
+
+
+static long long logical_and(const char **s)
+{
+  long long result= equality(s);
+  while (match(s, "&&"))
+  { 
+    result= result && equality(s);
+  }
+  return result;
+}
+
+
+static long long logical_or(const char **s)
+{
+  long long result= logical_and(s);
+  while (match(s, "||"))
+  {
+    result= result || logical_and(s);
+  }
+  return result;
+}
+
+
+static long long expr(const char **s)
+{
+  return logical_or(s);
+}
+
+
+static bool is_parserable(const char *s)
+{
+  // TODO: This is a temporary fix to allow the parser to handle strings
+  // Scan the string for any characters that are not part of a valid expression
+  // (digit, operator, parentheses, or whitespace). If we find any such
+  // character, we assume it's a plain string and not a candidate for the
+  
+  for (const char *p= s; *p; p++)
+  {
+    if (!isdigit(*p) && !isspace(*p) && !strchr("+-*/%<>=!&|()", *p)) return false;
+  }
+  return true;
+}
+
 /*
   Assign the variable <var_name> with <var_val>
 
@@ -5070,6 +5239,21 @@ void do_let(struct st_command *command)
     p++;
 
   do_eval(&let_rhs_expr, p, command->end, FALSE);
+
+  // TODO: This is a temporary fix to allow the parser to handle Strings vs Integers
+  if (is_parserable(let_rhs_expr.str))
+  {
+    const char *eval_ptr = let_rhs_expr.str;
+    long long result= expr(&eval_ptr);
+    skip_whitespace(&eval_ptr);
+    if (*eval_ptr != '\0')
+      die("Syntax error in expression near '%.*s'", (int)strlen(eval_ptr), eval_ptr);
+    
+    // Convert the integer result back into a string.
+    char result_buf[22];
+    my_snprintf(result_buf, sizeof(result_buf), "%lld", result);
+    dynstr_set(&let_rhs_expr, result_buf);
+  }
 
   command->last_argument= command->end;
   /* Assign var_val to var_name */

--- a/mysql-test/main/mysqltest_expression_evaluation.test
+++ b/mysql-test/main/mysqltest_expression_evaluation.test
@@ -1,0 +1,85 @@
+--echo #
+--echo # Expression Evaluation Test Suite for 'let' command
+--echo #
+
+--echo # -----------------------------------------
+--echo # 1. Simple Arithmetic
+--echo # -----------------------------------------
+let $a = 10 + 5;
+let $b = 10 - 4;
+let $c = 3 * 7;
+let $d = 20 / 4;
+let $e = 21 % 5;
+--echo # Results of simple arithmetic:
+--echo # Expected: 15 6 21 5 1
+--echo # Actual:   $a $b $c $d $e
+
+--echo # -----------------------------------------
+--echo # 2. Operator Precedence
+--echo # -----------------------------------------
+let $p1 = 2 + 3 * 4;
+let $p2 = 20 / 2 - 3;
+--echo # Results of operator precedence:
+--echo # Expected: 14 7
+--echo # Actual:   $p1 $p2
+
+--echo # -----------------------------------------
+--echo # 3. Parentheses
+--echo # -----------------------------------------
+let $p3 = (2 + 3) * 4;
+let $p4 = 20 / (5 - 3);
+--echo # Results of parentheses:
+--echo # Expected: 20 10
+--echo # Actual:   $p3 $p4
+
+--echo # -----------------------------------------
+--echo # 4. Using Variables in Expressions
+--echo # -----------------------------------------
+let $v1 = 100;
+let $v2 = 25;
+let $v_res = $v1 / $v2 + 1;
+--echo # Result of using variables:
+--echo # Expected: 5
+--echo # Actual:   $v_res
+
+--echo # -----------------------------------------
+--echo # 5. Comparison and Logical Operators
+--echo # -----------------------------------------
+let $comp1 = 10 > 5;
+let $comp2 = 10 < 5;
+let $comp3 = 5 == 5;
+let $comp4 = 5 != 5;
+let $log1 = $comp1 && $comp3;  # 1 && 1
+let $log2 = $comp1 && $comp2;  # 1 && 0
+let $log3 = $comp2 || $comp3;  # 0 || 1
+let $log4 = !$comp1;        # !1
+--echo # Results of comparison/logical ops:
+--echo # Expected: 1 0 1 0 1 0 1 0
+--echo # Actual:   $comp1 $comp2 $comp3 $comp4 $log1 $log2 $log3 $log4
+
+--echo # -----------------------------------------
+--echo # 6. Complex Expression
+--echo # -----------------------------------------
+let $n_complex = 2;
+let $c_complex = 3;
+# The expression: 3 + 2 + 435 + 3 + 4 * (2 - 1) && 5 < 2
+# Evaluates to:  447 && 0
+let $res_complex = $c_complex + $n_complex + 435 + 3 + 4 * (2 - 1) && 5 < 2;
+--echo # Result of complex expression:
+--echo # Expected: 0
+--echo # Actual:   $res_complex
+
+--echo # -----------------------------------------
+--echo # 7. String assignment
+--echo # -----------------------------------------
+let $str_test = This is a test string;
+--echo # Expected: This is a test string
+--echo # Actual:   $str_test
+
+--echo # -----------------------------------------
+--echo # 7. SQL query
+--echo # -----------------------------------------
+let $query_test = `SELECT 1+1`;
+--echo # Expected: 2
+--echo # Actual:   $query_test
+


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36107*


## Description
The `let` command can now evaluate mathematical and logical expressions.

## Release Notes
This patch integrates a recursive descent parser to handle arithmetic, comparisons, and logical operators.

TODO: Still working on it
To maintain backward compatibility, a heuristic function first checks if the right-hand side of an assignment looks like an expression. If not, the original string assignment logic is used.

## How can this PR be tested?

`
$ ./mtr main.mysqltest_expression_evaluation
`

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
