### PR TITLE
MDEV-36738: mariadb@.service incorrectly changing pam ownership in mariadb-install-db

### DIFF
--- a/support-files/MacOSX/ReadMe.txt
+++ b/support-files/MacOSX/ReadMe.txt
@@ -80,7 +80,7 @@ Note
    lib             Libraries
    man             Unix manual pages
    mysql-test      MySQL test suite
-   scripts         Contains the mysql_install_db script
+   scripts         Contains the mariadb-install-db script
    share/mysql     Error message files
    sql-bench       Benchmarks
    support-files   Scripts and sample configuration files
@@ -288,7 +288,7 @@ Note
    /usr/libexec                The mariadbd server
    /usr/share/man              Unix manual pages
    /usr/share/mysql/mysql-test MySQL test suite
-   /usr/share/mysql            Contains the mysql_install_db script
+   /usr/share/mysql            Contains the mariadb-install-db script
    /var/mysql/mysql.sock       The location of the MySQL Unix socket
 
 Note

--- a/support-files/MacOSX/postflight.sh
+++ b/support-files/MacOSX/postflight.sh
@@ -23,13 +23,13 @@
 # installation has been performed.
 #
 # This script will install the MySQL privilege tables using the
-# "mysql_install_db" script and will correct the ownerships of these files
+# "mariadb-install-db" script and will correct the ownerships of these files
 # afterwards.
 #
 
 if cd @prefix@ ; then
 	if [ ! -f data/mysql/db.frm ] ; then
-		./scripts/mysql_install_db --rpm
+		./scripts/mariadb-install-db --rpm
 	fi
 
 	if [ -d data ] ; then

--- a/support-files/binary-configure.sh
+++ b/support-files/binary-configure.sh
@@ -23,9 +23,9 @@ for arg do
   esac
 done
 
-if test ! -x  ./scripts/mysql_install_db
+if test ! -x  ./scripts/mariadb-install-db
 then
-  echo "I didn't find the script './scripts/mysql_install_db'."
+  echo "I didn't find the script './scripts/mariadb-install-db'."
   echo "Please execute this script in the mysql distribution directory!"
   exit 1;
 fi
@@ -38,7 +38,7 @@ echo "and start the MySQL server for you.  If you run into any trouble, please"
 echo "consult the MySQL manual, that you can find in the Docs directory."
 echo ""
 
-./scripts/mysql_install_db --no-defaults
+./scripts/mariadb-install-db --no-defaults
 if [ $? = 0 ]
 then
   echo "Starting the mariadbd server.  You can test that it is up and running"

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -82,7 +82,7 @@ ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
  && systemctl set-environment _WSREP_START_POSITION=$VAR || exit 1"
 
 # Needed to create system tables etc.
-# ExecStartPre=@scriptdir@/mysql_install_db -u mysql
+# ExecStartPre=@scriptdir@/mariadb-install-db -u mysql
 
 # Start main service
 # MYSQLD_OPTS here is for users to set in /etc/systemd/system/mariadb.service.d/MY_SPECIAL.conf

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -88,7 +88,7 @@
 #   User=%I
 #   ProtectHome=false
 #   ExecStartPre=
-#   ExecStartPre=@scriptdir@/mysql_install_db $MYSQLD_MULTI_INSTANCE \
+#   ExecStartPre=@scriptdir@/mariadb-install-db $MYSQLD_MULTI_INSTANCE \
 #       --auth-root-authentication-method=socket --auth-root-socket-user=%I
 #   Environment=MYSQLD_MULTI_INSTANCE="--defaults-file=/home/%I/my%I.cnf \
 #       --datadir=/home/%I/mysqldatadir --skip-networking --socket=@mysql-%I"
@@ -197,8 +197,8 @@ ProtectSystem=full
 # Prevent accessing /home, /root and /run/user
 ProtectHome=true
 
-# Needed to create system tables etc.
-ExecStartPre=@scriptdir@/mysql_install_db $MYSQLD_MULTI_INSTANCE
+# Needed to create system tables etc. --rpm to not do pam permission changes.
+ExecStartPre=@scriptdir@/mariadb-install-db $MYSQLD_MULTI_INSTANCE --rpm
 
 # Start main service
 # A few variables are here:


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36738*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

    It was mysql_install_db, and this is changed to mariadb-install-db.
    
    This install script is part of the service as a useful instigation
    step, and a no-op in subseqeuent runs.
    
    This script does however change the auth_pam_tool_dir ownership.
    When running a multi-instance based on username, changing the
    auth_pam_tool_dir will only cause troubles for the other users.
    
    If you are running multiple instances on username is seems you
    are unlikely do be having pam access for all users. Even
    if you where the solution on auth_pam_tool_dir would be a group
    permission and group access based on the users.
    
    As such skip the changing of ownership.

## Release Notes

per JIRA

## How can this PR be tested?

start service under a multi-instance username

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.