### PR TITLE
MDEV-37169: MSAN disable main.{mysqladmin,statistics_upgrade_not_done}

### DIFF
--- a/mysql-test/main/mysqladmin.test
+++ b/mysql-test/main/mysqladmin.test
@@ -1,5 +1,7 @@
 # Embedded server doesn't support external clients
 --source include/not_embedded.inc
+# MDEV-37169 - msan unknown failure
+--source include/not_msan.inc
 #
 # Test "mysqladmin ping"
 #

--- a/mysql-test/main/statistics_upgrade_not_done.test
+++ b/mysql-test/main/statistics_upgrade_not_done.test
@@ -1,4 +1,6 @@
 --source include/not_embedded.inc
+# MDEV-37169 - msan unknown failure
+--source include/not_msan.inc
 --source include/mysql_upgrade_preparation.inc
 --source include/have_innodb.inc
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37169*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The causes of these test failures are sparatic and haven't been generated locally. The stack trace looks like it could be an internal MSAN error too. Disable for the time being as there is some server coverage of these test paths elsewhere.

## Release Notes

nothing.

## How can this PR be tested?

see if they are skipped in msan.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] *This disables two tests that have unknown causes and have been unable to reproduce.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.