### PR TITLE
10.6 mdev 37057

### DIFF
--- a/mysql-test/main/derived_split_innodb.result
+++ b/mysql-test/main/derived_split_innodb.result
@@ -916,4 +916,457 @@ cnt
 6
 DROP TABLE t1;
 # End of 10.4 tests
+CREATE TABLE `t1` (
+`ID` bigint(20) NOT NULL,
+`a` varchar(128) NOT NULL,
+`b` varchar(256) DEFAULT NULL,
+`c` varchar(767) DEFAULT NULL,
+`d` bigint(20) DEFAULT NULL,
+`e` char(1) NOT NULL,
+KEY `t1_IDX` (`a`,`b`,`c`) USING BTREE
+) ENGINE=InnoDB;
+INSERT INTO `t1` VALUES
+(3952987,'gfduishsdifugh','g7gfdshsidfhugssdfghss',NULL,13,'Y'),
+(3952990,'gfduishsdifugh','g7gfdshsidfhugssdfghss',NULL,14,'N'),
+(11281269,'fd76gfsd76tfgsgdf','q87f6d7s657s6gfgfdsdfg',NULL,1,'Y'),
+(11600791,'fd76gfsd76tfgsgdf','q87f6d7s657s6gfgfdsdfg',NULL,3,'N'),
+(30687884,'oihgfdsuighdfg','asiduf_sdffdsiuhsdfhh',NULL,946,'Y'),
+(30687898,'oihgfdsuighdfg','asiduf_sdffdsiuhsdfhh',NULL,947,'N'),
+(30688870,'oihgfdsuighdfg','gfsdhyudfg_ff_fggffggffggf',NULL,952,'Y'),
+(30688937,'oihgfdsuighdfg','gfsdhyudfg_ff_fggffggffggf',NULL,953,'N'),
+(30698445,'oihgfdsuighdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,19598,'Y'),
+(30698479,'oihgfdsuighdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,19599,'N'),
+(179317919,'uigfsdhsghghgf','fd89asdf776asdf766s6',NULL,3856,'Y'),
+(179317923,'uigfsdhsghghgf','fd89asdf776asdf766s6',NULL,3857,'N'),
+(180354215,'uigfsdhsghghgf','asiduf_sdffdsiuhsdfhh',NULL,4279,'Y'),
+(180869514,'gyygfssdfgsdfg','asiduf_sdffdsiuhsdfhh',NULL,1920,'Y'),
+(181237156,'gyygfssdfgsdfg','asiduf_sdffdsiuhsdfhh',NULL,1924,'N'),
+(181283787,'gyygfssdfgsdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,43584,'Y'),
+(181284091,'uigfsdhsghghgf','asiduf_sdffdsiuhsdfhh',NULL,4308,'N'),
+(181284043,'gyygfssdfgsdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,43588,'N'),
+(181338945,'jbvgfsdihsdfg','g89gfdhsudyfyugsdfgyugsyugsss',NULL,48191,'Y'),
+(181348380,'jbvgfsdihsdfg','g89gfdhsudyfyugsdfgyugsyugsss',NULL,48234,'N');
+explain format=json select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b
+AND (t1.c = dt1.c OR (t1.c IS NULL AND dt1.c IS NULL))
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b
+AND (t1.c = dt2.c OR (t1.c IS NULL AND dt2.c IS NULL))
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "possible_keys": ["t1_IDX"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "t1.b is not null"
+    },
+    "table": {
+      "table_name": "<derived2>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "389",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "t1.d < dt1.maxd and (dt1.c = t1.c or t1.c is null and dt1.c is null)",
+      "materialized": {
+        "query_block": {
+          "select_id": 2,
+          "filesort": {
+            "sort_key": "t1.a, t1.b, t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["t1_IDX"],
+                "rows": "X",
+                "filtered": "X"
+              }
+            }
+          }
+        }
+      }
+    },
+    "table": {
+      "table_name": "<derived3>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "390",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "trigcond(!(t1.d <=> dt2.umaxd)) and trigcond((dt2.c = t1.c or t1.c is null and dt2.c is null) and trigcond(t1.b is not null))",
+      "materialized": {
+        "query_block": {
+          "select_id": 3,
+          "filesort": {
+            "sort_key": "t1.a, t1.b, t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["t1_IDX"],
+                "rows": "X",
+                "filtered": "X",
+                "attached_condition": "t1.e = 'Y'"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b
+AND (t1.c = dt1.c OR (t1.c IS NULL AND dt1.c IS NULL))
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b
+AND (t1.c = dt2.c OR (t1.c IS NULL AND dt2.c IS NULL))
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+count(*)
+0
+explain format=json select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b  AND t1.c <=> dt1.c
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b  AND t1.c <=> dt2.c
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "possible_keys": ["t1_IDX"],
+      "rows": "X",
+      "filtered": "X"
+    },
+    "block-nl-join": {
+      "table": {
+        "table_name": "<derived2>",
+        "access_type": "ALL",
+        "rows": "X",
+        "filtered": "X"
+      },
+      "buffer_type": "flat",
+      "buffer_size": "24Kb",
+      "join_type": "BNL",
+      "attached_condition": "dt1.a = t1.a and dt1.b = t1.b and t1.d < dt1.maxd and t1.c <=> dt1.c",
+      "materialized": {
+        "query_block": {
+          "select_id": 2,
+          "filesort": {
+            "sort_key": "t1.a, t1.b, t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["t1_IDX"],
+                "rows": "X",
+                "filtered": "X"
+              }
+            }
+          }
+        }
+      }
+    },
+    "table": {
+      "table_name": "<derived3>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "390",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "trigcond(!(t1.d <=> dt2.umaxd)) and trigcond(t1.c <=> dt2.c and trigcond(t1.b is not null))",
+      "materialized": {
+        "query_block": {
+          "select_id": 3,
+          "filesort": {
+            "sort_key": "t1.a, t1.b, t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["t1_IDX"],
+                "rows": "X",
+                "filtered": "X",
+                "attached_condition": "t1.e = 'Y'"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b  AND t1.c <=> dt1.c
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b  AND t1.c <=> dt2.c
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+count(*)
+0
+poison stats
+insert into t1
+select 1, x.seq, y.seq, z.seq, 1,  'N'
+  from seq_1_to_10 x, seq_1_to_20 y, seq_1_to_20 z;
+delete from t1 where ID = 1;
+explain format=json select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b
+AND (t1.c = dt1.c OR (t1.c IS NULL AND dt1.c IS NULL))
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b
+AND (t1.c = dt2.c OR (t1.c IS NULL AND dt2.c IS NULL))
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "possible_keys": ["t1_IDX"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "t1.b is not null"
+    },
+    "table": {
+      "table_name": "<derived2>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "389",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "t1.d < dt1.maxd and (dt1.c = t1.c or t1.c is null and dt1.c is null)",
+      "materialized": {
+        "lateral": 1,
+        "query_block": {
+          "select_id": 2,
+          "outer_ref_condition": "t1.b is not null",
+          "filesort": {
+            "sort_key": "t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ref",
+                "possible_keys": ["t1_IDX"],
+                "key": "t1_IDX",
+                "key_length": "389",
+                "used_key_parts": ["a", "b"],
+                "ref": ["test.t1.a", "test.t1.b"],
+                "rows": "X",
+                "filtered": "X",
+                "attached_condition": "t1.a <=> t1.a and t1.b <=> t1.b"
+              }
+            }
+          }
+        }
+      }
+    },
+    "table": {
+      "table_name": "<derived3>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "390",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "trigcond(!(t1.d <=> dt2.umaxd)) and trigcond((dt2.c = t1.c or t1.c is null and dt2.c is null) and trigcond(t1.b is not null))",
+      "materialized": {
+        "lateral": 1,
+        "query_block": {
+          "select_id": 3,
+          "outer_ref_condition": "t1.b is not null",
+          "filesort": {
+            "sort_key": "t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ref",
+                "possible_keys": ["t1_IDX"],
+                "key": "t1_IDX",
+                "key_length": "389",
+                "used_key_parts": ["a", "b"],
+                "ref": ["test.t1.a", "test.t1.b"],
+                "rows": "X",
+                "filtered": "X",
+                "attached_condition": "t1.a <=> t1.a and t1.b <=> t1.b and t1.e = 'Y'"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b
+AND (t1.c = dt1.c OR (t1.c IS NULL AND dt1.c IS NULL))
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b
+AND (t1.c = dt2.c OR (t1.c IS NULL AND dt2.c IS NULL))
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+count(*)
+0
+explain format=json select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b  AND t1.c <=> dt1.c
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b  AND t1.c <=> dt2.c
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "possible_keys": ["t1_IDX"],
+      "rows": "X",
+      "filtered": "X"
+    },
+    "block-nl-join": {
+      "table": {
+        "table_name": "<derived2>",
+        "access_type": "ALL",
+        "rows": "X",
+        "filtered": "X"
+      },
+      "buffer_type": "flat",
+      "buffer_size": "256Kb",
+      "join_type": "BNL",
+      "attached_condition": "dt1.a = t1.a and dt1.b = t1.b and t1.d < dt1.maxd and t1.c <=> dt1.c",
+      "materialized": {
+        "query_block": {
+          "select_id": 2,
+          "filesort": {
+            "sort_key": "t1.a, t1.b, t1.c",
+            "temporary_table": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["t1_IDX"],
+                "rows": "X",
+                "filtered": "X"
+              }
+            }
+          }
+        }
+      }
+    },
+    "table": {
+      "table_name": "<derived3>",
+      "access_type": "ref",
+      "possible_keys": ["key0"],
+      "key": "key0",
+      "key_length": "390",
+      "used_key_parts": ["a", "b"],
+      "ref": ["test.t1.a", "test.t1.b"],
+      "rows": "X",
+      "filtered": "X",
+      "attached_condition": "trigcond(!(t1.d <=> dt2.umaxd)) and trigcond(t1.c <=> dt2.c and trigcond(t1.b is not null))",
+      "materialized": {
+        "lateral": 1,
+        "query_block": {
+          "select_id": 3,
+          "outer_ref_condition": "t1.b is not null",
+          "table": {
+            "table_name": "t1",
+            "access_type": "ref",
+            "possible_keys": ["t1_IDX"],
+            "key": "t1_IDX",
+            "key_length": "1159",
+            "used_key_parts": ["a", "b", "c"],
+            "ref": ["test.t1.a", "test.t1.b", "test.t1.c"],
+            "rows": "X",
+            "filtered": "X",
+            "index_condition": "t1.a = dt1.a and t1.b = dt1.b",
+            "attached_condition": "t1.e = 'Y'"
+          }
+        }
+      }
+    }
+  }
+}
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b  AND t1.c <=> dt1.c
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b  AND t1.c <=> dt2.c
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+count(*)
+0
+DROP TABLE `t1`;
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/mysql-test/main/derived_split_innodb.test
+++ b/mysql-test/main/derived_split_innodb.test
@@ -549,4 +549,95 @@ DROP TABLE t1;
 
 --echo # End of 10.4 tests
 
+#
+# MDEV-37057 Wrong result with LATERAL DERIVED
+#
+
+CREATE TABLE `t1` (
+  `ID` bigint(20) NOT NULL,
+  `a` varchar(128) NOT NULL,
+  `b` varchar(256) DEFAULT NULL,
+  `c` varchar(767) DEFAULT NULL,
+  `d` bigint(20) DEFAULT NULL,
+  `e` char(1) NOT NULL,
+  KEY `t1_IDX` (`a`,`b`,`c`) USING BTREE
+) ENGINE=InnoDB;
+
+INSERT INTO `t1` VALUES
+(3952987,'gfduishsdifugh','g7gfdshsidfhugssdfghss',NULL,13,'Y'),
+(3952990,'gfduishsdifugh','g7gfdshsidfhugssdfghss',NULL,14,'N'),
+(11281269,'fd76gfsd76tfgsgdf','q87f6d7s657s6gfgfdsdfg',NULL,1,'Y'),
+(11600791,'fd76gfsd76tfgsgdf','q87f6d7s657s6gfgfdsdfg',NULL,3,'N'),
+(30687884,'oihgfdsuighdfg','asiduf_sdffdsiuhsdfhh',NULL,946,'Y'),
+(30687898,'oihgfdsuighdfg','asiduf_sdffdsiuhsdfhh',NULL,947,'N'),
+(30688870,'oihgfdsuighdfg','gfsdhyudfg_ff_fggffggffggf',NULL,952,'Y'),
+(30688937,'oihgfdsuighdfg','gfsdhyudfg_ff_fggffggffggf',NULL,953,'N'),
+(30698445,'oihgfdsuighdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,19598,'Y'),
+(30698479,'oihgfdsuighdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,19599,'N'),
+(179317919,'uigfsdhsghghgf','fd89asdf776asdf766s6',NULL,3856,'Y'),
+(179317923,'uigfsdhsghghgf','fd89asdf776asdf766s6',NULL,3857,'N'),
+(180354215,'uigfsdhsghghgf','asiduf_sdffdsiuhsdfhh',NULL,4279,'Y'),
+(180869514,'gyygfssdfgsdfg','asiduf_sdffdsiuhsdfhh',NULL,1920,'Y'),
+(181237156,'gyygfssdfgsdfg','asiduf_sdffdsiuhsdfhh',NULL,1924,'N'),
+(181283787,'gyygfssdfgsdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,43584,'Y'),
+(181284091,'uigfsdhsghghgf','asiduf_sdffdsiuhsdfhh',NULL,4308,'N'),
+(181284043,'gyygfssdfgsdfg','iufhd_fdssdfdfsd_fdssdfdfdfd',NULL,43588,'N'),
+(181338945,'jbvgfsdihsdfg','g89gfdhsudyfyugsdfgyugsyugsss',NULL,48191,'Y'),
+(181348380,'jbvgfsdihsdfg','g89gfdhsudyfyugsdfgyugsyugsss',NULL,48234,'N');
+
+let $q1=
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b
+  AND (t1.c = dt1.c OR (t1.c IS NULL AND dt1.c IS NULL))
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b
+  AND (t1.c = dt2.c OR (t1.c IS NULL AND dt2.c IS NULL))
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+
+let $q2=
+select STRAIGHT_JOIN count(*) FROM t1
+INNER JOIN
+(
+SELECT a, b, c, max(d) maxd  FROM t1
+GROUP BY a, b, c
+) dt1 ON t1.a = dt1.a AND t1.b = dt1.b  AND t1.c <=> dt1.c
+LEFT JOIN
+(
+SELECT a, b, c, max(d) umaxd  FROM t1  WHERE e = 'Y'
+GROUP BY a, b, c
+) dt2 ON t1.a = dt2.a AND t1.b = dt2.b  AND t1.c <=> dt2.c
+WHERE t1.d < dt1.maxd  AND NOT t1.d <=> dt2.umaxd;
+
+--replace_regex /"rows": [0-9]+/"rows": "X"/ /"filtered": [0-9.]+/"filtered": "X"/
+eval explain format=json $q1;
+eval $q1;
+
+--replace_regex /"rows": [0-9]+/"rows": "X"/ /"filtered": [0-9.]+/"filtered": "X"/
+eval explain format=json $q2;
+eval $q2;
+
+--echo  poison stats
+insert into t1
+  select 1, x.seq, y.seq, z.seq, 1,  'N'
+  from seq_1_to_10 x, seq_1_to_20 y, seq_1_to_20 z;
+delete from t1 where ID = 1;
+
+--replace_regex /"rows": [0-9]+/"rows": "X"/ /"filtered": [0-9.]+/"filtered": "X"/
+eval explain format=json $q1;
+eval $q1;
+
+--replace_regex /"rows": [0-9]+/"rows": "X"/ /"filtered": [0-9.]+/"filtered": "X"/
+eval explain format=json $q2;
+eval $q2;
+
+DROP TABLE `t1`;
+
+# End of 10.6 tests;
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/mysql-test/main/long_unique_bugs.result
+++ b/mysql-test/main/long_unique_bugs.result
@@ -809,3 +809,29 @@ hex(c1)	hex(c2)	c3	hex(c4)
 NULL	NULL	NULL	NULL
 drop table t1;
 # End of 10.5 tests
+#
+# MDEV-36852 Table definition gets corrupt after adding unique hash key
+#
+create table t1 (a text, b int, foreign key(a) references x(x)) engine=myisam;
+Warnings:
+Note	1071	Specified key was too long; max key length is 1000 bytes
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  KEY `a` (`a`(1000))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+alter table t1 add unique(a), add key(a);
+Warnings:
+Note	1071	Specified key was too long; max key length is 1000 bytes
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  UNIQUE KEY `a` (`a`) USING HASH,
+  KEY `a_2` (`a`(1000))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+drop table t1;
+# End of 10.6 tests

--- a/mysql-test/main/long_unique_bugs.test
+++ b/mysql-test/main/long_unique_bugs.test
@@ -772,3 +772,15 @@ select hex(c1), hex(c2), c3, hex(c4) from t1;
 drop table t1;
 
 --echo # End of 10.5 tests
+
+--echo #
+--echo # MDEV-36852 Table definition gets corrupt after adding unique hash key
+--echo #
+
+create table t1 (a text, b int, foreign key(a) references x(x)) engine=myisam;
+show create table t1;
+alter table t1 add unique(a), add key(a);
+show create table t1;
+drop table t1;
+
+--echo # End of 10.6 tests

--- a/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
+++ b/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
@@ -993,3 +993,15 @@ FTS_DOC_ID	f1	f2
 4294967298	txt	bbb
 100000000000	aaa	bbb
 DROP TABLE t1;
+#
+#  MDEV-30363  Failing assertion: trx->error_state == DB_SUCCESS
+#                    in que_run_threads
+#
+CREATE TABLE server_stopword (value VARCHAR(1))engine=innodb;
+SET GLOBAL innodb_ft_server_stopword_table='test/server_stopword';
+CREATE TABLE t (t VARCHAR(1) COLLATE utf8_unicode_ci,
+FULLTEXT (t))engine=innodb;
+TRUNCATE TABLE t;
+DROP TABLE t;
+DROP TABLE server_stopword;
+SET GLOBAL innodb_ft_server_stopword_table= default;

--- a/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
+++ b/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
@@ -967,3 +967,16 @@ CREATE FULLTEXT INDEX i ON t1 (f2);
 SELECT * FROM t1 WHERE match(f2) against("bbb");
 # Cleanup
 DROP TABLE t1;
+
+--echo #
+--echo #  MDEV-30363  Failing assertion: trx->error_state == DB_SUCCESS
+--echo #                    in que_run_threads
+--echo #
+CREATE TABLE server_stopword (value VARCHAR(1))engine=innodb;
+SET GLOBAL innodb_ft_server_stopword_table='test/server_stopword';
+CREATE TABLE t (t VARCHAR(1) COLLATE utf8_unicode_ci,
+                FULLTEXT (t))engine=innodb;
+TRUNCATE TABLE t;
+DROP TABLE t;
+DROP TABLE server_stopword;
+SET GLOBAL innodb_ft_server_stopword_table= default;

--- a/mysql-test/suite/sql_sequence/grant.result
+++ b/mysql-test/suite/sql_sequence/grant.result
@@ -97,6 +97,19 @@ ERROR 42000: SELECT, INSERT command denied to user 'u'@'localhost' for table `my
 disconnect con1;
 connection default;
 drop user u;
+create user u_alter;
+create table t1 (id int);
+grant alter on t1 to u_alter;
+connect con_alter,localhost,u_alter,,mysqltest_1;
+alter table t1 modify id int default nextval(s1);
+ERROR 42000: SELECT, INSERT command denied to user 'u_alter'@'localhost' for table `mysqltest_1`.`s1`
+connection default;
+grant insert, select on s1 to u_alter;
+connection con_alter;
+alter table t1 modify id int default nextval(s1);
+disconnect con_alter;
+connection default;
+drop user u_alter;
 drop database mysqltest_1;
 #
 # End of 10.11 tests

--- a/mysql-test/suite/sql_sequence/grant.test
+++ b/mysql-test/suite/sql_sequence/grant.test
@@ -106,6 +106,22 @@ create table t1 (a int not null default(nextval(s1)),
 --connection default
 drop user u;
 
+# ALTER for table with DEFAULT NEXTVAL(seq) column needs INSERT/SELECT on seq
+# just like CREATE does in the example above
+create user u_alter;
+create table t1 (id int);
+grant alter on t1 to u_alter;
+--connect(con_alter,localhost,u_alter,,mysqltest_1)
+--error ER_TABLEACCESS_DENIED_ERROR
+alter table t1 modify id int default nextval(s1);
+--connection default
+grant insert, select on s1 to u_alter;
+--connection con_alter
+alter table t1 modify id int default nextval(s1);
+--disconnect con_alter
+--connection default
+drop user u_alter;
+
 #
 # Cleanup
 #

--- a/sql/opt_split.cc
+++ b/sql/opt_split.cc
@@ -625,14 +625,7 @@ void TABLE::add_splitting_info_for_key_field(KEY_FIELD *key_field)
   added_key_field->level= 0;
   added_key_field->optimize= KEY_OPTIMIZE_EQ;
   added_key_field->eq_func= true;
-
-  Item *real= key_field->val->real_item();
-  if ((real->type() == Item::FIELD_ITEM) &&
-        ((Item_field*)real)->field->maybe_null())
-    added_key_field->null_rejecting= true;
-  else
-    added_key_field->null_rejecting= false;
-
+  added_key_field->null_rejecting= key_field->null_rejecting;
   added_key_field->cond_guard= NULL;
   added_key_field->sj_pred_no= UINT_MAX;
   return;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3337,8 +3337,6 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
     Create_field *auto_increment_key= 0;
     Key_part_spec *column;
 
-    bool is_hash_field_needed= key->key_create_info.algorithm
-                               == HA_KEY_ALG_LONG_HASH;
     if (key->type == Key::IGNORE_KEY)
     {
       /* ignore redundant keys */
@@ -3348,6 +3346,9 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
       if (!key)
 	break;
     }
+
+    bool is_hash_field_needed= key->key_create_info.algorithm
+                               == HA_KEY_ALG_LONG_HASH;
 
     if (key_check_without_overlaps(thd, create_info, alter_info, *key))
       DBUG_RETURN(true);

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2838,6 +2838,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
         hash_keypart->fieldnr= hash_field_used_no + 1;
         hash_field= share->field[hash_field_used_no];
         hash_field->flags|= LONG_UNIQUE_HASH_FIELD;//Used in parse_vcol_defs
+        DBUG_ASSERT(hash_field->invisible == INVISIBLE_FULL);
         keyinfo->flags|= HA_NOSAME;
         share->virtual_fields++;
         share->stored_fields--;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14088,10 +14088,10 @@ int ha_innobase::truncate()
                 trx);
     if (!err)
     {
+      trx->commit(deleted);
       m_prebuilt->table->acquire();
       create_table_info_t::create_table_update_dict(m_prebuilt->table,
                                                     m_user_thd, info, *table);
-      trx->commit(deleted);
     }
     else
     {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37057*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

    When populating the structure spl_opt_info for a TABLE, and evaluating a
    key_field for inclusion in spl_opt_info->added_key_fields, the null_rejecting
    attribute may be incorrectly set.  Originally, this attribute was
    assumed to be TRUE, then it was changed
    
      Item *real= key_field->val->real_item();
      if ((real->type() == Item::FIELD_ITEM) &&
            ((Item_field*)real)->field->maybe_null())
        added_key_field->null_rejecting= true;
      else
        added_key_field->null_rejecting= false;
    
    which also incorrectly assumed that the added key field depended on
    whether the field was able to set to null.
    
    The correct setting for this attribute is simply to pass it through from
    the key being evaluated.
    
    The result of an incorrect value is, in this test case, incorrect
    equality conditions being pushed into our (lateral) derived table, thus
    a wrong result being returned.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
