### PR TITLE
MDEV-37138 innochecksum misinterprets doublewrite buffer pages

### DIFF
--- a/extra/innochecksum.cc
+++ b/extra/innochecksum.cc
@@ -49,7 +49,6 @@ The parts not included are excluded by #ifndef UNIV_INNOCHECKSUM. */
 #include "page0zip.h"            /* page_zip_*() */
 #include "trx0undo.h"            /* TRX_* */
 #include "fil0crypt.h"           /* fil_space_verify_crypt_checksum */
-
 #include <string.h>
 
 #ifdef UNIV_NONINL
@@ -78,6 +77,8 @@ static ulint extent_size;
 static ulint xdes_size;
 ulong srv_page_size;
 uint32_t srv_page_size_shift;
+static uint32_t dblwr_1;
+static uint32_t dblwr_2;
 /* Current page number (0 based). */
 uint32_t		cur_page_num;
 /* Current space. */
@@ -101,8 +102,10 @@ FILE*				log_file = NULL;
 /* Enabled for log write option. */
 static bool			is_log_enabled = false;
 static bool			skip_freed_pages;
+static uint32_t 		tablespace_flags= 0;
 static byte field_ref_zero_buf[UNIV_PAGE_SIZE_MAX];
 const byte *field_ref_zero = field_ref_zero_buf;
+constexpr uint32_t USE_FSP_FLAGS{UINT32_MAX};
 
 #ifndef _WIN32
 /* advisory lock for non-window system. */
