### PR TITLE
MDEV-34388 debug clang

### DIFF
--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -3601,6 +3601,8 @@ static my_bool translog_is_LSN_chunk(uchar type)
   @retval 1 Error
 */
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 my_bool translog_init_with_table(const char *directory,
                                  uint32 log_file_max_size,
                                  uint32 server_version,
@@ -4234,6 +4236,7 @@ err:
   DBUG_RETURN(1);
 }
 
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 /*
   @brief Free transaction log file buffer.

--- a/storage/mroonga/vendor/groonga/CMakeLists.txt
+++ b/storage/mroonga/vendor/groonga/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGCXX)
   MY_CHECK_AND_SET_COMPILER_FLAG("-Wall")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-unused-but-set-variable")
+  MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-error=unused-but-set-variable")
   MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-pointer-sign")
   MY_CHECK_AND_SET_COMPILER_FLAG("-Wformat")
   MY_CHECK_AND_SET_COMPILER_FLAG("-Wstrict-aliasing=2")

--- a/storage/mroonga/vendor/groonga/lib/ii.c
+++ b/storage/mroonga/vendor/groonga/lib/ii.c
@@ -299,6 +299,8 @@ buffer_segment_new(grn_ctx *ctx, grn_ii *ii, uint32_t *segno)
   }
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 static grn_rc
 buffer_segment_reserve(grn_ctx *ctx, grn_ii *ii,
                        uint32_t *lseg0, uint32_t *pseg0,
@@ -384,6 +386,8 @@ buffer_segment_reserve(grn_ctx *ctx, grn_ii *ii,
   */
   return ctx->rc;
 }
+
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 #define BGQENQUE(lseg) do {\
   if (ii->header->binfo[lseg] != GRN_II_PSEG_NOT_ASSIGNED) {\
@@ -3338,6 +3342,8 @@ fake_map(grn_ctx *ctx, grn_io *io, grn_io_win *iw, void *addr, uint32_t seg, uin
   iw->addr = addr;
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 static grn_rc
 buffer_flush(grn_ctx *ctx, grn_ii *ii, uint32_t seg, grn_hash *h)
 {
@@ -3469,6 +3475,8 @@ buffer_flush(grn_ctx *ctx, grn_ii *ii, uint32_t seg, grn_hash *h)
   }
   return ctx->rc;
 }
+
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 void
 grn_ii_buffer_check(grn_ctx *ctx, grn_ii *ii, uint32_t seg)
@@ -3736,6 +3744,8 @@ array_update(grn_ctx *ctx, grn_ii *ii, uint32_t dls, buffer *db)
   }
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 static grn_rc
 buffer_split(grn_ctx *ctx, grn_ii *ii, uint32_t seg, grn_hash *h)
 {
@@ -3980,6 +3990,8 @@ buffer_split(grn_ctx *ctx, grn_ii *ii, uint32_t seg, grn_hash *h)
   }
   return ctx->rc;
 }
+
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 #define SCALE_FACTOR 2048
 #define MAX_NTERMS   8192
@@ -4520,7 +4532,7 @@ grn_ii_get_disk_usage(grn_ctx *ctx, grn_ii *ii)
 }
 
 
-PRAGMA_DISABLE_CHECK_STACK_FRAME
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 #define BIT11_01(x) ((x >> 1) & 0x7ff)
 #define BIT31_12(x) (x >> 12)
@@ -4797,7 +4809,7 @@ exit :
   return ctx->rc;
 }
 
-PRAGMA_REENABLE_CHECK_STACK_FRAME
+PRAGMA_DISABLE_CHECK_STACK_FRAME
 
 grn_rc
 grn_ii_delete_one(grn_ctx *ctx, grn_ii *ii, grn_id tid, grn_ii_updspec *u, grn_hash *h)
@@ -4911,6 +4923,8 @@ exit :
   if (bs) { GRN_FREE(bs); }
   return ctx->rc;
 }
+
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 #define CHUNK_USED    1
 #define BUFFER_USED   2
@@ -6309,6 +6323,8 @@ grn_uvector2updspecs(grn_ctx *ctx, grn_ii *ii, grn_id rid,
   }
 }
 
+PRAGMA_DISABLE_CHECK_STACK_FRAME
+
 grn_rc
 grn_ii_column_update(grn_ctx *ctx, grn_ii *ii, grn_id rid, unsigned int section,
                      grn_obj *oldvalue, grn_obj *newvalue, grn_obj *posting)
@@ -6627,6 +6643,8 @@ exit :
   if (new && new != newvalue) { grn_obj_close(ctx, new); }
   return ctx->rc;
 }
+
+PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 /* token_info */
 

--- a/storage/mroonga/vendor/groonga/plugins/tokenizers/mecab.c
+++ b/storage/mroonga/vendor/groonga/plugins/tokenizers/mecab.c
@@ -194,7 +194,14 @@ chunked_tokenize_utf8(grn_ctx *ctx,
   const char *string_end = string + string_bytes;
   grn_encoding encoding = tokenizer->query->encoding;
 
+#if defined __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
   if (string_bytes < grn_mecab_chunk_size_threshold) {
+#if defined __GNUC__
+# pragma GCC diagnostic pop
+#endif
     return chunked_tokenize_utf8_chunk(ctx,
                                        tokenizer,
                                        string,


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34388*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Clang under a debug build triggered a few too many -Werror conditions on stack.

The code on mroonga is kept be ready for its update #3864 where these directives aren’t' necessary.

https://github.com/MariaDB/server/pull/3961/files#diff-8adababce2dec657ca89490f1922da7d4d0ec4db824261594114d9542bc575cc

Didn't seem to hit this in 10.11 so this patch is omitted.

## Release Notes

noting - compile/debug only.

## How can this PR be tested?

Compile with clang and `-DCMAKE_BUILD_TYPE=Debug`

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
