### PR TITLE
MDEV-36159 mariabackup failed after upgrade 10.11.10

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -2068,6 +2068,7 @@ ulonglong get_current_lsn(MYSQL *connection)
 {
 	static const char lsn_prefix[] = "\nLog sequence number ";
 	ulonglong lsn = 0;
+	msg("Getting InnoDB LSN");
 	if (MYSQL_RES *res = xb_mysql_query(connection,
 					    "SHOW ENGINE INNODB STATUS",
 					    true, false)) {
@@ -2081,5 +2082,10 @@ ulonglong get_current_lsn(MYSQL *connection)
 		}
 		mysql_free_result(res);
 	}
+	msg("InnoDB LSN: %llu, Flushing Logs", lsn);
+        /* Make sure that current LSN is written and flushed to disk. */
+	xb_mysql_query(connection, "FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS",
+		       false, false);
+	msg("Flushed Logs");
 	return lsn;
 }

--- a/mysql-test/suite/mariabackup/full_backup.test
+++ b/mysql-test/suite/mariabackup/full_backup.test
@@ -10,7 +10,7 @@ let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
 --error 1
 exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=4095 > $backup_log 2>&1;
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=10000 > $backup_log 2>&1;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=10000 --innodb_log_checkpoint_now=1 > $backup_log 2>&1;
 --enable_result_log
 
 # The following warning must not appear after MDEV-27343 fix

--- a/mysql-test/suite/mariabackup/partial.test
+++ b/mysql-test/suite/mariabackup/partial.test
@@ -14,7 +14,7 @@ echo # xtrabackup backup;
 
 let targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables=test.*1" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables=test.*1" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 list_files $targetdir/test *.ibd;
 list_files $targetdir/test *.new;
@@ -96,6 +96,7 @@ exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --tables-file
 --enable_result_log
 
 --echo # table t2 is skipped. Shows only t1
+--replace_result .new .ibd
 list_files $targetdir/test;
 DROP TABLE t2, t1;
 rmdir $targetdir;

--- a/mysql-test/suite/mariabackup/partial_exclude.test
+++ b/mysql-test/suite/mariabackup/partial_exclude.test
@@ -28,7 +28,7 @@ echo # xtrabackup backup;
 
 let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.*2" "--databases-exclude=db2" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.*2" "--databases-exclude=db2" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 
 COMMIT;

--- a/mysql-test/suite/mariabackup/unsupported_redo.test
+++ b/mysql-test/suite/mariabackup/unsupported_redo.test
@@ -58,7 +58,7 @@ ALTER TABLE t21 FORCE, ALGORITHM=INPLACE;
 --echo # unsupported redo log for the table t21.
 
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.t21" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.t21" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 --list_files $targetdir/test *.ibd
 --list_files $targetdir/test *.new


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36159*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
1. Flush system LSN before waiting for logs to be copied up to the LSN.
2. Avoid return and 1 second sleep after parsing each mtr. This is a serious bug in buffered (innodb_log_file_mmap=OFF) redo copy mode and makes the copier thread sleep most of the time even when there are a lot of log data left to be copied resulting in redo log overwrite almost always when there is concurrent DML load.
3. Avoid wait for 5 seconds while finalizing redo log copy to wait for no LSN movement. It is enough to wait till target LSN.
4. Avoid "Retry" and repeated messages when there is no more redo log to copy.
5. For mariabackup, disable innodb_log_file_mmap by default
6. For mariabackup, disable innodb_log_checkpoint_now by default
7. Add log for checkpoint when issued from mariabackup.

## Release Notes
For mariabackup, innodb_log_file_mmap configuration is disabled by default.

## How can this PR be tested?
It is hard to create a repeatable mtr testcase for the issue. Manually, I could repeat with

1. Start mariadbd Server with following  configuration
--innodb_log_file_buffering=ON 
--innodb-buffer-pool-size=2G 
--innodb_flush_log_at_timeout=50000
--innodb_stats_persistent=0
--innodb_log_file_size=1G

2. Have some open transaction with uncommitted data. Confirm that Innodb_lsn_flushed should be few megabytes behind Innodb_lsn_current.
MariaDB [(none)]> show status like "%LSN%";

3. Attempt mariabackup with following parameters.
--backup 
--innodb-log-file-mmap=false 
--innodb_log_checkpoint_now=false

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
