### PR TITLE
MDEV-23699 Assertion failed in ha_tina::delete_row

### DIFF
--- a/mysql-test/main/repair.result
+++ b/mysql-test/main/repair.result
@@ -251,3 +251,14 @@ test.t1	repair	status	OK
 set myisam_repair_threads = default;
 drop table t1;
 # End of 10.2 tests
+#
+# Start of 10.11 tests
+#
+USE test;
+CREATE TEMPORARY TABLE t(c INT NOT NULL) ENGINE=CSV;
+INSERT INTO t VALUES(1);
+REPAIR TABLE t;
+Table	Op	Msg_type	Msg_text
+test.t	repair	status	OK
+DELETE FROM t;
+# End of 10.11 tests

--- a/mysql-test/main/repair.test
+++ b/mysql-test/main/repair.test
@@ -269,3 +269,14 @@ set myisam_repair_threads = default;
 drop table t1;
 
 --echo # End of 10.2 tests
+
+--echo #
+--echo # Start of 10.11 tests
+--echo #
+USE test;
+CREATE TEMPORARY TABLE t(c INT NOT NULL) ENGINE=CSV;
+INSERT INTO t VALUES(1);
+REPAIR TABLE t;
+DELETE FROM t;
+
+--echo # End of 10.11 tests

--- a/storage/csv/ha_tina.cc
+++ b/storage/csv/ha_tina.cc
@@ -1515,10 +1515,10 @@ error:
     check_opt   The options for repair. We do not use it currently.
 
   DESCRIPTION
-    If the file is empty, change # of rows in the file and complete recovery.
-    Otherwise, scan the table looking for bad rows. If none were found,
+    Scan the table looking for bad rows. If none were found,
     we mark file as a good one and return. If a bad row was encountered,
     we truncate the datafile up to the last good row.
+    If the file is empty, then do nothing and complete recovery.
 
    TODO: Make repair more clever - it should try to recover subsequent
          rows (after the first bad one) as well.
@@ -1536,10 +1536,7 @@ int ha_tina::repair(THD* thd, HA_CHECK_OPT* check_opt)
 
   /* empty file */
   if (!share->saved_data_file_length)
-  {
-    share->rows_recorded= 0;
     goto end;
-  }
 
   /* Don't assert in field::val() functions */
   table->use_all_columns();


### PR DESCRIPTION
When REPAIRing a CSV table, the CSV engine marks the table as having no rows in the case that there are rows only in memory but not yet written to disk.  In this case, there's actually nothing to repair, since nothing exists on disk; make REPAIR idempotent for CSV tables.
