### PR TITLE
MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function

### DIFF
--- a/libmysqld/CMakeLists.txt
+++ b/libmysqld/CMakeLists.txt
@@ -65,6 +65,7 @@ SET(SQL_EMBEDDED_SOURCES emb_qcache.cc libmysqld.c lib_sql.cc
            ../sql/item.cc ../sql/item_create.cc ../sql/item_func.cc 
            ../sql/item_geofunc.cc ../sql/item_row.cc ../sql/item_strfunc.cc 
            ../sql/item_subselect.cc ../sql/item_sum.cc ../sql/item_timefunc.cc 
+           ../sql/item_numconvfunc.cc
            ../sql/item_xmlfunc.cc ../sql/item_jsonfunc.cc
            ../sql/json_schema.cc ../sql/json_schema_helper.cc
            ../sql/key.cc ../sql/lock.cc ../sql/log.cc ../sql/log_cache.cc

--- a/mysql-test/main/func_numconv.result
+++ b/mysql-test/main/func_numconv.result
@@ -1,0 +1,1525 @@
+#
+# MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+#
+#
+# to_number() with one argument
+#
+SELECT to_number(ROW(1,1));
+ERROR 21000: Operand should contain 1 column(s)
+SELECT to_number(point(1,1));
+ERROR HY000: Illegal parameter data type point for operation 'to_number'
+# With one arg, to_number() works similarly CAST(expr AS DOUBLE)
+CREATE TABLE t1 AS SELECT
+to_number('123') AS c1,
+to_number(123) AS c2,
+to_number(123e0) AS c3,
+to_number(123.0) AS c4;
+SHOW COLUMNS IN t1;
+Field	Type	Null	Key	Default	Extra
+c1	double	YES		NULL	
+c2	double	YES		NULL	
+c3	double	YES		NULL	
+c4	double	YES		NULL	
+SELECT * FROM t1;
+c1	c2	c3	c4
+123	123	123	123
+DROP TABLE t1;
+SELECT to_number('') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='' value: '' for function to_number
+SELECT to_number('1E+400') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='' value: '1E+400' for function to_number
+SELECT to_number('123x') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='' value: '123x' for function to_number
+#
+# With two args only string+string are allowed
+#
+SELECT to_number(point(1,1), '');
+ERROR HY000: Illegal parameter data types point and varchar for operation 'to_number'
+SELECT to_number('',point(1,1));
+ERROR HY000: Illegal parameter data types varchar and point for operation 'to_number'
+SELECT to_number(1,'');
+ERROR HY000: Illegal parameter data types int and varchar for operation 'to_number'
+SELECT to_number('',1);
+ERROR HY000: Illegal parameter data types varchar and int for operation 'to_number'
+SELECT to_number(1e0,'');
+ERROR HY000: Illegal parameter data types double and varchar for operation 'to_number'
+SELECT to_number('',1e0);
+ERROR HY000: Illegal parameter data types varchar and double for operation 'to_number'
+#
+# Multiple dollar or B signs are not allowed
+#
+SELECT to_number('0', '99$99$');
+ERROR HY000: Incorrect <number format> value: '' for function to_number
+SELECT to_number('0', '$9999$');
+ERROR HY000: Incorrect <number format> value: '$9999 + $' for function to_number
+SELECT to_number('0', '$9.99$');
+ERROR HY000: Incorrect <number format> value: '$9.99 + $' for function to_number
+SELECT to_number('0', '9$9.9$99EEEE');
+ERROR HY000: Incorrect <number format> value: '9$9.9 + $99EEEE' for function to_number
+SELECT to_number('0', '99B99B');
+ERROR HY000: Incorrect <number format> value: '' for function to_number
+SELECT to_number('0', 'B99B99B');
+ERROR HY000: Incorrect <number format> value: '' for function to_number
+SELECT to_number('0', 'B999B');
+ERROR HY000: Incorrect <number format> value: 'B999 + B' for function to_number
+SELECT to_number('0', 'B9.99B');
+ERROR HY000: Incorrect <number format> value: 'B9.99 + B' for function to_number
+SELECT to_number('0', '9B9.9B99EEEE');
+ERROR HY000: Incorrect <number format> value: '9B9.9 + B99EEEE' for function to_number
+SELECT to_number('0', '.9$9BB$0B');
+ERROR HY000: Incorrect <number format> value: '$0B' for function to_number
+SELECT to_number('0', '.0$0BB$9B');
+ERROR HY000: Incorrect <number format> value: '$9B' for function to_number
+# Comma and G cannot co-exist
+SELECT to_number('1', '9G9,9G9');
+ERROR HY000: Incorrect <number format> value: '9G9' for function to_number
+SELECT to_number('1', '9,9G9,9');
+ERROR HY000: Incorrect <number format> value: '9,9' for function to_number
+SELECT to_number('1', '0G0,0G0');
+ERROR HY000: Incorrect <number format> value: '0G0' for function to_number
+SELECT to_number('1', '0,0G0,0');
+ERROR HY000: Incorrect <number format> value: '0,0' for function to_number
+#
+# Dollar and C,L,U cannot co-exist
+#
+SELECT to_number('1', '$C');
+ERROR HY000: Incorrect <number format> value: '$ + C' for function to_number
+SELECT to_number('1', '$L');
+ERROR HY000: Incorrect <number format> value: '$ + L' for function to_number
+SELECT to_number('1', '$U');
+ERROR HY000: Incorrect <number format> value: '$ + U' for function to_number
+SELECT to_number('1', '$C99');
+ERROR HY000: Incorrect <number format> value: '$ + C99' for function to_number
+SELECT to_number('1', '$L99');
+ERROR HY000: Incorrect <number format> value: '$ + L99' for function to_number
+SELECT to_number('1', '$U99');
+ERROR HY000: Incorrect <number format> value: '$ + U99' for function to_number
+SELECT to_number('1', '0$C');
+ERROR HY000: Incorrect <number format> value: '0$ + C' for function to_number
+SELECT to_number('1', '0$L');
+ERROR HY000: Incorrect <number format> value: '0$ + L' for function to_number
+SELECT to_number('1', '0$U');
+ERROR HY000: Incorrect <number format> value: '0$ + U' for function to_number
+SELECT to_number('1', '9$C');
+ERROR HY000: Incorrect <number format> value: '9$ + C' for function to_number
+SELECT to_number('1', '9$L');
+ERROR HY000: Incorrect <number format> value: '9$ + L' for function to_number
+SELECT to_number('1', '9$U');
+ERROR HY000: Incorrect <number format> value: '9$ + U' for function to_number
+SELECT to_number('1', 'C0$');
+ERROR HY000: Incorrect <number format> value: 'C0 + $' for function to_number
+SELECT to_number('1', 'L0$');
+ERROR HY000: Incorrect <number format> value: 'L0 + $' for function to_number
+SELECT to_number('1', 'U0$');
+ERROR HY000: Incorrect <number format> value: 'U0 + $' for function to_number
+SELECT to_number('1', '.$C');
+ERROR HY000: Incorrect <number format> value: '.$ + C' for function to_number
+SELECT to_number('1', '.$L');
+ERROR HY000: Incorrect <number format> value: '.$ + L' for function to_number
+SELECT to_number('1', '.$U');
+ERROR HY000: Incorrect <number format> value: '.$ + U' for function to_number
+SELECT to_number('1', 'D$C');
+ERROR HY000: Incorrect <number format> value: 'D$ + C' for function to_number
+SELECT to_number('1', 'D$L');
+ERROR HY000: Incorrect <number format> value: 'D$ + L' for function to_number
+SELECT to_number('1', 'D$U');
+ERROR HY000: Incorrect <number format> value: 'D$ + U' for function to_number
+SELECT to_number('1', 'V$C');
+ERROR HY000: Incorrect <number format> value: 'V$ + C' for function to_number
+SELECT to_number('1', 'V$L');
+ERROR HY000: Incorrect <number format> value: 'V$ + L' for function to_number
+SELECT to_number('1', 'V$U');
+ERROR HY000: Incorrect <number format> value: 'V$ + U' for function to_number
+SELECT to_number('1', '$.C');
+ERROR HY000: Incorrect <number format> value: '$. + C' for function to_number
+SELECT to_number('1', '$.L');
+ERROR HY000: Incorrect <number format> value: '$. + L' for function to_number
+SELECT to_number('1', '$.U');
+ERROR HY000: Incorrect <number format> value: '$. + U' for function to_number
+SELECT to_number('1', '$DC');
+ERROR HY000: Incorrect <number format> value: '$D + C' for function to_number
+SELECT to_number('1', '$DL');
+ERROR HY000: Incorrect <number format> value: '$D + L' for function to_number
+SELECT to_number('1', '$DU');
+ERROR HY000: Incorrect <number format> value: '$D + U' for function to_number
+#
+# Test that non-constant wrong formats raise a warning (not an error)
+#
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES ('$999$'),('C999');
+SELECT to_number('9999', fmt) FROM t1;
+to_number('9999', fmt)
+NULL
+NULL
+Warnings:
+Warning	1411	Incorrect <number format> value: '$999 + $' for function to_number
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='C999''
+DROP TABLE t1;
+#
+# An empty format is allowed and returns NULL
+#
+SELECT to_number('', '');
+to_number('', '')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='' value: '' for function to_number
+SELECT to_number('1', '');
+to_number('1', '')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='' value: '1' for function to_number
+#
+# B/dollar can go alone, in combination, with FM, and return NULL
+#
+SELECT to_number('1', 'B');
+to_number('1', 'B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B' value: '1' for function to_number
+SELECT to_number('1', '$');
+to_number('1', '$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$' value: '1' for function to_number
+SELECT to_number('1', 'B$');
+to_number('1', 'B$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B$' value: '1' for function to_number
+SELECT to_number('1', '$B');
+to_number('1', '$B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$B' value: '1' for function to_number
+SELECT to_number('$', '$');
+to_number('$', '$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$' value: '$' for function to_number
+SELECT to_number('$', 'B$');
+to_number('$', 'B$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B$' value: '$' for function to_number
+SELECT to_number('$', '$B');
+to_number('$', '$B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$B' value: '$' for function to_number
+SELECT to_number('1', 'FMB');
+to_number('1', 'FMB')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMB' value: '1' for function to_number
+SELECT to_number('1', 'FM$');
+to_number('1', 'FM$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FM$' value: '1' for function to_number
+SELECT to_number('1', 'FMB$');
+to_number('1', 'FMB$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMB$' value: '1' for function to_number
+SELECT to_number('1', 'FM$B');
+to_number('1', 'FM$B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FM$B' value: '1' for function to_number
+SELECT to_number('$', 'FM$');
+to_number('$', 'FM$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FM$' value: '$' for function to_number
+SELECT to_number('$', 'FMB$');
+to_number('$', 'FMB$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMB$' value: '$' for function to_number
+SELECT to_number('$', 'FM$B');
+to_number('$', 'FM$B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FM$B' value: '$' for function to_number
+#
+# . can go alone
+#
+SELECT to_number('.', '.');
+to_number('.', '.')
+0
+SELECT to_number('1', '.');
+to_number('1', '.')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='.' value: '1' for function to_number
+#
+# 'S', 'MI', 'PR' alone are allowed (optionally with FM), NULL returned
+#
+SELECT to_number('-', 'S');
+to_number('-', 'S')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S' value: '-' for function to_number
+SELECT to_number('-', 'MI');
+to_number('-', 'MI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='MI' value: '-' for function to_number
+SELECT to_number('<>', 'PR');
+to_number('<>', 'PR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='PR' value: '<>' for function to_number
+SELECT to_number('-', 'FMS');
+to_number('-', 'FMS')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMS' value: '-' for function to_number
+SELECT to_number('-', 'SFM');
+to_number('-', 'SFM')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='SFM' value: '-' for function to_number
+SELECT to_number('-', 'FMMI');
+to_number('-', 'FMMI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMMI' value: '-' for function to_number
+SELECT to_number('<>', 'FMPR');
+to_number('<>', 'FMPR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMPR' value: '<>' for function to_number
+SELECT to_number('1', 'S');
+to_number('1', 'S')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S' value: '1' for function to_number
+SELECT to_number('1', 'MI');
+to_number('1', 'MI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='MI' value: '1' for function to_number
+SELECT to_number('1', 'PR');
+to_number('1', 'PR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='PR' value: '1' for function to_number
+SELECT to_number('1', 'FMMI');
+to_number('1', 'FMMI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMMI' value: '1' for function to_number
+SELECT to_number('1', 'FMPR');
+to_number('1', 'FMPR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMPR' value: '1' for function to_number
+#
+# Integer
+#
+SELECT to_number('1', 'x999');
+ERROR HY000: Incorrect <number format> value: '999' for function to_number
+SELECT to_number('1', '999x');
+ERROR HY000: Incorrect <number format> value: 'x' for function to_number
+# Correct formats
+SELECT to_number('1', '999');
+to_number('1', '999')
+1
+SELECT to_number('$12', '$99');
+to_number('$12', '$99')
+12
+SELECT to_number('$12', '9$9');
+to_number('$12', '9$9')
+12
+SELECT to_number('$12', '99$');
+to_number('$12', '99$')
+12
+SELECT to_number('1', 'B99');
+to_number('1', 'B99')
+1
+SELECT to_number('1', '9B9');
+to_number('1', '9B9')
+1
+SELECT to_number('1', '99B');
+to_number('1', '99B')
+1
+SELECT to_number('$1', 'B$9');
+to_number('$1', 'B$9')
+1
+SELECT to_number('$1', '9B$');
+to_number('$1', '9B$')
+1
+SELECT to_number('$1', '$B9');
+to_number('$1', '$B9')
+1
+SELECT to_number('$1', '9$B');
+to_number('$1', '9$B')
+1
+SELECT to_number('1', '9,9,9,9');
+to_number('1', '9,9,9,9')
+1
+SELECT to_number('1', '9G9G9G9');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='9G9G9G9''
+SELECT to_number('1', '0000');
+to_number('1', '0000')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='0000' value: '1' for function to_number
+SELECT to_number('1', '0,0,0,0');
+to_number('1', '0,0,0,0')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='0,0,0,0' value: '1' for function to_number
+SELECT to_number('1', '9999');
+to_number('1', '9999')
+1
+SELECT to_number('1', '9,9,9,9');
+to_number('1', '9,9,9,9')
+1
+SELECT to_number('1', '0G0G0G0');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='0G0G0G0''
+SELECT to_number('1', '00009999');
+to_number('1', '00009999')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='00009999' value: '1' for function to_number
+SELECT to_number('1', '99999999');
+to_number('1', '99999999')
+1
+SELECT to_number('1', '0,0,0,0,9,9,9,9');
+to_number('1', '0,0,0,0,9,9,9,9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='0,0,0,0,9,9,9,9 value: '1' for function to_number
+SELECT to_number('1', '9,9,9,9,9,9,9,9');
+to_number('1', '9,9,9,9,9,9,9,9')
+1
+SELECT to_number('1', '0G0G0G0G9G9G9G9');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='0G0G0G0G9G9G9G9''
+SELECT to_number('1', '99990000');
+to_number('1', '99990000')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='99990000' value: '1' for function to_number
+SELECT to_number('1', '99999999');
+to_number('1', '99999999')
+1
+SELECT to_number('1', '9,9,9,9,0,0,0,0');
+to_number('1', '9,9,9,9,0,0,0,0')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='9,9,9,9,0,0,0,0 value: '1' for function to_number
+SELECT to_number('1', '9,9,9,9,9,9,9,9');
+to_number('1', '9,9,9,9,9,9,9,9')
+1
+SELECT to_number('1', '9G9G9G9G0G0G0G0');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='9G9G9G9G0G0G0G0''
+SELECT to_number('123456.123456', '999999.999999') AS c1;
+c1
+123456.123456
+SELECT to_number('123,456.123456', '999,999.999999') AS c1;
+c1
+123456.123456
+SELECT to_number('1,2,3,4,5,6.123456', '9,9,9,9,9,9.999999') AS c1;
+c1
+123456.123456
+#
+# Integer: 0 vs 9
+#
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES
+('0'),('9'),
+('00'),('09'),('90'),('99'),
+('000'),('009'),('090'),('099'), ('900'),('909'),('990'),('999');
+CREATE TABLE t2 (sbj VARCHAR(32));
+INSERT INTO t2 VALUES ('0'),('00'),('000'),('0000');
+# Expect NULL if
+# - the subject is shorter than the format, or
+# - if there's a format 0 outside of the subject length
+SELECT
+fmt, sbj, to_number(sbj,fmt),
+IF(length(fmt)<length(sbj) OR
+(fmt LIKE '0_' AND sbj LIKE '_') OR
+(fmt LIKE '0__' AND sbj LIKE '__') OR
+(fmt LIKE '0__' AND sbj LIKE '_') OR
+(fmt LIKE '_0_' AND sbj LIKE '_'),
+'Expect NULL','') AS comment
+FROM t1, t2
+WHERE length(fmt)>=length(sbj)
+ORDER BY length(fmt),fmt,sbj;
+fmt	sbj	to_number(sbj,fmt)	comment
+0	0	0	
+9	0	0	
+00	0	NULL	Expect NULL
+00	00	0	
+09	0	NULL	Expect NULL
+09	00	0	
+90	0	0	
+90	00	0	
+99	0	0	
+99	00	0	
+000	0	NULL	Expect NULL
+000	00	NULL	Expect NULL
+000	000	0	
+009	0	NULL	Expect NULL
+009	00	NULL	Expect NULL
+009	000	0	
+090	0	NULL	Expect NULL
+090	00	NULL	Expect NULL
+090	000	0	
+099	0	NULL	Expect NULL
+099	00	NULL	Expect NULL
+099	000	0	
+900	0	NULL	Expect NULL
+900	00	0	
+900	000	0	
+909	0	NULL	Expect NULL
+909	00	0	
+909	000	0	
+990	0	0	
+990	00	0	
+990	000	0	
+999	0	0	
+999	00	0	
+999	000	0	
+Warnings:
+Warning	1411	Incorrect <number format>='00' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='09' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='000' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='000' value: '00' for function to_number
+Warning	1411	Incorrect <number format>='009' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='009' value: '00' for function to_number
+Warning	1411	Incorrect <number format>='090' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='090' value: '00' for function to_number
+Warning	1411	Incorrect <number format>='099' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='099' value: '00' for function to_number
+Warning	1411	Incorrect <number format>='900' value: '0' for function to_number
+Warning	1411	Incorrect <number format>='909' value: '0' for function to_number
+DROP TABLE t1, t2;
+#
+# Fraction
+#
+SELECT to_number('.', '.');
+to_number('.', '.')
+0
+SELECT to_number('.', 'B.');
+to_number('.', 'B.')
+0
+SELECT to_number('.', 'B.9');
+to_number('.', 'B.9')
+0
+SELECT to_number('.1', 'B.9');
+to_number('.1', 'B.9')
+0.1
+SELECT to_number('1', 'B.');
+to_number('1', 'B.')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B.' value: '1' for function to_number
+SELECT to_number('1', 'B.9');
+to_number('1', 'B.9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B.9' value: '1' for function to_number
+#
+# Fraction + dollar
+#
+SELECT to_number('$.', '$.');
+to_number('$.', '$.')
+0
+SELECT to_number('1', '$.');
+to_number('1', '$.')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$.' value: '1' for function to_number
+SELECT to_number('.1', '.9999');
+to_number('.1', '.9999')
+0.1
+SELECT to_number('.1', '.99990000');
+to_number('.1', '.99990000')
+0.1
+SELECT to_number('$.1', '.9$9B');
+to_number('$.1', '.9$9B')
+0.1
+SELECT to_number('.1', '.0000');
+to_number('.1', '.0000')
+0.1
+SELECT to_number('.1', '.00009999');
+to_number('.1', '.00009999')
+0.1
+SELECT to_number('$.1', '.0$0B');
+to_number('$.1', '.0$0B')
+0.1
+SELECT to_number('1', '$.9');
+to_number('1', '$.9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$.9' value: '1' for function to_number
+SELECT to_number('1', '$.9');
+to_number('1', '$.9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$.9' value: '1' for function to_number
+#
+# Decimal
+#
+SELECT to_number('1', '9999.');
+to_number('1', '9999.')
+1
+SELECT to_number('1', '9999.9999');
+to_number('1', '9999.9999')
+1
+SELECT to_number('1', '9999.99990000');
+to_number('1', '9999.99990000')
+1
+SELECT to_number('1', '9999.00009999');
+to_number('1', '9999.00009999')
+1
+SELECT to_number('1', '9999.');
+to_number('1', '9999.')
+1
+SELECT to_number('1', '9999.9999');
+to_number('1', '9999.9999')
+1
+SELECT to_number('1', '9999.99990000');
+to_number('1', '9999.99990000')
+1
+SELECT to_number('1', '9999.00009999');
+to_number('1', '9999.00009999')
+1
+# The subject has more integer digits than the format
+SELECT to_number('111.1','9.9');
+to_number('111.1','9.9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='9.9' value: '111.1' for function to_number
+# The subject has more fractional digits than the format
+SELECT to_number('1.111','9.9');
+to_number('1.111','9.9')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='9.9' value: '1.111' for function to_number
+# Multiple dollar and B prefix flags are not allowed
+select to_number('$1','$$9.9');
+ERROR HY000: Incorrect <number format> value: '$ + $9.9' for function to_number
+select to_number('11','BB9.9');
+ERROR HY000: Incorrect <number format> value: 'B + B9.9' for function to_number
+#
+# Decimal starting with zeros
+#
+CREATE TABLE t1 (num VARCHAR(32), fmt VARCHAR(64));
+INSERT INTO t1 VALUES
+('1', '0.999'),
+('111', '000.999'),
+('111111','000999.999'),
+('11111111','00090909.999');
+SELECT to_number(num, fmt), fmt FROM t1;
+to_number(num, fmt)	fmt
+1	0.999
+111	000.999
+111111	000999.999
+11111111	00090909.999
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','D')), @fmt FROM t1;
+to_number(num, @fmt:=REPLACE(fmt,'.','D'))	@fmt
+NULL	0D999
+NULL	000D999
+NULL	000999D999
+NULL	00090909D999
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0D999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000D999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999D999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909D999''
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','V')), @fmt FROM t1;
+to_number(num, @fmt:=REPLACE(fmt,'.','V'))	@fmt
+NULL	0V999
+NULL	000V999
+NULL	000999V999
+NULL	00090909V999
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0V999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000V999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999V999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909V999''
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','C')), @fmt FROM t1;
+to_number(num, @fmt:=REPLACE(fmt,'.','C'))	@fmt
+NULL	0C999
+NULL	000C999
+NULL	000999C999
+NULL	00090909C999
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0C999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000C999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999C999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909C999''
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','L')), @fmt FROM t1;
+to_number(num, @fmt:=REPLACE(fmt,'.','L'))	@fmt
+NULL	0L999
+NULL	000L999
+NULL	000999L999
+NULL	00090909L999
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0L999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000L999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999L999''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909L999''
+DROP TABLE t1;
+#
+# Decimal + flags B/dollar + signs
+#
+SELECT to_number('-1', 'SB');
+to_number('-1', 'SB')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='SB' value: '-1' for function to_number
+SELECT to_number('-$1', 'S$');
+to_number('-$1', 'S$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$' value: '-$1' for function to_number
+SELECT to_number('-$1', 'SB$');
+to_number('-$1', 'SB$')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='SB$' value: '-$1' for function to_number
+SELECT to_number('-$1', 'S$B');
+to_number('-$1', 'S$B')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$B' value: '-$1' for function to_number
+SELECT to_number('1', 'BS');
+to_number('1', 'BS')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='BS' value: '1' for function to_number
+SELECT to_number('1', 'BMI');
+to_number('1', 'BMI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='BMI' value: '1' for function to_number
+SELECT to_number('1', 'BPR');
+to_number('1', 'BPR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='BPR' value: '1' for function to_number
+SELECT to_number('1', '$S');
+to_number('1', '$S')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$S' value: '1' for function to_number
+SELECT to_number('1', '$MI');
+to_number('1', '$MI')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$MI' value: '1' for function to_number
+SELECT to_number('1', '$PR');
+to_number('1', '$PR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$PR' value: '1' for function to_number
+SELECT to_number('1', 'BC');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BC''
+SELECT to_number('1', 'BL');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BL''
+SELECT to_number('1', 'BU');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BU''
+SELECT to_number('1', 'BC99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BC99''
+SELECT to_number('1', 'BL99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BL99''
+SELECT to_number('1', 'BU99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BU99''
+SELECT to_number('1', 'BV');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BV''
+SELECT to_number('1', 'BV99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BV99''
+SELECT to_number('1', '$V');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='$V''
+SELECT to_number('1', '$V99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='$V99''
+SELECT to_number('1', 'B.');
+to_number('1', 'B.')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B.' value: '1' for function to_number
+SELECT to_number('1', 'BD');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BD''
+SELECT to_number('1', 'B.99');
+to_number('1', 'B.99')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='B.99' value: '1' for function to_number
+SELECT to_number('1', 'BD99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='BD99''
+SELECT to_number('1', '$.');
+to_number('1', '$.')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$.' value: '1' for function to_number
+SELECT to_number('1', '$D');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='$D''
+SELECT to_number('1', '$.99');
+to_number('1', '$.99')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$.99' value: '1' for function to_number
+SELECT to_number('1', '$D99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='$D99''
+#
+# Number1 (i.e. not starting with zeros)
+#
+SELECT to_number('1', 'CB,999');
+ERROR HY000: Incorrect <number format> value: ',999' for function to_number
+SELECT to_number('1', 'CBG999');
+ERROR HY000: Incorrect <number format> value: 'G999' for function to_number
+SELECT to_number('1', 'C999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C999''
+SELECT to_number('1', 'C000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C000''
+SELECT to_number('1', 'CB999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CB999''
+SELECT to_number('1', 'CB000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CB000''
+SELECT to_number('1', 'C');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C''
+SELECT to_number('1', 'C.');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C.''
+SELECT to_number('1', 'CD');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CD''
+SELECT to_number('1', 'CV');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CV''
+SELECT to_number('1', 'C.99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C.99''
+SELECT to_number('1', 'CD99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CD99''
+SELECT to_number('1', 'CV99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CV99''
+SELECT to_number('1', 'CB.999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CB.999''
+SELECT to_number('1', 'CBD999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CBD999''
+SELECT to_number('1', 'CB');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='CB''
+SELECT to_number('1', 'L999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L999''
+SELECT to_number('1', 'L000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L000''
+SELECT to_number('1', 'LB999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LB999''
+SELECT to_number('1', 'LB000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LB000''
+SELECT to_number('1', 'L');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L''
+SELECT to_number('1', 'L.');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L.''
+SELECT to_number('1', 'LD');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LD''
+SELECT to_number('1', 'LV');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LV''
+SELECT to_number('1', 'L.99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L.99''
+SELECT to_number('1', 'LD99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LD99''
+SELECT to_number('1', 'LV99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LV99''
+SELECT to_number('1', 'LB.999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LB.999''
+SELECT to_number('1', 'LBD999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LBD999''
+SELECT to_number('1', 'LB');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='LB''
+SELECT to_number('1', 'U999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U999''
+SELECT to_number('1', 'U000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U000''
+SELECT to_number('1', 'UB999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UB999''
+SELECT to_number('1', 'UB000');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UB000''
+SELECT to_number('1', 'U');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U''
+SELECT to_number('1', 'U.');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U.''
+SELECT to_number('1', 'UD');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UD''
+SELECT to_number('1', 'UV');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UV''
+SELECT to_number('1', 'U.99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U.99''
+SELECT to_number('1', 'UD99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UD99''
+SELECT to_number('1', 'UV99');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UV99''
+SELECT to_number('1', 'UB.999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UB.999''
+SELECT to_number('1', 'UBD999');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UBD999''
+SELECT to_number('1', 'UB');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='UB''
+#
+# Number0: zeros + postfix sign
+#
+SELECT to_number('12-', '00S');
+to_number('12-', '00S')
+-12
+SELECT to_number('12+', '00S');
+to_number('12+', '00S')
+12
+SELECT to_number('12-', '00MI');
+to_number('12-', '00MI')
+-12
+SELECT to_number('12 ', '00MI');
+to_number('12 ', '00MI')
+12
+SELECT to_number('<12>', '00PR');
+to_number('<12>', '00PR')
+-12
+SELECT to_number(' 12 ', '00PR');
+to_number(' 12 ', '00PR')
+12
+SELECT to_number('[12]', '00PR');
+to_number('[12]', '00PR')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='00PR' value: '[12]' for function to_number
+SELECT to_number('<1234>', '999999PR') AS c1;
+c1
+-1234
+SELECT to_number(' 1234 ', '999999PR') AS c1;
+c1
+1234
+#
+# Postfix sign
+#
+SELECT to_number('12-', '99S');
+to_number('12-', '99S')
+-12
+SELECT to_number('12+', '99S');
+to_number('12+', '99S')
+12
+SELECT to_number('12-', '99MI');
+to_number('12-', '99MI')
+-12
+SELECT to_number('12 ', '99MI');
+to_number('12 ', '99MI')
+12
+SELECT to_number('<12>', '99PR');
+to_number('<12>', '99PR')
+-12
+SELECT to_number(' 12 ', '99PR');
+to_number(' 12 ', '99PR')
+12
+#
+# Prefix sign
+#
+SELECT to_number('-1', 'S');
+to_number('-1', 'S')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S' value: '-1' for function to_number
+SELECT to_number('-1', 'S00');
+to_number('-1', 'S00')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S00' value: '-1' for function to_number
+SELECT to_number('-12', 'S00');
+to_number('-12', 'S00')
+-12
+SELECT to_number('-1', 'S99');
+to_number('-1', 'S99')
+-1
+SELECT to_number('1', 'FMS');
+to_number('1', 'FMS')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FMS' value: '1' for function to_number
+SELECT to_number('-12', 'FMS00');
+to_number('-12', 'FMS00')
+-12
+SELECT to_number('-12', 'FMS99');
+to_number('-12', 'FMS99')
+-12
+SELECT to_number('1', 'SFM');
+to_number('1', 'SFM')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='SFM' value: '1' for function to_number
+SELECT to_number('-12', 'SFM00');
+to_number('-12', 'SFM00')
+-12
+SELECT to_number('-12', 'SFM99');
+to_number('-12', 'SFM99')
+-12
+#
+# Prefix-signed currency
+#
+# CLU are not supported yet
+SELECT to_number('1', 'S00.99C');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S00.99C''
+SELECT to_number('1', 'S99.99L');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99.99L''
+SELECT to_number('1', 'S99.99U');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99.99U''
+SELECT to_number('1', 'S00D99C');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S00D99C''
+SELECT to_number('1', 'S99D99L');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99D99L''
+SELECT to_number('1', 'S99D99U');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99D99U''
+SELECT to_number('-$12,345.67', 'S$999,099.99') AS c1;
+c1
+-12345.67
+SELECT to_number('+$12,345.67', 'S$999,099.99') AS c1;
+c1
+12345.67
+SELECT to_number('-$12,345.67', 'S$999,999.99') AS c1;
+c1
+-12345.67
+SELECT to_number('+$12,345.67', 'S$999,999.99') AS c1;
+c1
+12345.67
+SELECT to_number('$12,345.67', 'S$999,099.99')  AS c1, 'Missing sign' AS comment;
+c1	comment
+NULL	Missing sign
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '$12,345.67' for function to_number
+SELECT to_number('-$45', 'S$999,099.99') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '-$45' for function to_number
+SELECT to_number('+$45', 'S$999,099.99') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '+$45' for function to_number
+SELECT to_number('$45', 'S$999,099.99')  AS c1, 'Missing sign' AS comment;
+c1	comment
+NULL	Missing sign
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '$45' for function to_number
+SELECT to_number('-$45', 'S$999,999.99') AS c1;
+c1
+-45
+SELECT to_number('+$45', 'S$999,999.99') AS c1;
+c1
+45
+SELECT to_number('$45', 'S$999,999.99')  AS c1, 'Missing sign' AS comment;
+c1	comment
+NULL	Missing sign
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,999.99' value: '$45' for function to_number
+SELECT to_number('+$5', 'S$999,099.99') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '+$5' for function to_number
+SELECT to_number('+$45', 'S$999,099.99') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '+$45' for function to_number
+SELECT to_number('+$045', 'S$999,099.99') AS c1;
+c1
+45
+SELECT to_number('+$0,045', 'S$999,099.99') AS c1;
+c1
+45
+SELECT to_number('+$00,045', 'S$999,099.99') AS c1;
+c1
+45
+SELECT to_number('+$000,045', 'S$999,099.99') AS c1;
+c1
+45
+SELECT to_number('+$0000,045', 'S$999,099.99') AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='S$999,099.99' value: '+$0000,045' for function to_number
+#
+# FM
+#
+SELECT to_number('1', 'FM');
+to_number('1', 'FM')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='FM' value: '1' for function to_number
+SELECT to_number('1', 'FM9');
+to_number('1', 'FM9')
+1
+SELECT to_number('1,2', 'FM9,9');
+to_number('1,2', 'FM9,9')
+12
+SELECT to_number('1.2', 'FM9.9');
+to_number('1.2', 'FM9.9')
+1.2
+SELECT to_number('1-', 'FM9S');
+to_number('1-', 'FM9S')
+-1
+SELECT to_number('-1', 'FMS9');
+to_number('-1', 'FMS9')
+-1
+SELECT to_number('12-', 'FM00S');
+to_number('12-', 'FM00S')
+-12
+SELECT to_number('12-', 'FM99S');
+to_number('12-', 'FM99S')
+-12
+SELECT to_number('12-', 'FM99S');
+to_number('12-', 'FM99S')
+-12
+SELECT to_number('12-', 'FM00.99S');
+to_number('12-', 'FM00.99S')
+-12
+SELECT to_number('12-', 'FM99.99S');
+to_number('12-', 'FM99.99S')
+-12
+SELECT to_number('12-', 'FM99.99S');
+to_number('12-', 'FM99.99S')
+-12
+SELECT to_number('12.34-', 'FM00.99S');
+to_number('12.34-', 'FM00.99S')
+-12.34
+SELECT to_number('12.34-', 'FM99.99S');
+to_number('12.34-', 'FM99.99S')
+-12.34
+SELECT to_number('12.34-', 'FM99.99S');
+to_number('12.34-', 'FM99.99S')
+-12.34
+#
+# Long examples
+#
+SELECT to_number('123,456,789','999,999,999') AS c1;
+c1
+123456789
+SELECT to_number('111,222,333,444,555','999,999,999,999,999') AS c1;
+c1
+111222333444555
+SELECT to_number('111,222,333,444,555,666,777,888,999',
+'999,999,999,999,999,999,999,999,999') AS c1;
+c1
+1.1122233344455566e26
+#
+# EEEE specific tests
+#
+# EEEE cannot go without any integer digits
+SELECT to_number('', 'EEEE');
+ERROR HY000: Incorrect <number format> value: 'EEEE' for function to_number
+SELECT to_number('', '.EEEE');
+ERROR HY000: Incorrect <number format> value: '. + EEEE' for function to_number
+SELECT to_number('', '.9EEEE');
+ERROR HY000: Incorrect <number format> value: '.9 + EEEE' for function to_number
+SELECT to_number('1', '.999EEEE');
+ERROR HY000: Incorrect <number format> value: '.999 + EEEE' for function to_number
+SELECT to_number('1', '.9$9EEEE');
+ERROR HY000: Incorrect <number format> value: '.9$9 + EEEE' for function to_number
+SELECT to_number('1', '.9B9EEEE');
+ERROR HY000: Incorrect <number format> value: '.9B9 + EEEE' for function to_number
+SELECT to_number('1', '$EEEE');
+ERROR HY000: Incorrect <number format> value: 'EEEE' for function to_number
+SELECT to_number('1', 'BEEEE');
+ERROR HY000: Incorrect <number format> value: 'EEEE' for function to_number
+SELECT to_number('', 'S.9EEEE');
+ERROR HY000: Incorrect <number format> value: 'S.9 + EEEE' for function to_number
+SELECT to_number('', 'S.9EEEES');
+ERROR HY000: Incorrect <number format> value: 'S' for function to_number
+SELECT to_number('', 'FM.EEEE');
+ERROR HY000: Incorrect <number format> value: 'FM. + EEEE' for function to_number
+#
+# EEEE correct formats
+#
+# Currency CLU is not supported yet
+SELECT to_number('1', 'C0EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C0EEEE''
+SELECT to_number('1', 'L0EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L0EEEE''
+SELECT to_number('1', 'U0EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U0EEEE''
+SELECT to_number('1', 'C9EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='C9EEEE''
+SELECT to_number('1', 'L9EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='L9EEEE''
+SELECT to_number('1', 'U9EEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='U9EEEE''
+#
+# The following formats are not supported in Oracle.
+# However, it works if change C/L/U to dollar sign.
+# Looks like a bug in Oracle.
+# Anyway, CLU is not supported yet.
+#
+SELECT to_number('1', 'S00.99CEEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S00.99CEEEE''
+SELECT to_number('1', 'S99.99LEEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99.99LEEEE''
+SELECT to_number('1', 'S99.99UEEEE');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='S99.99UEEEE''
+# Trailing gargabe:
+SELECT to_number('1E+3x', '99EEEE');
+to_number('1E+3x', '99EEEE')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='99EEEE' value: '1E+3x' for function to_number
+SELECT to_number('$1E+3x', '$99EEEE');
+to_number('$1E+3x', '$99EEEE')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$99EEEE' value: '$1E+3x' for function to_number
+#
+# Simple examples with EEEE
+#
+SELECT to_number('1', '9EEEE');
+to_number('1', '9EEEE')
+1
+SELECT to_number('1', '9.9EEEE');
+to_number('1', '9.9EEEE')
+1
+SELECT to_number('1.2', '9.9EEEE');
+to_number('1.2', '9.9EEEE')
+1.2
+#
+# EEEE formats starting with zeros
+#
+SELECT to_number('1', '00EEEE');
+to_number('1', '00EEEE')
+1
+CREATE TABLE t1 (num VARCHAR(32), fmt VARCHAR(64));
+INSERT INTO t1 VALUES
+('1', '0.999'),
+('111', '000.999'),
+('111111','000999.999'),
+('11111111','00090909.999');
+SELECT to_number(num, @fmt:=CONCAT(fmt,'EEEE')), @fmt FROM t1;
+to_number(num, @fmt:=CONCAT(fmt,'EEEE'))	@fmt
+1	0.999EEEE
+111	000.999EEEE
+111111	000999.999EEEE
+11111111	00090909.999EEEE
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','D'),'EEEE')), @fmt FROM t1;
+to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','D'),'EEEE'))	@fmt
+NULL	0D999EEEE
+NULL	000D999EEEE
+NULL	000999D999EEEE
+NULL	00090909D999EEEE
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0D999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000D999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999D999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909D999EEEE''
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','V'),'EEEE')), @fmt FROM t1;
+to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','V'),'EEEE'))	@fmt
+NULL	0V999EEEE
+NULL	000V999EEEE
+NULL	000999V999EEEE
+NULL	00090909V999EEEE
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0V999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000V999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999V999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909V999EEEE''
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','C'),'EEEE')), @fmt FROM t1;
+to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','C'),'EEEE'))	@fmt
+NULL	0C999EEEE
+NULL	000C999EEEE
+NULL	000999C999EEEE
+NULL	00090909C999EEEE
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0C999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000C999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999C999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909C999EEEE''
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','L'),'EEEE')), @fmt FROM t1;
+to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','L'),'EEEE'))	@fmt
+NULL	0L999EEEE
+NULL	000L999EEEE
+NULL	000999L999EEEE
+NULL	00090909L999EEEE
+Warnings:
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='0L999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000L999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='000999L999EEEE''
+Warning	1235	This version of MariaDB doesn't yet support '<number format>='00090909L999EEEE''
+DROP TABLE t1;
+#
+# B and dollar inside a EEEE format
+#
+SELECT to_number('1', 'B0EEEE');
+to_number('1', 'B0EEEE')
+1
+SELECT to_number('1', 'B9EEEE');
+to_number('1', 'B9EEEE')
+1
+SELECT to_number('1', 'B0.EEEE');
+to_number('1', 'B0.EEEE')
+1
+SELECT to_number('1', 'B9.EEEE');
+to_number('1', 'B9.EEEE')
+1
+SELECT to_number('1', 'B0.9EEEE');
+to_number('1', 'B0.9EEEE')
+1
+SELECT to_number('1', 'B9.9EEEE');
+to_number('1', 'B9.9EEEE')
+1
+SELECT to_number('$1E+1', '$0EEEE');
+to_number('$1E+1', '$0EEEE')
+10
+SELECT to_number('$1E+1', '$9EEEE');
+to_number('$1E+1', '$9EEEE')
+10
+SELECT to_number('$1E+1', '$0.EEEE');
+to_number('$1E+1', '$0.EEEE')
+10
+SELECT to_number('$1E+1', '$9.EEEE');
+to_number('$1E+1', '$9.EEEE')
+10
+SELECT to_number('$1.E+1', '$0.EEEE');
+to_number('$1.E+1', '$0.EEEE')
+10
+SELECT to_number('$1.E+1', '$9.EEEE');
+to_number('$1.E+1', '$9.EEEE')
+10
+SELECT to_number('$1.2E+1', '$0.EEEE');
+to_number('$1.2E+1', '$0.EEEE')
+12
+SELECT to_number('$1.2E+1', '$9.EEEE');
+to_number('$1.2E+1', '$9.EEEE')
+12
+SELECT to_number('$1.2E+1', '$0.9EEEE');
+to_number('$1.2E+1', '$0.9EEEE')
+12
+SELECT to_number('$1.2E+1', '$9.9EEEE');
+to_number('$1.2E+1', '$9.9EEEE')
+12
+SELECT to_number('1', '999EEEE');
+to_number('1', '999EEEE')
+1
+SELECT to_number('1', '999.EEEE');
+to_number('1', '999.EEEE')
+1
+SELECT to_number('1', '999.9999EEEE');
+to_number('1', '999.9999EEEE')
+1
+SELECT to_number ('$1', '9$9EEEE');
+to_number ('$1', '9$9EEEE')
+1
+SELECT to_number ('$1', '9$9.EEEE');
+to_number ('$1', '9$9.EEEE')
+1
+SELECT to_number('1', '9B9EEEE');
+to_number('1', '9B9EEEE')
+1
+SELECT to_number('1', '9B9.EEEE');
+to_number('1', '9B9.EEEE')
+1
+#
+# EEEE formats with prefix and postfix signs and FM
+#
+SELECT to_number('1.2E+1-',  '99EEEES');
+to_number('1.2E+1-',  '99EEEES')
+-12
+SELECT to_number('1.2E+1+',  '99EEEES');
+to_number('1.2E+1+',  '99EEEES')
+12
+SELECT to_number('1.2E+1-',  '99EEEEMI');
+to_number('1.2E+1-',  '99EEEEMI')
+-12
+SELECT to_number('1.2E+1 ',  '99EEEEMI');
+to_number('1.2E+1 ',  '99EEEEMI')
+12
+SELECT to_number('<1.2E+1>', '99EEEEPR');
+to_number('<1.2E+1>', '99EEEEPR')
+-12
+SELECT to_number(' 1.2E+1 ', '99EEEEPR');
+to_number(' 1.2E+1 ', '99EEEEPR')
+12
+SELECT to_number('-12.34E+2', 'S00.99EEEE');
+to_number('-12.34E+2', 'S00.99EEEE')
+-1234
+SELECT to_number('-12.34E+2', 'S99.99EEEE');
+to_number('-12.34E+2', 'S99.99EEEE')
+-1234
+SELECT to_number('$1.2E+1-',  '$9.9EEEES');
+to_number('$1.2E+1-',  '$9.9EEEES')
+-12
+SELECT to_number('$1.2E+1+',  '$9.9EEEES');
+to_number('$1.2E+1+',  '$9.9EEEES')
+12
+SELECT to_number('$1.2E+1-',  '$9.9EEEEMI');
+to_number('$1.2E+1-',  '$9.9EEEEMI')
+-12
+SELECT to_number('$1.2E+1 ',  '$9.9EEEEMI');
+to_number('$1.2E+1 ',  '$9.9EEEEMI')
+12
+SELECT to_number('<$1.2E+1>', '$9.9EEEEPR');
+to_number('<$1.2E+1>', '$9.9EEEEPR')
+-12
+SELECT to_number(' $1.2E+1 ', '$9.9EEEEPR');
+to_number(' $1.2E+1 ', '$9.9EEEEPR')
+12
+SELECT to_number('12.34E+2-', 'FM00.99EEEES');
+to_number('12.34E+2-', 'FM00.99EEEES')
+-1234
+SELECT to_number('12.34E+2-', 'FM99.99EEEES');
+to_number('12.34E+2-', 'FM99.99EEEES')
+-1234
+#
+# X formats (hexadecimal)
+#
+# X cannot co-exist with dollar, B, dec, group, signs, currency
+SELECT to_number('0', '$X');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'BX');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'X,X');
+ERROR HY000: Incorrect <number format> value: ',X' for function to_number
+SELECT to_number('0', 'XGX');
+ERROR HY000: Incorrect <number format> value: 'GX' for function to_number
+SELECT to_number('0', 'X.X');
+ERROR HY000: Incorrect <number format> value: '.X' for function to_number
+SELECT to_number('0', 'XCX');
+ERROR HY000: Incorrect <number format> value: 'CX' for function to_number
+SELECT to_number('0', 'XLX');
+ERROR HY000: Incorrect <number format> value: 'LX' for function to_number
+SELECT to_number('0', 'XUX');
+ERROR HY000: Incorrect <number format> value: 'UX' for function to_number
+SELECT to_number('0', 'SX');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', '$X');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'CX');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'LX');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'UX');
+ERROR HY000: Incorrect <number format> value: 'X' for function to_number
+SELECT to_number('0', 'X$');
+ERROR HY000: Incorrect <number format> value: '$' for function to_number
+SELECT to_number('0', 'XC');
+ERROR HY000: Incorrect <number format> value: 'C' for function to_number
+SELECT to_number('0', 'XL');
+ERROR HY000: Incorrect <number format> value: 'L' for function to_number
+SELECT to_number('0', 'XU');
+ERROR HY000: Incorrect <number format> value: 'U' for function to_number
+SELECT to_number('0', 'XMI');
+ERROR HY000: Incorrect <number format> value: 'MI' for function to_number
+SELECT to_number('0', 'XPR');
+ERROR HY000: Incorrect <number format> value: 'PR' for function to_number
+SELECT to_number('0', 'XS');
+ERROR HY000: Incorrect <number format> value: 'S' for function to_number
+#
+# FM and X can co-exist
+#
+SELECT to_number('F', 'FMXXXX');
+to_number('F', 'FMXXXX')
+15
+SELECT to_number('FF', 'FMXXXX');
+to_number('FF', 'FMXXXX')
+255
+SELECT to_number('FFF', 'FMXXXX');
+to_number('FFF', 'FMXXXX')
+4095
+SELECT to_number('FFFF', 'FMXXXX');
+to_number('FFFF', 'FMXXXX')
+65535
+#
+# X simple exaples
+#
+SELECT to_number('0', 'X');
+to_number('0', 'X')
+0
+SELECT to_number('20', 'XX');
+to_number('20', 'XX')
+32
+SELECT to_number('020', 'XXX');
+to_number('020', 'XXX')
+32
+SELECT to_number('2020', 'XXXX');
+to_number('2020', 'XXXX')
+8224
+SELECT to_number('02020', 'XXXXX');
+to_number('02020', 'XXXXX')
+8224
+SELECT to_number('202020', 'XXXXXX');
+to_number('202020', 'XXXXXX')
+2105376
+SELECT to_number('202020', 'XXXXX');
+to_number('202020', 'XXXXX')
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='XXXXX' value: '202020' for function to_number
+#
+# Zeros + xchain
+#
+SELECT to_number('061', '00X');
+to_number('061', '00X')
+97
+SELECT to_number('0061', '00XX');
+to_number('0061', '00XX')
+97
+SELECT to_number('00061', '00XXX');
+to_number('00061', '00XXX')
+97
+SELECT to_number('000061', '00XXXX');
+to_number('000061', '00XXXX')
+97
+SELECT to_number('0000061', '00XXXXX');
+to_number('0000061', '00XXXXX')
+97
+SELECT to_number('00000061', '00XXXXXX');
+to_number('00000061', '00XXXXXX')
+97
+#
+# 0 vs X
+#
+CREATE TABLE t1 (fmt VARCHAR(32));
+CREATE TABLE t2 (sbj VARCHAR(32));
+FOR i IN 0..3 DO
+INSERT INTO t1 VALUES (CONCAT(REPEAT('0',i), REPEAT('X',4-i)));
+END FOR;
+$$
+FOR i IN 0..4 DO
+INSERT INTO t2 VALUES (REPEAT('1',i));
+END FOR;
+$$
+SELECT fmt, sbj, to_number(sbj, fmt) AS c1 FROM t1, t2 ORDER BY fmt, sbj;
+fmt	sbj	c1
+000X		NULL
+000X	1	NULL
+000X	11	NULL
+000X	111	NULL
+000X	1111	4369
+00XX		NULL
+00XX	1	NULL
+00XX	11	NULL
+00XX	111	NULL
+00XX	1111	4369
+0XXX		NULL
+0XXX	1	NULL
+0XXX	11	NULL
+0XXX	111	NULL
+0XXX	1111	4369
+XXXX		NULL
+XXXX	1	1
+XXXX	11	17
+XXXX	111	273
+XXXX	1111	4369
+DROP TABLE t1, t2;
+#
+# Format TM is not supported by to_number(), only supported by to_char()
+#
+SELECT to_number('1', 'TM');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='TM''
+SELECT to_number('1', 'TM9');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='TM9''
+SELECT to_number('1', 'TME');
+ERROR 42000: This version of MariaDB doesn't yet support '<number format>='TME''

--- a/mysql-test/main/func_numconv.test
+++ b/mysql-test/main/func_numconv.test
@@ -1,0 +1,953 @@
+--echo #
+--echo # MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+--echo #
+
+--echo #
+--echo # to_number() with one argument
+--echo #
+
+--error ER_OPERAND_COLUMNS
+SELECT to_number(ROW(1,1));
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPE_FOR_OPERATION
+SELECT to_number(point(1,1));
+
+--echo # With one arg, to_number() works similarly CAST(expr AS DOUBLE)
+CREATE TABLE t1 AS SELECT
+  to_number('123') AS c1,
+  to_number(123) AS c2,
+  to_number(123e0) AS c3,
+  to_number(123.0) AS c4;
+SHOW COLUMNS IN t1;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+# However, it returns NULL in case of
+# empty input, out of range values, trailing garbage
+
+SELECT to_number('') AS c1;
+SELECT to_number('1E+400') AS c1;
+SELECT to_number('123x') AS c1;
+
+
+--echo #
+--echo # With two args only string+string are allowed
+--echo #
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number(point(1,1), '');
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number('',point(1,1));
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number(1,'');
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number('',1);
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number(1e0,'');
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT to_number('',1e0);
+
+
+--echo #
+--echo # Multiple dollar or B signs are not allowed
+--echo #
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '99$99$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '$9999$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '$9.99$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '9$9.9$99EEEE');
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '99B99B');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'B99B99B');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'B999B');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'B9.99B');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '9B9.9B99EEEE');
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '.9$9BB$0B');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '.0$0BB$9B');
+
+--echo # Comma and G cannot co-exist
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '9G9,9G9');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '9,9G9,9');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '0G0,0G0');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '0,0G0,0');
+
+
+--echo #
+--echo # Dollar and C,L,U cannot co-exist
+--echo #
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$U');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$C99');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$L99');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$U99');
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '0$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '0$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '0$U');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '9$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '9$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '9$U');
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'C0$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'L0$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'U0$');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.$U');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'D$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'D$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'D$U');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'V$C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'V$L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'V$U');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$.C');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$.L');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$.U');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$DC');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$DL');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$DU');
+--error ER_WRONG_VALUE_FOR_TYPE
+
+
+--echo #
+--echo # Test that non-constant wrong formats raise a warning (not an error)
+--echo #
+
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES ('$999$'),('C999');
+SELECT to_number('9999', fmt) FROM t1;
+DROP TABLE t1;
+
+
+--echo #
+--echo # An empty format is allowed and returns NULL
+--echo #
+
+SELECT to_number('', '');
+SELECT to_number('1', '');
+
+
+--echo #
+--echo # B/dollar can go alone, in combination, with FM, and return NULL
+--echo #
+
+SELECT to_number('1', 'B');
+SELECT to_number('1', '$');
+SELECT to_number('1', 'B$');
+SELECT to_number('1', '$B');
+
+SELECT to_number('$', '$');
+SELECT to_number('$', 'B$');
+SELECT to_number('$', '$B');
+
+SELECT to_number('1', 'FMB');
+SELECT to_number('1', 'FM$');
+SELECT to_number('1', 'FMB$');
+SELECT to_number('1', 'FM$B');
+
+SELECT to_number('$', 'FM$');
+SELECT to_number('$', 'FMB$');
+SELECT to_number('$', 'FM$B');
+
+
+--echo #
+--echo # . can go alone
+--echo #
+
+SELECT to_number('.', '.');
+SELECT to_number('1', '.');
+
+
+--echo #
+--echo # 'S', 'MI', 'PR' alone are allowed (optionally with FM), NULL returned
+--echo #
+
+SELECT to_number('-', 'S');
+SELECT to_number('-', 'MI');
+SELECT to_number('<>', 'PR');
+SELECT to_number('-', 'FMS');
+SELECT to_number('-', 'SFM');
+SELECT to_number('-', 'FMMI');
+SELECT to_number('<>', 'FMPR');
+
+SELECT to_number('1', 'S');
+SELECT to_number('1', 'MI');
+SELECT to_number('1', 'PR');
+SELECT to_number('1', 'FMMI');
+SELECT to_number('1', 'FMPR');
+
+
+--echo #
+--echo # Integer
+--echo #
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'x999');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '999x');
+
+--echo # Correct formats
+
+SELECT to_number('1', '999');
+
+SELECT to_number('$12', '$99');
+SELECT to_number('$12', '9$9');
+SELECT to_number('$12', '99$');
+
+SELECT to_number('1', 'B99');
+SELECT to_number('1', '9B9');
+SELECT to_number('1', '99B');
+
+SELECT to_number('$1', 'B$9');
+SELECT to_number('$1', '9B$');
+
+SELECT to_number('$1', '$B9');
+SELECT to_number('$1', '9$B');
+
+SELECT to_number('1', '9,9,9,9');
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '9G9G9G9');
+SELECT to_number('1', '0000');
+SELECT to_number('1', '0,0,0,0');
+SELECT to_number('1', '9999');
+SELECT to_number('1', '9,9,9,9');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '0G0G0G0');
+
+SELECT to_number('1', '00009999');
+SELECT to_number('1', '99999999');
+SELECT to_number('1', '0,0,0,0,9,9,9,9');
+SELECT to_number('1', '9,9,9,9,9,9,9,9');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '0G0G0G0G9G9G9G9');
+
+SELECT to_number('1', '99990000');
+SELECT to_number('1', '99999999');
+SELECT to_number('1', '9,9,9,9,0,0,0,0');
+SELECT to_number('1', '9,9,9,9,9,9,9,9');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '9G9G9G9G0G0G0G0');
+
+SELECT to_number('123456.123456', '999999.999999') AS c1;
+SELECT to_number('123,456.123456', '999,999.999999') AS c1;
+SELECT to_number('1,2,3,4,5,6.123456', '9,9,9,9,9,9.999999') AS c1;
+
+--echo #
+--echo # Integer: 0 vs 9
+--echo #
+
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES
+('0'),('9'),
+('00'),('09'),('90'),('99'),
+('000'),('009'),('090'),('099'), ('900'),('909'),('990'),('999');
+CREATE TABLE t2 (sbj VARCHAR(32));
+INSERT INTO t2 VALUES ('0'),('00'),('000'),('0000');
+
+--echo # Expect NULL if
+--echo # - the subject is shorter than the format, or
+--echo # - if there's a format 0 outside of the subject length
+
+SELECT
+  fmt, sbj, to_number(sbj,fmt),
+  IF(length(fmt)<length(sbj) OR
+     (fmt LIKE '0_' AND sbj LIKE '_') OR
+     (fmt LIKE '0__' AND sbj LIKE '__') OR
+     (fmt LIKE '0__' AND sbj LIKE '_') OR
+     (fmt LIKE '_0_' AND sbj LIKE '_'),
+     'Expect NULL','') AS comment
+FROM t1, t2
+WHERE length(fmt)>=length(sbj)
+ORDER BY length(fmt),fmt,sbj;
+
+DROP TABLE t1, t2;
+
+
+--echo #
+--echo # Fraction
+--echo #
+
+SELECT to_number('.', '.');
+SELECT to_number('.', 'B.');
+SELECT to_number('.', 'B.9');
+SELECT to_number('.1', 'B.9');
+
+SELECT to_number('1', 'B.');
+SELECT to_number('1', 'B.9');
+
+
+--echo #
+--echo # Fraction + dollar
+--echo #
+
+SELECT to_number('$.', '$.');
+SELECT to_number('1', '$.');
+
+SELECT to_number('.1', '.9999');
+SELECT to_number('.1', '.99990000');
+SELECT to_number('$.1', '.9$9B');
+
+SELECT to_number('.1', '.0000');
+SELECT to_number('.1', '.00009999');
+SELECT to_number('$.1', '.0$0B');
+
+SELECT to_number('1', '$.9');
+SELECT to_number('1', '$.9');
+
+
+--echo #
+--echo # Decimal
+--echo #
+
+SELECT to_number('1', '9999.');
+SELECT to_number('1', '9999.9999');
+SELECT to_number('1', '9999.99990000');
+SELECT to_number('1', '9999.00009999');
+
+SELECT to_number('1', '9999.');
+SELECT to_number('1', '9999.9999');
+SELECT to_number('1', '9999.99990000');
+SELECT to_number('1', '9999.00009999');
+
+--echo # The subject has more integer digits than the format
+SELECT to_number('111.1','9.9');
+
+--echo # The subject has more fractional digits than the format
+SELECT to_number('1.111','9.9');
+
+--echo # Multiple dollar and B prefix flags are not allowed
+--error ER_WRONG_VALUE_FOR_TYPE
+select to_number('$1','$$9.9');
+--error ER_WRONG_VALUE_FOR_TYPE
+select to_number('11','BB9.9');
+
+--echo #
+--echo # Decimal starting with zeros
+--echo #
+
+CREATE TABLE t1 (num VARCHAR(32), fmt VARCHAR(64));
+INSERT INTO t1 VALUES
+('1', '0.999'),
+('111', '000.999'),
+('111111','000999.999'),
+('11111111','00090909.999');
+
+SELECT to_number(num, fmt), fmt FROM t1;
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','D')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','V')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','C')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=REPLACE(fmt,'.','L')), @fmt FROM t1;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # Decimal + flags B/dollar + signs
+--echo #
+
+# B/$ can follow a leading sign
+SELECT to_number('-1', 'SB');
+SELECT to_number('-$1', 'S$');
+SELECT to_number('-$1', 'SB$');
+SELECT to_number('-$1', 'S$B');
+
+# B/$ can be followed by a trailing sign
+SELECT to_number('1', 'BS');
+SELECT to_number('1', 'BMI');
+SELECT to_number('1', 'BPR');
+SELECT to_number('1', '$S');
+SELECT to_number('1', '$MI');
+SELECT to_number('1', '$PR');
+
+# B/$ can be followed a currency
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BC');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BL');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BU');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BC99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BL99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BU99');
+
+# B/$ can be followed a V
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BV');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BV99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '$V');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '$V99');
+
+# B/$ can be followed a decimal point
+SELECT to_number('1', 'B.');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BD');
+SELECT to_number('1', 'B.99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'BD99');
+
+SELECT to_number('1', '$.');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '$D');
+SELECT to_number('1', '$.99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', '$D99');
+
+
+--echo #
+--echo # Number1 (i.e. not starting with zeros)
+--echo #
+
+# Positional_currency+B cannot be followed by ,G
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'CB,999');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'CBG999');
+
+
+# Correct formats
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CB999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CB000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C.');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CD');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CV');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C.99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CD99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CV99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CB.999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CBD999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'CB');
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LB999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LB000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L.');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LD');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LV');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L.99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LD99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LV99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LB.999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LBD999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'LB');
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UB999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UB000');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U.');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UD');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UV');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U.99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UD99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UV99');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UB.999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UBD999');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'UB');
+
+
+--echo #
+--echo # Number0: zeros + postfix sign
+--echo #
+
+SELECT to_number('12-', '00S');
+SELECT to_number('12+', '00S');
+SELECT to_number('12-', '00MI');
+SELECT to_number('12 ', '00MI');
+SELECT to_number('<12>', '00PR');
+SELECT to_number(' 12 ', '00PR');
+SELECT to_number('[12]', '00PR');
+
+SELECT to_number('<1234>', '999999PR') AS c1;
+SELECT to_number(' 1234 ', '999999PR') AS c1;
+
+
+--echo #
+--echo # Postfix sign
+--echo #
+
+SELECT to_number('12-', '99S');
+SELECT to_number('12+', '99S');
+SELECT to_number('12-', '99MI');
+SELECT to_number('12 ', '99MI');
+SELECT to_number('<12>', '99PR');
+SELECT to_number(' 12 ', '99PR');
+
+--echo #
+--echo # Prefix sign
+--echo #
+
+SELECT to_number('-1', 'S');
+SELECT to_number('-1', 'S00');
+SELECT to_number('-12', 'S00');
+SELECT to_number('-1', 'S99');
+
+SELECT to_number('1', 'FMS');
+SELECT to_number('-12', 'FMS00');
+SELECT to_number('-12', 'FMS99');
+
+SELECT to_number('1', 'SFM');
+SELECT to_number('-12', 'SFM00');
+SELECT to_number('-12', 'SFM99');
+
+
+--echo #
+--echo # Prefix-signed currency
+--echo #
+
+--echo # CLU are not supported yet
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S00.99C');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99.99L');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99.99U');
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S00D99C');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99D99L');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99D99U');
+
+
+SELECT to_number('-$12,345.67', 'S$999,099.99') AS c1;
+SELECT to_number('+$12,345.67', 'S$999,099.99') AS c1;
+SELECT to_number('-$12,345.67', 'S$999,999.99') AS c1;
+SELECT to_number('+$12,345.67', 'S$999,999.99') AS c1;
+SELECT to_number('$12,345.67', 'S$999,099.99')  AS c1, 'Missing sign' AS comment;
+
+SELECT to_number('-$45', 'S$999,099.99') AS c1;
+SELECT to_number('+$45', 'S$999,099.99') AS c1;
+SELECT to_number('$45', 'S$999,099.99')  AS c1, 'Missing sign' AS comment;
+
+SELECT to_number('-$45', 'S$999,999.99') AS c1;
+SELECT to_number('+$45', 'S$999,999.99') AS c1;
+SELECT to_number('$45', 'S$999,999.99')  AS c1, 'Missing sign' AS comment;
+
+SELECT to_number('+$5', 'S$999,099.99') AS c1;
+SELECT to_number('+$45', 'S$999,099.99') AS c1;
+SELECT to_number('+$045', 'S$999,099.99') AS c1;
+SELECT to_number('+$0,045', 'S$999,099.99') AS c1;
+SELECT to_number('+$00,045', 'S$999,099.99') AS c1;
+SELECT to_number('+$000,045', 'S$999,099.99') AS c1;
+SELECT to_number('+$0000,045', 'S$999,099.99') AS c1;
+
+
+--echo #
+--echo # FM
+--echo #
+
+SELECT to_number('1', 'FM');
+SELECT to_number('1', 'FM9');
+SELECT to_number('1,2', 'FM9,9');
+SELECT to_number('1.2', 'FM9.9');
+SELECT to_number('1-', 'FM9S');
+SELECT to_number('-1', 'FMS9');
+
+SELECT to_number('12-', 'FM00S');
+SELECT to_number('12-', 'FM99S');
+SELECT to_number('12-', 'FM99S');
+SELECT to_number('12-', 'FM00.99S');
+SELECT to_number('12-', 'FM99.99S');
+SELECT to_number('12-', 'FM99.99S');
+SELECT to_number('12.34-', 'FM00.99S');
+SELECT to_number('12.34-', 'FM99.99S');
+SELECT to_number('12.34-', 'FM99.99S');
+
+
+--echo #
+--echo # Long examples
+--echo #
+
+SELECT to_number('123,456,789','999,999,999') AS c1;
+SELECT to_number('111,222,333,444,555','999,999,999,999,999') AS c1;
+SELECT to_number('111,222,333,444,555,666,777,888,999',
+                 '999,999,999,999,999,999,999,999,999') AS c1;
+
+
+--echo #
+--echo # EEEE specific tests
+--echo #
+
+--echo # EEEE cannot go without any integer digits
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', 'EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', '.EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', '.9EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.999EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.9$9EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '.9B9EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', '$EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('1', 'BEEEE');
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', 'S.9EEEE');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', 'S.9EEEES');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('', 'FM.EEEE');
+
+--echo #
+--echo # EEEE correct formats
+--echo #
+
+--echo # Currency CLU is not supported yet
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C0EEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L0EEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U0EEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'C9EEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'L9EEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'U9EEEE');
+
+--echo #
+--echo # The following formats are not supported in Oracle.
+--echo # However, it works if change C/L/U to dollar sign.
+--echo # Looks like a bug in Oracle.
+--echo # Anyway, CLU is not supported yet.
+--echo #
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S00.99CEEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99.99LEEEE');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'S99.99UEEEE');
+
+--echo # Trailing gargabe:
+SELECT to_number('1E+3x', '99EEEE');
+SELECT to_number('$1E+3x', '$99EEEE');
+
+
+--echo #
+--echo # Simple examples with EEEE
+--echo #
+
+SELECT to_number('1', '9EEEE');
+SELECT to_number('1', '9.9EEEE');
+SELECT to_number('1.2', '9.9EEEE');
+
+--echo #
+--echo # EEEE formats starting with zeros
+--echo #
+
+SELECT to_number('1', '00EEEE');
+
+CREATE TABLE t1 (num VARCHAR(32), fmt VARCHAR(64));
+INSERT INTO t1 VALUES
+('1', '0.999'),
+('111', '000.999'),
+('111111','000999.999'),
+('11111111','00090909.999');
+
+SELECT to_number(num, @fmt:=CONCAT(fmt,'EEEE')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','D'),'EEEE')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','V'),'EEEE')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','C'),'EEEE')), @fmt FROM t1;
+SELECT to_number(num, @fmt:=CONCAT(REPLACE(fmt,'.','L'),'EEEE')), @fmt FROM t1;
+
+DROP TABLE t1;
+
+--echo #
+--echo # B and dollar inside a EEEE format
+--echo #
+
+SELECT to_number('1', 'B0EEEE');
+SELECT to_number('1', 'B9EEEE');
+SELECT to_number('1', 'B0.EEEE');
+SELECT to_number('1', 'B9.EEEE');
+SELECT to_number('1', 'B0.9EEEE');
+SELECT to_number('1', 'B9.9EEEE');
+
+SELECT to_number('$1E+1', '$0EEEE');
+SELECT to_number('$1E+1', '$9EEEE');
+SELECT to_number('$1E+1', '$0.EEEE');
+SELECT to_number('$1E+1', '$9.EEEE');
+SELECT to_number('$1.E+1', '$0.EEEE');
+SELECT to_number('$1.E+1', '$9.EEEE');
+SELECT to_number('$1.2E+1', '$0.EEEE');
+SELECT to_number('$1.2E+1', '$9.EEEE');
+SELECT to_number('$1.2E+1', '$0.9EEEE');
+SELECT to_number('$1.2E+1', '$9.9EEEE');
+
+SELECT to_number('1', '999EEEE');
+SELECT to_number('1', '999.EEEE');
+SELECT to_number('1', '999.9999EEEE');
+
+SELECT to_number ('$1', '9$9EEEE');
+SELECT to_number ('$1', '9$9.EEEE');
+
+SELECT to_number('1', '9B9EEEE');
+SELECT to_number('1', '9B9.EEEE');
+
+
+--echo #
+--echo # EEEE formats with prefix and postfix signs and FM
+--echo #
+
+SELECT to_number('1.2E+1-',  '99EEEES');
+SELECT to_number('1.2E+1+',  '99EEEES');
+SELECT to_number('1.2E+1-',  '99EEEEMI');
+SELECT to_number('1.2E+1 ',  '99EEEEMI');
+SELECT to_number('<1.2E+1>', '99EEEEPR');
+SELECT to_number(' 1.2E+1 ', '99EEEEPR');
+
+SELECT to_number('-12.34E+2', 'S00.99EEEE');
+SELECT to_number('-12.34E+2', 'S99.99EEEE');
+
+SELECT to_number('$1.2E+1-',  '$9.9EEEES');
+SELECT to_number('$1.2E+1+',  '$9.9EEEES');
+SELECT to_number('$1.2E+1-',  '$9.9EEEEMI');
+SELECT to_number('$1.2E+1 ',  '$9.9EEEEMI');
+SELECT to_number('<$1.2E+1>', '$9.9EEEEPR');
+# Oracle returns an error on ' $1.2E+1 '
+# but works with ' $1.2E+1' in the next
+# Looks like a bug in Oracle:
+SELECT to_number(' $1.2E+1 ', '$9.9EEEEPR');
+
+SELECT to_number('12.34E+2-', 'FM00.99EEEES');
+SELECT to_number('12.34E+2-', 'FM99.99EEEES');
+
+
+--echo #
+--echo # X formats (hexadecimal)
+--echo #
+
+--echo # X cannot co-exist with dollar, B, dec, group, signs, currency
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '$X');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'BX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'X,X');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XGX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'X.X');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XCX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XLX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XUX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'SX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', '$X');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'CX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'LX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'UX');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'X$');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XC');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XL');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XU');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XMI');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XPR');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('0', 'XS');
+
+
+--echo #
+--echo # FM and X can co-exist
+--echo #
+
+SELECT to_number('F', 'FMXXXX');
+SELECT to_number('FF', 'FMXXXX');
+SELECT to_number('FFF', 'FMXXXX');
+SELECT to_number('FFFF', 'FMXXXX');
+
+
+--echo #
+--echo # X simple exaples
+--echo #
+
+SELECT to_number('0', 'X');
+SELECT to_number('20', 'XX');
+SELECT to_number('020', 'XXX');
+SELECT to_number('2020', 'XXXX');
+SELECT to_number('02020', 'XXXXX');
+SELECT to_number('202020', 'XXXXXX');
+SELECT to_number('202020', 'XXXXX');
+
+
+--echo #
+--echo # Zeros + xchain
+--echo #
+
+SELECT to_number('061', '00X');
+SELECT to_number('0061', '00XX');
+SELECT to_number('00061', '00XXX');
+SELECT to_number('000061', '00XXXX');
+SELECT to_number('0000061', '00XXXXX');
+SELECT to_number('00000061', '00XXXXXX');
+
+--echo #
+--echo # 0 vs X
+--echo #
+
+CREATE TABLE t1 (fmt VARCHAR(32));
+CREATE TABLE t2 (sbj VARCHAR(32));
+DELIMITER $$;
+FOR i IN 0..3 DO
+  INSERT INTO t1 VALUES (CONCAT(REPEAT('0',i), REPEAT('X',4-i)));
+END FOR;
+$$
+FOR i IN 0..4 DO
+  INSERT INTO t2 VALUES (REPEAT('1',i));
+END FOR;
+$$
+DELIMITER ;$$
+--disable_warnings
+SELECT fmt, sbj, to_number(sbj, fmt) AS c1 FROM t1, t2 ORDER BY fmt, sbj;
+--enable_warnings
+DROP TABLE t1, t2;
+
+
+--echo #
+--echo # Format TM is not supported by to_number(), only supported by to_char()
+--echo #
+
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'TM');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'TM9');
+--error ER_NOT_SUPPORTED_YET
+SELECT to_number('1', 'TME');

--- a/mysql-test/main/func_numconv_format.result
+++ b/mysql-test/main/func_numconv_format.result
@@ -1,0 +1,100 @@
+SET @saved_debug_dbug= @@debug_dbug;
+SET @@debug_dbug='+d,numconv_format';
+#
+# MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+#
+CREATE FUNCTION bad(fmt VARCHAR(128)) RETURNS VARCHAR(128)
+BEGIN
+IF fmt RLIKE '(FM.*FM|B.*B|EEEE.*EEEE|[CLU$].*[CLU$]|[.VD].*[.VD]|(S|MI|PR).*(S|MI|PR))'
+  THEN
+RETURN 'FM/B/currency/dec/sign cannot repeat';
+END IF;
+IF fmt RLIKE '[09XBCDLUV,G.$].*FM' THEN RETURN 'Unexpected + FM'; END IF;
+IF fmt RLIKE '^[^09]*([.DV].*)?EEEE'         THEN RETURN 'EEEE with no int digits #1'; END IF;
+IF fmt RLIKE '^(FM|S)?[$B]+[CLU][0-9]*EEEE'  THEN RETURN 'EEEE with no int digits #2'; END IF;
+IF fmt RLIKE '.*EEEE.*(FM|[B09X.DV,GLCU$V])' THEN RETURN 'EEEE + unexpected'; END IF;
+IF fmt RLIKE '^([$BC.DLUVS]|FM)EEEE'         THEN RETURN '^Unexpected + EEEE immediately'; END IF;
+IF fmt RLIKE '(G.*,|,.*G)'          THEN RETURN 'comma and G cannot co-exist'; END IF;
+IF fmt RLIKE '^([$B]|[^09]|)*[,G]'  THEN RETURN 'group with no int digits'; END IF;
+IF fmt RLIKE '[.DV].*[,G]'          THEN RETURN 'dec + group'; END IF;
+IF fmt RLIKE '(FM|[S.DCLUV])[,G]'   THEN RETURN 'Unexpected + group immediately'; END IF;
+IF fmt RLIKE '(MI|PR).+' THEN RETURN 'Trailing sign + something'; END IF;
+IF fmt RLIKE '[$09BVCLUX.D,G].*TM' THEN RETURN 'Unexpected + TM'; END IF;
+IF fmt RLIKE 'TM([^E9].*|[E9].+)'  THEN RETURN 'TMx + something'; END IF;
+IF fmt RLIKE '([9BCDLUVS.,G$]|TM).*X' THEN RETURN 'Unexpected + X'; END IF;
+IF fmt RLIKE 'X[^X]'                  THEN RETURN 'X + unexpected'; END IF;
+-- Bad combinations consisting of three elements
+IF fmt RLIKE '[.VD].*[CLU].*[09]'                     THEN RETURN 'Dec + CLU + digit'; END IF;
+IF fmt RLIKE '[CLUV09.BD$].*[S].*([09$BVCLU.D]|EEEE)' THEN RETURN 'Trailing S sign + unexpected'; END IF;
+IF fmt RLIKE '[B09].*[CLUV].*[,GV.D]'                 THEN RETURN 'CLUV as dec + group/dec'; END IF;
+IF fmt RLIKE '[.DV].*[CLU].*[B]'                      THEN RETURN 'CLU as trailing currency + B'; END IF;
+RETURN '';
+END;
+$$
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES ('');
+INSERT INTO t1 VALUES ('FM')                 /* leading flags */;
+INSERT INTO t1 VALUES ('.'),('D'),('V')      /* dec */;
+INSERT INTO t1 VALUES (','),('G')            /* group */;
+INSERT INTO t1 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t1 VALUES ('C'),('L'),('U')      /* currency */;
+INSERT INTO t1 VALUES ('S')                  /* sign */;
+INSERT INTO t1 VALUES ('MI'),('PR')          /* trailing sign */;
+INSERT INTO t1 VALUES ('TM'),('TM9'),('TME') /* TM formats */;
+INSERT INTO t1 VALUES ('0'),('9'),('X')      /* digits */;
+INSERT INTO t1 VALUES ('EEEE')               /* approximate format */;
+SELECT fmt FROM t1 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+fmt
+SELECT fmt FROM t1 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+fmt
+CREATE VIEW v2 AS SELECT CONCAT(t1.fmt, t2.fmt) AS fmt FROM t1 t1, t1 t2;
+SELECT fmt FROM v2 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+fmt
+SELECT fmt FROM v2 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+fmt
+DROP VIEW v2;
+CREATE VIEW v3 AS SELECT CONCAT(t1.fmt, t2.fmt, t2.fmt) AS fmt FROM t1 t1, t1 t2, t1 t3;
+SELECT fmt FROM v3 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+fmt
+SELECT fmt FROM v3 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+fmt
+DROP VIEW v3;
+DROP TABLE t1;
+CREATE TABLE t4 (fmt VARCHAR(32));
+INSERT INTO t4 VALUES ('.'),('D'),('V')      /* dec */;
+INSERT INTO t4 VALUES (','),('G')            /* group */;
+INSERT INTO t4 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t4 VALUES ('C')                  /* currency - simplified */;
+INSERT INTO t4 VALUES ('0'),('9'),('X')      /* digits */;
+CREATE VIEW v4 AS
+SELECT CONCAT(t1.fmt, t2.fmt, t3.fmt,t4.fmt) AS fmt
+FROM t4 t1, t4 t2, t4 t3, t4 t4;
+SELECT fmt FROM v4 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+fmt
+SELECT fmt FROM v4 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+fmt
+DROP VIEW v4;
+DROP TABLE t4;
+CREATE TABLE t4 (fmt VARCHAR(32));
+INSERT INTO t4 VALUES ('');
+INSERT INTO t4 VALUES ('FM')                 /* leading flags */;
+INSERT INTO t4 VALUES ('.')                  /* dec - simplified */;
+INSERT INTO t4 VALUES (',')                  /* group - simplified */;
+INSERT INTO t4 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t4 VALUES ('C')                  /* currency - simplified */;
+INSERT INTO t4 VALUES ('S')                  /* sign */;
+INSERT INTO t4 VALUES ('MI')                 /* trailing sign - simplified */;
+INSERT INTO t4 VALUES ('TM9')                /* TM formats - simplified */;
+INSERT INTO t4 VALUES ('9'),('X')            /* digits - simplified */;
+INSERT INTO t4 VALUES ('EEEE')               /* approximate format */;
+CREATE VIEW v4 AS
+SELECT CONCAT(t1.fmt, t2.fmt, t3.fmt,t4.fmt) AS fmt
+FROM t4 t1, t4 t2, t4 t3, t4 t4;
+SELECT fmt FROM v4 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+fmt
+SELECT fmt FROM v4 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+fmt
+DROP VIEW v4;
+DROP TABLE t4;
+DROP FUNCTION bad;
+SET debug_dbug= @saved_debug_dbug;

--- a/mysql-test/main/func_numconv_format.test
+++ b/mysql-test/main/func_numconv_format.test
@@ -1,0 +1,139 @@
+--source include/have_debug.inc
+
+SET @saved_debug_dbug= @@debug_dbug;
+SET @@debug_dbug='+d,numconv_format';
+
+
+--echo #
+--echo # MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+--echo #
+
+# This function detects if the passed format is correct or wrong
+
+DELIMITER $$;
+CREATE FUNCTION bad(fmt VARCHAR(128)) RETURNS VARCHAR(128)
+BEGIN
+
+  IF fmt RLIKE '(FM.*FM|B.*B|EEEE.*EEEE|[CLU$].*[CLU$]|[.VD].*[.VD]|(S|MI|PR).*(S|MI|PR))'
+  THEN
+    RETURN 'FM/B/currency/dec/sign cannot repeat';
+  END IF;
+
+  IF fmt RLIKE '[09XBCDLUV,G.$].*FM' THEN RETURN 'Unexpected + FM'; END IF;
+
+  IF fmt RLIKE '^[^09]*([.DV].*)?EEEE'         THEN RETURN 'EEEE with no int digits #1'; END IF;
+  IF fmt RLIKE '^(FM|S)?[$B]+[CLU][0-9]*EEEE'  THEN RETURN 'EEEE with no int digits #2'; END IF;
+  IF fmt RLIKE '.*EEEE.*(FM|[B09X.DV,GLCU$V])' THEN RETURN 'EEEE + unexpected'; END IF;
+  IF fmt RLIKE '^([$BC.DLUVS]|FM)EEEE'         THEN RETURN '^Unexpected + EEEE immediately'; END IF;
+
+  IF fmt RLIKE '(G.*,|,.*G)'          THEN RETURN 'comma and G cannot co-exist'; END IF;
+  IF fmt RLIKE '^([$B]|[^09]|)*[,G]'  THEN RETURN 'group with no int digits'; END IF;
+  IF fmt RLIKE '[.DV].*[,G]'          THEN RETURN 'dec + group'; END IF;
+  IF fmt RLIKE '(FM|[S.DCLUV])[,G]'   THEN RETURN 'Unexpected + group immediately'; END IF;
+
+  IF fmt RLIKE '(MI|PR).+' THEN RETURN 'Trailing sign + something'; END IF;
+
+  IF fmt RLIKE '[$09BVCLUX.D,G].*TM' THEN RETURN 'Unexpected + TM'; END IF;
+  IF fmt RLIKE 'TM([^E9].*|[E9].+)'  THEN RETURN 'TMx + something'; END IF;
+
+  IF fmt RLIKE '([9BCDLUVS.,G$]|TM).*X' THEN RETURN 'Unexpected + X'; END IF;
+  IF fmt RLIKE 'X[^X]'                  THEN RETURN 'X + unexpected'; END IF;
+
+  -- Bad combinations consisting of three elements
+  IF fmt RLIKE '[.VD].*[CLU].*[09]'                     THEN RETURN 'Dec + CLU + digit'; END IF;
+  IF fmt RLIKE '[CLUV09.BD$].*[S].*([09$BVCLU.D]|EEEE)' THEN RETURN 'Trailing S sign + unexpected'; END IF;
+  IF fmt RLIKE '[B09].*[CLUV].*[,GV.D]'                 THEN RETURN 'CLUV as dec + group/dec'; END IF;
+  IF fmt RLIKE '[.DV].*[CLU].*[B]'                      THEN RETURN 'CLU as trailing currency + B'; END IF;
+
+  RETURN '';
+END;
+$$
+DELIMITER ;$$
+
+
+# Populate t1 with all known format elements
+
+CREATE TABLE t1 (fmt VARCHAR(32));
+INSERT INTO t1 VALUES ('');
+INSERT INTO t1 VALUES ('FM')                 /* leading flags */;
+INSERT INTO t1 VALUES ('.'),('D'),('V')      /* dec */;
+INSERT INTO t1 VALUES (','),('G')            /* group */;
+INSERT INTO t1 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t1 VALUES ('C'),('L'),('U')      /* currency */;
+INSERT INTO t1 VALUES ('S')                  /* sign */;
+INSERT INTO t1 VALUES ('MI'),('PR')          /* trailing sign */;
+INSERT INTO t1 VALUES ('TM'),('TM9'),('TME') /* TM formats */;
+INSERT INTO t1 VALUES ('0'),('9'),('X')      /* digits */;
+INSERT INTO t1 VALUES ('EEEE')               /* approximate format */;
+
+SELECT fmt FROM t1 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+--disable_warnings
+SELECT fmt FROM t1 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+--enable_warnings
+
+CREATE VIEW v2 AS SELECT CONCAT(t1.fmt, t2.fmt) AS fmt FROM t1 t1, t1 t2;
+SELECT fmt FROM v2 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+--disable_warnings
+SELECT fmt FROM v2 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+--enable_warnings
+DROP VIEW v2;
+
+CREATE VIEW v3 AS SELECT CONCAT(t1.fmt, t2.fmt, t2.fmt) AS fmt FROM t1 t1, t1 t2, t1 t3;
+SELECT fmt FROM v3 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+--disable_warnings
+SELECT fmt FROM v3 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+--enable_warnings
+DROP VIEW v3;
+
+DROP TABLE t1;
+
+# Populate t4 only with decimal number body format elements
+
+CREATE TABLE t4 (fmt VARCHAR(32));
+INSERT INTO t4 VALUES ('.'),('D'),('V')      /* dec */;
+INSERT INTO t4 VALUES (','),('G')            /* group */;
+INSERT INTO t4 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t4 VALUES ('C')                  /* currency - simplified */;
+INSERT INTO t4 VALUES ('0'),('9'),('X')      /* digits */;
+
+CREATE VIEW v4 AS
+SELECT CONCAT(t1.fmt, t2.fmt, t3.fmt,t4.fmt) AS fmt
+FROM t4 t1, t4 t2, t4 t3, t4 t4;
+
+SELECT fmt FROM v4 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+--disable_warnings
+SELECT fmt FROM v4 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+--enable_warnings
+DROP VIEW v4;
+DROP TABLE t4;
+
+
+# Populate t4 only with *some* known format elements, for performance purposes
+
+CREATE TABLE t4 (fmt VARCHAR(32));
+INSERT INTO t4 VALUES ('');
+INSERT INTO t4 VALUES ('FM')                 /* leading flags */;
+INSERT INTO t4 VALUES ('.')                  /* dec - simplified */;
+INSERT INTO t4 VALUES (',')                  /* group - simplified */;
+INSERT INTO t4 VALUES ('$'),('B')            /* inline flags */;
+INSERT INTO t4 VALUES ('C')                  /* currency - simplified */;
+INSERT INTO t4 VALUES ('S')                  /* sign */;
+INSERT INTO t4 VALUES ('MI')                 /* trailing sign - simplified */;
+INSERT INTO t4 VALUES ('TM9')                /* TM formats - simplified */;
+INSERT INTO t4 VALUES ('9'),('X')            /* digits - simplified */;
+INSERT INTO t4 VALUES ('EEEE')               /* approximate format */;
+
+CREATE VIEW v4 AS
+SELECT CONCAT(t1.fmt, t2.fmt, t3.fmt,t4.fmt) AS fmt
+FROM t4 t1, t4 t2, t4 t3, t4 t4;
+
+SELECT fmt FROM v4 WHERE bad(fmt)='' AND to_number('1',fmt) IS NULL;
+--disable_warnings
+SELECT fmt FROM v4 WHERE bad(fmt)<>'' AND to_number('1',fmt) IS NOT NULL;
+--enable_warnings
+DROP VIEW v4;
+DROP TABLE t4;
+
+DROP FUNCTION bad;
+
+SET debug_dbug= @saved_debug_dbug;

--- a/mysql-test/main/func_numconv_ucs2.result
+++ b/mysql-test/main/func_numconv_ucs2.result
@@ -1,0 +1,58 @@
+#
+# MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+#
+SET NAMES utf8mb4;
+SELECT to_number('$123-', CONVERT('$999S' USING ucs2)) AS c1;
+c1
+-123
+SELECT to_number('$123-', CONVERT('$999Š' USING ucs2)) AS c1;
+ERROR HY000: Incorrect <number format> value: 'Š' for function to_number
+SELECT to_number(CONVERT('$123-' USING ucs2), '$999S') AS c1;
+c1
+-123
+SELECT to_number(CONVERT('$123-' USING ucs2), CONVERT('$999S' USING ucs2)) AS c1;
+c1
+-123
+SELECT to_number(CONVERT('GarbageŠ' USING ucs2), CONVERT('$999S' USING ucs2)) AS c1;
+c1
+NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$999S' value: 'GarbageŠ' for function to_number
+CREATE TABLE t1 (fmt VARCHAR(32) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('$999S'), ('$999MI'), ('$999Š');
+SELECT fmt, to_number('$123-', fmt) AS c1 FROM t1;
+fmt	c1
+$999S	-123
+$999MI	-123
+$999Š	NULL
+Warnings:
+Warning	1411	Incorrect <number format> value: 'Š' for function to_number
+SELECT fmt, to_number('GarbageŠ', fmt) AS c1 FROM t1;
+fmt	c1
+$999S	NULL
+$999MI	NULL
+$999Š	NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$999S' value: 'GarbageŠ' for function to_number
+Warning	1411	Incorrect <number format>='$999MI' value: 'GarbageŠ' for function to_number
+Warning	1411	Incorrect <number format> value: 'Š' for function to_number
+DROP TABLE t1;
+CREATE TABLE t1 (fmt VARCHAR(32) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('$999S'), ('$999MI'), ('$999Š');
+SELECT fmt, to_number(CONVERT('$123-' USING ucs2), fmt) AS c1 FROM t1;
+fmt	c1
+$999S	-123
+$999MI	-123
+$999Š	NULL
+Warnings:
+Warning	1411	Incorrect <number format> value: 'Š' for function to_number
+SELECT fmt, to_number(CONVERT('GarbageŠ' USING ucs2), fmt) AS c1 FROM t1;
+fmt	c1
+$999S	NULL
+$999MI	NULL
+$999Š	NULL
+Warnings:
+Warning	1411	Incorrect <number format>='$999S' value: 'GarbageŠ' for function to_number
+Warning	1411	Incorrect <number format>='$999MI' value: 'GarbageŠ' for function to_number
+Warning	1411	Incorrect <number format> value: 'Š' for function to_number
+DROP TABLE t1;

--- a/mysql-test/main/func_numconv_ucs2.test
+++ b/mysql-test/main/func_numconv_ucs2.test
@@ -1,0 +1,38 @@
+--source include/have_ucs2.inc
+
+--echo #
+--echo # MDEV-20022 sql_mode="oracle" does not support TO_NUMBER() function
+--echo #
+
+SET NAMES utf8mb4;
+
+# Constant UCS2 format
+SELECT to_number('$123-', CONVERT('$999S' USING ucs2)) AS c1;
+
+# Make sure the error is readable
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT to_number('$123-', CONVERT('$999Š' USING ucs2)) AS c1;
+
+# UCS2 subject + utf8mb4 format
+SELECT to_number(CONVERT('$123-' USING ucs2), '$999S') AS c1;
+
+# UCS2 subject + UCS2 format
+SELECT to_number(CONVERT('$123-' USING ucs2), CONVERT('$999S' USING ucs2)) AS c1;
+
+# UCS2 subject + UCS2 format - check the warning:
+SELECT to_number(CONVERT('GarbageŠ' USING ucs2), CONVERT('$999S' USING ucs2)) AS c1;
+
+
+# utf8mb4 subject + non-constant UCS2 format
+CREATE TABLE t1 (fmt VARCHAR(32) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('$999S'), ('$999MI'), ('$999Š');
+SELECT fmt, to_number('$123-', fmt) AS c1 FROM t1;
+SELECT fmt, to_number('GarbageŠ', fmt) AS c1 FROM t1;
+DROP TABLE t1;
+
+# UCS2 subject + non-constant UCS2 format
+CREATE TABLE t1 (fmt VARCHAR(32) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('$999S'), ('$999MI'), ('$999Š');
+SELECT fmt, to_number(CONVERT('$123-' USING ucs2), fmt) AS c1 FROM t1;
+SELECT fmt, to_number(CONVERT('GarbageŠ' USING ucs2), fmt) AS c1 FROM t1;
+DROP TABLE t1;

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -107,6 +107,7 @@ SET (SQL_SOURCE
                hostname.cc init.cc item.cc item_buff.cc item_cmpfunc.cc
                item_create.cc item_func.cc item_geofunc.cc item_row.cc
                item_strfunc.cc item_subselect.cc item_sum.cc item_timefunc.cc
+               item_numconvfunc.cc
                key.cc log.cc log_cache.cc lock.cc
                log_event.cc log_event_server.cc
                rpl_record.cc rpl_reporting.cc

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -37,6 +37,7 @@
 #include "sql_time.h"
 #include "sql_type_geom.h"
 #include "item_vectorfunc.h"
+#include "item_numconvfunc.h"
 #include <mysql/plugin_function.h>
 
 
@@ -6553,6 +6554,7 @@ const Native_func_registry func_array[] =
   { { STRING_WITH_LEN("TIME_TO_SEC") }, BUILDER(Create_func_time_to_sec)},
   { { STRING_WITH_LEN("TO_BASE64") }, BUILDER(Create_func_to_base64)},
   { { STRING_WITH_LEN("TO_CHAR") }, BUILDER(Create_func_to_char)},
+  { { STRING_WITH_LEN("TO_NUMBER") }, &create_func_to_number},
   { { STRING_WITH_LEN("TO_DAYS") }, BUILDER(Create_func_to_days)},
   { { STRING_WITH_LEN("TO_SECONDS") }, BUILDER(Create_func_to_seconds)},
   { { STRING_WITH_LEN("UCASE") }, BUILDER(Create_func_ucase)},

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -742,6 +742,44 @@ public:
   };
 
 
+  class Handler_double: public Handler
+  {
+  public:
+    const Type_handler *return_type_handler(const Item_handled_func *)
+                                                        const override
+    {
+      return &type_handler_double;
+    }
+
+    String *val_str(Item_handled_func *item, String *to) const override
+    {
+      double nr= val_real(item);
+      if (item->null_value)
+        return 0;
+      to->set_real(nr, NOT_FIXED_DEC, item->collation.collation);
+      return to;
+    }
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
+    {
+      return item->Item::val_str_ascii(to);
+    }
+    double val_real(Item_handled_func *item) const override= 0;
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
+    {
+      return item->val_decimal_from_real(to);
+    }
+    bool get_date(THD *thd, Item_handled_func *item,
+                  MYSQL_TIME *to, date_mode_t fuzzydate) const override
+    {
+      return item->get_date_from_real(thd, to, fuzzydate);
+    }
+    longlong val_int(Item_handled_func *item) const override
+    {
+      return item->val_int_from_real();
+    }
+  };
+
+
   class Handler_int: public Handler
   {
   public:
@@ -826,6 +864,8 @@ public:
 protected:
   const Handler *m_func_handler;
 public:
+  Item_handled_func(THD *thd, List<Item> & args)
+   :Item_func(thd, args), m_func_handler(NULL) { }
   Item_handled_func(THD *thd, Item *a)
    :Item_func(thd, a), m_func_handler(NULL) { }
   Item_handled_func(THD *thd, Item *a, Item *b)

--- a/sql/item_numconvfunc.cc
+++ b/sql/item_numconvfunc.cc
@@ -1,0 +1,3279 @@
+/*
+   Copyright (c) 2009, 2025, MariaDB Corporation.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA
+*/
+
+#include "mariadb.h"
+#include "sql_priv.h"
+#include "sql_class.h"
+#include "sql_base.h"
+#include "m_ctype.h"
+#include "strfunc.h"
+#include "item_numconvfunc.h"
+#include "lex_ident_sys.h"
+#include "simple_tokenizer.h"
+#include "sql_list.h"
+#include "sql_string.h"
+
+#define SIMPLE_PARSER_V2
+#include "simple_parser.h"
+#undef SIMPLE_PARSER_V2
+
+
+// An alias for a shorter code notation
+using enum_warning_level= Sql_state_errno_level::enum_warning_level;
+
+
+class Tokenizer: public Extended_string_tokenizer
+{
+public:
+  Tokenizer(CHARSET_INFO *cs, const LEX_CSTRING &str)
+   :Extended_string_tokenizer(cs, str)
+  { }
+
+  /*
+    A class to detect quickly if a certain character is a one-character token.
+    It also handles case-insensitivity for these tokens.
+  */
+  class Single_char_token
+  {
+  public:
+    static constexpr uchar _C= 'C'; // Positional currency (C, L, U)
+    static constexpr uchar _B= 'B'; // Prefix/inline flag B
+    static constexpr uchar _S= 'S'; // Sign S
+    static constexpr uchar _G= 'G'; // Group decimiter G
+    // Single char tokens: $ B . D , G 09 C L U
+    static uchar elem(uchar ch)
+    {
+      static const uchar elements[256]=
+      {
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, /*  !"#$%&'()*+,-./ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0123456789:;<=>? */
+         0, 0,_B,_C, 1, 0, 0,_G, 0, 0, 0, 0,_C, 0, 0, 0, /* @ABCDEFGHIJKLMNO */
+         0, 0, 0,_S, 0,_C, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* PQRSTUVWXYZ[\]^_ */
+         0, 0,_B,_C, 1, 0, 0,_G, 0, 0, 0, 0,_C, 0, 0, 0, /* `abcdefghijklmno */
+         0, 0, 0,_S, 0,_C, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* pqrstuvwxyz{|}~. */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* ................ */
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  /* ................ */
+      };
+      return elements[ch];
+    }
+  };
+
+  // Wrappers for the above class
+  static bool is_positional_currency(char ch)
+  {
+    return Single_char_token::elem((uchar) ch) == Single_char_token::_C;
+  }
+  static bool is_currency_flag_B(char ch)
+  {
+    return Single_char_token::elem((uchar) ch) == Single_char_token::_B;
+  }
+  static bool is_group_delimiter_G(char ch)
+  {
+    return Single_char_token::elem((uchar) ch) == Single_char_token::_G;
+  }
+  static bool is_sign_S(char ch)
+  {
+    return Single_char_token::elem((uchar) ch) == Single_char_token::_S;
+  }
+  // Combining wrappers
+  static bool is_currency_flag(char ch)
+  {
+    return ch == '$' || is_currency_flag_B((uchar) ch);
+  }
+
+  enum class TokenID
+  {
+    // Special purpose tokens:
+    tNULL=  0, // returned if the tokenizer failed to detect a token
+               // also used if the parser failed to parse a token
+    tEMPTY= 1, // returned on empty optional constructs in a grammar like:
+               //   rule ::= [ rule1 ]
+               // when rule1 does not present in the input.
+    tEOF=   2, // returned when the end of input is reached
+
+    // One character tokens
+    tCOMMA= ',',
+    tDOLLAR= '$',
+    tPERIOD= '.',
+    tB= 'B',
+    tC= 'C',
+    tD= 'D',
+    tG= 'G',
+    tL= 'L',
+    tU= 'U',
+    tV= 'V',
+    tS= 'S',
+    // Other tokens, values must be greater than any of the above
+    tMI= 256,
+    tFM,
+    tPR,
+    tTM,
+    tTM9,
+    tTME,
+    tZEROS,
+    tNINES,
+    tXCHAIN,
+    tEEEE
+  };
+
+  // A helper wrapper for Lex_cstring with convenience methods
+  class LS: public Lex_cstring
+  {
+  public:
+    using Lex_cstring::Lex_cstring;
+    const char *ptr() const { return Lex_cstring::str; }
+    size_t length() const { return Lex_cstring::length; }
+    const char *end() const
+    {
+      return ptr() ? ptr() + length() : nullptr;
+    }
+    static LS empty()
+    {
+      return empty_clex_str;
+    }
+    void print(String *str) const
+    {
+      str->append(ptr(), length());
+    }
+    void print_var_value(String *str, const LS & name) const
+    {
+      str->append(name);
+      str->append("='", 2);
+      str->append(ptr(), length());
+      str->append('\'');
+    }
+    const LS & to_LS() const
+    {
+      return *this;
+    }
+    LS ltrim(CHARSET_INFO *cs) const
+    {
+      const char *start= ptr() + cs->scan(ptr(), end(), MY_SEQ_SPACES);
+      return {start, end()};
+    }
+    LS ltrim_currency_flags() const
+    {
+      const char *p;
+      for (p= ptr() ; p < end() && is_currency_flag((uchar) *p) ; p++)
+      { }
+      return {p, end()};
+    }
+    const char *find_dollar(size_t skip) const
+    {
+      for (const char *p= ptr(); p < end(); p++)
+      {
+        if (*p == '$')
+        {
+          if (skip == 0)
+            return p;
+          skip--;
+        }
+      }
+      return nullptr;
+    }
+    const char *find_currency_flag_B(size_t skip) const
+    {
+      for (const char *p= ptr(); p < end(); p++)
+      {
+        if (is_currency_flag_B(*p))
+        {
+          if (skip == 0)
+            return p;
+          skip--;
+        }
+      }
+      return nullptr;
+    }
+    /*
+      Return a string with the left character removed.
+      The string must not be empty.
+    */
+    LS chop_left() const
+    {
+      DBUG_ASSERT(ptr());
+      DBUG_ASSERT(length() > 0);
+      return {ptr() + 1, length() - 1};
+    }
+    /*
+      Return a string with the right character removed.
+      The string must not be empty.
+    */
+    LS chop_right() const
+    {
+      DBUG_ASSERT(ptr());
+      DBUG_ASSERT(length() > 0);
+      return {ptr(), length() - 1};
+    }
+    // A byte at the given position
+    char at(size_t pos) const
+    {
+      DBUG_ASSERT(pos < length());
+      return ptr()[pos];
+    }
+    // A byte at the very first postion
+    char front() const
+    {
+      return at(0);
+    }
+    // The very last byte
+    char back() const
+    {
+      DBUG_ASSERT(ptr());
+      DBUG_ASSERT(length() > 0);
+      return ptr()[length() - 1];
+    }
+  };
+
+
+  class Token: public LS
+  {
+    TokenID m_id;
+  public:
+    Token()
+     :LS(), m_id(TokenID::tNULL)
+    { }
+    Token(const LEX_CSTRING &str, TokenID id)
+     :LS(str), m_id(id)
+    { }
+    TokenID id() const { return m_id; }
+    static Token empty(const char *pos)
+    {
+      return Token(LS(pos, pos), TokenID::tEMPTY);
+    }
+    static Token empty()
+    {
+      return Token(LS::empty(), TokenID::tEMPTY);
+    }
+    operator bool() const
+    {
+      return m_id != TokenID::tNULL;
+    }
+  };
+
+
+protected:
+
+  Token get_token(CHARSET_INFO *cs)
+  {
+    if (eof())
+      return Token(LS(m_ptr, m_ptr), TokenID::tEOF);
+
+    const char *head= m_ptr;
+
+    if (Single_char_token::elem((uchar) *head))
+    {
+      TokenID id= (TokenID) my_toupper(system_charset_info, head[0]);
+      return m_ptr++, Token(LS(m_ptr - 1, 1), id);
+    }
+    // Digit chains - return as a single token
+    if (head[0] == '0' || head[0] == '9' || head[0] == 'X' || head[0] == 'x')
+    {
+      for ( ; !get_char(head[0]) ;)
+      { }
+      if (head[0] == '0')
+        return Token(LS(head, m_ptr), TokenID::tZEROS);
+      if (head[0] == '9')
+        return Token(LS(head, m_ptr), TokenID::tNINES);
+      if (head[0] == 'X' || head[0] == 'x')
+        return Token(LS(head, m_ptr), TokenID::tXCHAIN);
+    }
+
+    // Two-char tokens
+    if (m_ptr + 2 <= m_end)
+    {
+      const LEX_CSTRING str= LS(m_ptr, 2);
+      if ("MI"_Lex_ident_column.streq(str))
+        return m_ptr+=2, Token(str, TokenID::tMI);
+      if ("FM"_Lex_ident_column.streq(str))
+        return m_ptr+=2, Token(str, TokenID::tFM);
+      if ("PR"_Lex_ident_column.streq(str))
+        return m_ptr+=2, Token(str, TokenID::tPR);
+      if ("TM"_Lex_ident_column.streq(str))
+      {
+        if (m_ptr + 3 <= m_end)
+        {
+          // Three-char tokens: TM9 TME
+          if (m_ptr[2] == '9')
+            return m_ptr+= 3, Token(LS(head, m_ptr), TokenID::tTM9);
+          if (m_ptr[2]=='E' || m_ptr[2]=='e')
+            return m_ptr+= 3, Token(LS(head, m_ptr), TokenID::tTME);
+        }
+        return m_ptr+=2, Token(LS(head, m_ptr), TokenID::tTM);
+      }
+    }
+
+    // Four-char tokens: EEEE
+    if (m_ptr + 4 <= m_end)
+    {
+      const LEX_CSTRING str= LS(m_ptr, 4);
+      if ("EEEE"_Lex_ident_column.streq(str))
+        return m_ptr+=4, Token(str, TokenID::tEEEE);
+    }
+
+    return Token(LS(m_ptr, m_ptr), TokenID::tNULL);
+  }
+
+#ifndef DBUG_OFF
+  // A helper method for debugging
+  void trace_tokens(CHARSET_INFO *cs, const LEX_CSTRING &fmt)
+  {
+    Tokenizer::Token tok;
+    for (tok= get_token(cs) ;
+         tok && tok.id() != Tokenizer::TokenID::tEOF;
+         tok= get_token(cs))
+    { }
+  }
+#endif
+
+}; // End of class Tokenizer
+
+
+/*
+   A convenience operator,
+   to use:       "123"_LS
+   instead of:   CSTRING_WITH_LEN("123").
+   Must be outside of a class.
+*/
+static inline constexpr
+Tokenizer::LS
+operator""_LS(const char *str, size_t length)
+{
+  return Tokenizer::LS(str, length);
+}
+
+
+
+class Parser: public Tokenizer,
+              public Parser_templates
+{
+private:
+  THD *m_thd;
+  Token m_look_ahead_token;
+  LEX_CSTRING m_func_name;
+  const char *m_start;
+  bool m_error; // Syntax or raised by the caller, e.g. in methods add()
+public:
+
+  Parser()
+   :Tokenizer(&my_charset_bin, null_clex_str),
+    m_thd(nullptr),
+    m_look_ahead_token(Token()),
+    m_func_name(null_clex_str),
+    m_start(nullptr),
+    m_error(true)
+  { }
+
+  Parser(THD *thd, const LEX_CSTRING func_name,
+                CHARSET_INFO *cs, const LEX_CSTRING &str)
+   :Tokenizer(cs, str),
+    m_thd(thd),
+    m_look_ahead_token(get_token(cs)),
+    m_func_name(func_name),
+    m_start(str.str),
+    m_error(false)
+  { }
+  void set_syntax_error()
+  {
+    m_error= true;
+  }
+  void set_fatal_error()
+  {
+    m_error= true;
+  }
+
+  bool is_error() const
+  {
+    return m_error;
+  }
+
+  LS buffer() const
+  {
+    return {m_start, m_end};
+  }
+
+  TokenID look_ahead_token_id() const
+  {
+    return is_error() ? TokenID::tNULL : m_look_ahead_token.id();
+  }
+  /*
+    Return an empty token at the position of the current
+    look ahead token with a zero length. Used for optional grammar constructs.
+
+    For example, if the grammar is "rule ::= ruleA [ruleB] ruleC"
+    and the input is "A C", then:
+    - the optional rule "ruleB" will point to the input position "C"
+      with a zero length
+    - while the rule "ruleC" will point to the same input position "C"
+      with a non-zero length
+  */
+  Token empty_token() const // For templates in simple_parser.h
+  {
+    return Token::empty(m_look_ahead_token.ptr());
+  }
+  static Token null_token() // For templates in simple_parser.h
+  {
+    return Token();
+  }
+
+  /*
+    Return the current look ahead token and scan the next one
+  */
+  Token shift()
+  {
+    DBUG_ASSERT(!is_error());
+    const Token res= m_look_ahead_token;
+    m_look_ahead_token= get_token(m_cs);
+    return res;
+  }
+
+  THD *thd() const { return m_thd; }
+public:
+
+  /*
+    Return the current look ahead token if it matches the given ID
+    and scan the next one.
+  */
+  Token token(TokenID id)
+  {
+    if (m_look_ahead_token.id() != id || is_error())
+      return null_token();
+    return shift();
+  }
+
+  void raise_not_supported_yet(THD *thd, enum_warning_level level,
+                               const LS & str) const
+  {
+    char buff[128];
+    size_t errlen= my_snprintf(buff, sizeof(buff), "<number format>='%.*s'",
+                               (int) str.length(), str.ptr());
+    ErrConvString txt(buff, errlen, m_cs);
+    if (level == Sql_condition::WARN_LEVEL_ERROR)
+      my_error(ER_NOT_SUPPORTED_YET, MYF(0), txt.ptr());
+    else
+      push_warning_printf(thd, level, ER_NOT_SUPPORTED_YET,
+                          ER_THD(thd, ER_NOT_SUPPORTED_YET), txt.ptr());
+  }
+
+  void raise_bad_format_at(THD *thd, enum_warning_level level,
+                           ErrConvString *txt) const
+  {
+    if (level == Sql_condition::WARN_LEVEL_ERROR)
+      my_error(ER_WRONG_VALUE_FOR_TYPE, MYF(0),
+               "<number format>", txt->ptr(), m_func_name.str);
+    else
+      push_warning_printf(thd, level,
+                          ER_WRONG_VALUE_FOR_TYPE,
+                          ER_THD(thd, ER_WRONG_VALUE_FOR_TYPE),
+                          "<number format>", txt->ptr(), m_func_name.str);
+  }
+
+  void raise_bad_format_at(THD *thd, enum_warning_level level,
+                           const char *pos= nullptr) const
+  {
+    const LS buf= buffer();
+    if (!pos)
+      pos= m_look_ahead_token.ptr();
+    DBUG_ASSERT(pos >= buf.ptr() && pos <= buf.end());
+    ErrConvString txt(pos, buf.end() - pos, m_cs);
+    raise_bad_format_at(thd, level, &txt);
+  }
+
+  enum feature_t
+  {
+    F_NONE=                 0,
+    F_INT_DIGIT=       1 << 0,
+    F_INT_B=           1 << 1,
+    F_INT_DOLLAR=      1 << 2,
+    F_INT_GROUP_COMMA= 1 << 3,
+    F_INT_GROUP_G=     1 << 4,
+    F_INT_HEX=         1 << 5,
+
+    F_FRAC_DIGIT=      1 << 10,
+    F_FRAC_B=          1 << 11,
+    F_FRAC_DOLLAR=     1 << 12,
+    F_FRAC_DEC_PERIOD= 1 << 13,
+    F_FRAC_DEC_D=      1 << 14,
+    F_FRAC_DEC_V=      1 << 15,
+    F_FRAC_DEC_CLU=    1 << 16,
+
+    F_EEEE=            1 << 17,
+
+    F_POSTFIX_CLU=     1 << 20,
+    F_PREFIX_CLU=      1 << 21,
+
+    F_PREFIX_B=        1 << 22,
+    F_PREFIX_DOLLAR=   1 << 23,
+
+    F_PREFIX_SIGN=     1 << 25,
+    F_POSTFIX_SIGN=    1 << 26,
+    F_FMT_TM=          1 << 27,
+    F_FMT_FLAG_FM=     1 << 28
+  };
+
+
+  // A common parent class for various containers
+  class LS_container: public LS
+  {
+  public:
+    using Container= LS_container;
+    using LS::LS;
+    static LS_container empty(const Parser &parser)
+    {
+      return parser.empty_token();
+    }
+    static LS_container empty()
+    {
+      return LS::empty();
+    }
+    operator bool() const
+    {
+      return ptr() != nullptr;
+    }
+    /*
+      Concatenate list elements into a single container.
+      There must be no any delimiters in between.
+      As far as spaces are not allowed in the format, it's always true.
+    */
+    bool concat(LS && rhs)
+    {
+      if (!ptr())
+      {
+        LS::operator=(rhs);
+        return false;
+      }
+      if (rhs.length() == 0)
+        return false;
+      if (end() != rhs.ptr())
+      {
+        DBUG_ASSERT(0);
+        return true;
+      }
+      Lex_cstring::length+= rhs.length();
+      return false;
+    }
+    // Methods that allow to pass it as a container to LIST.
+    size_t count() const { return length(); }
+    bool add(Parser *p, LS && rhs)
+    {
+      return concat(std::move(rhs));
+    }
+  };
+
+
+  /*
+    Counters:
+    - for flags '$' and 'B'
+    - group separators '.' and 'G'
+    - digits '0'
+
+    Currency prefix flags can have flags '$' and 'B':           'BC99.9'
+
+    Integer and fraction parts of the format can have
+    digits '0', '9', 'X', and additional elements:
+    - Integer digits can have both flags and group separators:  '9,B,9$'
+    - Fractional digits can have flags '$' and 'B' only:        '.9B$9'
+      (but cannot have group separators)
+  */
+  class Decimal_flag_counters
+  {
+  public:
+    using Container= Decimal_flag_counters;
+    uint32 m_dollar_count;
+    uint32 m_B_count;
+    uint32 m_comma_count;
+    uint32 m_G_count;
+    uint32 m_0_count;
+    Decimal_flag_counters()
+     :m_dollar_count(0),
+      m_B_count(0),
+      m_comma_count(0),
+      m_G_count(0),
+      m_0_count(0)
+    { }
+    Decimal_flag_counters(Decimal_flag_counters && rhs) = default;
+    Decimal_flag_counters & operator=(Decimal_flag_counters && rhs) = default;
+    void join(const Decimal_flag_counters & rhs)
+    {
+      m_dollar_count+= rhs.m_dollar_count;
+      m_B_count+= rhs.m_B_count;
+      m_comma_count+= rhs.m_comma_count;
+      m_G_count+= rhs.m_G_count;
+      m_0_count+= rhs.m_0_count;
+    }
+    void add(char ch)
+    {
+      if (ch == '$') { m_dollar_count++; return; }
+      if (ch == ',') { m_comma_count++; return; }
+      if (ch == '0') { m_0_count++; return ; }
+      if (is_group_delimiter_G(ch)) { m_G_count++; return ; }
+      if (is_currency_flag_B(ch)) { m_B_count++; return; }
+      DBUG_ASSERT(ch == '9');
+    }
+    // Methods needed to pass this class to templates in simple_parser.h
+    static Decimal_flag_counters empty(const Parser & parser)
+    {
+      return Decimal_flag_counters();
+    }
+    static Decimal_flag_counters empty()
+    {
+      return Decimal_flag_counters();
+    }
+    operator bool() const
+    {
+      return true;
+    }
+    // Other methods
+    size_t non_digit_length() const
+    {
+      return m_dollar_count + m_B_count + m_comma_count + m_G_count;
+    }
+  };
+
+
+  /********** Rules consisting of a single token *****/
+
+  class TokenEOF: public TOKEN<Parser, TokenID::tEOF> { using TOKEN::TOKEN; };
+
+  // Prefix/inline flag 'B'
+  class TokenB: public TOKEN<Parser, TokenID::tB> { using TOKEN::TOKEN; };
+
+  /*
+    The following chains are returned by the tokenizer as a single token:
+
+    GRAMMAR:  zeros: '0' [ '0'... ]
+    GRAMMAR:  nines: '9' [ '9'... ]
+    GRAMMAR:  xchain: 'X' [ 'X'...]
+  */
+  class Zeros: public TOKEN<Parser, TokenID::tZEROS>   { using TOKEN::TOKEN; };
+  class Nines: public TOKEN<Parser, TokenID::tNINES>   { using TOKEN::TOKEN; };
+  class XChain: public TOKEN<Parser, TokenID::tXCHAIN> { using TOKEN::TOKEN; };
+
+
+  /********** Rules consisting of a single token with their own container ***/
+
+  /** The containers appear in the final structure Format::Goal after parsing */
+
+  // Format prefix flag 'FM'. There are no any other format prefix flags.
+  class Format_flags: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Container= CONTAINER1<Parser, LS_container, Format_flags>;
+    using LParser= TOKEN<Parser, TokenID::tFM>;
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT("FM"_Lex_ident_column.streq(to_LS()));
+      return F_FMT_FLAG_FM;
+    }
+  };
+
+  // EEEE - scientific modifier
+  class EEEE: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Container= CONTAINER1<Parser, LS_container, EEEE>;
+    using LParser= TOKEN<Parser, TokenID::tEEEE>;
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT("EEEE"_Lex_ident_column.streq(to_LS()));
+      return F_EEEE;
+    }
+  };
+
+  // prefix_sign: 'S'
+  class Prefix_sign: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Container= CONTAINER1<Parser, LS_container, Prefix_sign>;
+    using LParser= TOKEN<Parser, TokenID::tS>;
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 1);
+      DBUG_ASSERT(is_sign_S(front()));
+      return F_PREFIX_SIGN;
+    }
+
+    /*
+      Get a prefix sign from the subject string "ls"
+      according to the format in "this". Strip the sign (if found)
+      from the string "ls".
+
+      @param OUT neg   - the sign is returned here:
+                         true if minus was scanned from "ls"
+                         false if plus was scanned from "ls"
+                         undefinite if "this" does not contain a prefix sign
+      @param IN/OUT ls - the subject string, we search for "+" or "-" in
+                         the front of it.
+      @retval false      Success:
+                          - the format in "this" does not have a sign
+                          - the format in "this" contains a sign, and
+                            the sign was scanned fron the subject string
+      @retval true       Error:
+                          - the format in "this" has a non-empty sign, but
+                            the subject string does not have a prefix sign
+    */
+    bool get(bool *neg, LS *ls) const
+    {
+      *neg= false;
+      if (length() == 0)
+        return false; // There is no a prefix sign in the format
+      if (!is_sign_S(front()))
+      {
+        DBUG_ASSERT(0); // Unknown prefix sign
+        return true;
+      }
+      if (ls->length() == 0)
+        return true;  // The subject string is empty, could not scan the sign
+      const char sign= ls->front();
+      if (sign != '+' && sign != '-')
+        return true; // The subject string does not start with a sign
+      *neg= sign == '-';
+      *ls= ls->chop_left(); // Strip the sign from the subject string
+      return false; // Sign found
+    }
+  };
+
+
+  /********** Rules consisting of 2 token choices ***/
+
+  // GRAMMAR: decimal_flag: 'B' | '$'
+  using Decimal_flag_cond= TokenChoiceCond2<Parser,
+                                            TokenID::tB,
+                                            TokenID::tDOLLAR>;
+  // GRAMMAR: group_separator: ',' | 'G'
+  using Group_separator_cond= TokenChoiceCond2<Parser,
+                                               TokenID::tCOMMA,
+                                               TokenID::tG>;
+  class Group_separator: public TokenChoice<Parser, Group_separator_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+  // GRAMMAR: zeros_or_nines: zeros | nines
+  using Zeros_or_nines_cond= TokenChoiceCond2<Parser,
+                                              TokenID::tZEROS,
+                                              TokenID::tNINES>;
+  class Zeros_or_nines: public TokenChoice<Parser, Zeros_or_nines_cond>
+  {
+  public:
+    using TokenChoice::TokenChoice;
+    // Initializing from rules
+    Zeros_or_nines(Zeros && rhs)
+     :TokenChoice(std::move(rhs))
+    { }
+    Zeros_or_nines(Nines && rhs)
+     :TokenChoice(std::move(rhs))
+    { }
+  };
+
+
+  /********** Postfix sign ****/
+
+  // GRAMMAR: postfix_sign_signature: 'S' | 'MI' | 'PR'
+  using Postfix_sign_cond= TokenChoiceCond3<Parser,
+                                            TokenID::tS,
+                                            TokenID::tMI,
+                                            TokenID::tPR>;
+  class Postfix_sign_signature: public TokenChoice<Parser, Postfix_sign_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+  // GRAMMAR: postfix_specific_sign_signature: 'MI' | 'PR'
+  using Postfix_specific_sign_cond= TokenChoiceCond2<Parser,
+                                                     TokenID::tMI,
+                                                     TokenID::tPR>;
+  class Postfix_specific_sign_signature:
+                               public TokenChoice<Parser,
+                                                  Postfix_specific_sign_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+  /*
+    A container for the postfix sign.
+    Depending on the grammar rule, the postfix sign can be:
+    - postfix_specific_sign:  MI, PR
+    - postfix_sign:           MI, PR, S (all sign variants)
+  */
+  class Postfix_sign: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Container= CONTAINER1<Parser, LS_container, Postfix_sign>;
+    // Initializing from rules
+    Postfix_sign(Postfix_sign_signature && rhs)
+     :LS_container(std::move(static_cast<LS_container&&>(rhs)))
+    { }
+    Postfix_sign(Postfix_specific_sign_signature && rhs)
+     :LS_container(std::move(static_cast<LS_container&&>(rhs)))
+    { }
+
+    // Conversion methods
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 1 || length() == 2);
+      return F_POSTFIX_SIGN;
+    }
+
+    /*
+      Get a trailing sign (S, MI) from a subject string in "ls"
+      Strip the sign from 'ls' if found.
+
+      @param OUT neg     - the sign is returned here:
+                           true if a negative sign was scanned from "ls"
+                           false if a positive sign was scanned from "ls"
+                           undefinite if "this" does not have a postfix sign
+      @param IN/OUT ls   - the subject string, we search postfix signs in it
+      @param IN positive - the character that represents a positive sign
+      @param IN negative - the character that represents a negative sign
+      @retval false      Success:
+                          - the format in "this" does not have a sign
+                          - the format in "this" contains a sign, and
+                            the sign was scanned fron the subject string
+      @retval true       Error:
+                          - the format in "this" has a non-empty sign, but
+                            the subject string does not have a postfix sign
+    */
+    static bool get_S_MI(bool *neg, LS *ls, char positive, char negative)
+    {
+      if (!ls->length())
+        return true; // The subject string is empty, failed to get the sign
+      char sign= ls->back();
+      if (sign != positive && sign != negative)
+        return true; // Not a sign character
+      *neg= sign == negative;
+      *ls= ls->chop_right();
+      return false;
+    }
+
+    /*
+      Get a PR-style angle-surrounding sign from a subject string in "ls".
+      Strip the sign from 'ls' if found.
+
+      @param OUT neg     - the sign is returned here:
+                           true if a negative sign was scanned from "ls"
+                           false if a positive sign was scanned from "ls"
+                           undefinite if "this" does not have a PR sign
+      @param IN/OUT ls   - the subject string, we search a surrounding sign in
+      @retval false      Success:
+                          - the format in "this" does not have a sign
+                          - the format in "this" contains a sign, and
+                            the sign was scanned fron the subject string
+      @retval true       Error:
+                          - the format in "this" has a non-empty sign, but
+                            the subject string does not have a surrounding sign
+    */
+    static bool get_PR(bool *neg, LS *ls)
+    {
+      if (ls->length() < 2)
+        return true; // The subject string needs at least two characers
+      char leading= ls->front();
+      char trailing= ls->back();
+      if (!(leading == ' ' && trailing == ' ') &&
+          !(leading == '<' && trailing == '>'))
+        return true; // Unknown
+      *neg= leading == '<';
+      *ls= ls->chop_right().chop_left();
+      return false;
+    }
+
+    /*
+      Get any know postfix sign from the subject string "ls"
+      according to the format in "this". Strip the sign (if found)
+      from the string "ls".
+
+      @param OUT neg   - the sign is returned here:
+                         true if minus was scanned from "ls"
+                         false if plus was scanned from "ls"
+                         undefinite if "this" does not contain a postfix sign
+      @param IN/OUT ls - the subject string, we search postfix signs
+      @retval false      Success:
+                          - the format in "this" does not have a sign
+                          - the format in "this" contains a sign, and
+                            the sign was scanned fron the subject string
+      @retval true       Error:
+                          - the format in "this" has a non-empty sign, but
+                            the subject string does not have a matching sign
+    */
+
+    bool get(bool *neg, LS *ls) const
+    {
+      if (length() == 0)
+      {
+        *neg= false;
+        return false; // The format in "this" does not have a postfix sign
+      }
+      DBUG_ASSERT(length() <= 2); // S MI PR
+
+      if (is_sign_S(front()))
+        return get_S_MI(neg, ls, '+', '-'); // Search for '+' or '-' in the end
+
+      if ("MI"_Lex_ident_column.streq(to_LS()))
+        return get_S_MI(neg, ls, ' ', '-'); // Search for ' ' or '-' in the end
+
+      if ("PR"_Lex_ident_column.streq(to_LS()))
+        return get_PR(neg, ls); // Search for blanks or angle brakets around
+      DBUG_ASSERT(0); // Unknown postfix sign format
+      return true;
+    }
+
+  };
+
+
+  /*
+    GRAMMAR: positional_currency_signature: 'C' | 'L' | 'U'
+
+    The position of CLU inside the format is important, hence the name.
+
+    Note, the position of the dollar sign is not important, it can be
+    specified once on any position inside the number.
+  */
+  using Positional_currency_signature_cond= TokenChoiceCond3<Parser,
+                                                             TokenID::tC,
+                                                             TokenID::tL,
+                                                             TokenID::tU>;
+
+  // GRAMMAR: prefix_currency_signature: positional_currency_signature
+  class Prefix_currency: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    class Cond: public Positional_currency_signature_cond { };
+    using Container= CONTAINER1<Parser, LS_container, Prefix_currency>;
+    using LParser= TokenChoice<Parser, Cond>;
+    // Conversion methods
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 1);
+      DBUG_ASSERT(is_positional_currency((uchar) front()));
+      return (feature_t) F_PREFIX_CLU;
+    }
+  };
+
+  // GRAMMAR: postfix_currency_signature: positional_currency_signature
+  class Postfix_currency: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    class Cond: public Positional_currency_signature_cond { };
+    using Container= CONTAINER1<Parser, LS_container, Postfix_currency>;
+    using LParser= TokenChoice<Parser, Cond>;
+    // Conversion methods
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 1);
+      DBUG_ASSERT(is_positional_currency((uchar) front()));
+      return (feature_t) F_PREFIX_CLU;
+    }
+  };
+
+  // GRAMMAR: dec_delimiter_currency_signature: positional_currency_signature
+  class Dec_delimiter_pDVCLU: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    class Cond: public Positional_currency_signature_cond { };
+    using Container= CONTAINER1<Parser, LS_container, Dec_delimiter_pDVCLU>;
+    using LParser= TokenChoice<Parser, Cond>;
+    // Conversion methods
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 1);
+      if (is_positional_currency(front()))
+        return F_FRAC_DEC_CLU;
+      switch (front()) {
+      case '.':
+        return F_FRAC_DEC_PERIOD;
+      case 'D':
+      case 'd':
+        return F_FRAC_DEC_D;
+      case 'V':
+      case 'v':
+        return F_FRAC_DEC_V;
+      default:
+        break;
+      }
+      DBUG_ASSERT(0);
+      return F_NONE;
+    }
+  };
+
+
+  // GRAMMAR: format_TM_signature: 'TM' | 'TM9' | 'TME'
+  class Format_TM: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Cond= TokenChoiceCond3<Parser, TokenID::tTM,
+                                         TokenID::tTM9,
+                                         TokenID::tTME>;
+    using Container= CONTAINER1<Parser, LS_container, Format_TM>;
+    using LParser= TokenChoice<Parser, Cond>;
+    // Delete copying
+    Format_TM(const Format_TM & rhs) = delete;
+    Format_TM & operator=(const Format_TM & rhs) = delete;
+    // Initializing from itself
+    Format_TM(Format_TM && rhs) = default;
+    Format_TM & operator=(Format_TM && rhs) = default;
+    // Initializing from its components
+    Format_TM(LS_container && rhs)
+     :LS_container(std::move(rhs))
+    { }
+    // Initializing from rules
+    Format_TM(LParser && rhs)
+     :LS_container(std::move(rhs))
+    { }
+    // Conversion methods
+    feature_t features_found() const
+    {
+      if (!length())
+        return F_NONE;
+      DBUG_ASSERT(length() == 2 || length() == 3);
+      return F_FMT_TM;
+    }
+  };
+
+
+  // GRAMMAR: fraction_pDV_signature: '.' | 'D' | 'V'
+  using Fraction_pDV_signature_cond= TokenChoiceCond3<Parser,
+                                                      TokenID::tPERIOD,
+                                                      TokenID::tD,
+                                                      TokenID::tV>;
+  class Fraction_pDV_signature: public TokenChoice<Parser,
+                                                   Fraction_pDV_signature_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+
+  // Rules consisting of more complex token choices
+
+  // GRAMMAR: fractional_element: zeros_or_nines | decimal_flag
+  class Fractional_element_cond
+  {
+  public:
+    static bool allowed_token_id(TokenID id)
+    {
+      return Zeros_or_nines_cond::allowed_token_id(id) ||
+             Decimal_flag_cond::allowed_token_id(id);
+    }
+  };
+  class Fractional_element: public TokenChoice<Parser, Fractional_element_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+  // GRAMMAR: integer_element: fractional_element | group_separator
+  class Integer_element_cond
+  {
+  public:
+    static bool allowed_token_id(TokenID id)
+    {
+      return Fractional_element_cond::allowed_token_id(id) ||
+             Group_separator_cond::allowed_token_id(id);
+    }
+  };
+  class Integer_element: public TokenChoice<Parser, Integer_element_cond>
+  { using TokenChoice::TokenChoice; };
+
+
+
+  /*
+    Rules consisting of a LIST of token choices
+  */
+
+  // GRAMMAR: currency_prefix_flag: decimal_flag
+  // GRAMMAR: currency_prefix_flags: currency_prefix_flag [ currency_prefix_flag...]
+  class Currency_prefix_flags: public LS_container
+  {
+  public:
+    using LS_container::LS_container;
+    using Container= CONTAINER1<Parser, LS_container, Currency_prefix_flags>;
+    using Flag= TokenChoice<Parser, Decimal_flag_cond>;
+    using LParser= LIST<Parser, Container, Flag,
+                        TokenID::tNULL /* not separated */,
+                        1 /* needs at least one element */>;
+    // Conversion methods
+    Decimal_flag_counters prefix_flag_counters() const
+    {
+      Decimal_flag_counters tmp;
+      for (size_t i= 0; i < length(); i++)
+        tmp.add(at(i));
+      return tmp;
+    }
+    feature_t features_found() const
+    {
+      DBUG_ASSERT(length() <= 2); // $ + B
+      uint res= F_NONE;
+      for (size_t i= 0; i < length(); i++)
+      {
+        if (at(i) == '$')
+          res|= F_PREFIX_DOLLAR;
+        else if (is_currency_flag_B(at(i)))
+          res|= F_PREFIX_B;
+        else
+        {
+          DBUG_ASSERT(0);
+        }
+      }
+      return (feature_t) res;
+    }
+  };
+
+
+  /*
+    Digits:
+    - decimal digit placeholders: 0 9
+    - hex digit placeholders:     X    (only in the integer part of a number)
+    - inline flags:               $ B
+    - group separators:           , G  (only in the integer part of a number)
+  */
+  class Digits: public LS_container,
+                public Decimal_flag_counters
+  {
+    using A= LS_container;
+    using B= Decimal_flag_counters;
+  public:
+    using Container= OR_CONTAINER2<Parser, Digits, A, B>;
+    // Default ctor
+    Digits() = default;
+    // Delete copying
+    Digits(const Digits & rhs) = delete;
+    Digits & operator=(const Digits & rhs) = delete;
+    // Initializing from itself
+    Digits(Digits && rhs) = default;
+    Digits & operator=(Digits && rhs) = default;
+    // Initializing from its components
+    Digits(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+    // Initializing from rules
+    Digits(Zeros_or_nines && rhs)
+     :A(std::move(rhs))
+    { }
+    Digits(XChain && rhs)
+     :A(std::move(rhs))
+    { }
+
+    // Other methods
+    /*
+      Check if the counters are valid:
+      @retval false - OK - the counters are valid
+      @retval true  - Error - the counters are not valid (e.g. double B)
+    */
+    bool check_counters() const
+    {
+      /*
+        - $ can appear only once
+        - B can appear only once
+        - Comma and G cannot co-exist
+      */
+      return m_dollar_count > 1 || m_B_count > 1 ||
+             (m_comma_count > 0 && m_G_count > 0);
+    }
+    operator bool() const
+    {
+      return LS_container::operator bool() && !check_counters();
+    }
+
+    /*
+      Hide the inherited concat() to prevent descendants from using it
+      in a mistake instead of join().
+    */
+    bool concat()= delete;
+
+    // Join two consequence sequences of digits '00'+'99' -> '0099'
+    bool join(Digits && rhs)
+    {
+      B::join(std::move(rhs));
+      return A::concat(std::move(rhs));
+    }
+    bool add(Parser *p, LS && rhs) // for LIST
+    {
+      DBUG_ASSERT(rhs.length() > 0);
+      B::add(rhs.front());
+      if (check_counters())
+        return true;
+      return A::add(p, std::move(rhs));
+    }
+
+  }; // End of class Digits
+
+
+
+  /********** Rules related to the integer part of a number ***/
+
+  // GRAMMAR: integer: integer_element [ integer_element...]
+  class Integer: public Digits
+  {
+  public:
+    using Container= CONTAINER1<Parser, Digits, Integer>;
+    using Digits::Digits;
+
+    // Deleting copying
+    Integer(const Integer & rhs) = delete;
+    Integer & operator=(const Integer & rhs) = delete;
+
+    // Initializing from itself
+    Integer(Integer && rhs) = default;
+    Integer & operator=(Integer && rhs) = default;
+
+    // Initializing from its components
+    Integer(Digits && rhs)
+     :Digits(std::move(rhs))
+    { }
+
+    // Helper constructors used in descendants
+
+    // Zeros_or_nines + extra digits
+    Integer(Zeros_or_nines && head, Integer && tail)
+     :Digits(std::move(head))
+    {
+      /*
+        According to the grammar, in the integer context "head"
+        can be either zeros or nines. A mixture of zeros and nines
+        is only possible in the fractional part. So if front() is '0',
+        it means the entire head consists of zeros.
+      */
+      DBUG_ASSERT(!head.length() || head.front() == head.back());
+      if (head.length() && head.front() == '0')
+        m_0_count= (uint32) head.length(); // see the comment above
+      Integer::join(std::move(tail));
+    }
+
+    /*
+      A tail of an integer number.
+      It can start with a group character.
+    */
+    using Tail= LIST<Parser, Container,
+                     Integer_element,
+                     TokenID::tNULL /*not separated*/,
+                     1 /* needs at least one element*/>;
+
+    // Conversion methods
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t) (F_INT_DIGIT | F_INT_B | F_INT_GROUP_COMMA);
+    }
+    feature_t features_found() const
+    {
+      uint res= F_NONE;
+      if (length() > non_digit_length())
+      {
+        res|= F_INT_DIGIT;
+        if (back() == 'X' || back() == 'x')
+          res|= F_INT_HEX;
+      }
+      if (m_B_count)
+        res|= F_INT_B;
+      if (m_dollar_count)
+        res|= F_INT_DOLLAR;
+      if (m_comma_count)
+        res|= F_INT_GROUP_COMMA;
+      if (m_G_count)
+        res|= F_INT_GROUP_G;
+      return (feature_t) res;
+    }
+
+    Double_null to_dbln_fixed(LS sbj, CHARSET_INFO *cs) const
+    {
+      DBUG_ASSERT(m_G_count == 0);
+      size_t non_digit_count= m_dollar_count + m_B_count + m_G_count;
+      sbj= sbj.ltrim(cs);
+      DBUG_ASSERT(non_digit_count <= length());
+      // $ and B are flags, they don't need to match anything in sbj
+      size_t chars_to_match= length() - non_digit_count;
+      if (chars_to_match < sbj.length())
+        return Double_null(); // Can never match
+
+      /*
+        Skip the leading format characters which require a match in
+        the subject string (i.e. digits and commas) and which are outside
+        of the subject length.
+          sbj='12, fmt= '$99B9' -> fmt= '9B9'
+      */
+      size_t skip= chars_to_match - sbj.length();
+      LS fmt(ptr(), end());
+      for ( ; fmt.length() > 0 && skip > 0; fmt= fmt.chop_left())
+      {
+        /*
+          Can not skip zeros, they must have a match in the subject string
+          and thus can be used to set the mininum number of digits, e.g.
+          in to_number(.., '099')  the subject string must have at least
+          3 digits.
+        */
+        if (fmt.front() == '0')
+          return Double_null();
+        if (!is_currency_flag(fmt.front()))
+          skip--;
+      }
+      DBUG_ASSERT(fmt.length() >= sbj.length());
+
+      double nr= 0;
+      size_t digit_matched= 0;
+      for (size_t pos= 0; pos < sbj.length(); pos++, fmt= fmt.chop_left())
+      {
+        fmt= fmt.ltrim_currency_flags();
+        if (fmt.front() == ',')
+        {
+          if (sbj.at(pos) != ',')
+            return Double_null();
+          continue;
+        }
+        DBUG_ASSERT(fmt.front() == '0' || fmt.front() == '9');
+        if (sbj.at(pos) < '0' || sbj.at(pos) > '9')
+          return Double_null();
+        digit_matched++;
+        nr*= 10;
+        nr+= (uint) ((uint) (uchar) sbj.at(pos)) - (uchar) '0';
+      }
+      DBUG_ASSERT(fmt.ltrim_currency_flags().length() == 0);
+
+      return digit_matched ? Double_null(nr) : Double_null();
+    }
+  };
+
+
+
+  /********** Rules related to the fractional part of a number ***/
+
+  // GRAMMAR: fraction_body: fractional_digit [ fractional_digit ... ]
+  class Fraction_body: public Digits
+  {
+  public:
+    using Digits::Digits;
+    using Container= CONTAINER1<Parser, Digits, Fraction_body>;
+    using LParser= LIST<Parser, Fraction_body::Container, Fractional_element,
+                        TokenID::tNULL /* not separated */, 1>;
+
+    // Initializing from its components
+    Fraction_body(Digits && rhs)
+     :Digits(std::move(rhs))
+    { }
+    // Conversion methods
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t) (F_FRAC_DIGIT | F_FRAC_B | F_FRAC_DEC_PERIOD);
+    }
+
+    feature_t features_found() const
+    {
+      uint res= F_NONE;
+      if (length() > non_digit_length())
+        res|= F_FRAC_DIGIT;
+      if (m_B_count)
+        res|= F_FRAC_B;
+      if (m_dollar_count)
+        res|= F_FRAC_DOLLAR;
+      return (feature_t) res;
+    }
+
+    Double_null to_dbln_fixed(LS sbj, CHARSET_INFO *cs) const
+    {
+      size_t flag_count= m_dollar_count + m_B_count;
+      sbj= sbj.ltrim(cs);
+      DBUG_ASSERT(flag_count <= length());
+      // $ and B are flags, they don't need to match anything in sbj
+      size_t chars_to_match= length() - flag_count;
+      if (chars_to_match < sbj.length())
+        return Double_null(); // Can never match
+
+      /*
+        Skip the trailing format characters which require a match in
+        the subject string (i.e. digits) and which are outside
+        of the subject length.
+          sbj='.99', fmt= '.99B9' -> fmt= '.99B'
+          sbj='.99', fmt= '.9B99' -> fmt= '.9B9'
+      */
+      size_t skip= chars_to_match - sbj.length();
+      LS fmt= to_LS();
+      for ( ; fmt.length() && skip > 0; fmt= fmt.chop_right())
+      {
+        if (!is_currency_flag(fmt.back()))
+          skip--;
+      }
+      DBUG_ASSERT(fmt.length() >= sbj.length());
+
+      double nr= 0;
+      size_t digits_matched= 0;
+      for (size_t pos= 0; pos < sbj.length(); pos++, fmt= fmt.chop_left())
+      {
+        fmt= fmt.ltrim_currency_flags();
+        DBUG_ASSERT(fmt.front() == '0' || fmt.front() == '9');
+        if (sbj.at(pos) < '0' && sbj.at(pos) > '9')
+          return Double_null();
+        digits_matched++;
+        nr*= 10;
+        nr+= ((uint) (uchar) sbj.at(pos)) - (uchar) '0';
+      }
+      DBUG_ASSERT(fmt.ltrim_currency_flags().ptr() == fmt.end());
+      double tmp= digits_matched < array_elements(log_10) ?
+                  log_10[digits_matched] : pow(10.0, (double) digits_matched);
+      /*
+        Unlike Integer, Fraction does not need any digits to match
+        to return a not-NULL result.
+        It's enough that the decimal delimiter matched:
+          to_number('.', '.') -> 0
+      */
+      return digits_matched ? Double_null(nr / tmp) : Double_null(0);
+    }
+
+  };
+
+
+  /*
+    GRAMMAR: fraction_pDV: fraction_pDV_signature [ fraction_body ]
+
+    GRAMMAR: fraction_pDVCLU: positional_currency [ fraction_body ]
+    GRAMMAR:                | fraction_pDV [ postfix_currency_signature ]
+  */
+
+  class Fraction: public Dec_delimiter_pDVCLU,
+                  public Fraction_body,
+                  public Postfix_currency
+  {
+    using A= Dec_delimiter_pDVCLU;
+    using B= Fraction_body;
+    using C= Postfix_currency;
+  public:
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool() && C::operator bool();
+    }
+    using Container= OR_CONTAINER3<Parser, Fraction, A, B, C>;
+
+    size_t length() const
+    {
+      return A::length() + B::length() +  C::length();
+    }
+
+    // Default ctor and initialization from its components
+    Fraction() = default;
+    Fraction(A && a, B && b, C && c)
+     :A(std::move(a)), B(std::move(b)), C(std::move(c))
+    { }
+
+    // Sub-component rules
+    class pDV: public AND2<Parser,
+                           Fraction_pDV_signature,
+                           Fraction_body::LParser::Opt>
+    { using AND2::AND2; };
+
+  private:
+    class pDVCLU_signature_Opt_Fraction_body:
+                                    public AND2<Parser,
+                                                Dec_delimiter_pDVCLU::LParser,
+                                                Fraction_body::LParser::Opt>
+    { using AND2::AND2; };
+    class pDV_Opt_Postfix_currency: public AND2<Parser,
+                                                pDV,
+                                                Postfix_currency::LParser::Opt>
+    { using AND2::AND2; };
+  public:
+
+    // Initialization from rules
+    Fraction(pDV && rhs)
+     :A(std::move(static_cast<Fraction_pDV_signature&&>(rhs))),
+      B(std::move(static_cast<Fraction_body&&>(rhs))),
+      C(C::empty())
+    { }
+    Fraction(pDV::Opt && rhs)
+     :A(std::move(static_cast<Fraction_pDV_signature&&>(rhs))),
+      B(std::move(static_cast<Fraction_body&&>(rhs))),
+      C(C::empty())
+    { }
+
+    Fraction(pDVCLU_signature_Opt_Fraction_body && rhs)
+     :A(std::move(static_cast<Dec_delimiter_pDVCLU::LParser&&>(rhs))),
+      B(std::move(static_cast<Fraction_body::LParser::Opt&&>(rhs))),
+      C(C::empty())
+    { }
+
+    Fraction(pDV_Opt_Postfix_currency && rhs)
+     :A(std::move(static_cast<Fraction_pDV_signature&&>(rhs))),
+      B(std::move(static_cast<Fraction_body::Container&&>(rhs))),
+      C(std::move(static_cast<Postfix_currency::LParser::Opt&&>(rhs)))
+    { }
+
+
+    using LParser= OR2C<Parser, Fraction::Container,
+                        pDVCLU_signature_Opt_Fraction_body,
+                        pDV_Opt_Postfix_currency>;
+
+    // Conversion methods
+    feature_t features_found() const
+    {
+      return (feature_t) (A::features_found() |
+                          B::features_found() |
+                          C::features_found());
+    }
+
+    Double_null to_dbln_fixed(LS ls, CHARSET_INFO *cs) const
+    {
+      DBUG_ASSERT(!(features_found() & (F_FRAC_DEC_D | F_FRAC_DEC_CLU)));
+      if (!ls.length() || ls.front() != '.')
+        return Double_null();
+      return Fraction_body::to_dbln_fixed(ls.chop_left(), cs);
+    }
+  };
+
+
+
+  /********** A tail of a decimal number ***/
+
+  /*
+    GRAMMAR: decimal_tail_pDVCLU: integer_tail [ fraction_pDVCLU ]
+    GRAMMAR:                    | fraction_pDVCLU
+
+    GRAMMAR: decimal_tail_pDV: integer_tail [ fraction_pDV ]
+    GRAMMAR:                 | fraction_pDV
+  */
+
+  class Decimal_tail: public Integer,
+                      public Fraction
+  {
+    using A= Integer;
+    using B= Fraction;
+  public:
+    using Container= OR_CONTAINER2<Parser, Decimal_tail, A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Default ctor and initializing from its componenets
+    Decimal_tail() = default;
+    Decimal_tail(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+    Decimal_tail(B && b)
+     :A(A::Container::empty()), B(std::move(b))
+    { }
+
+    // Dependency rules
+private:
+    using Integer_tail_Opt_Fraction_pDVCLU= AND2<Parser,
+                                                 Integer::Tail,
+                                                 Fraction::LParser::Opt>;
+
+    using Integer_tail_Opt_Fraction_pDV= AND2<Parser,
+                                              Integer::Tail,
+                                              Fraction::pDV::Opt>;
+public:
+
+    // Initializing from rules
+    Decimal_tail(Integer_tail_Opt_Fraction_pDVCLU && rhs)
+     :A(static_cast<Integer::Tail&&>(std::move(rhs))),
+      B(static_cast<Fraction&&>(std::move(rhs)))
+    { }
+    Decimal_tail(Integer_tail_Opt_Fraction_pDV && rhs)
+     :A(static_cast<Integer::Tail&&>(std::move(rhs))),
+      B(static_cast<Fraction::pDV::Opt&&>(std::move(rhs)))
+    { }
+
+    Decimal_tail(Fraction::pDV && rhs)
+     :A(A::Container::empty()), B(std::move(rhs))
+    { }
+
+    // Derived rules
+    using Tail_pDVCLU= OR2C<Parser, Container,
+                            Integer_tail_Opt_Fraction_pDVCLU,
+                            Fraction::LParser>;
+
+    using Tail_pDV= OR2C<Parser, Container,
+                         Integer_tail_Opt_Fraction_pDV,
+                         Fraction::pDV>;
+  };
+
+
+
+  /********** A decimal number ****/
+
+  class Decimal: public Decimal_tail
+  {
+  public:
+    using Decimal_tail::Decimal_tail;
+    using Container= CONTAINER1<Parser, Decimal_tail, Decimal>;
+
+    // Initializing from rules
+    Decimal(XChain && rhs)
+     :Decimal_tail(std::move(rhs), Fraction::Container::empty())
+    { }
+
+    // Helper constructors used in descendants
+    Decimal(Zeros_or_nines && head, Decimal_tail && tail)
+     :Decimal_tail(
+        Integer::Container(std::move(head),
+                           std::move(static_cast<Integer&&>(tail))),
+        std::move(static_cast<Fraction&&>(tail)))
+    { }
+
+  };
+
+
+  /********** A tail of an approximate number (scientific notation) ***/
+
+  /*
+    An approximate tail:
+    Its integer part can start with a group character.
+
+    GRAMMAR: approximate_tail_pDVCLU: decimal_tail_pDVCLU [ EEEE ]
+    GRAMMAR:                        | EEEE
+    GRAMMAR: approximate_tail_pDV: decimal_tail_pDV [ EEEE ]
+    GRAMMAR:                     | EEEE
+  */
+  class Approximate_tail: public Decimal_tail,
+                          public EEEE
+  {
+    using A= Decimal_tail;
+    using B= EEEE;
+  public:
+    using Container= OR_CONTAINER2<Parser, Approximate_tail, A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Default ctor
+    Approximate_tail() = default;
+    // Deleting copying
+    Approximate_tail(const Approximate_tail & rhs) = delete;
+    Approximate_tail & operator=(const Approximate_tail & rhs) = delete;
+    // Initialization from itself
+    Approximate_tail(Approximate_tail && rhs) = default;
+    Approximate_tail & operator=(Approximate_tail && rhs) = default;
+    // Initialization from its components
+    Approximate_tail(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+
+    // Dependency rules
+private:
+    using Decimal_tail_pDVCLU_Opt_EEEE= AND2<Parser,
+                                             Decimal::Tail_pDVCLU,
+                                             EEEE::LParser::Opt>;
+    using Decimal_tail_pDV_Opt_EEEE= AND2<Parser,
+                                          Decimal::Tail_pDV,
+                                          EEEE::LParser::Opt>;
+public:
+    // Initialization from rules
+    Approximate_tail(EEEE::LParser::Opt && rhs)
+     :A(A::Container::empty()), B(std::move(rhs))
+    { }
+    Approximate_tail(Decimal_tail_pDVCLU_Opt_EEEE && rhs)
+     :A(std::move(static_cast<Decimal::Tail_pDVCLU&&>(rhs))),
+      B(std::move(static_cast<EEEE::LParser::Opt&&>(rhs)))
+    { }
+    Approximate_tail(Decimal_tail_pDV_Opt_EEEE && rhs)
+     :A(std::move(static_cast<Decimal::Tail_pDV&&>(rhs))),
+      B(std::move(static_cast<EEEE::LParser::Opt&&>(rhs)))
+    { }
+    Approximate_tail(XChain && rhs)
+     :A(Decimal(std::move(rhs))), B(B::Container::empty())
+    { }
+    Approximate_tail(Fraction::pDV && rhs)
+     :A(std::move(rhs)), B(B::Container::empty())
+    { }
+    Approximate_tail(Fraction && rhs)
+     :A(Decimal_tail::Container(std::move(rhs))), B(B::Container::empty())
+    { }
+
+    // Derived rules
+    using Tail_pDVCLU= OR2C<Parser, Container,
+                            Decimal_tail_pDVCLU_Opt_EEEE,
+                            EEEE::LParser::Opt>;
+
+    using Tail_pDV= OR2C<Parser, Container,
+                         Decimal_tail_pDV_Opt_EEEE,
+                         EEEE::LParser::Opt>;
+
+  };
+
+
+  /********** A well formed approximate number ***/
+  /*
+    Its integer part starts with a valid element (a digit or a flag).
+    It cannot start with a group character.
+
+    GRAMMAR: approximate_pDVCLU: zero_or_nines [ approximate_tail_pDVCLU ]
+    GRAMMAR:                   | fraction_pDVCLU
+
+    GRAMMAR: approximate_pDV: zero_or_nines [ approximate_tail_pDV ]
+    GRAMMAR:                | fraction_pDV
+  */
+
+  class Approximate: public Approximate_tail
+  {
+  public:
+    using Approximate_tail::Approximate_tail;
+    using Container= CONTAINER1<Parser, Approximate_tail, Approximate>;
+
+    // Delete copying
+    Approximate(const Approximate & rhs) = delete;
+    Approximate & operator=(const Approximate & rhs) = delete;
+    // Initializing from itself
+    Approximate(Approximate && rhs) = default;
+    Approximate & operator=(Approximate && rhs) = default;
+
+    // Dependency rules
+private:
+    using Zeros_or_nines_Opt_approximate_tail_pDVCLU=
+                                       AND2<Parser,
+                                            Zeros_or_nines,
+                                            Approximate_tail::Tail_pDVCLU::Opt>;
+
+    using Zeros_or_nines_Opt_approximate_tail_pDV=
+                                          AND2<Parser,
+                                               Zeros_or_nines,
+                                               Approximate_tail::Tail_pDV::Opt>;
+
+protected:
+    // Dependency rules, also used by Unsigned_currency
+    using Nines_Opt_approximate_tail_pDVCLU=
+                                      AND2<Parser,
+                                           Nines,
+                                           Approximate_tail::Tail_pDVCLU::Opt>;
+
+    using Zeros_Opt_approximate_tail_pDVCLU=
+                                       AND2<Parser,
+                                            Zeros,
+                                            Approximate_tail::Tail_pDVCLU::Opt>;
+public:
+
+    // Initializing from rules
+    Approximate(Zeros_Opt_approximate_tail_pDVCLU && rhs)
+     :Approximate_tail(
+       Decimal(
+         std::move(static_cast<Zeros &&>(rhs)),
+         std::move(static_cast<Decimal_tail &&>(rhs))),
+       std::move(static_cast<EEEE&&>(rhs)))
+    {  }
+
+    Approximate(Nines_Opt_approximate_tail_pDVCLU && rhs)
+     :Approximate_tail(
+       Decimal(
+         std::move(static_cast<Nines &&>(rhs)),
+         std::move(static_cast<Decimal_tail &&>(rhs))),
+       std::move(static_cast<EEEE&&>(rhs)))
+    { }
+
+    Approximate(Zeros_or_nines_Opt_approximate_tail_pDVCLU && rhs)
+     :Approximate_tail(
+       Decimal(
+         std::move(static_cast<Zeros_or_nines &&>(rhs)),
+         std::move(static_cast<Decimal_tail &&>(rhs))),
+       std::move(static_cast<EEEE&&>(rhs)))
+    { }
+
+    Approximate(Zeros_or_nines_Opt_approximate_tail_pDV && rhs)
+     :Approximate_tail(
+       Decimal(
+         std::move(static_cast<Zeros_or_nines &&>(rhs)),
+         std::move(static_cast<Decimal_tail &&>(rhs))),
+       std::move(static_cast<EEEE&&>(rhs)))
+    { }
+
+    // Derived rules
+    using pDVCLU= OR2C<Parser, Container,
+                       Zeros_or_nines_Opt_approximate_tail_pDVCLU,
+                       Fraction::LParser>;
+
+    using pDV= OR2C<Parser, Container,
+                    Zeros_or_nines_Opt_approximate_tail_pDV,
+                    Fraction::pDV>;
+
+    // Other methods
+
+    bool check(const Parser & parser, const char **pos) const
+    {
+      if (Integer::length() == 0 && EEEE::length() != 0)
+      {
+        *pos= EEEE::ptr();
+        return true;
+      }
+      return false;
+    }
+
+    void print(String *str) const
+    {
+      DBUG_ASSERT(Dec_delimiter_pDVCLU::length() ||
+                  !Fraction_body::length());
+      str->append("A='"_LS);
+      Integer::print(str);
+      if (Dec_delimiter_pDVCLU::length())
+      {
+        str->append("["_LS);
+        Dec_delimiter_pDVCLU::print(str);
+        str->append("]"_LS);
+      }
+      Fraction_body::print(str);
+      str->append("'"_LS);
+      if (Postfix_currency::length())
+        Postfix_currency::print_var_value(str, "RC"_LS);
+      EEEE::print(str);
+    }
+
+    // Other methods
+
+    /*
+      Return the fragment consisting only of digits,
+      without trailing currency and without EEEE.
+    */
+    LS to_LS_digits() const
+    {
+      /*
+        Integer and Fraction_body can be empty and point to empty_lex_cstring.
+        In this case it's not correct to concatenate them.
+      */
+      if (!Integer::length())
+        return Fraction_body::to_LS();
+      if (!Fraction_body::length())
+        return Integer::to_LS();
+      // Ok to contatenate
+      DBUG_ASSERT(Integer::end() < Fraction_body::ptr());
+      return {Integer::ptr(), Fraction_body::end()};
+    }
+
+    // Conversion methods
+    feature_t features_found() const
+    {
+      return (feature_t) (Integer::features_found() |
+                          Fraction::features_found() |
+                          EEEE::features_found());
+    }
+
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t)
+             (Integer::features_supported_by_to_dbln_fixed() |
+              Fraction::features_supported_by_to_dbln_fixed());
+    }
+
+    static feature_t features_supported_by_to_dbln_EEEE()
+    {
+      // Group separators are not supported in for EEEE
+      return (feature_t)
+             (F_INT_DIGIT  | F_INT_B  | F_INT_DOLLAR  |
+              F_FRAC_DIGIT | F_FRAC_B | F_FRAC_DOLLAR |
+              F_FRAC_DEC_PERIOD |  F_EEEE);
+    }
+
+    Double_null to_dbln_fixed(const LS sbj, CHARSET_INFO *cs) const
+    {
+      for (const char *period= sbj.ptr(); period < sbj.end(); period++)
+      {
+        if (*period == '.')
+        {
+          const LS ls_int(sbj.ptr(), period);
+          const LS ls_frac(period, sbj.end());
+          // Integer format length it can be 0 in a format like this: '$.9'
+          Double_null d_int= ls_int.length() == 0 ?
+                             Double_null(0) :
+                             Integer::to_dbln_fixed(ls_int, cs);
+          if (d_int.is_null())
+            return d_int;
+          Double_null d_frac= Fraction::to_dbln_fixed(ls_frac, cs);
+          if (d_frac.is_null())
+            return d_frac;
+          return Double_null(d_int.value() + d_frac.value());
+        }
+      }
+      return Integer::to_dbln_fixed(sbj, cs);
+    }
+
+    Double_null to_dbln_EEEE(const LS sbj, CHARSET_INFO *cs) const
+    {
+      if (sbj.length() > 0)
+      {
+        char *end;
+        int error;
+        double nr= cs->strntod((char *)sbj.ptr(), sbj.length(), &end, &error);
+        if (!error && end >= sbj.end())
+          return Double_null(nr);
+      }
+      /*
+        - Empty,
+        - Out or range
+        - Trailing garbage: to_number('1e+3x', '99EEEE')
+      */
+      return Double_null();
+    }
+  };
+
+
+  /********** Rules related to a number with a prefix currency signature ***/
+
+  /*
+    GRAMMAR: lflagged_approximate: 'B' approximate_pDV
+  */
+  class LFlagged_approximate: public Currency_prefix_flags,
+                              public Approximate
+  {
+    using A= Currency_prefix_flags;
+    using B= Approximate;
+  public:
+    using Container= OR_CONTAINER2<Parser, LFlagged_approximate, A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Default ctor
+    LFlagged_approximate() = default;
+    // Delete copying
+    LFlagged_approximate(const LFlagged_approximate & rhs) = delete;
+    LFlagged_approximate & operator=(const LFlagged_approximate & rhs) = delete;
+    // Initialization from itself
+    LFlagged_approximate(LFlagged_approximate && rhs) = default;
+    LFlagged_approximate & operator=(LFlagged_approximate && rhs) = default;
+    // Initialization from its components
+    LFlagged_approximate(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+    // Dependency rules
+    using B_Opt_Approximate_pDV= AND2<Parser, TokenB, Approximate::pDV::Opt>;
+    // Initialization from rules
+    LFlagged_approximate(B_Opt_Approximate_pDV && rhs)
+     :A(std::move(static_cast<TokenB&&>(rhs))),
+      B(std::move(static_cast<Approximate::Container&&>(rhs)))
+    { }
+    LFlagged_approximate(Approximate::pDV && rhs)
+     :A(A::empty()),
+      B(std::move(rhs))
+    { }
+  };
+
+
+  /********** Unsigned currency ***/
+
+  /*
+    GRAMMAR: unsigned_currency: unsigned_currency0
+    GRAMMAR:                  | unsigned_currency1
+
+    GRAMMAR: usigned_currency0: zeros [ approximate_tail_pDVCLU ];
+
+    Unsigned_currency1 - a currency not starting with zeros:
+
+    GRAMMAR: unsigned_currency1:
+    GRAMMAR:     nines [ approximate_tail_pDVCLU ]
+    GRAMMAR:   | decimal_flags [ approximate_pDVCLU ]
+    GRAMMAR:   | left_currency
+    GRAMMAR:   | fraction_pDV [EEEE] [ positional_currency ]
+
+
+    GRAMMAR: left_currency: prefix_currency_signature     [ approximate_pDV ]
+    GRAMMAR:              | prefix_currency_signature 'B' [ approximate_pDV ]
+  */
+
+  class Unsigned_currency: public Prefix_currency,
+                           public Currency_prefix_flags,
+                           public Approximate
+  {
+    using A= Prefix_currency;
+    using B= Currency_prefix_flags;
+    using C= Approximate;
+  public:
+    using Container= OR_CONTAINER3<Parser, Unsigned_currency, A, B, C>;
+
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool() && C::operator bool();
+    }
+    // Default ctor
+    Unsigned_currency() = default;
+    // Delete copying
+    Unsigned_currency(const Unsigned_currency & rhs) = delete;
+    Unsigned_currency & operator=(const Unsigned_currency & rhs) = delete;
+    // Initializing from itself
+    Unsigned_currency(Unsigned_currency &&rhs) = default;
+    Unsigned_currency & operator=(Unsigned_currency && rhs) = default;
+    // Initializing from its componenents
+    Unsigned_currency(A && a, B && b, C && c)
+     :A(std::move(a)), B(std::move(b)), C(std::move(c))
+    { }
+    // Dependency rules
+private:
+    using Left_currency_tail= OR2C<Parser, LFlagged_approximate::Container,
+                                   Approximate::pDV,
+                                   LFlagged_approximate::B_Opt_Approximate_pDV>;
+
+    using Left_currency= AND2<Parser,
+                              Prefix_currency::LParser,
+                              Left_currency_tail::Opt>;
+
+    using Decimal_flags_Opt_approximate_pDVCLU=
+                                         AND2<Parser,
+                                              Currency_prefix_flags::LParser,
+                                              Approximate::pDVCLU::Opt>;
+
+    using Fraction_pDV_Opt_EEEE_Opt_postfix_currency=
+                                           AND3<Parser,
+                                                Fraction::pDV,
+                                                EEEE::LParser::Opt,
+                                                Postfix_currency::LParser::Opt>;
+public:
+    // Initializing from rules
+    Unsigned_currency(Nines_Opt_approximate_tail_pDVCLU &&rhs)
+     :A(A::empty()),
+      B(B::empty()),
+      C(std::move(rhs))
+    { }
+    Unsigned_currency(Decimal_flags_Opt_approximate_pDVCLU &&rhs)
+     :A(A::empty()),
+      B(std::move(static_cast<Currency_prefix_flags::LParser&&>(rhs))),
+      C(std::move(static_cast<Approximate::Container&&>(rhs)))
+    { }
+    Unsigned_currency(Left_currency &&rhs)
+     :A(std::move(static_cast<Prefix_currency::LParser&&>(rhs))),
+      B(std::move(static_cast<Currency_prefix_flags&&>(rhs))),
+      C(std::move(static_cast<Approximate&&>(rhs)))
+    { }
+    Unsigned_currency(Fraction_pDV_Opt_EEEE_Opt_postfix_currency &&rhs)
+     :A(A::empty()),
+      B(B::empty()),
+      C(Decimal(Fraction(
+          std::move(static_cast<Fraction_pDV_signature&&>(rhs)),
+          std::move(static_cast<Fraction_body::LParser::Opt&&>(rhs)),
+          std::move(static_cast<Postfix_currency::LParser::Opt&&>(rhs)))),
+        EEEE(std::move(static_cast<EEEE::LParser::Opt&&>(rhs))))
+    { }
+    Unsigned_currency(Zeros_Opt_approximate_tail_pDVCLU && rhs)
+     :A(A::empty()),
+      B(B::empty()),
+      C(std::move(rhs))
+    { }
+
+    using Unsigned_currency0= Zeros_Opt_approximate_tail_pDVCLU;
+
+    using Unsigned_currency1= OR4C<Parser, Container,
+                                   Nines_Opt_approximate_tail_pDVCLU,
+                                   Decimal_flags_Opt_approximate_pDVCLU,
+                                   Left_currency,
+                                   Fraction_pDV_Opt_EEEE_Opt_postfix_currency>;
+
+    using LParser= OR2C<Parser, Container,
+                        Unsigned_currency0,
+                        Unsigned_currency1>;
+
+    // Other methods
+    bool check(const Parser & parser,
+               const Decimal_flag_counters & prefix_flag_counters,
+               const char **pos) const
+    {
+      if (Approximate::check(parser, pos))
+        return true;
+
+      size_t approx_dollar_count= Integer::m_dollar_count +
+                                  Fraction::m_dollar_count;
+      // e.g. '$.$'
+      if (prefix_flag_counters.m_dollar_count + approx_dollar_count > 1)
+      {
+        if (prefix_flag_counters.m_dollar_count > 1)
+          *pos= Currency_prefix_flags::to_LS().find_dollar(1);
+        else
+          *pos= Approximate::to_LS_digits().
+                    find_dollar(!prefix_flag_counters.m_dollar_count);
+        return true;
+      }
+
+      // e.g. 'B.B'
+      if (prefix_flag_counters.m_B_count +
+          Integer::m_B_count + Fraction::m_B_count > 1)
+      {
+        if (prefix_flag_counters.m_B_count > 1)
+          *pos= Currency_prefix_flags::to_LS().find_currency_flag_B(1);
+        else
+          *pos= Approximate::to_LS_digits().
+                  find_currency_flag_B(!prefix_flag_counters.m_B_count);
+        return true;
+      }
+
+      // '$9C'  '9$C'
+      if (prefix_flag_counters.m_dollar_count || approx_dollar_count)
+      {
+        if (Dec_delimiter_pDVCLU::length())
+        {
+          const char *dec= Dec_delimiter_pDVCLU::ptr();
+          if (is_positional_currency(dec[0]))
+          {
+            *pos= dec;
+            return true;
+          }
+        }
+        // '$.C'
+        if (Postfix_currency::length())
+        {
+          *pos= Postfix_currency::ptr();
+          return true;
+        }
+      }
+
+      // 'C0$', 'C$U' 'V$U'
+      if (Prefix_currency::length() && approx_dollar_count)
+      {
+        *pos= Approximate::to_LS_digits().find_dollar(0);
+        return true;
+      }
+
+      return false;
+    }
+
+    // Conversion methods
+    feature_t features_found() const
+    {
+      return (feature_t) (A::features_found() |
+                          B::features_found() |
+                          C::features_found());
+    }
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t)
+             (Approximate::features_supported_by_to_dbln_fixed() |
+              F_PREFIX_B | F_PREFIX_DOLLAR | F_INT_DOLLAR | F_FRAC_DOLLAR);
+    }
+
+    static feature_t features_supported_by_to_dbln_EEEE()
+    {
+      return (feature_t)
+             (Approximate::features_supported_by_to_dbln_EEEE() |
+              //F_PREFIX_CLU
+              F_PREFIX_B |
+              F_PREFIX_DOLLAR
+             );
+    }
+
+    bool get_prefix_dollar_sign(LS *ls) const
+    {
+      if (Currency_prefix_flags::prefix_flag_counters().m_dollar_count ||
+          Integer::m_dollar_count ||
+          Fraction::m_dollar_count)
+      {
+        if (!ls->length() || ls->front() != '$')
+          return true;
+        *ls= ls->chop_left();
+      }
+      return false;
+    }
+
+    Double_null to_dbln_fixed(LS src, CHARSET_INFO *cs) const
+    {
+      return get_prefix_dollar_sign(&src) ?
+             Double_null() :
+             Approximate::to_dbln_fixed(src, cs);
+    }
+
+    Double_null to_dbln_EEEE(LS src, CHARSET_INFO *cs) const
+    {
+      return get_prefix_dollar_sign(&src) ?
+             Double_null() :
+             Approximate::to_dbln_EEEE(src, cs);
+    }
+  };
+
+
+  /********** A currency with a postfix sign ***/
+  /*
+    For the grammar simplicity, currency0_with_postfix_sign includes
+    xchain (optionally preceding by zeros), allthough it cannot really
+    be followed by a postfix sign. "xxx_with_postix_sign" here means
+    "xxx which can optionally be followed by a postfix sign", or
+    "xxx which does not have a preceeding prefix sign".
+
+
+    currency0_with_postfix_sign: zeros xchain
+                               | zeros [ approximate_tail_pDVCLU ]
+                                       [ postfix_sign ]
+    Rewriting the grammar as:
+    GRAMMAR: currency0_with_postfix_sign: zeros [ zeros_tail ]
+    GRAMMAR: zeros_tail: xchain
+    GRAMMAR:           | approximate_tail_pDVCLU [ postfix_sign ]
+    GRAMMAR:           | postfix_sign
+  */
+
+  class Currency0_tail_with_postfix_sign: public Approximate_tail,
+                                          public Postfix_sign
+  {
+    using A= Approximate_tail;
+    using B= Postfix_sign;
+  public:
+    using Container= OR_CONTAINER2<Parser, Currency0_tail_with_postfix_sign,
+                                    A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Delete copying
+    Currency0_tail_with_postfix_sign(const Currency0_tail_with_postfix_sign &)
+                                                                    = delete;
+    Currency0_tail_with_postfix_sign & operator=
+                          (const Currency0_tail_with_postfix_sign & rhs)
+                                                                    = delete;
+    // Initialization from itself
+    Currency0_tail_with_postfix_sign(Currency0_tail_with_postfix_sign && rhs)
+                                                                  = default;
+    Currency0_tail_with_postfix_sign & operator=
+                          (Currency0_tail_with_postfix_sign && rhs) = default;
+    // Initialization from its components
+    Currency0_tail_with_postfix_sign(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+
+    // Dependency rules
+  private:
+    using Approximate_tail_pDVCLU_Opt_postfix_sign=
+                                             AND2<Parser,
+                                                  Approximate_tail::Tail_pDVCLU,
+                                                  Postfix_sign_signature::Opt>;
+  public:
+    // Initialization from rules
+    Currency0_tail_with_postfix_sign(XChain && rhs)
+     :A(std::move(rhs)), B(B::empty())
+    { }
+    Currency0_tail_with_postfix_sign(
+                                Approximate_tail_pDVCLU_Opt_postfix_sign &&rhs)
+     :A(std::move(static_cast<Approximate_tail::Container&&>(rhs))),
+      B(std::move(static_cast<Postfix_sign_signature::Opt&&>(rhs)))
+    { }
+    Currency0_tail_with_postfix_sign(Postfix_sign_signature::Opt && rhs)
+     :A(A::Container::empty()), B(std::move(rhs))
+    { }
+
+    using LParser=OR3C<Parser, Currency0_tail_with_postfix_sign::Container,
+                       XChain,
+                       Approximate_tail_pDVCLU_Opt_postfix_sign,
+                       Postfix_sign_signature::Opt>;
+  };
+
+
+  /*
+    GRAMMAR: currency_with_postfix_sign: xchain
+    GRAMMAR:                           | currency0_with_postfix_sign
+    GRAMMAR:                           | unsigned_currency1 [ postfix_sign ]
+    GRAMMAR:                           | postfix_specific_sign_signature
+  */
+  class Currency_with_postfix_sign: public Unsigned_currency,
+                                    public Postfix_sign
+  {
+    using A= Unsigned_currency;
+    using B= Postfix_sign;
+  public:
+    using Container= OR_CONTAINER2<Parser, Currency_with_postfix_sign, A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Default ctor
+    Currency_with_postfix_sign() = default;
+    // Delete copying
+    Currency_with_postfix_sign(const Currency_with_postfix_sign &) = delete;
+    Currency_with_postfix_sign & operator=(const Currency_with_postfix_sign &)
+                                                                  = delete;
+    // Initialization from itself
+    Currency_with_postfix_sign(Currency_with_postfix_sign && rhs) = default;
+    Currency_with_postfix_sign & operator=(Currency_with_postfix_sign && rhs)
+                                                                  = default;
+    // Initialization from its components
+    Currency_with_postfix_sign(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+
+    // Dependency rules
+private:
+    using Currency0_with_postfix_sign=
+                                AND2<Parser,
+                                     Zeros,
+                                     Currency0_tail_with_postfix_sign::LParser>;
+
+    using Unsigned_currency1_Opt_Postfix_sign=
+                                     AND2<Parser,
+                                          Unsigned_currency::Unsigned_currency1,
+                                          Postfix_sign_signature::Opt>;
+public:
+    // Initialization from rules
+    Currency_with_postfix_sign(XChain && rhs)
+     :A(Unsigned_currency::Container(Approximate::Container(std::move(rhs)))),
+      B(B::Container::empty())
+    { }
+
+    Currency_with_postfix_sign(Currency0_with_postfix_sign && rhs)
+     :A(Unsigned_currency::Container(
+          Approximate::Container(
+            Decimal(
+              std::move(Zeros_or_nines(static_cast<Zeros&&>(rhs))),
+              std::move(static_cast<Decimal_tail&&>(rhs))),
+            std::move(static_cast<EEEE&&>(rhs))))),
+      B(std::move(static_cast<Postfix_sign&&>(rhs)))
+    { }
+
+    Currency_with_postfix_sign(Unsigned_currency1_Opt_Postfix_sign && rhs)
+     :A(std::move(static_cast<Unsigned_currency::Container&&>(rhs))),
+      B(std::move(static_cast<Postfix_sign_signature::Opt&&>(rhs)))
+    { }
+
+    Currency_with_postfix_sign(Postfix_specific_sign_signature && rhs)
+     :A(A::Container::empty()),
+      B(std::move(rhs))
+    { }
+
+    using LParser= OR4C<Parser, Currency_with_postfix_sign::Container,
+                        XChain,
+                        Currency0_with_postfix_sign,
+                        Unsigned_currency1_Opt_Postfix_sign,
+                        Postfix_specific_sign_signature>;
+
+    // Other methods
+    bool check(const Parser & parser,
+               const Decimal_flag_counters & prefix_flag_counters,
+               const char **pos) const
+    {
+      return Unsigned_currency::check(parser, prefix_flag_counters, pos);
+    }
+
+    void print(String *str) const
+    {
+      if (Currency_prefix_flags::length())
+        Currency_prefix_flags::print_var_value(str, "CFl"_LS);
+
+      if (Prefix_currency::length())
+        Prefix_currency::print_var_value(str, "LC"_LS);
+
+      Approximate::print(str);
+
+      if (Postfix_sign::length())
+        Postfix_sign::print_var_value(str, "RS"_LS);
+    }
+
+    // Conversion methods
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t)
+             (Unsigned_currency::features_supported_by_to_dbln_fixed() |
+              F_POSTFIX_SIGN);
+    }
+    static feature_t features_supported_by_to_dbln_EEEE()
+    {
+      return (feature_t)
+             (Unsigned_currency::features_supported_by_to_dbln_EEEE() |
+              F_POSTFIX_SIGN);
+    }
+    feature_t features_found() const
+    {
+      return (feature_t) (Postfix_sign::features_found() |
+                          Unsigned_currency::features_found());
+    }
+
+    Double_null to_dbln_fixed(LS src, CHARSET_INFO *cs) const
+    {
+      bool neg;
+      if (Postfix_sign::get(&neg, &src))
+        return Double_null();
+      const Double_null rc= Unsigned_currency::to_dbln_fixed(src, cs);
+      return rc.is_null() || !neg ? rc : -rc;
+    }
+
+    Double_null to_dbln_EEEE(LS src, CHARSET_INFO *cs) const
+    {
+      bool neg;
+      if (Postfix_sign::get(&neg, &src))
+        return Double_null();
+      const Double_null rc= Unsigned_currency::to_dbln_EEEE(src, cs);
+      return rc.is_null() || !neg ? rc : -rc;
+    }
+  };
+
+
+  /********** An unsigned format ***/
+
+  /*
+    GRAMMAR: unsigned_format: unsigned_currency
+    GRAMMAR:                | format_TM_signature
+  */
+
+  class Unsigned_format: public Unsigned_currency,
+                         public Format_TM
+  {
+    using A= Unsigned_currency;
+    using B= Format_TM;
+  public:
+    using Container= OR_CONTAINER2<Parser, Unsigned_format, A, B>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool();
+    }
+    // Default ctor
+    Unsigned_format() = default;
+    // Delete copying
+    Unsigned_format(const Unsigned_format & rhs) = delete;
+    Unsigned_format & operator=(const Unsigned_format & rhs) = delete;
+    // Initializing from itself
+    Unsigned_format(Unsigned_format && rhs) = default;
+    Unsigned_format & operator=(Unsigned_format && rhs) = default;
+
+    // Initializing from its componenet
+    Unsigned_format(A && a, B && b)
+     :A(std::move(a)), B(std::move(b))
+    { }
+
+    // Initilizing from rules
+    Unsigned_format(Unsigned_currency::LParser && rhs)
+     :A(std::move(rhs)), B(B::empty())
+    { }
+
+    Unsigned_format(Format_TM::LParser && rhs)
+     :A(A::Container::empty()), B(std::move(rhs))
+    { }
+    using LParser= OR2C<Parser, Container,
+                        Unsigned_currency::LParser,
+                        Format_TM::LParser>;
+  };
+
+
+  /********** The format - the top level rules ****/
+
+  /*
+    GRAMMAR: format_FM_tail: currency_with_postfix_sign
+    GRAMMAR:               | 'S' [ unsigned_format ]
+    GRAMMAR:               | format_TM
+  */
+
+  class Format_FM_tail: public Prefix_sign,
+                        public Unsigned_format,
+                        public Postfix_sign
+  {
+    using A= Prefix_sign;
+    using B= Unsigned_format;
+    using C= Postfix_sign;
+  public:
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool() && C::operator bool();
+    }
+    using Container= OR_CONTAINER3<Parser, Format_FM_tail, A, B, C>;
+    // Delete copying
+    Format_FM_tail(const Format_FM_tail & rhs) = delete;
+    Format_FM_tail & operator=(const Format_FM_tail & rhs) = delete;
+    // Initializing from itself
+    Format_FM_tail(Format_FM_tail && rhs) = default;
+    Format_FM_tail & operator=(Format_FM_tail && rhs) = default;
+    // Initialization from its components
+    Format_FM_tail(A && a, B && b, C && c)
+     :A(std::move(a)), B(std::move(b)), C(std::move(c))
+    { }
+
+    // Dependency rules
+private:
+    using Prefix_sign_Opt_unsigned_format= AND2<Parser,
+                                                Prefix_sign::LParser,
+                                                Unsigned_format::LParser::Opt>;
+public:
+    // Initializing from rules
+    Format_FM_tail(Format_TM::LParser &&rhs)
+     :A(A::Container::empty()),
+      B(Unsigned_format::Container(std::move(rhs))),
+      C(C::empty())
+    { }
+
+    Format_FM_tail(Currency_with_postfix_sign::LParser && rhs)
+     :A(A::empty()),
+      B(Unsigned_format::Container(static_cast<Unsigned_currency&&>(rhs))),
+      C(std::move(static_cast<Postfix_sign&&>(rhs)))
+    { }
+
+    Format_FM_tail(Prefix_sign_Opt_unsigned_format && rhs)
+     :A(std::move(static_cast<Prefix_sign::LParser&&>(rhs))),
+      B(std::move(static_cast<Unsigned_format::Container&&>(rhs))),
+      C(C::empty())
+    { }
+
+    using LParser= OR3C<Parser, Container,
+                        Format_TM::LParser,
+                        Prefix_sign_Opt_unsigned_format,
+                        Currency_with_postfix_sign::LParser>;
+  };
+
+
+
+  /*
+    GRAMMAR: format: currency_with_postfix_sign
+    GRAMMAR:       | 'FM' [ format_FM_tail ]
+    GRAMMAR:       | 'S' ['FM'] [ unsigned_format ]
+    GRAMMAR:       | format_TM_signature
+  */
+  class Format: public Format_flags,
+                public Prefix_sign,
+                public Currency_with_postfix_sign,
+                public Format_TM
+  {
+    using A= Format_flags;
+    using B= Prefix_sign;
+    using C= Currency_with_postfix_sign;
+    using D= Format_TM;
+  public:
+    using Container= OR_CONTAINER4<Parser, Format, A, B, C, D>;
+    operator bool() const
+    {
+      return A::operator bool() && B::operator bool() &&
+             C::operator bool() && D::operator bool();
+    }
+    // Delete copying
+    Format(const Format & rhs) = delete;
+    Format & operator=(const Format & rhs) = delete;
+
+    // Initialization from itself
+    Format(Format && rhs) = default;
+    Format & operator=(Format && rhs) = default;
+
+    // Initialization from its components
+    Format(A && a, B && b, C && c, D && d)
+     :A(std::move(a)), B(std::move(b)), C(std::move(c)), D(std::move(d))
+    { }
+
+    // Dependency rules
+private:
+    using Format_FM= AND2<Parser,
+                          Format_flags::LParser,
+                          Format_FM_tail::LParser::Opt>;
+
+    using Format_prefix_sign_Opt_FM_Opt_unsigned_format=
+                                            AND3<Parser,
+                                                 Prefix_sign::LParser,
+                                                 Format_flags::LParser::Opt,
+                                                 Unsigned_format::LParser::Opt>;
+public:
+    // Initialization from rules
+    Format(Format_FM && rhs)
+     :A(std::move(static_cast<Format_flags::LParser&&>(rhs))),
+      B(std::move(static_cast<Prefix_sign&&>(rhs))),
+      C(std::move(static_cast<Unsigned_currency&&>(rhs)),
+        std::move(static_cast<Postfix_sign&&>(rhs))),
+      D(std::move(static_cast<Format_TM&&>(rhs)))
+    { }
+
+    Format(Format_prefix_sign_Opt_FM_Opt_unsigned_format && rhs)
+     :A(std::move(static_cast<Format_flags::LParser::Opt&&>(rhs))),
+      B(std::move(static_cast<Prefix_sign::LParser&&>(rhs))),
+      C(Currency_with_postfix_sign::Container(
+          std::move(static_cast<Unsigned_currency&&>(rhs)))),
+      D(std::move(static_cast<Format_TM&&>(rhs)))
+    { }
+
+    Format(Format_TM::LParser && rhs)
+     :A(A::Container::empty()),
+      B(B::Container::empty()),
+      C(C::Container::empty()),
+      D(Format_TM::Container(std::move(rhs)))
+    { }
+
+    using LParser= OR4C<Parser, Container,
+                        Currency_with_postfix_sign::LParser,
+                        Format_FM,
+                        Format_prefix_sign_Opt_FM_Opt_unsigned_format,
+                        Format_TM::LParser>;
+
+    // Other methods
+    bool check(const Parser & parser, const char **pos) const
+    {
+      if (Currency_with_postfix_sign::operator bool() &&
+          Currency_with_postfix_sign::check(parser, prefix_flag_counters(),
+                                            pos))
+        return true;
+
+      return false;
+    }
+
+    void print(String *str) const
+    {
+      if (Format_flags::length() > 0)
+        Format_flags::print_var_value(str, "FFl"_LS);
+
+      if (Prefix_sign::length() > 0)
+        Prefix_sign::print_var_value(str, "LS"_LS);
+
+      if (Currency_with_postfix_sign::operator bool())
+        Currency_with_postfix_sign::print(str);
+
+      if (Format_TM::length())
+        Format_TM::print_var_value(str, "TM"_LS);
+    }
+
+    void print_as_note(THD *thd) const
+    {
+      StringBuffer<64> tmp;
+      print(&tmp);
+      push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+                          ER_UNKNOWN_ERROR,
+                          "%.*s", (int) tmp.length(), tmp.ptr());
+    }
+
+    // Conversion methods
+    feature_t features_found() const
+    {
+      return (feature_t) (A::features_found() | B::features_found() |
+                          C::features_found() | D::features_found());
+    };
+    static feature_t features_supported_by_to_dbln_fixed()
+    {
+      return (feature_t)
+         (Currency_with_postfix_sign::features_supported_by_to_dbln_fixed() |
+         F_PREFIX_SIGN | F_FMT_FLAG_FM);
+    }
+    static feature_t features_supported_by_to_dbln_EEEE()
+    {
+      return (feature_t)
+             (Currency_with_postfix_sign::features_supported_by_to_dbln_EEEE() |
+              F_PREFIX_SIGN |  F_FMT_FLAG_FM);
+    }
+    static feature_t features_supported_by_to_dbln_XXXX()
+    {
+      return (feature_t) (F_INT_DIGIT | F_INT_HEX | F_FMT_FLAG_FM);
+    }
+
+    Double_null to_dbln_XXXX(LS sbj, CHARSET_INFO *cs) const
+    {
+      /*
+        Return NULL if:
+        - The subject string is empty, or
+        - The subject string is longer than the format, or
+        - The format has leading 0s and the subject is shorter than the format
+      */
+      if (!sbj.length() || sbj.length() > Integer::length() ||
+          (Integer::m_0_count > 0 && sbj.length() < Integer::length()))
+        return Double_null();
+
+      double res= 0;
+      for (size_t i= 0; i < sbj.length(); i++)
+      {
+        int hex_char= hexchar_to_int(sbj.at(i));
+        if (hex_char < 0)
+          return Double_null();
+        res*= 16;
+        res+= hex_char;
+      }
+      return Double_null(res);
+    }
+
+    Double_null to_dbln_fixed(LS src, CHARSET_INFO *cs) const
+    {
+      bool neg;
+      if (Prefix_sign::get(&neg, &src))
+        return Double_null();
+      const Double_null nr= Currency_with_postfix_sign::to_dbln_fixed(src, cs);
+      return nr.is_null() || !neg ? nr : -nr;
+    }
+
+    Double_null to_dbln_EEEE(LS src, CHARSET_INFO *cs) const
+    {
+      bool neg;
+      if (Prefix_sign::get(&neg, &src))
+        Double_null();
+      const Double_null nr= Currency_with_postfix_sign::to_dbln_EEEE(src, cs);
+      return nr.is_null() || !neg ? nr : -nr;
+    }
+  };
+
+
+public:
+  // goal: [ format ] EOF
+  class Goal: public AND2<Parser, Format::LParser::Opt, TokenEOF>
+  {
+  public:
+    using AND2::AND2;
+    // Delete copying
+    Goal(const Goal & rhs) = delete;
+    Goal & operator=(const Goal & rhs) = delete;
+    // Initializing from itself
+    Goal & operator=(Goal && rhs) = default;
+    bool check(const Parser & parser, enum_warning_level level) const
+    {
+      if (!operator bool())
+      {
+        parser.raise_bad_format_at(parser.thd(), level);
+        return true;
+      }
+      const char *pos= nullptr;
+      if (!Format::check(parser, &pos))
+        return false;
+      DBUG_ASSERT(pos);
+      const LS buffer(parser.buffer());
+      if (pos > buffer.ptr() && pos < buffer.end())
+      {
+        /*
+          If an error happened in the middle of the format,
+          let's print it into two parts:
+            '$999$' -> '$999 + $'
+          to see the whole format and the position where the error happened.
+        */
+        StringBuffer<STRING_BUFFER_USUAL_SIZE> tmp(parser.charset());
+        const LS part1(buffer.ptr(), pos);
+        const LS part2(pos, buffer.end());
+        tmp.append(part1.ptr(), part1.length());
+        tmp.append(" + "_LS);
+        tmp.append(part2.ptr(), part2.length());
+        ErrConvString err(&tmp);
+        parser.raise_bad_format_at(parser.thd(), level, &err);
+        return true;
+      }
+      parser.raise_bad_format_at(parser.thd(), level, pos);
+      return true;
+    }
+  };
+}; /* End of class Parser */
+
+
+class Item_func_to_number: public Item_handled_func
+{
+  /*
+    Structures used to cache the format if args[1] is an evaluable
+    constant during fix_length_and_dec_time.
+  */
+  Parser::Goal m_format;
+  Parser m_parser;
+  StringBuffer<32> m_format_buffer;
+public:
+  Item_func_to_number(THD *thd, List<Item> &list)
+   :Item_handled_func(thd, list)
+  { }
+  LEX_CSTRING func_name_cstring() const override
+  {
+    static LEX_CSTRING name= {STRING_WITH_LEN("to_number") };
+    return name;
+  }
+  Item *do_get_copy(THD *thd) const override { return nullptr; }
+
+  // Get an Item_func_to_number pointer from a Item_handled_func pointer.
+  static Item_func_to_number *to_func_to_number(Item_handled_func *func)
+  {
+    DBUG_ASSERT(dynamic_cast<Item_func_to_number*>(func));
+    return static_cast<Item_func_to_number*>(func);
+  }
+
+  double val_real_from_dbln(const String & sbj, const Double_null &nr)
+  {
+    null_value= nr.is_null();
+    if (null_value)
+      raise_conversion_warning(current_thd, m_format_buffer, sbj);
+    return nr.is_null() ? 0 : nr.value();
+  }
+
+  bool fix_length_and_dec_double()
+  {
+    set_maybe_null();
+    decimals= NOT_FIXED_DEC;
+    max_length= float_length(decimals);
+    return false;
+  }
+
+
+  /********** Helper methods to handle String ***/
+  /*
+    Note, the code in Parser does not support character sets
+    with mbminlen>1, so in case of ucs2, utf16, utf32 arguments
+    we need to convert them to some character set with mbminlen==1.
+    Let's use utf8mb4 as such character set.
+  */
+
+
+  /*
+    Convert a string to utf8mb4, if needed.
+    If mbminlen is already 1, then do nothing.
+  */
+  bool convert_to_mb1_if_needed(String *str)
+  {
+    if (str->charset()->mbminlen == 1)
+      return false;
+    uint errors= 0;
+    String tmp;
+    if (tmp.copy(str, &my_charset_utf8mb4_bin, &errors))
+      return true;
+    str->swap(tmp);
+    return false;
+  }
+
+  /*
+    Copy with a character set conversion if needed.
+    If "from" has mbminlen > 1 then convert to utf8mb4, otherwise just copy.
+    "to" and "from" must be two different objects.
+  */
+  bool copy_or_convert_to_mb1(String *to, const String & from)
+  {
+    DBUG_ASSERT(to != &from);
+    uint errors= 0;
+    return from.charset()->mbminlen > 1 ?
+           to->copy(&from, &my_charset_utf8mb4_bin, &errors) :
+           to->copy(from);
+  }
+
+  /*
+    Similar to copy_or_convert_to_mb1(), but "to" can point to "from".
+  */
+  bool copy_or_convert_to_mb1_maybe_self(String *to, const String & from)
+  {
+    if (to != &from)
+      return copy_or_convert_to_mb1(to, from);
+    if (from.charset()->mbminlen == 1)
+      return false;
+    String tmp;
+    if (copy_or_convert_to_mb1(&tmp, from))
+      return true;
+    to->swap(tmp);
+    return false;
+  }
+
+
+  /********** Item_handled_func::Handler implementations ****/
+
+  // A helper abstract class, to define fix_length_and_dec().
+  class Ha_double: public Item_handled_func::Handler_double
+  {
+  public:
+    bool fix_length_and_dec(Item_handled_func *func) const override
+    {
+      return to_func_to_number(func)->fix_length_and_dec_double();
+    }
+  };
+
+
+  /** Helper templates to get args[0] and convert it according to the format **/
+
+  template<class T>
+  double val_real_fixed(const Parser::Format & format)
+  {
+   DBUG_EXECUTE_IF("numconv_format", null_value= false; return 0;);
+    StringBuffer<STRING_BUFFER_USUAL_SIZE> subject_buffer;
+    String *sbj= args[0]->val_str(&subject_buffer);
+    if ((null_value= !sbj || convert_to_mb1_if_needed(sbj)))
+      return 0;
+    const T & exec= static_cast<const T &>(format);
+    return val_real_from_dbln(*sbj,
+                              exec.to_dbln_fixed(sbj->to_lex_cstring(),
+                                                 sbj->charset()));
+  }
+
+  template<class T>
+  double val_real_signed_EEEE(const Parser::Format & format)
+  {
+   DBUG_EXECUTE_IF("numconv_format", null_value= false; return 0;);
+    StringBuffer<STRING_BUFFER_USUAL_SIZE> subject_buffer;
+    String *sbj= args[0]->val_str(&subject_buffer);
+    if ((null_value= !sbj || convert_to_mb1_if_needed(sbj)))
+      return 0;
+    const T & exec= static_cast<const T &>(format);
+    return val_real_from_dbln(*sbj,
+                              exec.to_dbln_EEEE(sbj->to_lex_cstring(),
+                                                sbj->charset()));
+  }
+
+  template<class T>
+  double val_real_XXXX(const Parser::Format & format)
+  {
+   DBUG_EXECUTE_IF("numconv_format", null_value= false; return 0;);
+    StringBuffer<STRING_BUFFER_USUAL_SIZE> subject_buffer;
+    String *sbj= args[0]->val_str(&subject_buffer);
+    if ((null_value= !sbj || convert_to_mb1_if_needed(sbj)))
+      return 0;
+    const T & exec= static_cast<const T &>(format);
+    return val_real_from_dbln(*sbj,
+                              exec.to_dbln_XXXX(sbj->to_lex_cstring(),
+                                                sbj->charset()));
+  }
+
+
+  /***** Classes to handle the case with arg_count==1:  to_number('123') */
+
+  // With numeric input
+  class Ha_double_without_format_using_val_real: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      DBUG_EXECUTE_IF("numconv_format", func->null_value= false; return 0;);
+      return to_func_to_number(func)->val_real_from_item(func->arguments()[0]);
+    }
+    static const Ha_double_without_format_using_val_real s_singleton;
+  };
+
+  // With string input
+  class Ha_double_without_format_using_val_str: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_signed_EEEE<Parser::Format>(tfunc->m_format);
+    }
+    static const Ha_double_without_format_using_val_str s_singleton;
+  };
+
+  /********** Classes to handle a number with a fixed format ***/
+
+
+  // Integer-only formats (with or without group separators)
+  class Ha_double_integer: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_fixed<Parser::Integer>(tfunc->m_format);
+    }
+    static const Ha_double_integer s_singleton;
+  };
+
+  // Fraction-only formats starting with a decimal delimiter
+  class Ha_double_fraction: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_fixed<Parser::Fraction>(tfunc->m_format);
+    }
+    static const Ha_double_fraction s_singleton;
+  };
+
+
+  // Unsigned currency
+  class Ha_double_unsigned_currency: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_fixed<Parser::Unsigned_currency>(tfunc->m_format);
+    }
+    static const Ha_double_unsigned_currency s_singleton;
+  };
+
+
+  // A currency with a postfix sign
+  class Ha_double_currency_with_postfix_sign: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_fixed<Parser::Currency_with_postfix_sign>
+                                                            (tfunc->m_format);
+    }
+    static const Ha_double_currency_with_postfix_sign s_singleton;
+  };
+
+
+  // Signed currency (with a prefix or postfix sign)
+  class Ha_double_signed_currency: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_fixed<Parser::Format>(tfunc->m_format);
+    }
+    static const Ha_double_signed_currency s_singleton;
+  };
+
+
+  /***** The class to handler a number with a EEEE (scientific) format ***/
+
+  class Ha_double_signed_EEEE: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_signed_EEEE<Parser::Format>(tfunc->m_format);
+    }
+    static const Ha_double_signed_EEEE s_singleton;
+  };
+
+
+  /***** The class to handler a number with a XXXX (hexadecimal) format ***/
+
+  class Ha_double_XXXX: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_XXXX<Parser::Format>(tfunc->m_format);
+    }
+    static const Ha_double_XXXX s_singleton;
+  };
+
+
+  /********** Format detected per row ***/
+  double val_real_with_format_per_row()
+  {
+    auto const level= Sql_condition::WARN_LEVEL_WARN;
+    StringBuffer<STRING_BUFFER_USUAL_SIZE> subject_buffer;
+    String *sbj, *fmt;
+    if ((null_value= !(sbj= args[0]->val_str(&subject_buffer)) ||
+                     !(fmt= args[1]->val_str(&m_format_buffer)) ||
+                     copy_or_convert_to_mb1_maybe_self(&m_format_buffer, *fmt)))
+      return 0;
+    // Parse the format and validate it
+    THD *thd= current_thd;
+    m_parser= Parser(thd, func_name_cstring(),
+                     m_format_buffer.charset(),
+                     m_format_buffer.to_lex_cstring());
+    m_format= Parser::Goal(&m_parser);
+    if ((null_value= m_format.check(m_parser, level)))
+      return 0;
+    /*
+      If the caller wants to check the format syntax only, let's leave here,
+      to avoid func_handler_by_format() raising "unsupported format" errors.
+    */
+    DBUG_EXECUTE_IF("numconv_format", null_value= false; return 0;);
+    const Handler *ha= func_handler_by_format(thd, m_format,
+                                              m_parser, level);
+    if ((null_value= !ha))
+       return 0;
+    return ha->val_real(this);
+  }
+
+  class Ha_double_with_format_per_row: public Ha_double
+  {
+  public:
+    double val_real(Item_handled_func *func) const override
+    {
+      Item_func_to_number *tfunc= to_func_to_number(func);
+      return tfunc->val_real_with_format_per_row();
+    }
+    static const Ha_double_with_format_per_row s_singleton;
+  };
+
+  /********** A warning on conversion failures ***/
+  void raise_conversion_warning(THD *thd, const String &fmt, const String &sbj)
+  {
+    StringBuffer<STRING_BUFFER_USUAL_SIZE> tmp_fmt(fmt.charset());
+    tmp_fmt.append("<number format>='"_LS);
+    tmp_fmt.append(fmt.ptr(), fmt.length());
+    tmp_fmt.append("'"_LS);
+    ErrConvString err_fmt(&tmp_fmt);
+    ErrConvString err_sbj(&sbj);
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                        ER_WRONG_VALUE_FOR_TYPE,
+                        ER_THD(thd, ER_WRONG_VALUE_FOR_TYPE),
+                        err_fmt.ptr(), err_sbj.ptr(), func_name());
+  }
+
+
+  /********** fix_length_and_dec() related methods ***/
+
+  const Item_handled_func::Handler *
+  func_handler_by_format(THD *thd,
+                         const Parser::Goal & format,
+                         const Parser & parser,
+                         enum_warning_level level) const
+  {
+    /*
+      Format TM is not tested here. It returns an error or a warning with NULL.
+      It's not supported by to_number(). It's only supported by to_char().
+    */
+
+    const Parser::feature_t features_found= format.features_found();
+    Parser::feature_t f_supported= Parser::F_NONE;
+
+    // Hexadecimal formats
+    if (features_found & Parser::F_INT_HEX)
+    {
+      f_supported= Parser::Format::features_supported_by_to_dbln_XXXX();
+      if ((features_found & ~f_supported) == 0)
+        return &Ha_double_XXXX::s_singleton;
+    }
+
+    // Scientific numeric formats
+    if (format.EEEE::length())
+    {
+      f_supported= Parser::Format::features_supported_by_to_dbln_EEEE();
+      if ((features_found & ~f_supported) == 0)
+        return &Ha_double_signed_EEEE::s_singleton;
+    }
+
+    // Fixed numeric formats
+    f_supported= Parser::Integer::features_supported_by_to_dbln_fixed();
+    if ((features_found & ~f_supported) == 0)
+      return &Ha_double_integer::s_singleton;
+
+    f_supported= Parser::Fraction::features_supported_by_to_dbln_fixed();
+    if ((features_found & ~f_supported) == 0)
+      return &Ha_double_fraction::s_singleton;
+
+    f_supported= Parser::Unsigned_currency::
+                                  features_supported_by_to_dbln_fixed();
+    if ((features_found & ~f_supported) == 0)
+      return &Ha_double_unsigned_currency::s_singleton;
+
+    f_supported= Parser::Currency_with_postfix_sign::
+                                  features_supported_by_to_dbln_fixed();
+    if ((features_found & ~f_supported) == 0)
+      return &Ha_double_currency_with_postfix_sign::s_singleton;
+
+    f_supported= Parser::Format::features_supported_by_to_dbln_fixed();
+    if ((features_found & ~f_supported) == 0)
+      return &Ha_double_signed_currency::s_singleton;
+
+    // A syntactically correct but not supported yet format
+    parser.raise_not_supported_yet(thd, level, parser.buffer());
+    return nullptr;
+  }
+
+  bool set_func_handler_for_const_format(THD *thd)
+  {
+    const auto level= Sql_condition::WARN_LEVEL_ERROR;
+    // Evaluate the format and cache its value in m_format_buffer.
+    String *fmt= args[1]->val_str(&m_format_buffer);
+    if (!fmt || copy_or_convert_to_mb1_maybe_self(&m_format_buffer, *fmt))
+      return null_value= true;// SQL NULL or EOM
+    // Parse the format and validate it
+    m_parser= Parser(thd, func_name_cstring(),
+                     m_format_buffer.charset(),
+                     m_format_buffer.to_lex_cstring());
+    m_format= Parser::Goal(&m_parser);
+    if ((null_value= m_format.check(m_parser, level)))
+      return true;
+    DBUG_EXECUTE_IF("numconv_format", (m_format.print_as_note(thd)););
+    // Determine the handler
+    const Handler *ha= func_handler_by_format(thd, m_format, m_parser, level);
+    if (!ha)
+      return true;
+    set_func_handler(ha);
+    return false;
+  }
+
+  bool fix_length_and_dec(THD *thd) override
+  {
+    DBUG_ASSERT(arg_count >= 1 && arg_count <= 2);
+    const Type_handler *th0= args[0]->type_handler();
+    if (arg_count == 1) // to_number('123')
+    {
+      bool using_string= th0->cmp_type() == STRING_RESULT;
+      if (!(using_string ? th0->can_return_text() : th0->can_return_real()))
+      {
+        my_error(ER_ILLEGAL_PARAMETER_DATA_TYPE_FOR_OPERATION, MYF(0),
+                 th0->name().ptr(), func_name());
+        return true;
+      }
+      if (using_string)
+        set_func_handler(&Ha_double_without_format_using_val_str::s_singleton);
+      else
+        set_func_handler(&Ha_double_without_format_using_val_real::s_singleton);
+      return m_func_handler->fix_length_and_dec(this);
+    }
+
+    const Type_handler *th1= args[1]->type_handler();
+    if (th0->cmp_type() != STRING_RESULT || !th0->can_return_text() ||
+        th1->cmp_type() != STRING_RESULT || !th1->can_return_text())
+    {
+      my_error(ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION, MYF(0),
+               th0->name().ptr(), th1->name().ptr(), func_name());
+      return true;
+    }
+
+    if (args[1]->can_eval_in_optimize()) // to_number('123',const_expr)
+    {
+      /*
+        If args[1] is a contant, then evaluate the format, parse and cache
+        the parsed format, to avoid its evaluation and parsing per row.
+      */
+      if (set_func_handler_for_const_format(thd))
+        return true;
+    }
+    else // The format is not constant
+      set_func_handler(&Ha_double_with_format_per_row::s_singleton);
+    return m_func_handler->fix_length_and_dec(this);
+  }
+};
+
+
+/********** Handler's singletons ****/
+
+const Item_func_to_number::Ha_double_without_format_using_val_real
+  Item_func_to_number::Ha_double_without_format_using_val_real::s_singleton;
+
+const Item_func_to_number::Ha_double_without_format_using_val_str
+  Item_func_to_number::Ha_double_without_format_using_val_str::s_singleton;
+
+const Item_func_to_number::Ha_double_XXXX
+  Item_func_to_number::Ha_double_XXXX::s_singleton;
+
+const Item_func_to_number::Ha_double_with_format_per_row
+  Item_func_to_number::Ha_double_with_format_per_row::s_singleton;
+
+const Item_func_to_number::Ha_double_integer
+  Item_func_to_number::Ha_double_integer::s_singleton;
+
+const Item_func_to_number::Ha_double_fraction
+  Item_func_to_number::Ha_double_fraction::s_singleton;
+
+const Item_func_to_number::Ha_double_unsigned_currency
+  Item_func_to_number::
+    Ha_double_unsigned_currency::s_singleton;
+
+const Item_func_to_number::Ha_double_currency_with_postfix_sign
+  Item_func_to_number::
+    Ha_double_currency_with_postfix_sign::s_singleton;
+
+const Item_func_to_number::Ha_double_signed_currency
+  Item_func_to_number::
+    Ha_double_signed_currency::s_singleton;
+
+const Item_func_to_number::Ha_double_signed_EEEE
+  Item_func_to_number::Ha_double_signed_EEEE::s_singleton;
+
+
+/********** Create_func related things ***/
+
+class Create_func_to_number : public Create_native_func
+{
+public:
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                     List<Item> * args) override
+  {
+    if (unlikely(!args || args->elements < 1 || args->elements > 2))
+    {
+      my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name->str);
+      return NULL;
+    }
+    return new (thd->mem_root) Item_func_to_number(thd, *args);
+  }
+
+  static Create_func_to_number s_singleton;
+
+protected:
+  Create_func_to_number() = default;
+  ~Create_func_to_number() override = default;
+};
+
+Create_func_to_number Create_func_to_number::s_singleton;
+Create_func & create_func_to_number= Create_func_to_number::s_singleton;

