### PR TITLE
fix incorrect merge 15700f54c212 (part 2) rocksdb_rpl.rpl_xa

### DIFF
--- a/storage/rocksdb/mysql-test/rocksdb_rpl/r/rpl_xa.result
+++ b/storage/rocksdb/mysql-test/rocksdb_rpl/r/rpl_xa.result
@@ -36,7 +36,7 @@ insert into t2 values (0);
 xa end 's';
 xa prepare 's';
 Warnings:
-Warning	4196	Pseudo thread id should not be modified by the client as it will be overwritten
+Warning	4205	Pseudo thread id should not be modified by the client as it will be overwritten
 include/save_master_gtid.inc
 connection slave;
 include/sync_with_master_gtid.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-none*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

In 805e7ca3adef50e17889ea17a1b86da6c3fb8580 the errors codes for "Pseudo thread id should not be modified by the client as it will be overwritten" changed from 4196 back to 4205 where it was previously however this test case wasn't re-recorded.

## Release Notes

nothing - test change only.

## How can this PR be tested?

mtr test rocksdb_rpl.rpl_xa
If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
