### PR TITLE
MDEV-37044 derived_wth_keys optimization not applied where it should

### DIFF
--- a/mysql-test/main/derived.result
+++ b/mysql-test/main/derived.result
@@ -5355,4 +5355,120 @@ drop table t10, t20, t30;
 #
 # End of 11.7 tests
 #
+#
+# MDEV-37044 derived_wth_keys optimization not applied where it should
+#
+# MI_MAX_KEY_LENGTH < key length < tmp_table_max_key_length()
+# must use <derived2>, <derived3> with ref access (not ALL)
+create table t1
+(
+`CTC_DATABASE` varchar(128) NOT NULL,
+`CTC_TABLE` varchar(256) DEFAULT NULL,
+`CTC_PARTITION` varchar(767) DEFAULT NULL
+) DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+insert into t1
+select
+concat('db-', seq),
+concat('tbl-', seq),
+concat('part-', seq)
+from
+seq_1_to_100;
+explain select * from
+(select * from t1 limit 100) A,
+(select * from t1 limit 101) B
+where
+A.ctc_database=B.ctc_database and
+A.ctc_table=B.ctc_table and
+A.ctc_partition=B.ctc_partition;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	100	Using where
+1	PRIMARY	<derived3>	ref	key0	key0	1159	A.CTC_DATABASE,A.CTC_TABLE,A.CTC_PARTITION	10	
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+# key length > tmp_table_max_key_length()
+# This uses <derived2>, <derived3> with type=ALL as index on temp table
+# would be too long
+alter table t1 CONVERT TO CHARACTER SET utf8;
+explain select * from
+(select * from t1 limit 100) A,
+(select * from t1 limit 101) B
+where
+A.ctc_database=B.ctc_database and
+A.ctc_table=B.ctc_table and
+A.ctc_partition=B.ctc_partition;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	100	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	100	Using where; Using join buffer (flat, BNL join)
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+drop table t1;
+# number of key parts > tmp_table_max_key_parts()
+# This uses <derived2>, <derived3> with type=ALL as index on temp table
+# would have too many parts
+create table t1
+(
+c0  varchar(10) NOT NULL,
+c1  varchar(10),
+c2  varchar(10),
+c3  varchar(10),
+c4  varchar(10),
+c5  varchar(10),
+c6  varchar(10),
+c7  varchar(10),
+c8  varchar(10),
+c9  varchar(10),
+c10  varchar(10),
+c11  varchar(10),
+c12  varchar(10),
+c13  varchar(10),
+c14  varchar(10),
+c15  varchar(10),
+c16  varchar(10),
+c17  varchar(10),
+c18  varchar(10),
+c19  varchar(10),
+c20  varchar(10),
+c21  varchar(10),
+c22  varchar(10),
+c23  varchar(10),
+c24  varchar(10),
+c25  varchar(10),
+c26  varchar(10),
+c27  varchar(10),
+c28  varchar(10),
+c29  varchar(10),
+c30  varchar(10),
+c31  varchar(10),
+c32  varchar(10),
+c33  varchar(10)
+);
+insert into t1
+select
+seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq,
+seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq,
+seq, seq, seq, seq
+from
+seq_1_to_100;
+explain select * from
+(select * from t1 limit 100) A,
+(select * from t1 limit 101) B
+where
+A.c0 = B.c0 and A.c1 = B.c1 and A.c2 = B.c2 and A.c3 = B.c3 and
+A.c4 = B.c4 and A.c5 = B.c5 and A.c6 = B.c6 and A.c7 = B.c7 and
+A.c8 = B.c8 and A.c9 = B.c9 and A.c10 = B.c10 and A.c11 = B.c11 and
+A.c12 = B.c12 and A.c13 = B.c13 and A.c14 = B.c14 and A.c15 = B.c15 and
+A.c16 = B.c16 and A.c17 = B.c17 and A.c18 = B.c18 and A.c19 = B.c19 and
+A.c20 = B.c20 and A.c21 = B.c21 and A.c22 = B.c22 and A.c23 = B.c23 and
+A.c24 = B.c24 and A.c25 = B.c25 and A.c26 = B.c26 and A.c27 = B.c27 and
+A.c28 = B.c28 and A.c29 = B.c29 and A.c30 = B.c30 and A.c31 = B.c31 and
+A.c32 = B.c32 and A.c33 = B.c33;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	100	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	100	Using where; Using join buffer (flat, BNL join)
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	
+drop table t1;
+#
+# End of 12.0 tests
+#
 ALTER DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci;

--- a/mysql-test/main/derived.test
+++ b/mysql-test/main/derived.test
@@ -2235,4 +2235,112 @@ drop table t10, t20, t30;
 --echo # End of 11.7 tests
 --echo #
 
