### PR TITLE
MDEV-36839 Optimize Rows_log_event Reporting of Process Info

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2726,6 +2726,9 @@ private:
   { DBUG_ASSERT(0); return Statement::is_conventional(); }
 
 public:
+  /// Type for @ref proc_info and @ref wsrep_info
+  using Rows_log_event_info= char [128];
+
   MDL_context mdl_context;
 
   /* Used to execute base64 coded binlog events in MySQL server */
@@ -5552,7 +5555,7 @@ public:
   uint32                    wsrep_rand;
   rpl_group_info            *wsrep_rgi;
   bool                      wsrep_converted_lock_session;
-  char                      wsrep_info[128]; /* string for dynamic proc info */
+  Rows_log_event_info       wsrep_info; /* string for dynamic proc info */
   ulong                     wsrep_retry_counter; // of autocommit
   bool                      wsrep_PA_safe;
   char*                     wsrep_retry_query;


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-36839](https://jira.mariadb.org/browse/MDEV-36839)*

## Description
This patch resolves a performance regression [MDEV-7409](https://jira.mariadb.org/browse/MDEV-7409) manifested.
MDEV-7409 added the table name to the SQL thread’s PROCESSLIST status for steps of processing `Rows_log event`s, which made them dynamic.
It, however, left the generating code inside the for-each-row loop, where the steps set these statuses. This meant that the messages regenerate for each row, despite all rows of an event belonging to the same table.
The generations also share the same memory region; without synchronization, an unfortunate SHOW PROCESSLIST could catch it mid-overwrite and read an amalgamated message.

Additionally, WSRep (Galera) has its own status format, but the non-WSRep messages still generate only for the WSRep ones to replace them.

This patch extracts the generation code to a common method that merges both non-WSRep and WSRep variants. Subclasses of `Rows_log_event` fill this template method in with their steps before the for-each-row loop, so the loop only needs to assign pre-written messages like before MDEV-7409.

As MDEV-36839 suggested, this patch also collapses the `if(!state) ASSERT(false)` in `Write_rows_log_event::do_exec_row()` to simply `ASSERT(state)`.

### Release Notes
*How would a technical writer summarize this for the common audience?*

### How can this PR be tested?
Run the existing tests (namely, MDEV-7409’s `rpl.rpl_rbr_monitor`) to confirm that the mini-refactoring didn’t break things.
* Only benchmarking on dedicated machine(s) (physical or virtual) can assert performance differences.
* Testing for the mid-overwrite amalgamation possible-bug requires an out-of-place breakpoint in the middle of `my_snprintf`.

## Basing the PR against the correct MariaDB version
This PR is based on `10.11` because it “fixes” a _performance_ “regression”.
This will rebase on `main` if benchmarks find the “regression” insignificant.
* [ ] *This is a new feature or __a refactoring__, and the PR is based against the `main` branch.*
* [x] *This is a bug __fix__, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.