### PR TITLE
MDEV-37049 my_assume_aligned assertion in mariabackup

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -2593,6 +2593,7 @@ error:
 	return true;
 }
 
+alignas(8)
 static byte log_hdr_buf[log_t::START_OFFSET + SIZE_OF_FILE_CHECKPOINT];
 
 /** Initialize an InnoDB log file header in log_hdr_buf[] */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37049*
## Description
`log_hdr_buf`: Align to an 8-byte boundary, because we will actually assume at least 4-byte alignment in `log_crypt_write_header()`.

This fixes a regression that had been introduced in commit 685d958e38b825ad9829be311f26729cccf37c46 (MDEV-14425) where a 512-byte alignment requirement was relaxed too much.
## Release Notes
Depending on the build settings, `mariadb-backup --backup` might produce a corrupted log when the server is running with `innodb_encrypt_log`. This bug was only caught in internal testing with non-standard build parameters.
## How can this PR be tested?
Build with clang, targeting ARMv8, and run
```sh
./mtr encryption.recovery_memory
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.