### PR TITLE
MDEV-36850: SIGSEGV in Item_sp_variable::save_in_field | fill_record

### DIFF
--- a/plugin/type_assoc_array/mysql-test/type_assoc_array/sp-assoc-array.result
+++ b/plugin/type_assoc_array/mysql-test/type_assoc_array/sp-assoc-array.result
@@ -2894,3 +2894,29 @@ c1
 Warnings:
 Warning	1264	Out of range value for column 'i' at row 0
 DROP PROCEDURE p1;
+#
+# MDEV-36850 - SIGSEGV in Item_sp_variable::save_in_field | fill_record
+#
+CREATE OR REPLACE TABLE t1 (a INT);
+DECLARE
+TYPE first_names_t IS TABLE OF VARCHAR2(64) INDEX BY VARCHAR2(20) CHARACTER SET latin1;
+first_names first_names_t;
+nick VARCHAR(64) CHARACTER SET latin1:= 'Monty';
+BEGIN
+first_names('Monty') := 'Michael';
+INSERT INTO t1 VALUES (first_names(nick || CONVERT(' ' USING ucs2)));
+END;
+$$
+Warnings:
+Warning	1366	Incorrect integer value: 'Michael' for column `test`.`t1`.`a` at row 1
+DECLARE
+TYPE rec_t IS RECORD (i INT);
+TYPE assoc0_t IS TABLE OF rec_t INDEX BY VARCHAR2(20) CHARACTER SET latin1;
+assoc0 assoc0_t;
+nick VARCHAR(64) CHARACTER SET latin1:= 'Monty';
+BEGIN
+assoc0('Monty') := rec_t(1);
+INSERT INTO t1 VALUES (assoc0(nick || CONVERT(' ' USING ucs2)).i);
+END;
+$$
+DROP TABLE t1;

--- a/plugin/type_assoc_array/mysql-test/type_assoc_array/sp-assoc-array.test
+++ b/plugin/type_assoc_array/mysql-test/type_assoc_array/sp-assoc-array.test
@@ -3341,3 +3341,32 @@ $$
 DELIMITER ;$$
 CALL p1;
 DROP PROCEDURE p1;
+
+
+--echo #
+--echo # MDEV-36850 - SIGSEGV in Item_sp_variable::save_in_field | fill_record
+--echo #
+CREATE OR REPLACE TABLE t1 (a INT);
+DELIMITER $$;
+DECLARE
+  TYPE first_names_t IS TABLE OF VARCHAR2(64) INDEX BY VARCHAR2(20) CHARACTER SET latin1;
+  first_names first_names_t;
+  nick VARCHAR(64) CHARACTER SET latin1:= 'Monty';
+BEGIN
+  first_names('Monty') := 'Michael';
+  INSERT INTO t1 VALUES (first_names(nick || CONVERT(' ' USING ucs2)));
+END;
+$$
+DECLARE
+  TYPE rec_t IS RECORD (i INT);
+  TYPE assoc0_t IS TABLE OF rec_t INDEX BY VARCHAR2(20) CHARACTER SET latin1;
+  assoc0 assoc0_t;
+  nick VARCHAR(64) CHARACTER SET latin1:= 'Monty';
+BEGIN
+  assoc0('Monty') := rec_t(1);
+  INSERT INTO t1 VALUES (assoc0(nick || CONVERT(' ' USING ucs2)).i);
+END;
+$$
+DELIMITER ;$$
+ 
+DROP TABLE t1;

--- a/plugin/type_assoc_array/sql_type_assoc_array.h
+++ b/plugin/type_assoc_array/sql_type_assoc_array.h
@@ -285,9 +285,9 @@ public:
   bool get_key(String *key, bool is_first) override;
   bool get_next_key(const String *curr_key, String *next_key) override;
   bool get_prior_key(const String *curr_key, String *prior_key) override;
-  Item_field *element_by_key(THD *thd, String *key) override;
-  Item_field *element_by_key(THD *thd, String *key) const override;
-  Item **element_addr_by_key(THD *thd, String *key) override;
+  Item_field *element_by_key(THD *thd, const String &key) override;
+  Item_field *element_by_key(THD *thd, const String &key) const override;
+  Item **element_addr_by_key(THD *thd, const String &key) override;
   bool delete_all_elements() override;
   bool delete_element_by_key(String *key) override;
   void expr_event_handler(THD *thd, expr_event_t event) override
