### PR TITLE
MDEV-37116 Replication should remain async until the primary receives `rpl_semi_sync_master_wait_for_slave_count` no. of ACKs

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_master_wait_for_slave_count.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_master_wait_for_slave_count.result
@@ -164,6 +164,8 @@ SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_%\_tx';
 Variable_name	Value
 Rpl_semi_sync_master_no_tx	0
 Rpl_semi_sync_master_yes_tx	1
+# Case 2.4: "Stays Async" is not "fails to return to Semi-Sync"
+FOUND 2 matches in mysqld.1.err
 # Cleanup
 SET @@GLOBAL.debug_dbug= @dbug_reset;
 SET @@SESSION.debug_sync= 'RESET';

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_master_wait_for_slave_count.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_master_wait_for_slave_count.test
@@ -89,8 +89,13 @@ SET @@GLOBAL.rpl_semi_sync_master_wait_for_slave_count= 2;
 SHOW STATUS LIKE 'Rpl\_semi\_sync\_master\_%\_tx';
 
 
-SET STATEMENT sql_log_bin=0 FOR
-  CALL mtr.add_suppression('Timeout waiting for reply of binlog');
+--let $timeout_warning= Timeout waiting for reply of binlog
+eval SET STATEMENT sql_log_bin=0 FOR
+  CALL mtr.add_suppression('$timeout_warning');
+--let SEARCH_FILE= `SELECT @@log_error`
+--let SEARCH_PATTERN= $timeout_warning
+--let SEARCH_OUTPUT= count
+
 --let $wait_no_slave= 0
 while ($wait_no_slave < 2)
 {
@@ -150,6 +155,12 @@ while ($wait_no_slave < 2)
 
   --inc $wait_no_slave
 }
+
+--echo # Case 2.4: "Stays Async" is not "fails to return to Semi-Sync"
+# The number of timeouts should be 2, 1 from Case 2.1 per loop.
+#TODO: MDEV-36936 Expose rpl_semi_sync_master_wait_timeouts
+# grep the Error Log for `$timeout_warning` in the mean time
+--source include/search_pattern_in_file.inc
 
 
 --echo # Cleanup

--- a/sql/semisync_master.h
+++ b/sql/semisync_master.h
@@ -362,13 +362,23 @@ public:
                         my_off_t log_file_pos);
 
   /**
+    Commit the active transaction nodes until (exclusive) the specified node. If
+    it's not in the collection (e.g., is `nullptr`), everything will be flushed.
+
+    @return whether the node is *not* in the collection or is `nullptr`
+    @pre Repl_semi_sync_binlog::LOCK_binlog
+  */
+  bool flush_active_tranx_nodes(Tranx_node *until_node);
+
+  /**
     Flush and clear the active transaction nodes until (exclusive) the specified
     node. If it's not in the collection (e.g., is `nullptr`), everything will
     be cleared: the sorted list and the hash table will be reset to empty.
 
     @pre Repl_semi_sync_binlog::LOCK_binlog
+    @see flush_active_tranx_nodes()
   */
-  void clear_active_tranx_nodes(Tranx_node *node);
+  void clear_active_tranx_nodes(Tranx_node *new_front);
 
   /**
     Find (if any) the __last__ transaction with at least


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-37116](https://jira.mariadb.org/browse/MDEV-37116)*
  * Follow-up to [MDEV-18983][]

## Description
`rpl_semi_sync_master_wait_for_slave_count` from [MDEV-18983][] only applied when Semi-Sync is active, but not to the condition to automatically return to Semi-Sync after it fell back to Async (due to timeout or `rpl_semi_sync_master_wait_no_slave=0`).

This commit expands the Semi-Sync transaction queue – specifically, its ACKs counter from MDEV-18983 – to be also used during Async.
* When Semi-Sync automatically falls back to Async, it no longer clears the queue, only lets the queued transactions finish.
* Async transactions also enqueue, but without a waiting thread.
* The condition to return from Async to Semi-Sync (and dequeue past Async transactions) is now inside the `…_wait_for_slave_count` check.

## Release Notes
Amend [MDEV-18983][] (#4037)’s notes.

## How can this PR be tested?
I’ve updated `rpl.rpl_semi_sync_master_wait_for_slave_count` to cover the issue.

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
  * This bug is a QA finding of [MDEV-18983][], an unreleased new feature, so I based the PR on its PR, #4037; okay?

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

[MDEV-18983]: https://jira.mariadb.org/browse/MDEV-18983