@@ -257,12 +260,9 @@ void print_leaf_stats(
 }
 
 /** Init the page size for the tablespace.
-@param[in]	buf	buffer used to read the page */
-static void init_page_size(const byte* buf)
+@param[in]	flags	InnoDB tablespace flags */
+static void init_page_size_from_flags(const uint32_t flags)
 {
-	const unsigned	flags = mach_read_from_4(buf + FIL_PAGE_DATA
-						 + FSP_SPACE_FLAGS);
-
 	if (fil_space_t::full_crc32(flags)) {
 		const uint32_t ssize = FSP_FLAGS_FCRC32_GET_PAGE_SSIZE(flags);
 		srv_page_size_shift = UNIV_ZIP_SIZE_SHIFT_MIN - 1 + ssize;
@@ -544,24 +544,15 @@ static bool is_page_corrupted(byte *buf, bool is_encrypted, uint32_t flags)
 	return(is_corrupted);
 }
 
-/********************************************//*
- Check if page is doublewrite buffer or not.
- @param [in] page	buffer page
-
- @retval true  if page is doublewrite buffer otherwise false.
-*/
-static
-bool
-is_page_doublewritebuffer(
-	const byte*	page)
+/** Check if page is doublewrite buffer or not.
+@retval true  if page is doublewrite buffer otherwise false. */
+static bool is_page_doublewritebuffer()
 {
-	if ((cur_page_num >= extent_size)
-		&& (cur_page_num < extent_size * 3)) {
-		/* page is doublewrite buffer. */
-		return (true);
-	}
-
-	return (false);
+  if (cur_space != 0) return false;
+  const uint32_t extent{static_cast<uint32_t>(
+    cur_page_num & ~(extent_size - 1))};
+  return cur_page_num > FSP_DICT_HDR_PAGE_NO &&
+	 extent && (extent == dblwr_1 || extent == dblwr_2);
 }
 
 /*******************************************************//*
@@ -768,7 +759,7 @@ Parse the page and collect/dump the information about page type
 @param [in] file	file for diagnosis.
 @param [in] is_encrypted  tablespace is encrypted
 */
-void
+static void
 parse_page(
 	const byte*	page,
 	byte*		xdes,
@@ -788,6 +779,12 @@ parse_page(
 	str = skip_page ? "Double_write_buffer" : "-";
 	page_no = mach_read_from_4(page + FIL_PAGE_OFFSET);
 	if (skip_freed_pages) {
+
+		/** Skip doublewrite pages when -r is enabled */
+		if (is_page_doublewritebuffer()) {
+			return;
+		}
+
 		const byte *des= xdes + XDES_ARR_OFFSET +
 			xdes_size * ((page_no & (physical_page_size - 1))
 				     / extent_size);
@@ -981,6 +978,18 @@ parse_page(
 		if (file) {
 			fprintf(file, "#::" UINT32PF "\t\t|\t\tTransaction system "
 				"page\t\t|\t%s\n", cur_page_num, str);
+		}
+
+		if (cur_space == 0 &&
+		    (mach_read_from_4(page + TRX_SYS_DOUBLEWRITE +
+			             TRX_SYS_DOUBLEWRITE_MAGIC) ==
+		     TRX_SYS_DOUBLEWRITE_MAGIC_N))  {
+			dblwr_1 = mach_read_from_4(
+					page + TRX_SYS_DOUBLEWRITE +
+					TRX_SYS_DOUBLEWRITE_BLOCK1);
+			dblwr_2 = mach_read_from_4(
+					page + TRX_SYS_DOUBLEWRITE +
+					TRX_SYS_DOUBLEWRITE_BLOCK2);
 		}
 		break;
 
@@ -1224,6 +1233,9 @@ static struct my_option innochecksum_options[] = {
   {"skip-freed-pages", 'r', "skip freed pages for the tablespace",
    &skip_freed_pages, &skip_freed_pages, 0, GET_BOOL, NO_ARG,
    0, 0, 0, 0, 0, 0},
+  {"tablespace-flags", 0, "InnoDB tablespace flags (default: 4294967295 "
+   "= read from page 0)", &tablespace_flags, &tablespace_flags, 0,
+   GET_UINT, REQUIRED_ARG, USE_FSP_FLAGS, 0, USE_FSP_FLAGS, 0, 0, 0},
 
   {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
@@ -1298,6 +1310,14 @@ innochecksum_get_one_option(
 		my_end(0);
 		exit(EXIT_SUCCESS);
 		break;
+	default:
+	  if (tablespace_flags != USE_FSP_FLAGS &&
+	      !fil_space_t::is_valid_flags(tablespace_flags, false) &&
+	      !fil_space_t::is_valid_flags(tablespace_flags, true)) {
+		fprintf(stderr, "Error: Provided --tablespace-flags "
+			"is not valid.");
+		return true;
+	  }
 	}
 
 	return(false);
@@ -1426,6 +1446,87 @@ rewrite_checksum(
 	page compressed tables this is not currently supported. */
 	return do_write && !is_encrypted && !is_compressed
 		&& !write_file(filename, fil_in, buf, flags, pos);
+}
+
+/** Read and validate page 0, then initialize tablespace flags
+and page size.
+@param	fil_in        File pointer
+@param	buf           Buffer to read page into
+@return whether the page was read successfully */
+static bool read_and_validate_page0(FILE *fil_in, byte *buf)
+{
+  /* Read the minimum page size first */
+  size_t initial_page_size= UNIV_ZIP_SIZE_MIN;
+  if (tablespace_flags != USE_FSP_FLAGS)
+  {
+    init_page_size_from_flags(tablespace_flags);
+    initial_page_size= physical_page_size;
+  }
+
+  /* Read just enough to get the tablespace flags */
+  size_t bytes= fread(buf, 1, initial_page_size, fil_in);
+
+  if (bytes != initial_page_size)
+  {
+    fprintf(stderr, "Error: Was not able to read the "
+            "minimum page size of %zu bytes. Bytes read "
+            "was %zu\n", initial_page_size, bytes);
+    return false;
+  }
+
+  /* Read space_id and page offset */
+  cur_space= mach_read_from_4(buf + FIL_PAGE_SPACE_ID);
+  cur_page_num= mach_read_from_4(buf + FIL_PAGE_OFFSET);
+
+  /* Get tablespace flags from the FSP header */
+  uint32_t flags= mach_read_from_4(buf + FSP_HEADER_OFFSET +
+                                   FSP_SPACE_FLAGS);
+
+  if (tablespace_flags != USE_FSP_FLAGS)
+  {
+    if (cur_page_num == 0 && flags != tablespace_flags)
+      fprintf(stderr, "Error: Mismatch between provided tablespace "
+              "flags (0x%x) and file flags (0x%x)\n",
+              tablespace_flags, flags);
+  }
+  else
+  {
+    if (cur_page_num)
+    {
+      fprintf(stderr, "Error: First page of the tablespace file "
+              "should be 0, but encountered page number %" PRIu32 ". "
+              "If you are checking multi file system "
+              "tablespace files, please specify the correct "
+              "tablespace flags using --tablespace-flags option.\n",
+              cur_page_num);
+      return false;
+    }
+    /* Initialize page size parameters based on flags */
+    init_page_size_from_flags(flags);
+    /* Read the rest of the page if it's larger than the minimum size */
+    if (physical_page_size > UNIV_ZIP_SIZE_MIN)
+    {
+      /* Read rest of the page 0 to determine crypt_data */
+      ulint bytes= read_file(buf, true, physical_page_size, fil_in);
+      if (bytes != physical_page_size)
+      {
+        fprintf(stderr, "Error: Was not able to read the rest of the "
+		"page of " ULINTPF " bytes. Bytes read was " ULINTPF "\n",
+		physical_page_size - UNIV_ZIP_SIZE_MIN, bytes);
+        return false;
+      }
+    }
+    tablespace_flags= flags;
+  }
+
+  if (physical_page_size < UNIV_ZIP_SIZE_MIN ||
+      physical_page_size > UNIV_PAGE_SIZE_MAX)
+  {
+    fprintf(stderr, "Error: Invalid page size " ULINTPF
+            " encountered\n", physical_page_size);
+    return false;
+  }
+  return true;
 }
 
 int main(
@@ -1563,51 +1664,13 @@ int main(
 			}
 		}
 
-		/* Read the minimum page size. */
-		bytes = fread(buf, 1, UNIV_ZIP_SIZE_MIN, fil_in);
-		partial_page_read = true;
-
-		if (bytes != UNIV_ZIP_SIZE_MIN) {
-			fprintf(stderr, "Error: Was not able to read the "
-				"minimum page size ");
-			fprintf(stderr, "of %d bytes.  Bytes read was " ULINTPF "\n",
-				UNIV_ZIP_SIZE_MIN, bytes);
-
+		/* Read and validate page 0 */
+		if (!read_and_validate_page0(fil_in, buf)) {
 			exit_status = 1;
 			goto my_exit;
 		}
 
-		/* enable variable is_system_tablespace when space_id of given
-		file is zero. Use to skip the checksum verification and rewrite
-		for doublewrite pages. */
-		cur_space = mach_read_from_4(buf + FIL_PAGE_SPACE_ID);
-		cur_page_num = mach_read_from_4(buf + FIL_PAGE_OFFSET);
-
-		/* Determine page size, zip_size and page compression
-		from fsp_flags and encryption metadata from page 0 */
-		init_page_size(buf);
-
-		uint32_t flags = mach_read_from_4(FSP_HEADER_OFFSET + FSP_SPACE_FLAGS + buf);
-
-		if (physical_page_size == UNIV_ZIP_SIZE_MIN) {
-			partial_page_read = false;
-		} else {
-			/* Read rest of the page 0 to determine crypt_data */
-			bytes = read_file(buf, partial_page_read, physical_page_size, fil_in);
-			if (bytes != physical_page_size) {
-				fprintf(stderr, "Error: Was not able to read the "
-					"rest of the page ");
-				fprintf(stderr, "of " ULINTPF " bytes.  Bytes read was " ULINTPF "\n",
-					physical_page_size - UNIV_ZIP_SIZE_MIN, bytes);
-
-				exit_status = 1;
-				goto my_exit;
-			}
-			partial_page_read = false;
-		}
-
-
-		/* Now that we have full page 0 in buffer, check encryption */
+		/* Check if tablespace is encrypted */
 		bool is_encrypted = check_encryption(filename, buf);
 
 		/* Verify page 0 contents. Note that we can't allow
@@ -1618,7 +1681,8 @@ int main(
 			allow_mismatches = 0;
 
 			exit_status = verify_checksum(buf, is_encrypted,
-						      &mismatch_count, flags);
+						      &mismatch_count,
+						      tablespace_flags);
 
 			if (exit_status) {
 				fprintf(stderr, "Error: Page 0 checksum mismatch, can't continue. \n");
@@ -1629,7 +1693,8 @@ int main(
 
 		if ((exit_status = rewrite_checksum(
 					filename, fil_in, buf,
-					&pos, is_encrypted, flags))) {
+					&pos, is_encrypted,
+					tablespace_flags))) {
 			goto my_exit;
 		}
 
@@ -1825,7 +1890,7 @@ unexpected_eof:
 first_non_zero:
 			if (is_system_tablespace) {
 				/* enable when page is double write buffer.*/
-				skip_page = is_page_doublewritebuffer(buf);
+				skip_page = is_page_doublewritebuffer();
 			} else {
 				skip_page = false;
 			}
@@ -1846,13 +1911,16 @@ first_non_zero:
 			    && !is_page_free(xdes, physical_page_size, cur_page_num)
 			    && (exit_status = verify_checksum(
 						buf, is_encrypted,
-						&mismatch_count, flags))) {
+						&mismatch_count,
+						tablespace_flags))) {
 				goto my_exit;
 			}
 
-			if ((exit_status = rewrite_checksum(
-						filename, fil_in, buf,
-						&pos, is_encrypted, flags))) {
+			if (!is_page_doublewritebuffer() &&
+			    (exit_status = rewrite_checksum(
+				    filename, fil_in, buf,
+				    &pos, is_encrypted,
+				    tablespace_flags))) {
 				goto my_exit;
 			}
 

--- a/mysql-test/suite/innodb/r/innochecksum_flags_and_skip.result
+++ b/mysql-test/suite/innodb/r/innochecksum_flags_and_skip.result
@@ -1,0 +1,28 @@
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
+SET GLOBAL innodb_log_checkpoint_now=ON;
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+INSERT INTO t1 SET a=1;
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+# Skip InnoDB Doublewrite Buffer
+Should not exist when summary excludes dblwr pages
+Should exist when summary includes dblwr pages
+# restart
+CREATE TABLE ibd_1(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+INSERT INTO ibd_1 VALUES(1), (2), (3), (4);
+# Pass wrong tablespace flag for ibdata2
+FOUND 1 /Error: Page 0 checksum mismatch/ in result.log
+# Pass wrong tablespace flag for ibdata1
+FOUND 1 /Error: Mismatch between provided tablespace flags/ in result.log
+# Pass invalid tablespace flag for ibdata1
+FOUND 1 /Error: Provided --tablespace-flags is not valid/ in result.log
+# innochecksum should be succesfull
+NOT FOUND /Fail/ in result.log
+# Create a tablespace with page number > 2^31
+# Test innochecksum with the modified ibdata3
+FOUND 1 /Error: First page of the tablespace file should be 0, but encountered page number 2147483649/ in result.log
+# Test innochecksum with the modified ibdata3 with tablespace flags
+FOUND 1 /Exceeded the maximum allowed checksum mismatch/ in result.log
+# restart
+DROP TABLE t1, ibd_1;

--- a/mysql-test/suite/innodb/t/innochecksum_flags_and_skip.opt
+++ b/mysql-test/suite/innodb/t/innochecksum_flags_and_skip.opt
@@ -1,0 +1,2 @@
+--innodb_data_file_path=ibdata1:3M;ibdata2:1M:autoextend
+--innodb_sys_tablespaces

--- a/mysql-test/suite/innodb/t/innochecksum_flags_and_skip.test
+++ b/mysql-test/suite/innodb/t/innochecksum_flags_and_skip.test
@@ -1,0 +1,171 @@
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+--source include/have_debug.inc
+let MYSQLD_DATADIR= `SELECT @@datadir`;
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
+SET GLOBAL innodb_log_checkpoint_now=ON;
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+INSERT INTO t1 SET a=1;
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+
+let INDEX_ID= `select INDEX_ID FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE TABLE_ID = (SELECT TABLE_ID FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME="test/t1")`;
+
+let FLAG= `SELECT flag FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME="innodb_system"`;
+
+let $shutdown_timeout=0;
+--source include/shutdown_mysqld.inc
+let $resultlog=$MYSQLTEST_VARDIR/tmp/result.log;
+let $resultlog_1=$MYSQLTEST_VARDIR/tmp/result_1.log;
+
+exec $INNOCHECKSUM -S -r $MYSQLD_DATADIR/ibdata1 > $resultlog;
+--echo # Skip InnoDB Doublewrite Buffer
+exec $INNOCHECKSUM -S $MYSQLD_DATADIR/ibdata1 > $resultlog_1;
+
+perl;
+use strict;
+use warnings;
+use File::Spec::Functions qw(catfile);
+
+sub check_index_in_file {
+    my ($filename, $search_id, $file_desc, $expect_found) = @_;
+    my $found = 0;
+    open(my $fh, '<', $filename) or die "Could not open file '$filename': $!\n";
+    my $line_count = 0;
+    while (my $line = <$fh>) {
+        $line_count++;
+        chomp $line;
+        # Skip empty lines and header lines
+        next if $line =~ /^\s*$/;
+        next if $line =~ /index_id.*#pages/;  # Skip header line
+        # Split the line by whitespace
+        my @fields = grep { $_ ne '' } split(/\s+/, $line);
+        next unless @fields;  # Skip if no fields
+        # The first field is the index_id
+        my $current_id = $fields[0];
+        # Check if this is the ID we're looking for
+        if (defined $current_id && $current_id eq $search_id) {
+            $found = 1;
+            last;
+        }
+    }
+    close $fh;
+
+    if ($found != $expect_found) {
+        print "\n=== UNEXPECTED RESULT - SHOWING FILE CONTENTS ($file_desc) ===\n";
+        open($fh, '<', $filename) or die "Cannot reopen file: $!";
+        print while <$fh>;
+        close $fh;
+        print "=== END OF FILE ===\n\n";
+    }
+}
+
+my $search_id = $ENV{'INDEX_ID'};
+
+# Define file paths
+my $resultlog = catfile($ENV{'MYSQLTEST_VARDIR'}, 'tmp', 'result.log');
+my $resultlog_1 = catfile($ENV{'MYSQLTEST_VARDIR'}, 'tmp', 'result_1.log');
+
+# Check both files
+print "Should not exist when summary excludes dblwr pages\n";
+check_index_in_file($resultlog, $search_id, 'result.log', 0);
+
+print "Should exist when summary includes dblwr pages\n";
+check_index_in_file($resultlog_1, $search_id, 'result_1.log', 1);
+EOF
+
+remove_file $resultlog;
+remove_file $resultlog_1;
+
+# We expect deterministic checksum error when we pass
+# incorrect wrong flags to innochecksum. Below restart is needed
+# to make sure that we flush all the pages.
+--source include/start_mysqld.inc
+CREATE TABLE ibd_1(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+INSERT INTO ibd_1 VALUES(1), (2), (3), (4);
+let $shutdown_timeout=;
+--source include/shutdown_mysqld.inc
+--echo # Pass wrong tablespace flag for ibdata2
+--error 1
+exec $INNOCHECKSUM -S --tablespace_flags=39 $MYSQLD_DATADIR/ibdata2 > $resultlog 2>&1;
+
+let SEARCH_FILE=$resultlog;
+let SEARCH_PATTERN=Error: Page 0 checksum mismatch;
+--source include/search_pattern_in_file.inc
+remove_file $resultlog;
+
+--echo # Pass wrong tablespace flag for ibdata1
+--error 1
+exec $INNOCHECKSUM -S --tablespace_flags=39 $MYSQLD_DATADIR/ibdata1 > $resultlog 2>&1;
+
+let SEARCH_PATTERN=Error: Mismatch between provided tablespace flags;
+--source include/search_pattern_in_file.inc
+remove_file $resultlog;
+
+--echo # Pass invalid tablespace flag for ibdata1
+--error 1
+exec $INNOCHECKSUM -S --tablespace_flags=89 $MYSQLD_DATADIR/ibdata1 > $resultlog 2>&1;
+
+let SEARCH_PATTERN=Error: Provided --tablespace-flags is not valid;
+--source include/search_pattern_in_file.inc
+remove_file $resultlog;
+
+--echo # innochecksum should be succesfull
+exec $INNOCHECKSUM -S --tablespace_flags=$FLAG $MYSQLD_DATADIR/ibdata2 > $resultlog 2>&1;
+
+let SEARCH_PATTERN=Fail;
+--source include/search_pattern_in_file.inc
+
+--echo # Create a tablespace with page number > 2^31
+--let $ibdata3 = $MYSQLD_DATADIR/ibdata3
+perl;
+do "$ENV{MTR_SUITE_DIR}/include/crc32.pl";
+my $polynomial = 0x82f63b78; # CRC-32C
+my $ps = 16384; # Default InnoDB page size
+my $page_num = 2147483649; # 2^31 + 1
+my $filename = "$ENV{MYSQLD_DATADIR}/ibdata3";
+
+# Create a zero-filled page
+my $page = "\0" x $ps;
+
+# Set page number (FIL_PAGE_OFFSET)
+substr($page, 4, 4) = pack('NN', $page_num);
+# Set a valid LSN (log sequence number)
+my $lsn = 0x12345678;
+substr($page, 16, 8) = pack('NN', $lsn & 0xFFFFFFFF, $lsn >> 32);
+
+# Calculate the checksum
+my $checksum = pack('N',
+    mycrc32(substr($page, 4, 22), 0, $polynomial) ^
+    mycrc32(substr($page, 38, $ps - 38 - 8), 0, $polynomial)
+);
+# Write the checksum at the beginning (FIL_PAGE_SPACE_OR_CHKSUM)
+# and at the end (FIL_PAGE_END_LSN_OLD_CHKSUM) of the page
+substr($page, 0, 4) = $checksum;
+substr($page, $ps - 8, 4) = $checksum;
+
+# Write the page to file
+open(my $fh, '>', $filename) or die "Could not open file $filename: $!";
+binmode $fh;
+print $fh $page;
+close $fh;
+EOF
+
+--echo # Test innochecksum with the modified ibdata3
+--error 1
+exec $INNOCHECKSUM -S $ibdata3 > $resultlog 2>&1;
+let SEARCH_PATTERN=Error: First page of the tablespace file should be 0, but encountered page number 2147483649;
+--source include/search_pattern_in_file.inc
+remove_file $resultlog;
+
+--echo # Test innochecksum with the modified ibdata3 with tablespace flags
+--error 1
+exec $INNOCHECKSUM -S --tablespace_flags=$FLAG $ibdata3 > $resultlog 2>&1;
+let SEARCH_PATTERN=Exceeded the maximum allowed checksum mismatch;
+--source include/search_pattern_in_file.inc
+
+remove_file $ibdata3;
+--source include/start_mysqld.inc
+DROP TABLE t1, ibd_1;
+remove_file $resultlog;

--- a/mysql-test/suite/innodb_zip/r/innochecksum_2.result
+++ b/mysql-test/suite/innodb_zip/r/innochecksum_2.result
@@ -14,6 +14,12 @@ INSERT INTO t1 SELECT * from t1;
 INSERT INTO t1 SELECT * from t1;
 INSERT INTO t1 SELECT * from t1;
 INSERT INTO t1 SELECT * from t1;
+CREATE TABLE t2 (j LONGBLOB) ENGINE = InnoDB
+ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2;
+CREATE TABLE t3 (j LONGBLOB) ENGINE = InnoDB
+ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+CREATE TABLE t4(c1 INT PRIMARY KEY,c2 VARCHAR(20),
+INDEX(c2(10))) ENGINE=InnoDB;
 # stop the server
 
 Variables (--variable-name=value)
@@ -35,6 +41,7 @@ log                               (No default value)
 leaf                              FALSE
 merge                             0
 skip-freed-pages                  FALSE
+tablespace-flags                  4294967295
 [1]:# check the both short and long options for "help"
 [2]:# Run the innochecksum when file isn't provided.
 # It will print the innochecksum usage similar to --help option.
@@ -69,6 +76,9 @@ See https://mariadb.com/kb/en/library/innochecksum/ for usage hints.
                       pages
   -r, --skip-freed-pages 
                       skip freed pages for the tablespace
+  --tablespace-flags=# 
+                      InnoDB tablespace flags (default: 4294967295 = read from
+                      page 0)
 
 Variables (--variable-name=value)
 and boolean options {FALSE|TRUE}  Value (after reading options)
@@ -88,9 +98,12 @@ log                               (No default value)
 leaf                              FALSE
 merge                             0
 skip-freed-pages                  FALSE
+tablespace-flags                  4294967295
 [3]:# check the both short and long options for "count" and exit
 Number of pages:#
 Number of pages:#
 [4]:# Print the version of innochecksum and exit
-innochecksum Ver #.#.## Restart the DB server
-DROP TABLE t1;
+innochecksum Ver #.#.#
+[5]:# check t1.ibd and t2.ibd summary with and without tablespace_flags
+# Restart the DB server
+DROP TABLE t4, t3, t2, t1;

--- a/mysql-test/suite/innodb_zip/r/innochecksum_3.result
+++ b/mysql-test/suite/innodb_zip/r/innochecksum_3.result
@@ -140,6 +140,7 @@ log                               (No default value)
 leaf                              FALSE
 merge                             0
 skip-freed-pages                  FALSE
+tablespace-flags                  4294967295
 [5]: Page type dump for with shortform for tab1.ibd
 
 

--- a/mysql-test/suite/innodb_zip/t/innochecksum_2.opt
+++ b/mysql-test/suite/innodb_zip/t/innochecksum_2.opt
@@ -1,1 +1,2 @@
 --skip-innodb-doublewrite
+--innodb_sys_tablespaces

--- a/mysql-test/suite/innodb_zip/t/innochecksum_2.test
+++ b/mysql-test/suite/innodb_zip/t/innochecksum_2.test
@@ -25,6 +25,23 @@ while ($i > 0) {
   dec $i;
 }
 
+CREATE TABLE t2 (j LONGBLOB) ENGINE = InnoDB
+ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2;
+
+CREATE TABLE t3 (j LONGBLOB) ENGINE = InnoDB
+ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+
+CREATE TABLE t4(c1 INT PRIMARY KEY,c2 VARCHAR(20),
+		INDEX(c2(10))) ENGINE=InnoDB;
+
+let FLAG= `SELECT flag FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME="test/t1"`;
+
+let FLAG2= `SELECT flag FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME="test/t2"`;
+
+let FLAG3= `SELECT flag FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME="test/t3"`;
+
+let FLAG4= `SELECT flag FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME="test/t4"`;
+
 --echo # stop the server
 --source include/shutdown_mysqld.inc
 
@@ -80,10 +97,24 @@ EOF
 --exec $INNOCHECKSUM -c $MYSQLD_DATADIR/test/t1.ibd
 
 --echo [4]:# Print the version of innochecksum and exit
---replace_regex /.*innochecksum.*Ver.*[0-9]*.[0-9]*.[0-9]*.*/innochecksum Ver #.#.#/
---exec $INNOCHECKSUM -V $MYSQLD_DATADIR/test/t1.ibd
+--replace_regex /.*innochecksum.*Ver [0-9]*\.[0-9]*\.[0-9]*, for .*\)/innochecksum Ver #.#.#/
+--exec $INNOCHECKSUM -V
 
+--echo [5]:# check t1.ibd and t2.ibd summary with and without tablespace_flags
+let $resultlog=$MYSQLTEST_VARDIR/tmp/result.log;
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t1.ibd -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t2.ibd -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t3.ibd -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t4.ibd -s 3 -e 5 > $resultlog
+
+
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t1.ibd --tablespace_flags=$FLAG -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t2.ibd --tablespace_flags=$FLAG2 -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t3.ibd --tablespace_flags=$FLAG3 -s 3 -e 5 > $resultlog
+--exec $INNOCHECKSUM -S $MYSQLD_DATADIR/test/t4.ibd --tablespace_flags=$FLAG4 -s 3 -e 5 > $resultlog
+
+remove_file $resultlog;
 --echo # Restart the DB server
 --source include/start_mysqld.inc
 
-DROP TABLE t1;
+DROP TABLE t4, t3, t2, t1;

--- a/storage/innobase/include/fsp0types.h
+++ b/storage/innobase/include/fsp0types.h
@@ -149,6 +149,7 @@ enum fsp_reserve_t {
 	FSP_CLEANING,	/* reservation done during purge operations */
 	FSP_BLOB	/* reservation being done for BLOB insertion */
 };
+#endif /* UNIV_INNOCHECKSUM */
 
 /* Number of pages described in a single descriptor page: currently each page
 description takes less than 1 byte; a descriptor page is repeated every
@@ -189,6 +190,7 @@ every XDES_DESCRIBED_PER_PAGE pages in every tablespace. */
 /*--------------------------------------*/
 /* @} */
 
+#ifndef UNIV_INNOCHECKSUM
 /** Check if tablespace is system temporary.
 @param[in]      space_id        verify is checksum is enabled for given space.
 @return true if tablespace is system temporary. */

--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -24,6 +24,7 @@ Transaction system
 Created 3/26/1996 Heikki Tuuri
 *******************************************************/
 
+#ifndef UNIV_INNOCHECKSUM
 #pragma once
 #include "buf0buf.h"
 #include "fil0fil.h"
@@ -277,6 +278,7 @@ FIXED WSREP XID info offsets for 4k page size 10.0.32-galera
 #define TRX_SYS_WSREP_XID_BQUAL_LEN 12
 #define TRX_SYS_WSREP_XID_DATA      16
 #endif /* WITH_WSREP*/
+#endif /* !UNIV_INNOCHECKSUM */
 
 /** Doublewrite buffer */
 /* @{ */
@@ -325,7 +327,7 @@ constexpr uint32_t TRX_SYS_DOUBLEWRITE_MAGIC_N= 536853855;
 /** Contents of TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED */
 constexpr uint32_t TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED_N= 1783657386;
 /* @} */
-
+#ifndef UNIV_INNOCHECKSUM
 trx_t* current_trx();
 
 struct rw_trx_hash_element_t
@@ -1307,3 +1309,4 @@ private:
 
 /** The transaction system */
 extern trx_sys_t trx_sys;
+#endif /* !UNIV_INNOCHECKSUM */

--- a/storage/innobase/include/trx0undo.h
+++ b/storage/innobase/include/trx0undo.h
@@ -27,9 +27,8 @@ Created 3/26/1996 Heikki Tuuri
 #ifndef trx0undo_h
 #define trx0undo_h
 
-#ifndef UNIV_INNOCHECKSUM
 #include "trx0sys.h"
-
+#ifndef UNIV_INNOCHECKSUM
 /** The LSB of the "is insert" flag in DB_ROLL_PTR */
 #define ROLL_PTR_INSERT_FLAG_POS 55
 /** The LSB of the 7-bit trx_rseg_t::id in DB_ROLL_PTR */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37138*

## Description
    MDEV-37138: Innochecksum fails to handle doublewrite buffer and
                    multiple file tablespace
    
    Problem:
    =======
    - innochecksum was incorrectly interpreting doublewrite buffer
    pages as index pages, causing confusion about stale tables
    in the system tablespace.
    
    - innochecksum fails to parse the multi-file system tablespace
    
    Solution:
    ========
    1. Doublewrite buffer pages and rewrite checksum of
    doublewrite buffer pages are skipped when skip_freed_pages
    is enabled.
    
    2. Introduced the option --tablespace-flags which can be used
    to initialize page size. This option can handle the ibdata2,
    ibdata3 etc without parsing ibdata1.

## Release Notes
Innochecksum tool
- Correctly skips doublewrite buffer pages when requested (-r or --skip-freed-pages option)
-  Added option called --tablespace-flags which can be helpful while parsing the system
multiple file tablespace.


## How can this PR be tested?
./mtr innodb.innochecksum_flags_and_skip

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
