### PR TITLE
MDEV-37033 UBSAN: row_log_table_apply_ops runtime error: applying non-zero offset 1048576 to null pointer

### DIFF
--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -2691,7 +2691,8 @@ all_done:
 	ut_ad((mrec == NULL) == (index->online_log->head.bytes == 0));
 
 #ifdef UNIV_DEBUG
-	if (next_mrec_end == index->online_log->head.block
+	if (index->online_log->head.block &&
+	    next_mrec_end == index->online_log->head.block
 	    + srv_sort_buf_size) {
 		/* If tail.bytes == 0, next_mrec_end can also be at
 		the end of tail.block. */
@@ -2706,7 +2707,8 @@ all_done:
 			ut_ad(index->online_log->tail.blocks
 			      > index->online_log->head.blocks);
 		}
-	} else if (next_mrec_end == index->online_log->tail.block
+	} else if (index->online_log->tail.block &&
+		   next_mrec_end == index->online_log->tail.block
 		   + index->online_log->tail.bytes) {
 		ut_ad(next_mrec == index->online_log->tail.block
 		      + index->online_log->head.bytes);


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37033*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

In a UBSAN debug build, the comparisons with next_mrec_end are made with index->online_log's head/tail members' block ptr with a sort buffer size offset (1048576).

The logic that flows though to this point means that even srv_sort_buf_size above a null pointer wouldn't contain the value of next_mrec_end.

As such this is a UBSAN type fix where we first check if the head.block / tail.block is null before doing the asserts around this debug condition. This would be required for the assertions conditions not to segfault anyway.

## Release Notes

nothing - test environment only change

## How can this PR be tested?

clang-20.1 UBSAN + Debug build and run mtr test per test suite.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.