### PR TITLE
Enable use of elf_aux_info() to detect CPU features on aarch64 and powerpc64

### DIFF
--- a/mysys/crc32/crc32_arm64.c
+++ b/mysys/crc32/crc32_arm64.c
@@ -33,7 +33,7 @@ my_crc32_t crc32c_aarch64_available(void)
 }
 # else
 #  include <sys/auxv.h>
-#  ifdef __FreeBSD__
+#  if defined(__FreeBSD__) || defined(__OpenBSD__)
 static unsigned long getauxval(unsigned int key)
 {
   unsigned long val;

--- a/mysys/crc32/crc32c.cc
+++ b/mysys/crc32/crc32c.cc
@@ -455,10 +455,12 @@ static int arch_ppc_probe(void) {
 
   return arch_ppc_crc32;
 }
-# elif defined __FreeBSD__
-#  include <machine/cpu.h>
+# elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #  include <sys/auxv.h>
-#  include <sys/elf_common.h>
+#  ifdef __FreeBSD__
+#    include <machine/cpu.h>
+#    include <sys/elf_common.h>
+#  endif
 static int arch_ppc_probe(void) {
   unsigned long cpufeatures;
   arch_ppc_crc32 = 0;
@@ -470,12 +472,12 @@ static int arch_ppc_probe(void) {
 
   return arch_ppc_crc32;
 }
-# elif defined(_AIX) || defined(__OpenBSD__)
+# elif defined(_AIX)
 static int arch_ppc_probe(void) {
   arch_ppc_crc32 = 0;
 
 #  if defined(__powerpc64__)
-  // AIX 7.1+/OpenBSD has vector crypto features on all POWER 8+
+  // AIX 7.1+ has vector crypto features on all POWER 8+
   arch_ppc_crc32 = 1;
 #  endif /* __powerpc64__ */
 


### PR DESCRIPTION
## Description
Enable use of elf_aux_info() to detect CPU features on aarch64 and powerpc64.

## How can this PR be tested?

Build test on OpenBSD.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
