### PR TITLE
MDEV-37102: Fix Test by Waiting for the State

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_master_disable_with_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_master_disable_with_slave.result
@@ -11,11 +11,8 @@ connection slave;
 connection master;
 SELECT ID INTO @binlog_dump_tid
 FROM information_schema.PROCESSLIST WHERE COMMAND = 'Binlog Dump';
-# Control State
-SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
-STATE
-Master has sent all binlog to slave; waiting for more updates
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+# Wait for the Control State
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	1
 # Disable Semi-Sync while the dump thread is still connected to its slave
@@ -23,14 +20,14 @@ SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
 SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
 STATE
 Master has sent all binlog to slave; waiting for more updates
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	1
 # Disconnect the slave and wait until the master's dump thread is gone
 connection slave;
 STOP SLAVE;
 connection master;
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	0
 # Cleanup

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_master_disable_with_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_master_disable_with_slave.test
@@ -33,9 +33,12 @@ SELECT ID INTO @binlog_dump_tid
   FROM information_schema.PROCESSLIST WHERE COMMAND = 'Binlog Dump';
 --enable_cursor_protocol
 
---echo # Control State
-SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+--echo # Wait for the Control State
+let $wait_condition=
+  SELECT STATE LIKE 'Master has sent all binlog to slave%'
+    FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 
 --echo # Disable Semi-Sync while the dump thread is still connected to its slave
 SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
@@ -43,7 +46,7 @@ SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
 --source include/wait_for_status_var.inc
 
 SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 
 --echo # Disconnect the slave and wait until the master's dump thread is gone
 --connection slave
@@ -54,9 +57,10 @@ STOP SLAVE;
 
 # MDEV-36359: The disconnection would crash the master and leave the wait with
 # error 2013 'Lost connection to server during query'
---let $wait_condition= SELECT COUNT(*)=0 FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid
+let $wait_condition= SELECT COUNT(*)=0
+  FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
 --source include/wait_condition.inc
-SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_clients';
 
 --echo # Cleanup
 --eval SET @@GLOBAL.rpl_semi_sync_master_enabled= $orig_master_enabled


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-37102](https://jira.mariadb.org/browse/MDEV-37102)*

## Description
`rpl.rpl_semi_sync_master_disable_with_slave` from [MDEV-36359](https://jira.mariadb.org/browse/MDEV-36359) expected the primary to be at the control state when the replica syncs up.
However, this timing is not guaranteed.
In consequence, the test would occasionally fail with the primary at an incorrect (likely the previous) state.

This patch overcomes this by replacing the state assertion with a wait.
While there, the patch also escapes the `_`s in the LIKE operand.

## Release Notes
N/A

## How can this PR be tested?
Good question. Add a debugger break somewhere near the end of the binlog dump loop, maybe?

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest *maintained* branch in which the bug can be reproduced.*
  * 10.6 now only receives critical fixes.
    MDEV-36359 fixed a crash, but this doesn’t.

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.