### PR TITLE
MDEV-37048 revert MSAN my_vsnprintf_ex for double workaround

### DIFF
--- a/strings/my_vsnprintf.c
+++ b/strings/my_vsnprintf.c
@@ -739,13 +739,7 @@ size_t my_vsnprintf_ex(CHARSET_INFO *cs, char *to, size_t n,
     else if (*fmt == 'f' || *fmt == 'g')
     {
       double d;
-#if __has_feature(memory_sanitizer)         /* QQ: MSAN has double trouble? */
-      __msan_check_mem_is_initialized(ap, sizeof(double));
-#endif
       d= va_arg(ap, double);
-#if __has_feature(memory_sanitizer)        /* QQ: MSAN has double trouble? */
-      __msan_unpoison(&d, sizeof(double));
-#endif
       to= process_dbl_arg(to, end, width, d, *fmt);
       continue;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37048*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

5 years ago e843033d0233927b8f51d7dbe21993bdfb01ecdf worked around a MSAN bug when retrieving a double from a va_list.

The construct {{__msan_check_mem_is_initialized(ap,size)}} where ap is a va_list is undefined as {{__msan_check_mem_is_initialized}} expects a pointer. The implementation detail of va_list is architecture dependant and on aarch64 this isn't a pointer.

The need to do any msan action is no unnecessary since this has been corrected in recent clang versions.

As such the additions from e843033d0233927b8f51d7dbe21993bdfb01ecdf have been reverted.

Tested with clang-20.1 and the test cases from MDEV-22690 and MDEV-22691.

## Release Notes

not user visible change

## How can this PR be tested?

msan builder on arm64 (https://github.com/MariaDB/buildbot/pull/769)
```
main.opt_trace_ucs2                      w5 [ pass ]    153
main.opt_trace_security                  w4 [ pass ]    720
maria.maria-recovery2                    w6 [ pass ]   8533
main.opt_trace_index_merge_innodb        w3 [ pass ]   9618
main.opt_trace_index_merge               w2 [ pass ]  21641
main.opt_trace                           w1 [ pass ]  26391
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 67.056 of 43 seconds executing testcases

Completed: All 6 tests were successful.

buildbot@83789079768a:/build$ uname -a ; sql/mariadbd --version
Linux 83789079768a 6.1.0-28-arm64 #1 SMP Debian 6.1.119-1 (2024-11-22) aarch64 GNU/Linux
sql/mariadbd  Ver 11.4.8-MariaDB-debug for Linux on aarch64 (Source distribution)
```

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] *This is a enabling change to deploy a MSAN Debug builder in BB*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.