### PR TITLE
MDEV-37224: Lift `not_*san` in `not_ubsan` Tests

### DIFF
--- a/mysql-test/include/not_ubsan.inc
+++ b/mysql-test/include/not_ubsan.inc
@@ -1,8 +1,0 @@
-# This file should only be used with test that finds bugs in ASan that can not
-# be overcome. In normal cases one should fix the bug server/test case or in
-# the worst case add a (temporary?) suppression in asan.supp or lsan.supp
-
-if (`select count(*) from information_schema.system_variables where variable_name='have_sanitizer' and global_value LIKE "%UBSAN"`)
-{
---skip Can't be run with UBSAN
-}

--- a/mysql-test/main/mysqld--help.test
+++ b/mysql-test/main/mysqld--help.test
@@ -2,8 +2,6 @@
 # mysqld --help
 #
 --source include/not_embedded.inc
---source include/not_asan.inc
---source include/not_ubsan.inc
 --source include/have_perfschema.inc
 --source include/have_profiling.inc
 --source include/platform.inc

--- a/mysql-test/suite/plugins/t/multiauth.test
+++ b/mysql-test/suite/plugins/t/multiauth.test
@@ -1,5 +1,3 @@
---source include/not_ubsan.inc
-
 let $REGEX_VERSION_ID=/$mysql_get_server_version/VERSION_ID/;
 let $REGEX_PASSWORD_LAST_CHANGED=/password_last_changed": [0-9]*/password_last_changed": #/;
 let $REGEX_GLOBAL_PRIV=$REGEX_PASSWORD_LAST_CHANGED $REGEX_VERSION_ID;

--- a/mysql-test/suite/sys_vars/t/thread_stack_basic.test
+++ b/mysql-test/suite/sys_vars/t/thread_stack_basic.test
@@ -1,20 +1,18 @@
 #
 # only global
 #
---source include/not_asan.inc
---source include/not_ubsan.inc
 --source include/not_msan.inc
---replace_result 392192 299008
+--replace_result 392192 299008 11534336 299008
 select @@global.thread_stack;
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 select @@session.thread_stack;
---replace_result 392192 299008
+--replace_result 392192 299008 11534336 299008
 show global variables like 'thread_stack';
---replace_result 392192 299008
+--replace_result 392192 299008 11534336 299008
 show session variables like 'thread_stack';
---replace_result 392192 299008
+--replace_result 392192 299008 11534336 299008
 select * from information_schema.global_variables where variable_name='thread_stack';
---replace_result 392192 299008
+--replace_result 392192 299008 11534336 299008
 select * from information_schema.session_variables where variable_name='thread_stack';
 
 #


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-25123 support MSVC ASAN](https://jira.mariadb.org/browse/MDEV-25123)*~~

## Description
Delete `not_ubsan.inc` and remove calls from all 3 tests —
It is for tests impacted by UBSan bugs, but UBSan may’ve fixed them.
If more arise, we should inform the UBSan devs rather than put a `not_ubsan` lid on it.

Because ASAN builds have a different `@@GLOBAL.thread_stack` to compensate for MSVC (MDEV-25123), 2 of those 3 tests also had a `not_asan.inc` kludge since dfa6fba959.
This commit also lifts this limitation:
* `main.mysqld--help`: It skips `thread_stack` since Merge 28d6530571.
* `sys_vars.thread_stack_basic`: It now accepts the ASAN value through `--replace_result`.

## Release Notes
N/A

## How can this PR be tested?
Run the changed tests with ASan & UBSan. (?)

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] ~~I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.~~
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.