### PR TITLE
MDEV-37143 mariabackup fails with "self-signed certificate" on Windows

### DIFF
--- a/mysql-test/suite/mariabackup/backup_ssl.result
+++ b/mysql-test/suite/mariabackup/backup_ssl.result
@@ -15,3 +15,8 @@ DROP USER backup_user;
 # MDEV-32473 --disable-ssl doesn't disable it
 #
 # tcp skip-ssl
+#
+# MDEV-37143 Mariadb-backup fails on Windows with SSL certificate is self-signed error
+#
+# do not fail with passwordless with default protocol
+# do not fail with passwordless with 127.0.0.1 TCP

--- a/mysql-test/suite/mariabackup/backup_ssl.test
+++ b/mysql-test/suite/mariabackup/backup_ssl.test
@@ -19,8 +19,14 @@ echo # MDEV-31855 validate ssl certificates using client password in the interna
 echo #;
 # fails to connect, passwordless root
 echo # tcp ssl ssl-verify-server-cert;
+let $host=;
+if ($MARIADB_UPGRADE_EXE) {
+  # On Windows, we need host different from "127.0.0.1","::1" or "localhost"
+  # to trigger self-signed error
+  let $host=--host=127.0.0.2;
+}
 error 1;
-exec $XTRABACKUP --no-defaults --protocol=tcp --user=root --port=$MASTER_MYPORT --backup --target-dir=$targetdir;
+exec $XTRABACKUP --no-defaults $host --protocol=tcp --user=root --port=$MASTER_MYPORT --backup --target-dir=$targetdir;
 
 --echo #
 --echo # MDEV-32473 --disable-ssl doesn't disable it
@@ -28,4 +34,18 @@ exec $XTRABACKUP --no-defaults --protocol=tcp --user=root --port=$MASTER_MYPORT 
 # connects fine
 echo # tcp skip-ssl;
 exec $XTRABACKUP --no-defaults --protocol=tcp --user=root --skip-ssl --port=$MASTER_MYPORT --backup --target-dir=$targetdir;
+rmdir $targetdir;
+
+--echo #
+--echo # MDEV-37143 Mariadb-backup fails on Windows with SSL certificate is self-signed error
+--echo #
+--echo # do not fail with passwordless with default protocol
+let $port_or_socket=--socket=$MASTER_MYSOCK;
+if ($MARIADB_UPGRADE_EXE) { # windows
+  let  $port_or_socket=--port=$MASTER_MYPORT;
+}
+exec $XTRABACKUP --no-defaults --user=root --backup $port_or_socket --target-dir=$targetdir;
+rmdir $targetdir;
+--echo # do not fail with passwordless with 127.0.0.1 TCP
+exec $XTRABACKUP --no-defaults --host=127.0.0.1 --protocol=tcp --port=$MASTER_MYPORT --user=root --backup --target-dir=$targetdir;
 rmdir $targetdir;

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1994,6 +1994,29 @@ error:
   return res;
 }
 
+/**
+  Checks if self-signed certificate error should be ignored.
+*/
+static my_bool is_local_connection(const char *hostname, enum enum_vio_type viotype)
+{
+  const char *local_host_names[]= {
+#ifdef _WIN32
+  "localhost",
+#endif
+  "127.0.0.1", "::1"};
+  size_t i;
+
+  if (viotype != VIO_TYPE_TCPIP || !hostname)
+    return TRUE;
+
+  for (i= 0; i < array_elements(local_host_names); i++)
+  {
+    if (strcmp(hostname, local_host_names[i]) == 0)
+      return TRUE;
+  }
+  return FALSE;
+}
+
 #define MAX_CONNECTION_ATTR_STORAGE_LENGTH 65536
 
 /**
@@ -2122,6 +2145,7 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     enum enum_ssl_init_error ssl_init_error;
     const char *cert_error;
     unsigned long ssl_error;
+    my_bool is_local;
 
     /*
       Send mysql->client_flag, max_packet_size - unencrypted otherwise
@@ -2169,10 +2193,11 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     }
     DBUG_PRINT("info", ("IO layer change done!"));
 
+    is_local= is_local_connection(mysql->host, vio_type);
     /* Verify server cert */
     if ((!mysql->options.extension ||
          !mysql->options.extension->tls_allow_invalid_server_cert) &&
-        ssl_verify_server_cert(mysql, &cert_error, vio_type == VIO_TYPE_SOCKET))
+        ssl_verify_server_cert(mysql, &cert_error, is_local))
     {
       set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
                                ER(CR_SSL_CONNECTION_ERROR), cert_error);
@@ -2181,14 +2206,13 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     if (mysql->tls_self_signed_error)
     {
       /*
-        If the transport is secure (see opt_require_secure_transport) we
-        allow a self-signed cert as we know it came from the server.
+        If connection is local, we allow self-signed cert.
 
         If no password or plugin uses insecure protocol - refuse the cert.
 
         Otherwise one last cert check after auth.
       */
-      if (vio_type == VIO_TYPE_SOCKET)
+      if (is_local)
         mysql->tls_self_signed_error= 0;
       else if (!mysql->passwd || !mysql->passwd[0] ||
                !mpvio->plugin->hash_password_bin)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

- [x] *The Jira issue number for this PR is: MDEV-37143*

## Description
Passwordless authentication fails for mariabackup with "certificate is self-signed", is a  side-effect of the new zero configuration SSL + SSL by default + SSL server verification by default in 11.4

It was previously corrected on *nix, and unix socket only in MDEV-35368. That fix did not work on Windows, where passwordless connections can be secure with auth_gssapi  (on by default for "root")

Fixed by implementing [the same logic as Connector/C has](https://github.com/mariadb-corporation/mariadb-connector-c/blob/b5a2c9f3c275861447ca21ee1f01560135ec6c2f/plugins/auth/my_auth.c#L66)

## Release Notes
mariadb-backup  failure with "Certificate is self-signed" for passwordless authentication was fixed.

## How can this PR be tested?
mtr tests updated
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