--- a/sql/item_numconvfunc.h
+++ b/sql/item_numconvfunc.h
@@ -1,0 +1,25 @@
+#ifndef ITEM_NUMCONVFUNC_INCLUDED
+#define ITEM_NUMCONVFUNC_INCLUDED
+
+/*
+   Copyright (c) 2009, 2025, MariaDB Corporation
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+
+#include "item_create.h"
+
+extern Create_func & create_func_to_number;
+
+#endif // ITEM_NUMCONVFUNC_INCLUDED

--- a/sql/simple_tokenizer.h
+++ b/sql/simple_tokenizer.h
@@ -239,6 +239,11 @@ public:
     m_cs(cs)
   { }
 
+  CHARSET_INFO *charset() const
+  {
+    return m_cs;
+  }
+
   // Skip all leading spaces
   void get_spaces()
   {

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -955,10 +955,21 @@ class Double_null: public Null_flag
 protected:
   double m_value;
 public:
+  Double_null()
+   :Null_flag(true), m_value(0)
+  { }
   Double_null(double value, bool is_null)
    :Null_flag(is_null), m_value(value)
   { }
+  Double_null(double value)
+   :Null_flag(false), m_value(value)
+  { }
   double value() const { return m_value; }
+  Double_null operator-() const
+  {
+    DBUG_ASSERT(!is_null());
+    return Double_null(-m_value);
+  }
 };
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-20022*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This patch implements an Oracle style function to_number() with the following signatures:

- to_number(number_or_string_subject)
- to_number(string_subject, string_format)

The function is implemented in sql/item_numconvfunc.cc.

The function returns the DOUBLE data type for
all signatures and input data types.

The format parser understands the following components:

- Digits: 0, 9
- Hex digits: X
- Group separators: comma (,) and G
- Decimal delimiers: period (.) and D
- Approximate number signature: EEEE
- Currency/numeric flags: $ and B
- Currency signatures: C, L, U
- Sign signatures: S, MI, PR
- Special format signatures: V, TM, TM9, TME
- Format flag: FM

Note, the parser was implemented assuming that we'll also have the oppostite function to_char() soon for numeric input. So it parser all known components.
However, the function to_number() does not support:
- Formats V, TM, TM9, TME. to_number() returns NULL if the format string has these components. These componens are supported only by to_char() in Oracle.

Features not inclided into this patch:
- The ON CONVERSION ERROR clause
- The third parameter (nlsparam)
- Internationalized components: G, D, C, L, U. These features will be implemented later, under terms of MDEV-36978.

Notable changes in the other files:

- item_func.h: adding Item_handled_func::Handler_double

- simple_parser.h: adding a number of *CONTAINER* templates They help to save on duplicate code when creating classes suitable for passing into parsing templates such as OPT, OR2C, OR3C, etc

- simple_parser.h: Adding parsing templates OR4C and OR5C

- simple_parser.h: Moving the template "OPT" towars the beginning of the file Rule parsing templates TOKEN, TokenChoice, AND2, OR2C, OR3C, OR4C, OR5C, LIST now provide a sub-class Opt, to parse its optional rule.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

Tests are added to the suite.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
