### PR TITLE
MDEV-36906: RBR crashes upon DML after CONVERT PARTITION

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_alter_convert_partition.result
+++ b/mysql-test/suite/rpl/r/rpl_alter_convert_partition.result
@@ -1,0 +1,80 @@
+include/master-slave.inc
+[connection master]
+#
+# Ensure initial CREATE TABLE with partitioned data is replicated
+# correctly
+connection master;
+create table t (a int, b int, key(a)) engine=innodb partition by range (b) (partition p1 values less than (10), partition pn values less than (maxvalue));
+insert into t values (1,5),(2,100);
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.t,slave:test.t]
+#
+# Ensure ALTER TABLE .. CONVERT PARTITION .. TO TABLE replicates
+# correctly
+connection master;
+alter table t convert partition p1 to table offspring;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.t,slave:test.t]
+include/diff_tables.inc [master:test.offspring,slave:test.offspring]
+#
+# Ensure data can be inserted into existing table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+insert into t values (3, 6);
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.t,slave:test.t]
+#
+# Ensure data can be inserted into offspring table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+insert into offspring values (4, 101);
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.offspring,slave:test.offspring]
+#
+# Ensure data can be updated in existing table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+update t set b=b+1 where a=3;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.t,slave:test.t]
+#
+# Ensure data can be updated in offspring table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+update offspring set b=b+1 where a=4;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.offspring,slave:test.offspring]
+#
+# Ensure data can be deleted in existing table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+delete from t;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.t,slave:test.t]
+#
+# Ensure data can be deleted in offspring table after
+# ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+connection master;
+delete from offspring;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/diff_tables.inc [master:test.offspring,slave:test.offspring]
+connection master;
+drop table t, offspring;
+include/rpl_end.inc
+# End of rpl_alter_convert_partition

--- a/mysql-test/suite/rpl/t/rpl_alter_convert_partition.test
+++ b/mysql-test/suite/rpl/t/rpl_alter_convert_partition.test
@@ -1,0 +1,117 @@
+#
+# This test ensures that ALTER TABLE ... CONVERT PARTITION ... TO TABLE
+# works with replication. I.e., the partitioning is done correctly, and
+# after partitioning, both tables can be updated correctly.
+#
+# References:
+#   MDEV-36906: RBR crashes upon DML after CONVERT PARTITION
+#
+
+--source include/have_innodb.inc
+--source include/have_partition.inc
+--source include/master-slave.inc
+
+
+--echo #
+--echo # Ensure initial CREATE TABLE with partitioned data is replicated
+--echo # correctly
+--connection master
+create table t (a int, b int, key(a)) engine=innodb partition by range (b) (partition p1 values less than (10), partition pn values less than (maxvalue));
+insert into t values (1,5),(2,100);
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.t,slave:test.t
+
+--source include/diff_tables.inc
+
+--echo #
+--echo # Ensure ALTER TABLE .. CONVERT PARTITION .. TO TABLE replicates
+--echo # correctly
+--connection master
+alter table t convert partition p1 to table offspring;
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.t,slave:test.t
+--source include/diff_tables.inc
+--let $diff_tables=master:test.offspring,slave:test.offspring
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be inserted into existing table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+insert into t values (3, 6);
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.t,slave:test.t
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be inserted into offspring table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+insert into offspring values (4, 101);
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.offspring,slave:test.offspring
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be updated in existing table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+update t set b=b+1 where a=3;
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.t,slave:test.t
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be updated in offspring table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+update offspring set b=b+1 where a=4;
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.offspring,slave:test.offspring
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be deleted in existing table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+delete from t;
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.t,slave:test.t
+--source include/diff_tables.inc
+
+
+--echo #
+--echo # Ensure data can be deleted in offspring table after
+--echo # ALTER TABLE .. CONVERT PARTITION .. TO TABLE
+--connection master
+delete from offspring;
+--source include/save_master_gtid.inc
+--connection slave
+--source include/sync_with_master_gtid.inc
+--let $diff_tables=master:test.offspring,slave:test.offspring
+--source include/diff_tables.inc
+
+
+--connection master
+drop table t, offspring;
+--source include/rpl_end.inc
+--echo # End of rpl_alter_convert_partition

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -7626,7 +7626,7 @@ uint fast_alter_partition_table(THD *thd, TABLE *table,
         ERROR_INJECT("convert_partition_1") ||
         write_log_drop_shadow_frm(lpt) ||
         ERROR_INJECT("convert_partition_2") ||
-        mysql_write_frm(lpt, WFRM_WRITE_SHADOW) ||
+        mysql_write_frm(lpt, WFRM_WRITE_SHADOW|WFRM_ALTER_INFO_PREPARED) ||
         ERROR_INJECT("convert_partition_3") ||
         wait_while_table_is_used(thd, table, HA_EXTRA_NOT_USED) ||
         ERROR_INJECT("convert_partition_4") ||

--- a/sql/sql_table.h
+++ b/sql/sql_table.h
@@ -55,11 +55,13 @@ enum enum_explain_filename_mode
 /* depends on errmsg.txt Database `db`, Table `t` ... */
 #define EXPLAIN_FILENAME_MAX_EXTRA_LENGTH 63
 
+/* See mysql_write_frm function comment for explanations of these flags */
 #define WFRM_WRITE_SHADOW 1
 #define WFRM_INSTALL_SHADOW 2
 #define WFRM_KEEP_SHARE 4
 #define WFRM_WRITE_CONVERTED_TO 8
 #define WFRM_BACKUP_ORIGINAL 16
+#define WFRM_ALTER_INFO_PREPARED 32
 
 /* Flags for conversion functions. */
 static const uint FN_FROM_IS_TMP=  1 << 0;


### PR DESCRIPTION

## Description

Note this patch is a draft to showcase the issue and is constructed
in a way to elicit feedback from reviewers, rather than a patch
ready-to-be-approved.

MDEV-33658 part 1’s refactoring ecaedbe299fe11372c36319f9b732b81e9f54883
introduced a new function init_key_info which (in part) aims to
calculate the total key length; however, it doesn’t account for the
key already having been initialized (as happens when called via
ALTER TABLE .. CONVERT PARTITION .. TO TABLE). This leads to crashes
when this key is later iterated over, because the iterator will try
to iterate over additional key parts which don’t exist because the
length reports as longer than the actual memory owned. The crash
reported by MDEV-36906 highlights this in function key_copy. 


A few possibilities for fixes:
  1. In the ALTER TABLE .. CONVERT PARTITION .. TO TABLE case, I
think alter_info->key info is already initialized. Perhaps in this
case, we wouldn’t need to call into init_key_info() at all. 
  2. In init_key_info, while iterating keys, check if key->length
already exists, and if so, continue.
  3. In init_key_info, reset key->length before accumulating the
key_part lengths

This patch implements the third option because it preserves the
existing behavior as close as possible. I’m not sure the existing
behavior is right though, so I think option 1 may be more correct. I
briefly tried some attempt at option 1 (i.e by checking
alter_info->partition_flags for convert flags and if they exist,
skip init_key_info), but tests failed.


## Release Notes
TODO

## How can this PR be tested?
Test case rpl_alter_convert_partition tests this behavior.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
