### PR TITLE
MDEV-37052: JSON_TABLE stack overflow handling errors

### DIFF
--- a/sql/json_table.cc
+++ b/sql/json_table.cc
@@ -1428,22 +1428,29 @@ static bool add_extra_deps(List<TABLE_LIST> *join_list, table_map deps)
   @param  join_list    List of tables to process. Initial invocation should
                        supply the JOIN's top-level table list.
   @param  nest_tables  Bitmap of all tables in the join list.
+  @param  error        Pointer to value which is set to true on stack overrun
+                       error.
 
   @return Bitmap of all outside references that tables in join_list have,
-    or 0 on out of stack error.
+    or 0 on out of stack overrun error (in addition to *error= true).
 */
 
 table_map add_table_function_dependencies(List<TABLE_LIST> *join_list,
-                                          table_map nest_tables)
+                                          table_map nest_tables,
+					  bool *error)
 {
   TABLE_LIST *table;
   table_map res= 0;
   List_iterator<TABLE_LIST> li(*join_list);
 
   DBUG_EXECUTE_IF("json_check_min_stack_requirement",
-                  if (dbug_json_check_min_stack_requirement()) return 0;);
+                  if (dbug_json_check_min_stack_requirement())
+		    { *error= true; return 0; });
   if ((res=check_stack_overrun(current_thd, STACK_MIN_SIZE , NULL)))
-    return res;
+  {
+    *error= true;
+    return 0;
+  }
 
   // Recursively compute extra dependencies
   while ((table= li++))
@@ -1452,7 +1459,9 @@ table_map add_table_function_dependencies(List<TABLE_LIST> *join_list,
     if ((nested_join= table->nested_join))
     {
       res |= add_table_function_dependencies(&nested_join->join_list,
-                                             nested_join->used_tables);
+                                             nested_join->used_tables, error);
+      if (*error)
+	return 0;
     }
     else if (table->table_function)
     {
@@ -1465,7 +1474,10 @@ table_map add_table_function_dependencies(List<TABLE_LIST> *join_list,
   if (res)
   {
     if (add_extra_deps(join_list,  res))
+    {
+      *error= true;
       return 0;
+    }
   }
 
   return res;

--- a/sql/json_table.h
+++ b/sql/json_table.h
@@ -284,7 +284,7 @@ bool push_table_function_arg_context(LEX *lex, MEM_ROOT *alloc);
 TABLE *create_table_for_function(THD *thd, TABLE_LIST *sql_table);
 
 table_map add_table_function_dependencies(List<TABLE_LIST> *join_list,
-                                          table_map nest_tables);
+                                          table_map nest_tables, bool *error);
 
 #endif /* JSON_TABLE_INCLUDED */
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -2276,6 +2276,7 @@ JOIN::optimize_inner()
   SELECT_LEX *sel= select_lex;
   if (sel->first_cond_optimization)
   {
+    bool error= false;
     /*
       The following code will allocate the new items in a permanent
       MEMROOT for prepared statements and stored procedures.
@@ -2293,7 +2294,7 @@ JOIN::optimize_inner()
     /* Convert all outer joins to inner joins if possible */
     conds= simplify_joins(this, join_list, conds, TRUE, FALSE);
 
-    add_table_function_dependencies(join_list, table_map(-1));
+    add_table_function_dependencies(join_list, table_map(-1), &error);
 
     if (thd->is_error() ||
         (!select_lex->leaf_tables_saved && select_lex->save_leaf_tables(thd)))


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37052*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

More handling of add_table_function_dependencies stack overflow error to stop processing immediately.

## Release Notes

covered in MDEV.

## How can this PR be tested?

Not easily. Its a mostly internal behaviour change on stack overflow conditions.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
