### PR TITLE
MDEV-37123 dict_table_open_on_id() fails to release dict_sys.latch

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_defrag_stats.result
+++ b/mysql-test/suite/innodb/r/innodb_defrag_stats.result
@@ -131,3 +131,11 @@ ALTER TABLE t2 STATS_PERSISTENT=1;
 DROP TABLE t2;
 SELECT * FROM mysql.innodb_index_stats;
 database_name	table_name	index_name	last_update	stat_name	stat_value	sample_size	stat_description
+#
+# MDEV-37123  dict_table_open_on_id() fails to release dict_sys.latch
+#
+SET GLOBAL innodb_defragment_stats_accuracy=1;
+CREATE TABLE t (f INT,f2 CHAR(1),KEY k1 (f2),FULLTEXT KEY(f2),
+FOREIGN KEY(f2) REFERENCES t (f3)) ENGINE=InnoDB;
+ERROR HY000: Can't create table `test`.`t` (errno: 150 "Foreign key constraint is incorrectly formed")
+SET GLOBAL innodb_defragment_stats_accuracy=default;

--- a/mysql-test/suite/innodb/t/innodb_defrag_stats.test
+++ b/mysql-test/suite/innodb/t/innodb_defrag_stats.test
@@ -86,3 +86,12 @@ ALTER TABLE t2 STATS_PERSISTENT=1;
 DROP TABLE t2;
 
 SELECT * FROM mysql.innodb_index_stats;
+
+--echo #
+--echo # MDEV-37123  dict_table_open_on_id() fails to release dict_sys.latch
+--echo #
+SET GLOBAL innodb_defragment_stats_accuracy=1;
+--error ER_CANT_CREATE_TABLE
+CREATE TABLE t (f INT,f2 CHAR(1),KEY k1 (f2),FULLTEXT KEY(f2),
+                FOREIGN KEY(f2) REFERENCES t (f3)) ENGINE=InnoDB;
+SET GLOBAL innodb_defragment_stats_accuracy=default;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -927,6 +927,8 @@ retry:
     else if (table)
       table->acquire();
   }
+  else if (!dict_locked)
+    dict_sys.unfreeze();
 
   return table;
 }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37123*

## Description
While updating the persistent defragmentation statistics for the table, InnoDB opens the table only if it is in cache. If dict_table_open_on_id() fails to find the table in cache then it fails to unfreeze dict_sys.latch. This lead to crash

## How can this PR be tested?
./mtr innodb.innodb_defrag_stats

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
