### PR TITLE
MDEV-19574 innodb_stats_method is not honored when innodb_stats_persistent=ON

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_stats_method,NULLS_EQUAL.rdiff
+++ b/mysql-test/suite/innodb/r/innodb_stats_method,NULLS_EQUAL.rdiff
@@ -1,0 +1,9 @@
+--- innodb_stats_method.result	2025-07-11 20:02:18.854016407 +0530
++++ innodb_stats_method.reject	2025-07-11 20:02:41.077627513 +0530
+@@ -8,5 +8,5 @@
+ Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Ignored
+ t1	1	f1	1	f1	A	16341	NULL	NULL		BTREE			NO
+ t1	1	f1	2	f3	A	16341	NULL	NULL	YES	BTREE			NO
+-t1	1	f3	1	f3	A	16341	NULL	NULL	YES	BTREE			NO
++t1	1	f3	1	f3	A	2	NULL	NULL	YES	BTREE			NO
+ DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/innodb_stats_method.result
+++ b/mysql-test/suite/innodb/r/innodb_stats_method.result
@@ -1,0 +1,12 @@
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL,
+f3 INT, KEY(f1, f3), key(f3)) STATS_PERSISTENT=1,ENGINE=INNODB;
+INSERT INTO t1 SELECT seq, seq, NULL from seq_1_to_16384;
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+SHOW KEYS FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Ignored
+t1	1	f1	1	f1	A	16341	NULL	NULL		BTREE			NO
+t1	1	f1	2	f3	A	16341	NULL	NULL	YES	BTREE			NO
+t1	1	f3	1	f3	A	16341	NULL	NULL	YES	BTREE			NO
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/innodb_stats_method.test
+++ b/mysql-test/suite/innodb/t/innodb_stats_method.test
@@ -1,0 +1,9 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL,
+		f3 INT, KEY(f1, f3), key(f3)) STATS_PERSISTENT=1,ENGINE=INNODB;
+INSERT INTO t1 SELECT seq, seq, NULL from seq_1_to_16384;
+ANALYZE TABLE t1;
+SHOW KEYS FROM t1;
+DROP TABLE t1;

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -1571,9 +1571,11 @@ dict_stats_analyze_index_level(
 				level ? 0 : index->n_core_fields,
 				n_uniq, &heap);
 
-			cmp_rec_rec(prev_rec, rec,
-				    prev_rec_offsets, rec_offsets, index,
-				    false, &matched_fields);
+			cmp_rec_rec(prev_rec, rec, prev_rec_offsets,
+				    rec_offsets, index,
+				    (srv_innodb_stats_method
+				       > SRV_STATS_NULLS_EQUAL),
+				    &matched_fields);
 
 			for (i = matched_fields; i < n_uniq; i++) {
 
@@ -1812,7 +1814,9 @@ dict_stats_scan_page(
 		/* check whether rec != next_rec when looking at
 		the first n_prefix fields */
 		cmp_rec_rec(rec, next_rec, offsets_rec, offsets_next_rec,
-			    index, false, &matched_fields);
+			    index, (srv_innodb_stats_method
+				      > SRV_STATS_NULLS_EQUAL),
+			    &matched_fields);
 
 		if (matched_fields < n_prefix) {
 			/* rec != next_rec, => rec is non-boring */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-19574*

## Description
Problem:
=======
 InnoDB persistent statistics doesn't take innodb_stats_method
variable while calculating n_diff_pfx for the n-prefix index columns.

Solution:
=========
InnoDB consider all nulls as different value when innodb_stats_method is set to NULLS_UNEQUAL and NULLS_IGNORED.


## Release Notes
InnoDB consider innodb_stats_method while calculating persistent statistics

## How can this PR be tested?
./mtr innodb.innodb_stats_method

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
