### PR TITLE
MDEV-37029 Make vcol rewrite handle row-based INs

### DIFF
--- a/mysql-test/suite/vcol/r/vcol_misc.result
+++ b/mysql-test/suite/vcol/r/vcol_misc.result
@@ -591,3 +591,34 @@ DROP TABLE t;
 #
 # End of 10.5 tests
 #
+#
+# Start of 11.8 tests
+#
+create table t1 (a int, b int, vcol int as (a+1), index(vcol));
+insert into t1 (a,b) select seq, seq from seq_1_to_1000;
+explain select * from t1 where (a) IN (1,2,3);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	1000	Using where
+select * from t1 where (a) IN (1,2,3);
+a	b	vcol
+1	1	2
+2	2	3
+3	3	4
+explain select * from t1 where (a+1,b) IN ((2,1),(3,2),(4,3));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	vcol	vcol	5	NULL	3	Using where
+select * from t1 where (a+1,b) IN ((2,1),(3,2),(4,3));
+a	b	vcol
+1	1	2
+2	2	3
+3	3	4
+explain select * from t1 where (vcol,b) IN ((2,1),(3,2),(4,3));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	vcol	vcol	5	NULL	3	Using where
+select * from t1 where (vcol,b) IN ((2,1),(3,2),(4,3));
+a	b	vcol
+1	1	2
+2	2	3
+3	3	4
+drop table t1;
+# End of 11.8 tests

--- a/mysql-test/suite/vcol/t/vcol_misc.test
+++ b/mysql-test/suite/vcol/t/vcol_misc.test
@@ -1,5 +1,6 @@
 --source include/have_ucs2.inc
 --source include/have_debug.inc
+--source include/have_sequence.inc
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
@@ -560,3 +561,18 @@ DROP TABLE t;
 --echo #
 --echo # End of 10.5 tests
 --echo #
+
+--echo #
+--echo # Start of 11.8 tests
+--echo #
+create table t1 (a int, b int, vcol int as (a+1), index(vcol));
+insert into t1 (a,b) select seq, seq from seq_1_to_1000;
+explain select * from t1 where (a) IN (1,2,3);
+select * from t1 where (a) IN (1,2,3);
+explain select * from t1 where (a+1,b) IN ((2,1),(3,2),(4,3));
+select * from t1 where (a+1,b) IN ((2,1),(3,2),(4,3));
+explain select * from t1 where (vcol,b) IN ((2,1),(3,2),(4,3));
+select * from t1 where (vcol,b) IN ((2,1),(3,2),(4,3));
+drop table t1;
+
+--echo # End of 11.8 tests

--- a/sql/item_row.h
+++ b/sql/item_row.h
@@ -151,6 +151,7 @@ public:
   Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_row>(thd, this); }
   Item *do_build_clone(THD *thd) const override;
+  Item* vcol_subst_transformer(THD *thd, uchar *arg) override;
 };
 
 #endif /* ITEM_ROW_INCLUDED */


### PR DESCRIPTION
Queries having the form
  select * from t1 where (a+1, b) IN ((1,1),(2,2),(3,3));
where a+1 is a virtual column will now be optimized to use that virtual column such that the above becomes
  select * from t1 where (vcol, b) IN ((1,1),(2,2),(3,3));

In general, vcol substitution will occur when a row itself contains the matching vcol expression.  The optimizer will not only inspect the left-hand argument to IN for the matching expression, but will also unpack and inspect the left-hand argument when it is a row.
