### PR TITLE
MDEV-36650  Unexpected checkpoint in the test innodb.doublewrite

### DIFF
--- a/mysql-test/suite/innodb/t/doublewrite.test
+++ b/mysql-test/suite/innodb/t/doublewrite.test
@@ -60,7 +60,10 @@ connection default;
 
 flush table t1 for export;
 
---let CLEANUP_IF_CHECKPOINT=drop table t1, unexpected_checkpoint;
+# If we are skipping the test at this point due to an unexpected
+# checkpoint then page cleaner could be active after reading the
+# initial checkpoint information
+--let CLEANUP_IF_CHECKPOINT=XA COMMIT 'x'; drop table t1;
 --source ../include/no_checkpoint_end.inc
 
 --copy_file $MYSQLD_DATADIR/ibdata1 $MYSQLD_DATADIR/ibdata1.bak


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36650*

## Description
innodb.doublewrite: Added sleep to ensure page cleaner thread wake up from my_cond_wait

## How can this PR be tested?
Tested in s390x-ubuntu platform and no failure

Added the following code:
```
set global innodb_log_checkpoint_now=1;              
--let CLEANUP_IF_CHECKPOINT=XA COMMIT 'x';drop table t1;                
--source ../include/no_checkpoint_end.inc
```

After adding the above code, InnoDB gracefully skips the test case.
```
innodb.doublewrite '32k,strict_crc32'    [ skipped ]  Extra checkpoint 1 after 61047 (77875,77842)
innodb.doublewrite '64k,strict_crc32'    [ skipped ]  Extra checkpoint 1 after 61048 (94277,94228)
innodb.doublewrite '32k,strict_full_crc32' [ skipped ]  Extra checkpoint 1 after 60901 (77729,77696)
innodb.doublewrite '64k,strict_full_crc32' [ skipped ]  Extra checkpoint 1 after 60902 (94082,94131)
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
