### PR TITLE
MDEV-30711: Crash in add_keyuses_for_splitting() when joining with a …

### DIFF
--- a/mysql-test/main/derived_split_innodb.result
+++ b/mysql-test/main/derived_split_innodb.result
@@ -935,4 +935,37 @@ cnt
 6
 DROP TABLE t1;
 # End of 10.4 tests
+#
+# MDEV-30711: Crash in add_keyuses_for_splitting() when joining with a derived table
+#
+create table t1 (a int);
+insert into t1 values (1),(2);
+create table t2 (a int, index(a));
+insert into t2 values (1),(3);
+create view v1 as
+select
+nullif(tbl2.COL1,123) as COL10
+from
+t1 left join
+(select 1 as COL1, a from t2) tbl2 on t1.a=tbl2.a;
+create table t10 (grp_id int, a int, index(grp_id));
+insert into t10 select A.seq, B.seq from seq_1_to_100 A, seq_1_to_100 B;
+analyze table t10;
+Table	Op	Msg_type	Msg_text
+test.t10	analyze	status	Engine-independent statistics collected
+test.t10	analyze	status	Table is already up to date
+explain
+select * from
+v1,
+(select grp_id, count(*) from t10 group by grp_id) T
+where
+T.grp_id=v1.COL10;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	
+1	PRIMARY	t2	ref	a	a	5	test.t1.a	2	Using where; Using index
+1	PRIMARY	<derived2>	ref	key0	key0	5	func	10	Using where
+2	DERIVED	t10	index	grp_id	grp_id	5	NULL	10000	Using index; Using temporary; Using filesort
+drop table t1,t2, t10;
+drop view v1;
+# End of 10.11 tests
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/mysql-test/main/derived_split_innodb.test
+++ b/mysql-test/main/derived_split_innodb.test
@@ -549,4 +549,34 @@ DROP TABLE t1;
 
 --echo # End of 10.4 tests
 
+--echo #
+--echo # MDEV-30711: Crash in add_keyuses_for_splitting() when joining with a derived table
+--echo #
+create table t1 (a int);
+insert into t1 values (1),(2);
+create table t2 (a int, index(a));
+insert into t2 values (1),(3);
+
+create view v1 as
+select
+  nullif(tbl2.COL1,123) as COL10
+from
+  t1 left join
+  (select 1 as COL1, a from t2) tbl2 on t1.a=tbl2.a;
+
+create table t10 (grp_id int, a int, index(grp_id));
+insert into t10 select A.seq, B.seq from seq_1_to_100 A, seq_1_to_100 B;
+analyze table t10;
+
+explain
+select * from
+  v1,
+  (select grp_id, count(*) from t10 group by grp_id) T
+where
+  T.grp_id=v1.COL10;
+
+drop table t1,t2, t10;
+drop view v1;
+
+--echo # End of 10.11 tests
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/sql/item.h
+++ b/sql/item.h
@@ -6504,6 +6504,19 @@ public:
   { return get_item_copy<Item_direct_view_ref>(thd, this); }
   Item *field_transformer_for_having_pushdown(THD *, uchar *) override
   { return this; }
+  /*
+    Do the same thing as Item_field: if we were referring to a local view,
+    now we refer to somewhere outside of our SELECT.
+  */
+  bool set_fields_as_dependent_processor(void *arg) override
+  {
+    if (!(used_tables() & OUTER_REF_TABLE_BIT))
+    {
+      depended_from= (st_select_lex *) arg;
+      item_equal= NULL;
+    }
+    return 0;
+  }
 };
 
 

--- a/sql/opt_split.cc
+++ b/sql/opt_split.cc
@@ -610,6 +610,11 @@ void TABLE::add_splitting_info_for_key_field(KEY_FIELD *key_field)
     right_item->walk(&Item::set_fields_as_dependent_processor,
                      false, join->select_lex);
     right_item->update_used_tables();
+    /*
+      We've just pushed right_item down into the child select. It may only
+      have references to outside.
+    */
+    DBUG_ASSERT(!(right_item->used_tables() & ~PSEUDO_TABLE_BITS));
     eq_item= new (thd->mem_root) Item_func_eq(thd, left_item, right_item);
   }
   if (!eq_item)


### PR DESCRIPTION
…derived table

Split-Materialized optimization in add_keyuses_for_splitting() pushes "derived_split_table.field=right_expr" down into the derived_split_table. This requires that right_expr's attributes are updated. Typically it has references to tables in the parent select, those become references to outside in the child select.
This was done with the

  right_expr->walk(&Item::set_fields_as_dependent_processor, ...)

call. The function was implemented for Item_field objects. However it was not implemented for Item_direct_view_ref objects.

If an Item_direct_view_ref object didn't have an Item_field inside (e.g. view column referred to a constant) this would mean that used_tables() attribute would not be updated and right_expr will end up with wrong used_tables(), which could eventually cause a crash as it looked like a reference to non-existant table.

Fixed by adding Item_direct_view_ref::set_fields_as_dependent_processor() with the same logic as in Item_field.

- [x] *The Jira issue number for this PR is: MDEV-30711*
