### PR TITLE
MDEV-36190: Optimize transaction_lock_guard use

### DIFF
--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -1065,11 +1065,13 @@ top_loop:
 	}
 }
 
+#ifdef BTR_CUR_HASH_ADAPT
+TRANSACTIONAL_TARGET
+#endif
 /** Clear the index tree and reinitialize the root page, in the
 rollback of TRX_UNDO_EMPTY. The BTR_SEG_LEAF is freed and reinitialized.
 @param thr query thread
 @return error code */
-TRANSACTIONAL_TARGET
 dberr_t dict_index_t::clear(que_thr_t *thr)
 {
   mtr_t mtr;

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1746,7 +1746,6 @@ or on a page infimum record.
                   above!
 @param mtr        mini-transaction
 @return DB_SUCCESS on success or error code otherwise */
-TRANSACTIONAL_TARGET
 dberr_t btr_cur_search_to_nth_level(ulint level,
                                     const dtuple_t *tuple,
                                     rw_lock_type_t rw_latch,

--- a/storage/innobase/btr/btr0pcur.cc
+++ b/storage/innobase/btr/btr0pcur.cc
@@ -296,7 +296,6 @@ btr_pcur_t::SAME_UNIQ cursor position is on user rec and points on the
 record with the same unique field values as in the stored record,
 btr_pcur_t::NOT_SAME cursor position is not on user rec or points on
 the record with not the samebuniq field values as in the stored */
-TRANSACTIONAL_TARGET
 btr_pcur_t::restore_status
 btr_pcur_t::restore_position(btr_latch_mode restore_latch_mode, mtr_t *mtr)
 {

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2614,11 +2614,12 @@ buf_block_t *buf_pool_t::page_fix(const page_id_t id,
   }
 }
 
-TRANSACTIONAL_TARGET
 uint32_t buf_pool_t::page_guess(buf_block_t *b, page_hash_latch &latch,
                                 const page_id_t id) noexcept
 {
-  transactional_shared_lock_guard<page_hash_latch> g{latch};
+  /* On at least two Intel Xeon of different generation, it turns out
+  that transactional_shared_lock_guard would perform worse here. */
+  latch.lock_shared();
 #ifndef HAVE_UNACCESSIBLE_AFTER_MEM_DECOMMIT
   /* shrunk() and my_virtual_mem_decommit() could retain the original
   contents of the virtual memory range or zero it out immediately or
@@ -2630,8 +2631,13 @@ uint32_t buf_pool_t::page_guess(buf_block_t *b, page_hash_latch &latch,
 #else
   /* shrunk() made the memory inaccessible. */
   if (UNIV_UNLIKELY(reinterpret_cast<char*>(b) >= memory + size_in_bytes))
+  {
+    latch.unlock_shared();
     return 0;
+  }
 #endif
+  /* This synchronizes with buf_page_t::init() */
+  uint32_t state{b->page.zip.fix.load(std::memory_order_acquire)};
   const page_id_t block_id{b->page.id()};
 #ifndef HAVE_UNACCESSIBLE_AFTER_MEM_DECOMMIT
   /* shrunk() may have invoked MEM_UNDEFINED() on this memory to be able
@@ -2641,7 +2647,6 @@ uint32_t buf_pool_t::page_guess(buf_block_t *b, page_hash_latch &latch,
 
   if (id == block_id)
   {
-    uint32_t state= b->page.state();
 #ifndef HAVE_UNACCESSIBLE_AFTER_MEM_DECOMMIT
     /* shrunk() may have invoked MEM_UNDEFINED() on this memory to be able
     to catch any unintended access elsewhere in our code. */
@@ -2651,10 +2656,15 @@ uint32_t buf_pool_t::page_guess(buf_block_t *b, page_hash_latch &latch,
     avoid a race condition by looking up the block via page_hash. */
     if ((state >= buf_page_t::FREED && state < buf_page_t::READ_FIX) ||
         state >= buf_page_t::WRITE_FIX)
-      return b->page.fix();
+      state= b->page.fix();
+    else
+      state= 0;
     ut_ad(b->page.frame);
   }
-  return 0;
+  else
+    state= 0;
+  latch.unlock_shared();
+  return state;
 }
 
 /** Low level function used to get access to a database page.
@@ -2668,7 +2678,6 @@ or BUF_PEEK_IF_IN_POOL
 @param[out]	err			DB_SUCCESS or error code
 @return pointer to the block
 @retval nullptr	if the block is corrupted or unavailable */
-TRANSACTIONAL_TARGET
 buf_block_t*
 buf_page_get_gen(
 	const page_id_t		page_id,
@@ -3060,15 +3069,51 @@ void buf_block_t::initialise(const page_id_t page_id, ulint zip_size,
   page_zip_set_size(&page.zip, zip_size);
 }
 
-TRANSACTIONAL_TARGET
+void
+buf_pool_t::page_hash_table::append(buf_pool_t::hash_chain &chain,
+                                    buf_page_t *bpage) noexcept
+{
+  mysql_mutex_assert_owner(&buf_pool.mutex);
+  ut_ad(buf_pool.page_hash.lock_get(chain).is_locked());
+  ut_ad(!bpage->in_page_hash);
+  ut_ad(!bpage->hash);
+  ut_d(bpage->in_page_hash= true);
+  buf_page_t **prev= &chain.first;
+  while (*prev)
+  {
+    ut_ad((*prev)->in_page_hash);
+    prev= &(*prev)->hash;
+  }
+  *prev= bpage;
+}
+
+inline void
+buf_pool_t::page_hash_table::replace(buf_pool_t::hash_chain &chain,
+                                     buf_page_t *old,
+                                     buf_page_t *bpage) noexcept
+{
+  mysql_mutex_assert_owner(&buf_pool.mutex);
+
+  ut_ad(old->in_page_hash);
+  ut_ad(bpage->in_page_hash);
+  ut_d(old->in_page_hash= false);
+  ut_ad(bpage->hash == old->hash);
+  old->hash= nullptr;
+  buf_page_t **prev= &chain.first;
+  while (*prev != old)
+  {
+    ut_ad((*prev)->in_page_hash);
+    prev= &(*prev)->hash;
+  }
+  *prev= bpage;
+}
+
 static buf_block_t *buf_page_create_low(page_id_t page_id, ulint zip_size,
                                         mtr_t *mtr, buf_block_t *free_block)
   noexcept
 {
   ut_ad(mtr->is_active());
   ut_ad(page_id.space() != 0 || !zip_size);
-
-  free_block->initialise(page_id, zip_size, buf_page_t::MEMORY);
 
   buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(page_id.fold());
 retry:
@@ -3203,16 +3248,19 @@ retry:
   bpage= &free_block->page;
 
   ut_ad(bpage->state() == buf_page_t::MEMORY);
-  bpage->lock.x_lock();
+
+  {
+    page_hash_latch &hash_lock{buf_pool.page_hash.lock_get(chain)};
+    hash_lock.lock();
+    reinterpret_cast<buf_block_t*>(bpage)->
+      initialise(page_id, zip_size, buf_page_t::REINIT + 1);
+    bpage->lock.x_lock();
+    buf_pool.page_hash.append(chain, bpage);
+    hash_lock.unlock();
+  }
 
   /* The block must be put to the LRU list */
   buf_LRU_add_block(bpage, false);
-  {
-    transactional_lock_guard<page_hash_latch> g
-      {buf_pool.page_hash.lock_get(chain)};
-    bpage->set_state(buf_page_t::REINIT + 1);
-    buf_pool.page_hash.append(chain, bpage);
-  }
 
   if (UNIV_UNLIKELY(zip_size))
   {

--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -990,6 +990,23 @@ ATTRIBUTE_COLD void buf_pool_t::free_block(buf_block_t *block) noexcept
   mysql_mutex_unlock(&mutex);
 }
 
+inline void
+buf_pool_t::page_hash_table::remove(buf_pool_t::hash_chain &chain,
+                                    buf_page_t *bpage) noexcept
+{
+  mysql_mutex_assert_owner(&buf_pool.mutex);
+
+  ut_ad(bpage->in_page_hash);
+  buf_page_t **prev= &chain.first;
+  while (*prev != bpage)
+  {
+    ut_ad((*prev)->in_page_hash);
+    prev= &(*prev)->hash;
+  }
+  *prev= bpage->hash;
+  ut_d(bpage->in_page_hash= false);
+  bpage->hash= nullptr;
+}
 
 /** Remove bpage from buf_pool.LRU and buf_pool.page_hash.
 

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -1211,10 +1211,12 @@ inline void dict_sys_t::add(dict_table_t *table) noexcept
   ut_ad(dict_lru_validate());
 }
 
+#ifdef BTR_CUR_HASH_ADAPT
+TRANSACTIONAL_TARGET
+#endif
 /** Test whether a table can be evicted from dict_sys.table_LRU.
 @param table   table to be considered for eviction
 @return whether the table can be evicted */
-TRANSACTIONAL_TARGET
 static bool dict_table_can_be_evicted(dict_table_t *table)
 {
 	ut_ad(dict_sys.locked());
@@ -2083,9 +2085,11 @@ dict_index_add_to_cache(
 	return DB_SUCCESS;
 }
 
+#ifdef BTR_CUR_HASH_ADAPT
+TRANSACTIONAL_TARGET
+#endif
 /**********************************************************************//**
 Removes an index from the dictionary cache. */
-TRANSACTIONAL_TARGET
 static
 void
 dict_index_remove_from_cache_low(

--- a/storage/innobase/include/trx0purge.h
+++ b/storage/innobase/include/trx0purge.h
@@ -369,7 +369,7 @@ public:
   /** Determine if the history of a transaction is purgeable.
   @param trx_id  transaction identifier
   @return whether the history is purgeable */
-  TRANSACTIONAL_TARGET bool is_purgeable(trx_id_t trx_id) const;
+  bool is_purgeable(trx_id_t trx_id) const noexcept;
 
   /** A wrapper around ReadView::low_limit_no(). */
   trx_id_t low_limit_no() const

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2792,7 +2792,6 @@ lock_rec_inherit_to_gap_if_gap_lock(
 /*************************************************************//**
 Moves the locks of a record to another record and resets the lock bits of
 the donating record. */
-TRANSACTIONAL_TARGET
 static
 void
 lock_rec_move(
@@ -3035,7 +3034,6 @@ lock_move_reorganize_page(
 /*************************************************************//**
 Moves the explicit locks on user records to another page if a record
 list end is moved to another page. */
-TRANSACTIONAL_TARGET
 void
 lock_move_rec_list_end(
 /*===================*/
@@ -3169,7 +3167,6 @@ lock_move_rec_list_end(
 /*************************************************************//**
 Moves the explicit locks on user records to another page if a record
 list start is moved to another page. */
-TRANSACTIONAL_TARGET
 void
 lock_move_rec_list_start(
 /*=====================*/
@@ -3292,7 +3289,6 @@ lock_move_rec_list_start(
 /*************************************************************//**
 Moves the explicit locks on user records to another page if a record
 list start is moved to another page. */
-TRANSACTIONAL_TARGET
 void
 lock_rtr_move_rec_list(
 /*===================*/
@@ -4521,7 +4517,7 @@ released:
 /** Release the explicit locks of a committing transaction,
 and release possible other transactions waiting because of these locks.
 @return whether the operation succeeded */
-TRANSACTIONAL_TARGET static bool lock_release_try(trx_t *trx)
+static bool lock_release_try(trx_t *trx)
 {
   /* At this point, trx->lock.trx_locks cannot be modified by other
   threads, because our transaction has been committed.
@@ -5310,7 +5306,6 @@ http://bugs.mysql.com/36942 */
 /*********************************************************************//**
 Calculates the number of record lock structs in the record lock hash table.
 @return number of record locks */
-TRANSACTIONAL_TARGET
 static ulint lock_get_n_rec_locks()
 {
   ulint n_locks= 0;
@@ -5939,7 +5934,6 @@ be suspended for some reason; if not, then puts the transaction and
 the query thread to the lock wait state and inserts a waiting request
 for a gap x-lock to the lock queue.
 @return DB_SUCCESS, DB_LOCK_WAIT, or DB_DEADLOCK */
-TRANSACTIONAL_TARGET
 dberr_t
 lock_rec_insert_check_and_lock(
 /*===========================*/

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -1877,8 +1877,8 @@ trx_undo_report_row_operation(
 	} else if (!m.second || !trx->bulk_insert) {
 		bulk = false;
 	} else if (index->table->is_temporary()) {
-	} else if (trx_has_lock_x(*trx, *index->table)
-		   && index->table->bulk_trx_id == trx->id) {
+	} else if (index->table->bulk_trx_id == trx->id
+		   && trx_has_lock_x(*trx, *index->table)) {
 		m.first->second.start_bulk_insert(
 			index->table,
 			thd_sql_command(trx->mysql_thd) != SQLCOM_LOAD);
@@ -2117,7 +2117,6 @@ must hold a latch on the index page of the clustered index record.
 @retval DB_SUCCESS if previous version was successfully built,
 or if it was an insert or the undo record refers to the table before rebuild
 @retval DB_MISSING_HISTORY if the history is missing */
-TRANSACTIONAL_TARGET
 dberr_t trx_undo_prev_version_build(const rec_t *rec, dict_index_t *index,
                                     rec_offs *offsets, mem_heap_t *heap,
                                     rec_t **old_vers, mtr_t *mtr,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36190*
## Description
`buf_pool_t::page_guess()`: Avoid a memory transaction, because we would be checking several conditions inside it. Synchronize with `buf_page_t::init()` in order to avoid false guesses.

`buf_pool_t::page_hash_table::append()`: Define non-`inline`.

`buf_pool_t::page_hash_table::replace()`, `buf_pool_t::page_hash_table::remove()`: Move the inline definition to the compilation unit of the only caller, to declutter the header.

`buf_page_create_low()`, `buf_page_init_for_read()`: Do not initialize the block descriptor before holding a latch on `buf_pool.page_hash`, in order to avoid false positive matches in `buf_pool_t::page_guess()`.

`trx_undo_report_row_operation()`: Check the cheaper and less likely condition first.

Also, remove several redundant `TRANSACTIONAL_TARGET`. Some of the remaining ones will be made redundant by 9c8bdc6c15a89ffe9a9bd64d518fe90eb50edcf5.
## Release Notes
On some Intel Xeon CPUs, performance was improved slightly.
## How can this PR be tested?
Various performance test workloads on various CPU implementations that support hardware memory transactions. For x86-64, that would be Intel® Xeon® models.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This is a performance bug fix. The change to `buf_page_init_for_read()` depends on f27e9c894779a4c7ebe6446ba9aa408f1771c114, and 11.4 is the oldest maintained branch that includes that change.
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.