### PR TITLE
MDEV-37183 Scrubbing empty record breaks recovery

### DIFF
--- a/mysql-test/suite/innodb/r/scrub_debug.result
+++ b/mysql-test/suite/innodb/r/scrub_debug.result
@@ -15,5 +15,21 @@ FLUSH TABLE t1 FOR EXPORT;
 NOT FOUND /repairman/ in t1.ibd
 UNLOCK TABLES;
 DROP TABLE t1;
+#
+# MDEV-37183 innodb_immediate_scrub_data_uncompressed=ON may break
+# crash recovery
+#
+SET GLOBAL innodb_limit_optimistic_insert_debug=0;
+CREATE TABLE t(a VARCHAR(1) PRIMARY KEY,INDEX(a DESC)) ENGINE=InnoDB;
+INSERT INTO t VALUES('2'),('1'),(''),('6'),('4'),('3');
+SET GLOBAL innodb_limit_optimistic_insert_debug=3;
+INSERT INTO t VALUES('8');
+CHECK TABLE t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+SELECT COUNT(*) FROM t;
+COUNT(*)
+7
+DROP TABLE t;
 SET GLOBAL INNODB_LIMIT_OPTIMISTIC_INSERT_DEBUG=@save_debug;
 SET GLOBAL INNODB_IMMEDIATE_SCRUB_DATA_UNCOMPRESSED=@save_scrub;

--- a/mysql-test/suite/innodb/t/scrub_debug.test
+++ b/mysql-test/suite/innodb/t/scrub_debug.test
@@ -24,5 +24,20 @@ FLUSH TABLE t1 FOR EXPORT;
 -- source include/search_pattern_in_file.inc
 UNLOCK TABLES;
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-37183 innodb_immediate_scrub_data_uncompressed=ON may break
+--echo # crash recovery
+--echo #
+SET GLOBAL innodb_limit_optimistic_insert_debug=0;
+# Note: MariaDB 10.6 fails to reproduce the crash; it maps DESC to ASC.
+CREATE TABLE t(a VARCHAR(1) PRIMARY KEY,INDEX(a DESC)) ENGINE=InnoDB;
+INSERT INTO t VALUES('2'),('1'),(''),('6'),('4'),('3');
+SET GLOBAL innodb_limit_optimistic_insert_debug=3;
+INSERT INTO t VALUES('8');
+CHECK TABLE t;
+SELECT COUNT(*) FROM t;
+DROP TABLE t;
+
 SET GLOBAL INNODB_LIMIT_OPTIMISTIC_INSERT_DEBUG=@save_debug;
 SET GLOBAL INNODB_IMMEDIATE_SCRUB_DATA_UNCOMPRESSED=@save_scrub;

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -977,8 +977,9 @@ page_delete_rec_list_end(
       size+= s;
       n_recs++;
 
-      if (scrub)
-        mtr->memset(block, rec2 - page, rec_offs_data_size(offsets), 0);
+      if (UNIV_LIKELY(!scrub));
+      else if (size_t size= rec_offs_data_size(offsets))
+        mtr->memset(block, rec2 - page, size, 0);
 
       rec2= page_rec_get_next(rec2);
     }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37183*
## Description
`page_delete_rec_list_end()`: Do not attempt to scrub the data of an empty record.

The test case would reproduce a debug assertion failure in branches where 358921ce32203a9a8dd277a5ba7ac177c9e79e53 is present. MariaDB Server 10.6 only supports ascending indexes, and in those, the empty string would always be sorted first, never last in a page.

Nevertheless, we fix the bug also in 10.6, in case it would be reproducible in a slightly different scenario.
## Release Notes
This is a rare corner case, probably not worth mentioning. It only affects empty secondary index records where also the `PRIMARY KEY` is an empty string.
## How can this PR be tested?
I tested a cherry-pick of this on top of 56ce9e72a1832a581cfaea27602a290bf253e9e6 in the current 10.11 branch.
```sh
mysql-test/mtr innodb.scrub_debug
```
Without the fix but only the test, the server would crash as follows:
```
CURRENT_TEST: innodb.scrub_debug
mysqltest: At line 37: query 'INSERT INTO t VALUES('8')' failed: <Unknown> (2013): Lost connection to server during query
…
mariadbd: /…/storage/innobase/include/mtr0log.h:225: void mtr_t::memset(const buf_block_t&, ulint, ulint, byte): Assertion `len' failed.
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.