### PR TITLE
MDEV-37128  Avoid repetition of log message during mariabackup --backup

### DIFF
--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -541,8 +541,12 @@ public:
     @param[in,out]	start_lsn	in: read area start,
 					out: the last read valid lsn
     @param[in]		end_lsn		read area end
+    @param[in]		backup_read_lsn	last read lsn by mariabackup during
+					backup process. This is used to
+					display when we can report information
     @return	whether no invalid blocks (e.g checksum mismatch) were found */
-    bool read_log_seg(lsn_t* start_lsn, lsn_t end_lsn);
+    bool read_log_seg(lsn_t* start_lsn, lsn_t end_lsn,
+                      lsn_t* backup_read_lsn= nullptr);
 
     /** Initialize the redo log buffer. */
     void create();

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -299,6 +299,8 @@ public:
 				record, or 0 if none was parsed */
 	/** the time when progress was last reported */
 	time_t		progress_time;
+	/** Seconds for printing progress message */
+	uint32_t	progress_interval = 15;
 
   using map = std::map<const page_id_t, page_recv_t,
                        std::less<const page_id_t>,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37128*

## Description
problem:
========
mariadb-backup creates one background thread to copy innodb redo log. It does copy all the data file (in main thread and other concurrent threads), till it explicitly mentions the redo log thread to exit. This redo log copier thread run keep printing the current states of redo log copied lsn for every 15 seconds. If BACKUP STAGE command takes time to finish or any stall during data copy then redo log background continuously emitting the same log copy status gives the impression that redo log is being stuck

Solution:
=========
- Reduce the frequency for printing the log status by increasing the report time interval to 60 seconds
- Avoid printing the log status when there is no new redo log to copy

## How can this PR be tested?
Added the following patch to make the mariabackup to simulate the copy of data files
takes longer
```
diff --git a/extra/mariabackup/backup_copy.cc b/extra/mariabackup/backup_copy.cc
index ef3018c5644..d149d9657ec 100644
--- a/extra/mariabackup/backup_copy.cc
+++ b/extra/mariabackup/backup_copy.cc
@@ -1462,6 +1462,7 @@ bool backup_start(ds_ctxt *ds_data, ds_ctxt *ds_meta,
 
        corrupted_pages.backup_fix_ddl(ds_data, ds_meta);
 
+        my_sleep(100000 * 1000UL);
        // There is no need to stop slave thread before coping non-Innodb data when
        // --no-lock option is used because --no-lock option requires that no DDL or
        // DML to non-transaction tables can occur.
```


Without patch:
=============
```
2025-07-01 14:00:22 0 [Note] InnoDB: Read redo log up to LSN=14288896
2025-07-01 14:00:37 0 [Note] InnoDB: Read redo log up to LSN=14288896
2025-07-01 14:00:52 0 [Note] InnoDB: Read redo log up to LSN=14288896
2025-07-01 14:01:07 0 [Note] InnoDB: Read redo log up to LSN=14288896
2025-07-01 14:01:22 0 [Note] InnoDB: Read redo log up to LSN=14288896
2025-07-01 14:01:37 0 [Note] InnoDB: Read redo log up to LSN=14288896 
```

With patch:
===========
```
2025-07-01 14:03:39 0 [Note] InnoDB: Read redo log up to LSN=14288896
```

Mariabackup prints the only one error log when log copier thread doesn't have any redo log to copy

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
