### PR TITLE
Disable ps-protocol in test galera.MDEV-26266

### DIFF
--- a/mysql-test/suite/galera/t/MDEV-26266.test
+++ b/mysql-test/suite/galera/t/MDEV-26266.test
@@ -13,6 +13,7 @@
 --source include/have_innodb.inc
 --source include/force_restart.inc
 
+--disable_ps_protocol
 SET SESSION query_prealloc_size=8192;
 SET max_session_mem_used=50000;
 CREATE TABLE t1 (c1 INT NOT NULL) ENGINE=InnoDB ;
@@ -34,3 +35,4 @@ INSERT INTO t2 VALUES (5);
 --error ER_LOCK_DEADLOCK
 CREATE VIEW v1 AS SELECT c1 FROM t1 WHERE c1 IN (SELECT a FROM t2) GROUP BY c1;
 DROP TABLE t1,t2;
+--enable_ps_protocol


### PR DESCRIPTION
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This is a test only fix. Test behaves differently under --ps-protocol. Specifically, the test relies on `SET max_session_mem_used=50000` and expects certain statement to fail with ER_OPTION_PREVENTS_STATEMENT. Under ps-protocol, other statements fail with the error. Patch disables ps-protocol for this test.


## Release Notes
nothing 
## How can this PR be tested?
run test galera.MDEV-26266 with --ps-protocol and without

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
