### PR TITLE
MDEV-22250 InnoDB: Failing assertion: opt_no_lock during mariabackup --backup

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -908,8 +908,10 @@ lock_for_backup_stage_start(MYSQL *connection)
     xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false);
   }
 
+  msg("Starting BACKUP STAGE START");
   xb_mysql_query(connection, "BACKUP STAGE START", true);
   DBUG_MARIABACKUP_EVENT("after_backup_stage_start", {});
+  msg("Executed BACKUP STAGE START successfully");
   /* Set the maximum supported session value for
   lock_wait_timeout to prevent unnecessary timeouts when the
   global value is changed from the default */
@@ -930,10 +932,13 @@ lock_for_backup_stage_flush(MYSQL *connection) {
 	if (opt_kill_long_queries_timeout) {
 		start_query_killer();
 	}
+
+	msg("Starting BACKUP STAGE FLUSH");
 	xb_mysql_query(connection, "BACKUP STAGE FLUSH", true);
 	if (opt_kill_long_queries_timeout) {
 		stop_query_killer();
 	}
+	msg("Executed BACKUP STAGE FLUSH Successfully");
 	return true;
 }
 
@@ -942,11 +947,13 @@ lock_for_backup_stage_block_ddl(MYSQL *connection) {
 	if (opt_kill_long_queries_timeout) {
 		start_query_killer();
 	}
+	msg("Starting BACKUP STAGE BLOCK_DDL");
 	xb_mysql_query(connection, "BACKUP STAGE BLOCK_DDL", true);
 	DBUG_MARIABACKUP_EVENT("after_backup_stage_block_ddl", {});
 	if (opt_kill_long_queries_timeout) {
 		stop_query_killer();
 	}
+	msg("Executed BACKUP STAGE BLOCK_DDL Successfully");
 	return true;
 }
 
@@ -955,11 +962,14 @@ lock_for_backup_stage_commit(MYSQL *connection) {
 	if (opt_kill_long_queries_timeout) {
 		start_query_killer();
 	}
+
+	msg("Starting BACKUP STAGE BLOCK_COMMIT");
 	xb_mysql_query(connection, "BACKUP STAGE BLOCK_COMMIT", true);
 	DBUG_MARIABACKUP_EVENT("after_backup_stage_block_commit", {});
 	if (opt_kill_long_queries_timeout) {
 		stop_query_killer();
 	}
+	msg("Executed BACKUP STAGE BLOCK_COMMIT Successfully");
 	return true;
 }
 

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -5061,7 +5061,6 @@ class BackupStages {
 
 		bool stage_start(Backup_datasinks &backup_datasinks,
 		                 CorruptedPages &corrupted_pages) {
-			msg("BACKUP STAGE START");
 			if (!opt_no_lock) {
 				if (opt_safe_slave_backup) {
 					if (!wait_for_safe_slave(mysql_connection)) {
@@ -5109,7 +5108,6 @@ class BackupStages {
 		}
 
 		bool stage_flush() {
-			msg("BACKUP STAGE FLUSH");
 			if (!opt_no_lock && !lock_for_backup_stage_flush(m_bs_con)) {
 				msg("Error on BACKUP STAGE FLUSH query execution");
 				return false;
@@ -5168,7 +5166,8 @@ class BackupStages {
                                      CorruptedPages &corrupted_pages) {
 			if (!opt_no_lock) {
 				if (!lock_for_backup_stage_block_ddl(m_bs_con)) {
-					msg("BACKUP STAGE BLOCK_DDL");
+					msg("Error on BACKUP STAGE BLOCK_DDL "
+					    "query execution");
 					return false;
 				}
 				if (have_galera_enabled)
@@ -5236,7 +5235,6 @@ class BackupStages {
 		}
 
 		bool stage_block_commit(Backup_datasinks &backup_datasinks) {
-			msg("BACKUP STAGE BLOCK_COMMIT");
 			if (!opt_no_lock && !lock_for_backup_stage_commit(m_bs_con)) {
 				msg("Error on BACKUP STAGE BLOCK_COMMIT query execution");
 				return false;
@@ -5343,7 +5341,6 @@ class BackupStages {
 		}
 
 		bool stage_end(Backup_datasinks &backup_datasinks) {
-			msg("BACKUP STAGE END");
 			/* release all locks */
 			if (!opt_no_lock) {
 				unlock_all(m_bs_con);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7825,6 +7825,20 @@ write_bin_log_start_alter_rollback(THD *thd, uint64 &start_alter_id,
   return false;
 }
 
+/**
+  Check whether the table has fulltext index
+  @param table Table object
+  @retval true if fulltext index exist
+  @retval false if it doesn't have fulltext index
+*/
+static bool fulltext_index_exist(const TABLE* table)
+{
+  for (uint32_t i= 0; i < table->s->keys; i++)
+    if (table->key_info[i].algorithm == HA_KEY_ALG_FULLTEXT)
+      return true;
+  return false;
+}
+
 
 /**
   Perform in-place alter table.
@@ -7883,10 +7897,17 @@ static bool mysql_inplace_alter_table(THD *thd,
 
   const enum_alter_inplace_result inplace_supported=
     ha_alter_info->inplace_supported;
+  bool fts_rebuild= (inplace_supported == HA_ALTER_INPLACE_COPY_LOCK &&
+                     fulltext_index_exist(altered_table));
   DBUG_ENTER("mysql_inplace_alter_table");
 
-  /* Downgrade DDL lock while we are waiting for exclusive lock below */
-  backup_set_alter_copy_lock(thd, table);
+  /*
+    If an FTS rebuild is not required, downgrade the DDL lock while
+    waiting for an exclusive lock. Defer the downgradation after
+    prepare phase completion when FTS rebuild is required
+  */
+  if (!fts_rebuild)
+    backup_set_alter_copy_lock(thd, table);
 
   /*
     Upgrade to EXCLUSIVE lock if:
@@ -8021,6 +8042,11 @@ static bool mysql_inplace_alter_table(THD *thd,
     goto rollback_no_restore_lock;
 
   debug_crash_here("ddl_log_alter_after_prepare_inplace");
+
+  /* Downgrade the DDL lock after prepare phase when FTS table is
+  being rebuild */
+  if (fts_rebuild)
+    backup_set_alter_copy_lock(thd, table);
 
   /*
     Store the new table_version() as it may have not been available before


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-22250*

## Description
mysql_inplace_alter_table(): Defer the downgradation of DDL lock after prepare phase completion when fulltext index is being rebuilt


## How can this PR be tested?
10.11 version of pr#4148

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
