### PR TITLE
MDEV-37115: Optimize reverse index scan

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2236,8 +2236,9 @@ buf_page_t *buf_page_get_zip(const page_id_t page_id) noexcept
       hash_lock.unlock_shared();
       switch (dberr_t err= buf_read_page(page_id, false)) {
       case DB_SUCCESS:
-      case DB_SUCCESS_LOCKED_REC:
         mariadb_increment_pages_read(stats);
+        /* fall through */
+      case DB_SUCCESS_LOCKED_REC:
         continue;
       case DB_TABLESPACE_DELETED:
         return nullptr;
@@ -2655,8 +2656,9 @@ buf_block_t *buf_pool_t::page_fix(const page_id_t id,
         *err= local_err;
       return nullptr;
     case DB_SUCCESS:
-    case DB_SUCCESS_LOCKED_REC:
       mariadb_increment_pages_read(stats);
+      /* fall through */
+    case DB_SUCCESS_LOCKED_REC:
       buf_read_ahead_random(id, false);
     }
   }
@@ -2789,8 +2791,9 @@ loop:
 
 	switch (dberr_t local_err = buf_read_page(page_id)) {
 	case DB_SUCCESS:
-	case DB_SUCCESS_LOCKED_REC:
 		mariadb_increment_pages_read(stats);
+		/* fall through */
+	case DB_SUCCESS_LOCKED_REC:
 		buf_read_ahead_random(page_id, ibuf_inside(mtr));
 		break;
 	default:

--- a/storage/innobase/include/btr0pcur.h
+++ b/storage/innobase/include/btr0pcur.h
@@ -372,8 +372,16 @@ struct btr_pcur_t
   @retval NOT_SAME cursor position is not on user rec or points on
   the record with not the same uniq field values as in the stored
   @retval CORRUPTED if the index is corrupted */
-  restore_status restore_position(btr_latch_mode latch_mode, mtr_t *mtr);
-
+  restore_status restore_position(btr_latch_mode latch_mode, mtr_t *mtr)
+    noexcept;
+private:
+  restore_status restore_pessimistic(btr_latch_mode latch_mode, mtr_t *mtr)
+    noexcept;
+  bool restore_optimistic_prev(rw_lock_type_t mode, mtr_t *mtr,
+                               buf_block_t *block) noexcept;
+public:
+  restore_status restore_optimistic(btr_latch_mode latch_mode, mtr_t *mtr)
+    noexcept;
   /** Open the cursor on the first or last record.
   @param first         true=first record, false=last record
   @param index         B-tree


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37115*
## Description
`btr_pcur_move_backward_from_page()`: If a latch on the previous page can be acquired without waiting, move straight to that page without repositioning the cursor. Do trigger linear read-ahead if this is the first time access to the page.
## Release Notes
Reverse index scan (such as `ORDER BY…DESC` when the index is in `ASC `order) got slightly faster in InnoDB.
## How can this PR be tested?
```sql
--source include/have_innodb.inc
--source include/have_innodb_4k.inc
--source include/have_profiling.inc
--source include/have_sequence.inc
CREATE TABLE tbig2 (id int auto_increment not null,
c2 char(255) not null default '',
c3 char(255) not null default '',
c4 char(255) not null default '', primary key(id,c2,c3,c4(20)))
ENGINE=InnoDB default charset=ucs2;
SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
insert into tbig2 (c2) select '' from seq_1_to_524288;
--disable_result_log
set profiling=ON;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
select id from tbig2 order by id desc;
--enable_result_log
show profiles;
DROP TABLE tbig2;
```
This will create a 1.7 GiB data file, with 2 rows per index leaf page and 3 records per non-leaf page. That would be 262,144 leaf pages of 4 KiB each (1 GiB) and 0.7 GiB of non-leaf pages. I padded the `PRIMARY KEY` with the data, so that the tree would grow higher. With a short `PRIMARY KEY(id)` there would be fewer non-leaf pages and a smaller performance difference.

The difference for this test case in the environment where I tested is smaller than I expected, about 10%.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.