### PR TITLE
MDEV-37170 Enable AVX10.1 CRC-32 on GCC 16

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -25,7 +25,10 @@
 #else
 # include <cpuid.h>
 # ifdef __APPLE__ /* AVX512 states are not enabled in XCR0 */
-# elif (__GNUC__ >= 14 && __GNUC__ < 16) || (defined __clang_major__ && __clang_major__ >= 18)
+# elif __GNUC__ >= 15
+#  define TARGET "pclmul,avx10.1,vpclmulqdq"
+#  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
+# elif __GNUC__ >= 14 || (defined __clang_major__ && __clang_major__ >= 18)
 #  define TARGET "pclmul,evex512,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
 #  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
 # elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 9)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37170*
## Description
The AVX512 accelerated CRC-32 computation that had been added in #3195 was disabled in #4081 for GCC 16.

Let us enable that logic by applying
dr-m/crc32_simd@075bacb0cc7da8df18afa15a827ae4d11166fe32 which makes use of the `avx10.1` target attribute that had been introduced in GCC 15.
## Release Notes
N/A. GCC 16 had not been released yet, and there is no MariaDB release where the regression that was introduced in #4018 would not have been fixed.
## How can this PR be tested?
I tested this on https://godbolt.org by choosing x86-64 gcc version 15.1 or trunk. In clang, there is no `avx10.1` target attribute yet.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.