### PR TITLE
Updated the mtr_cases.pm to accept tests located in

### DIFF
--- a/mysql-test/lib/mtr_cases.pm
+++ b/mysql-test/lib/mtr_cases.pm
@@ -67,8 +67,8 @@ if (-d '../sql') {
   @plugin_suitedirs= ('storage/*/mysql-test', 'plugin/*/mysql-test', 'storage/*/*/mysql-test', );
   $overlay_regex= '\b(?:storage|plugin|storage[/][^/]*)/(\w+)/mysql-test\b';
 } else {
-  @plugin_suitedirs= ('mariadb-test/plugin/*');
-  $overlay_regex= '\bmariadb-test/plugin/(\w+)\b';
+  @plugin_suitedirs= ('mysql-test/plugin/*', 'mariadb-test/plugin/*');
+  $overlay_regex= '\b(?:mysql|mariadb)-test/plugin/(\w+)\b';
 }
 $plugin_suitedir_regex= $overlay_regex;
 $plugin_suitedir_regex=~ s/\Q(\w+)\E/\\w+/;


### PR DESCRIPTION
## Description
Updated the mtr_cases.pm to accept tests located in
/usr/share/mysql-test as well as /usr/share/mariadb-test. We at fedora package mariadb in a way that the files provided by test subpackage are located inside the /usr/share/mysql-test directory by specifying the -DINSTALL_MYSQLTESTDIR to share/mysql-test and this worked until we decided to port mariadb11.8.2 to fedora. In this version there were some changes to the way that the tests are being run as can be seen in this commit:
https://github.com/MariaDB/server/commit/320a4b52c9c73a37b3553cec6a9d170924957c36 Which broke the way we packaged the files needed for testing. I have designed this minimal patch to enable using the /usr/share/mariadb-test as well as /usr/share/mysql-test test file location, thus making the tests more versatile.

## Release Notes
Nothing much, just the ability to have the tests for mariadb located in /usr/share/mysql-test or /usr/share/mysql-test

## How can this PR be tested?
Running the testsuite using the mariadb-test-run.pl script while having it located inside of /usr/share/mariadb-test, moving it to /usr/share/mysql-test and running the testsuite again.


## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
