### PR TITLE
MDEV-37155  Fix can't break in loop of cursor in oracle mode

### DIFF
--- a/mysql-test/suite/compat/oracle/r/sp-anchor-type.result
+++ b/mysql-test/suite/compat/oracle/r/sp-anchor-type.result
@@ -145,5 +145,40 @@ DATA_TYPE	TYPE OF
 DTD_IDENTIFIER	"t1"."a"%TYPE
 DROP FUNCTION f1;
 #
+# MDEV-37155  Can't catch the NOT FOUND error and sp can't exit
+#
+CREATE TABLE t1 (a INT, b VARCHAR(10),c DATETIME(3));
+INSERT INTO t1 VALUES (1,'b1','2001-01-01 10:20:30.123');
+INSERT INTO t1 VALUES (2,'b2','2001-01-02 10:20:30.123');
+CREATE TABLE t2 LIKE t1;
+CREATE PROCEDURE p1()
+AS
+done INT DEFAULT 0;
+v_a t1.a%type;
+v_b t1.b%type;
+v_c t1.c%type;
+CURSOR c IS SELECT a,b,c FROM t1;
+CONTINUE HANDLER FOR NOT FOUND SET done=TRUE;
+BEGIN
+OPEN c;
+<<read_loop>> LOOP
+FETCH c INTO v_a, v_b, v_c;
+IF done THEN
+LEAVE read_loop;
+END IF;
+INSERT INTO t2 (a,b,c) VALUES (v_a, v_b, v_c);
+END LOOP;
+CLOSE c;
+END;
+$$
+CALL p1();
+select * from t2;
+a	b	c
+1	b1	2001-01-01 10:20:30.123
+2	b2	2001-01-02 10:20:30.123
+DROP PROCEDURE P1;
+DROP TABLE t1;
+DROP TABLE t2;
+#
 # End of 11.7 tests
 #

--- a/mysql-test/suite/compat/oracle/t/sp-anchor-type.test
+++ b/mysql-test/suite/compat/oracle/t/sp-anchor-type.test
@@ -106,6 +106,42 @@ FROM INFORMATION_SCHEMA.PARAMETERS WHERE SPECIFIC_SCHEMA='test';
 --horizontal_results
 DROP FUNCTION f1;
 
+--echo #
+--echo # MDEV-37155  Can't catch the NOT FOUND error and sp can't exit
+--echo #
+
+CREATE TABLE t1 (a INT, b VARCHAR(10),c DATETIME(3));
+INSERT INTO t1 VALUES (1,'b1','2001-01-01 10:20:30.123');
+INSERT INTO t1 VALUES (2,'b2','2001-01-02 10:20:30.123');
+CREATE TABLE t2 LIKE t1;
+DELIMITER $$;
+CREATE PROCEDURE p1()
+AS
+  done INT DEFAULT 0;
+  v_a t1.a%type;
+  v_b t1.b%type;
+  v_c t1.c%type;
+  CURSOR c IS SELECT a,b,c FROM t1;
+  CONTINUE HANDLER FOR NOT FOUND SET done=TRUE;
+BEGIN
+  OPEN c;
+  <<read_loop>> LOOP
+    FETCH c INTO v_a, v_b, v_c;
+    IF done THEN
+      LEAVE read_loop;
+    END IF;
+    INSERT INTO t2 (a,b,c) VALUES (v_a, v_b, v_c);
+  END LOOP;
+  CLOSE c;
+END;
+$$
+DELIMITER ;$$
+# without fix this will insert forever
+CALL p1();
+select * from t2;
+DROP PROCEDURE P1;
+DROP TABLE t1;
+DROP TABLE t2;
 
 --echo #
 --echo # End of 11.7 tests

--- a/sql/sp_rcontext.cc
+++ b/sql/sp_rcontext.cc
@@ -864,8 +864,13 @@ int sp_cursor::fetch(THD *thd, List<sp_fetch_target> *vars,
   if (! server_side_cursor->is_open())
   {
     m_found= false;
-    if (!error_on_no_data)
+    if (!error_on_no_data) {
+      // report the not found condition and 
+      // 'contitnue handler for not found' can catch it
+      push_warning(thd, Sql_condition::WARN_LEVEL_NOTE, ER_SP_FETCH_NO_DATA,
+                     ER_THD(thd, ER_SP_FETCH_NO_DATA));
       return 0;
+    }
     my_message(ER_SP_FETCH_NO_DATA, ER_THD(thd, ER_SP_FETCH_NO_DATA), MYF(0));
     return -1;
   }


### PR DESCRIPTION
In Oracle mode, although the NOT FOUND error cannot be raised when reading data with a cursor, it must be recorded in the current Diagnostics_area, otherwise, it cannot be captured by the NOT FOUND handler, which may result in errors during execution,
potentially leading to an infinite loop and other issues.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
