### PR TITLE
MDEV-36959 Deadlock does not rollback transaction fully

### DIFF
--- a/mysql-test/suite/innodb/r/trx_deadlock.result
+++ b/mysql-test/suite/innodb/r/trx_deadlock.result
@@ -1,0 +1,43 @@
+#
+# MDEV-36959 Deadlock does not rollback transaction fully
+#
+CREATE TABLE t1(col1 INT PRIMARY KEY, col2 INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 1), (2, 2);
+SELECT * FROM t1;
+col1	col2
+1	1
+2	2
+connect  con1,localhost,root,,;
+START TRANSACTION;
+# Trx-1: Lock 1st record
+UPDATE t1 SET col2=10 where col1=1;
+connection default;
+START TRANSACTION;
+# Trx-2: Lock 2nd record
+UPDATE t1 SET col2=100 where col1=2;
+connection con1;
+# Trx-1: Try locking 1st record : Wait
+UPDATE t1 SET col2=10 where col1=2;
+connection default;
+# Wait for Trx-1 to get into lock wait stage
+# Trx-2: Try locking 2nd record : Deadlock
+UPDATE t1 SET col2=100 where col1=1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection con1;
+ROLLBACK;
+connection default;
+SELECT @@in_transaction;
+@@in_transaction
+0
+UPDATE t1 SET col2=10 where col1=1;
+UPDATE t1 SET col2=100 where col1=2;
+SELECT @@in_transaction;
+@@in_transaction
+0
+ROLLBACK;
+disconnect con1;
+SELECT * FROM t1;
+col1	col2
+1	10
+2	100
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/trx_deadlock.opt
+++ b/mysql-test/suite/innodb/t/trx_deadlock.opt
@@ -1,0 +1,1 @@
+--innodb_lock_wait_timeout=60

--- a/mysql-test/suite/innodb/t/trx_deadlock.test
+++ b/mysql-test/suite/innodb/t/trx_deadlock.test
@@ -1,0 +1,52 @@
+--echo #
+--echo # MDEV-36959 Deadlock does not rollback transaction fully
+--echo #
+
+--source include/have_innodb.inc
+--source include/count_sessions.inc
+
+CREATE TABLE t1(col1 INT PRIMARY KEY, col2 INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 1), (2, 2);
+SELECT * FROM t1;
+
+--connect (con1,localhost,root,,)
+START TRANSACTION;
+--echo # Trx-1: Lock 1st record
+UPDATE t1 SET col2=10 where col1=1;
+
+--connection default
+START TRANSACTION;
+--echo # Trx-2: Lock 2nd record
+UPDATE t1 SET col2=100 where col1=2;
+
+--connection con1
+--echo # Trx-1: Try locking 1st record : Wait
+--send UPDATE t1 SET col2=10 where col1=2
+
+--connection default
+--echo # Wait for Trx-1 to get into lock wait stage
+let $wait_condition=
+  SELECT COUNT(*) >= 2 FROM INFORMATION_SCHEMA.INNODB_LOCKS
+  WHERE lock_table like "%t1%";
+--source include/wait_condition.inc
+
+--echo # Trx-2: Try locking 2nd record : Deadlock
+--error ER_LOCK_DEADLOCK
+UPDATE t1 SET col2=100 where col1=1;
+
+--connection con1
+--reap
+ROLLBACK;
+
+--connection default
+SELECT @@in_transaction;
+UPDATE t1 SET col2=10 where col1=1;
+UPDATE t1 SET col2=100 where col1=2;
+SELECT @@in_transaction;
+ROLLBACK;
+
+--disconnect con1
+
+SELECT * FROM t1;
+DROP TABLE t1;
+--source include/wait_until_count_sessions.inc

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -444,11 +444,11 @@ bool trans_rollback_implicit(THD *thd)
   DBUG_PRINT("info", ("clearing SERVER_STATUS_IN_TRANS"));
   res= ha_rollback_trans(thd, true);
   /*
-    We don't reset OPTION_BEGIN flag below to simulate implicit start
-    of new transacton in @@autocommit=1 mode. This is necessary to
-    preserve backward compatibility.
+    Implicit rollback should reset OPTION_BEGIN flag to avoid starting a
+    new transaction implicitly in next statement. It makes the behaviour
+    uniform with direct commit and rollback.
   */
-  thd->variables.option_bits&= ~(OPTION_BINLOG_THIS_TRX);
+  thd->variables.option_bits&= ~(OPTION_BEGIN | OPTION_BINLOG_THIS_TRX);
   thd->transaction->all.reset();
 
   /* Rollback should clear transaction_rollback_request flag. */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36959*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
A deadlock forces the on going transaction to rollback implicitly. Within a transaction block, started with START TRANSACTION / BEGIN, implicit rollback doesn't reset OPTION_BEGIN flag. It results in a new implicit transaction to start when the next statement is executed. This behaviour is unexpected and should be fixed. However, we should note that there is no issue with rollback.

We fix the issue to keep the behaviour of implicit rollback (deadlock) similar to explicit COMMIT and ROLLBACK i.e. the next statement after deadlock error is not going to start a transaction block implicitly unless autocommit is set to zero.

## Release Notes
This bug-fix corrects the behaviour by not starting a new transaction block implicitly after a deadlock error within a transaction block.

## How can this PR be tested?
./mtr innodb.trx_deadlock
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
