### PR TITLE
MDEV-36482: Make liburing work WITH_MSAN=ON

### DIFF
--- a/tpool/aio_liburing.cc
+++ b/tpool/aio_liburing.cc
@@ -15,6 +15,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 - 1301 USA*/
 
 #include "tpool_structs.h"
 #include "tpool.h"
+#include "my_valgrind.h"
 #include "mysql/service_my_print_error.h"
 #include "mysqld_error.h"
 
@@ -172,6 +173,10 @@ private:
       {
         iocb->m_err= 0;
         iocb->m_ret_len= res;
+#if __has_feature(memory_sanitizer)
+        if (iocb->m_opcode == aio_opcode::AIO_PREAD)
+          MEM_MAKE_DEFINED(iocb->m_buffer, res);
+#endif
       }
 
       io_uring_cqe_seen(&aio->uring_, cqe);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36482*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

same concept as #3949.

A read from liburing has its output buffer as defined by the nature of the system call.

Instrumenting the library proved difficult as the
completion events don't include the opcode or pointers that where there on submission. It was just easier to do this in the application code.

## Release Notes

non-user facing.

## How can this PR be tested?

compile in msan environment and run test suite with uring.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
