### PR TITLE
MDEV-35863 innodb.doublewrite_debug test case fails to start the server

### DIFF
--- a/mysql-test/suite/innodb/r/doublewrite_debug.result
+++ b/mysql-test/suite/innodb/r/doublewrite_debug.result
@@ -26,13 +26,13 @@ SET GLOBAL innodb_fast_shutdown = 0;
 # restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
 begin;
 insert into t1 values (6, repeat('%', 400));
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=0, innodb_max_dirty_pages_pct=0;
 # Make the first page dirty for system tablespace
 set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = 0;
 # Make the second page dirty for system tablespace
 set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
-set global innodb_buf_flush_list_now = 1;
 # Kill the server
 # Make the 1st page (page_no=0) and 2nd page (page_no=1)
 # of the system tablespace all zeroes.

--- a/mysql-test/suite/innodb/t/doublewrite_debug.test
+++ b/mysql-test/suite/innodb/t/doublewrite_debug.test
@@ -51,6 +51,8 @@ let $restart_parameters=--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_fl
 begin;
 insert into t1 values (6, repeat('%', 400));
 
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=0, innodb_max_dirty_pages_pct=0;
+
 --echo # Make the first page dirty for system tablespace
 set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = 0;
@@ -59,7 +61,11 @@ set global innodb_fil_make_page_dirty_debug = 0;
 set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
 
-set global innodb_buf_flush_list_now = 1;
+let $wait_condition =
+SELECT variable_value = 0
+FROM information_schema.global_status
+WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY';
+--source include/wait_condition.inc
 
 --let CLEANUP_IF_CHECKPOINT=drop table t1, unexpected_checkpoint;
 --source ../include/no_checkpoint_end.inc

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -843,12 +843,19 @@ srv_open_tmp_tablespace(bool create_new_db)
 	return(err);
 }
 
-/** Shutdown background threads, except the page cleaner. */
-static void srv_shutdown_threads()
+/** Shutdown background threads, except the page cleaner.
+@param init_abort set to true when InnoDB startup aborted */
+static void srv_shutdown_threads(bool init_abort= false)
 {
 	ut_ad(!srv_undo_sources);
 	srv_master_timer.reset();
-	srv_shutdown_state = SRV_SHUTDOWN_EXIT_THREADS;
+	/* In case of InnoDB start up aborted, Don't change
+	the srv_shutdown_state. Because innodb_shutdown()
+	does call innodb_preshutdown() which changes the
+	srv_shutdown_state back to SRV_SHUTDOWN_INITIATED */
+	if (!init_abort) {
+		srv_shutdown_state = SRV_SHUTDOWN_EXIT_THREADS;
+	}
 
 	if (purge_sys.enabled()) {
 		srv_purge_shutdown();
@@ -918,7 +925,7 @@ srv_init_abort_low(
 	}
 
 	srv_shutdown_bg_undo_sources();
-	srv_shutdown_threads();
+	srv_shutdown_threads(true);
 	return(err);
 }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35863*

## Description
Problem:
=======
- There are two failures occurs for this test case:

(1) set global innodb_buf_flush_list_now=1 doesn't make sure that pages are being flushed.

(2) InnoDB page cleaner thread aborts while writing the checkpoint information. Problem is that When InnoDB startup aborts, InnoDB changes the shutdown state to SRV_SHUTDOWN_EXIT_THREADS. By changing the shutdown state, InnoDB doesn't advance the log_sys.lsn (avoids fil_names_clear()). After InnoDB shutdown(innodb_shutdown()) is being initiated, shutdown state again changed to SRV_SHUTDOWN_INITIATED. This leads the page cleaner thread to fail with assertion ut_ad(srv_shutdown_state > SRV_SHUTDOWN_INITIATED) in log_write_checkpoint_info()

Solution:
=========
(1)  In order to avoid (1) failure, InnoDB can make the variable innodb_max_dirty_pages_pct_lwm, innodb_max_dirty_pages_pct to 0. Also make sure that InnoDB doesn't have any dirty pages in buffer pool by adding wait_condition.

(2) Avoid changing the srv_shutdown_state to SRV_SHUTDOWN_EXIT_THREADS when the InnoDB startup aborts

## How can this PR be tested?
./mtr innodb.doublewrite_debug{,,,,,,,,,,,,,,}

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