@@ -364,12 +364,12 @@ public:
   {
     return get_composite_field()->get_next_key(curr_key, next_key);
   }
-  Item *element_by_key(THD *thd, String *key) override
+  Item *element_by_key(THD *thd, const String &key) override
   {
     return ((const Field_composite *)get_composite_field())->
       element_by_key(thd, key);
   }
-  Item **element_addr_by_key(THD *thd, Item **ref, String *key) override
+  Item **element_addr_by_key(THD *thd, Item **ref, const String &key) override
   {
     return get_composite_field()->element_addr_by_key(thd, key);
   }
@@ -410,8 +410,9 @@ public:
   uint rows() const override;
   bool get_key(String *key, bool is_first) override;
   bool get_next_key(const String *curr_key, String *next_key) override;
-  Item *element_by_key(THD *thd, String *key) override;
-  Item **element_addr_by_key(THD *thd, Item **addr_arg, String *key) override;
+  Item *element_by_key(THD *thd, const String &key) override;
+  Item **element_addr_by_key(THD *thd, Item **addr_arg,
+                             const String &key) override;
 
   bool fix_fields(THD *thd, Item **ref) override;
   void bring_value() override;
@@ -427,6 +428,8 @@ class Item_splocal_assoc_array_base :public Item_composite_base
 {
 protected:
   Item *m_key;
+
+  String m_key_cache;
   /*
     In expressions:
       - assoc_array(key_expr)
@@ -436,11 +439,13 @@ protected:
     definition.
     @param thd        - Current thd
     @param array_addr - The run-time address of the assoc array variable.
+    @name             - The name of the assoc array variable. 
   */
-  bool fix_key(THD *thd, const sp_rcontext_addr &array_addr);
+  bool fix_key(THD *thd, const sp_rcontext_addr &array_addr,
+               const LEX_CSTRING &name);
+  bool cache_key(const LEX_CSTRING &name);
   bool is_element_exists(THD *thd,
-                         const Field_composite *field,
-                         const LEX_CSTRING &name) const;
+                         const Field_composite *field) const;
 public:
   Item_splocal_assoc_array_base(Item *key);
 };

--- a/sql/field_composite.h
+++ b/sql/field_composite.h
@@ -50,12 +50,18 @@ public:
   {
     return true;
   }
-  virtual Item_field *element_by_key(THD *thd, String *key) { return NULL; }
-  virtual Item_field *element_by_key(THD *thd, String *key) const
+  virtual Item_field *element_by_key(THD *thd, const String &key)
   {
     return NULL;
   }
-  virtual Item **element_addr_by_key(THD *thd, String *key) { return NULL; }
+  virtual Item_field *element_by_key(THD *thd, const String &key) const
+  {
+    return NULL;
+  }
+  virtual Item **element_addr_by_key(THD *thd, const String &key)
+  {
+    return NULL;
+  }
   virtual bool delete_all_elements() { return true; }
   virtual bool delete_element_by_key(String *key) { return true; }
 

--- a/sql/item_composite.h
+++ b/sql/item_composite.h
@@ -36,8 +36,8 @@ public:
   {
     return true;
   }
-  virtual Item *element_by_key(THD *thd, String *key) { return nullptr; }
-  virtual Item **element_addr_by_key(THD *thd, Item **addr_arg, String *key)
+  virtual Item *element_by_key(THD *thd, const String &key) { return nullptr; }
+  virtual Item **element_addr_by_key(THD *thd, Item **addr_arg, const String &key)
   {
     return addr_arg;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36850*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR resolves a crash introduced in MDEV-34319 (Associative arrays: DECLARE TYPE .. TABLE OF .. INDEX BY in stored routines) caused by key item 'resolving' to differing values depending on when it is called. The fix is to cache the key once and reuse it every time  `Item_splocal_assoc_array_element::this_item()` etc needs it.

## Release Notes
N/A

## How can this PR be tested?
mysql-test/mtr sp-assoc-array

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