+--echo #
+--echo # MDEV-37044 derived_wth_keys optimization not applied where it should
+--echo #
+
+--echo # MI_MAX_KEY_LENGTH < key length < tmp_table_max_key_length()
+--echo # must use <derived2>, <derived3> with ref access (not ALL)
+create table t1
+(
+  `CTC_DATABASE` varchar(128) NOT NULL,
+  `CTC_TABLE` varchar(256) DEFAULT NULL,
+  `CTC_PARTITION` varchar(767) DEFAULT NULL
+) DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+insert into t1
+select
+  concat('db-', seq),
+  concat('tbl-', seq),
+  concat('part-', seq)
+from
+  seq_1_to_100;
+
+let $q=
+select * from
+  (select * from t1 limit 100) A,
+  (select * from t1 limit 101) B
+where
+  A.ctc_database=B.ctc_database and
+  A.ctc_table=B.ctc_table and
+  A.ctc_partition=B.ctc_partition;
+eval explain $q;
+
+--echo # key length > tmp_table_max_key_length()
+--echo # This uses <derived2>, <derived3> with type=ALL as index on temp table
+--echo # would be too long
+alter table t1 CONVERT TO CHARACTER SET utf8;
+eval explain $q;
+
+drop table t1;
+
+--echo # number of key parts > tmp_table_max_key_parts()
+--echo # This uses <derived2>, <derived3> with type=ALL as index on temp table
+--echo # would have too many parts
+create table t1
+(
+  c0  varchar(10) NOT NULL,
+  c1  varchar(10),
+  c2  varchar(10),
+  c3  varchar(10),
+  c4  varchar(10),
+  c5  varchar(10),
+  c6  varchar(10),
+  c7  varchar(10),
+  c8  varchar(10),
+  c9  varchar(10),
+  c10  varchar(10),
+  c11  varchar(10),
+  c12  varchar(10),
+  c13  varchar(10),
+  c14  varchar(10),
+  c15  varchar(10),
+  c16  varchar(10),
+  c17  varchar(10),
+  c18  varchar(10),
+  c19  varchar(10),
+  c20  varchar(10),
+  c21  varchar(10),
+  c22  varchar(10),
+  c23  varchar(10),
+  c24  varchar(10),
+  c25  varchar(10),
+  c26  varchar(10),
+  c27  varchar(10),
+  c28  varchar(10),
+  c29  varchar(10),
+  c30  varchar(10),
+  c31  varchar(10),
+  c32  varchar(10),
+  c33  varchar(10)
+);
+insert into t1
+select
+  seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq,
+  seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq, seq,
+  seq, seq, seq, seq
+from
+  seq_1_to_100;
+let $q=
+select * from
+  (select * from t1 limit 100) A,
+  (select * from t1 limit 101) B
+where
+  A.c0 = B.c0 and A.c1 = B.c1 and A.c2 = B.c2 and A.c3 = B.c3 and
+  A.c4 = B.c4 and A.c5 = B.c5 and A.c6 = B.c6 and A.c7 = B.c7 and
+  A.c8 = B.c8 and A.c9 = B.c9 and A.c10 = B.c10 and A.c11 = B.c11 and
+  A.c12 = B.c12 and A.c13 = B.c13 and A.c14 = B.c14 and A.c15 = B.c15 and
+  A.c16 = B.c16 and A.c17 = B.c17 and A.c18 = B.c18 and A.c19 = B.c19 and
+  A.c20 = B.c20 and A.c21 = B.c21 and A.c22 = B.c22 and A.c23 = B.c23 and
+  A.c24 = B.c24 and A.c25 = B.c25 and A.c26 = B.c26 and A.c27 = B.c27 and
+  A.c28 = B.c28 and A.c29 = B.c29 and A.c30 = B.c30 and A.c31 = B.c31 and
+  A.c32 = B.c32 and A.c33 = B.c33;
+eval explain $q;
+
+drop table t1;
+
+
+--echo #
+--echo # End of 12.0 tests
+--echo #
+
 --source include/test_db_charset_restore.inc

--- a/mysql-test/main/derived_view.result
+++ b/mysql-test/main/derived_view.result
@@ -2912,7 +2912,7 @@ FROM t2, t1 GROUP BY t2.useraccessfamily, picturesubuser) y
 WHERE x.useraccessfamily = y.useraccessfamily;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	x	system	NULL	NULL	NULL	NULL	1	
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	Using where
+1	PRIMARY	<derived2>	ref	key0	key0	1539	const	0	
 2	DERIVED	t2	system	NULL	NULL	NULL	NULL	1	
 2	DERIVED	t1	index	NULL	index_td_familyid_id	772	NULL	2	Using index
 SELECT * FROM t2 x,

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -8611,12 +8611,10 @@ bool TABLE::check_tmp_key(uint key, uint key_parts,
       fld_store_len+= HA_KEY_BLOB_LENGTH;
     key_len+= fld_store_len;
   }
-  /*
-    We use MI_MAX_KEY_LENGTH (myisam's default) below because it is
-    smaller than MAX_KEY_LENGTH (heap's default) and it's unknown whether
-    myisam or heap will be used for the temporary table.
-  */
-  return key_len <= MI_MAX_KEY_LENGTH;
+
+  //  We use the on-disk storage engine's limit
+  return key_len <= tmp_table_max_key_length() &&
+         key_parts <= tmp_table_max_key_parts();
 }
 
 /**


### PR DESCRIPTION
MDEV-37044 derived_wth_keys optimization not applied where it should

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37044*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Since commit 271fed41061 we have these functions for key parameters tmp_table_max_key_length()
tmp_table_max_key_parts()
This commit uses these in TABLE::check_tmp_key() called from generate_derived_keys_for_table() used in key generation for result tables of materialized derived tables/views

## Release Notes
Materialized derived tables with long generated keys may be faster.

## How can this PR be tested?

mtr main.derived

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
