### PR TITLE
MDEV-37195:

### DIFF
--- a/mysql-test/main/log_state.result
+++ b/mysql-test/main/log_state.result
@@ -392,6 +392,57 @@ disconnect con2;
 connection default;
 DROP TABLE t1;
 TRUNCATE TABLE mysql.slow_log;
+#
+# MDEV-37195 Rows_examined is always 0 in the slow query log 
+# for queries with a subquery and degenerate select
+#
+SET GLOBAL log_output = "TABLE";
+SET GLOBAL slow_query_log = ON;
+SET GLOBAL long_query_time = 0.0;
+TRUNCATE TABLE mysql.slow_log;
+CREATE TABLE t1 (id INT);
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_10;
+connect  con2,localhost,root,,;
+SELECT 100 in (SELECT id FROM t1) AS res;
+res
+0
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+rows_examined	sql_text
+10	SELECT 100 in (SELECT id FROM t1) AS res
+TRUNCATE TABLE mysql.slow_log;
+SELECT 100 in (
+SELECT id FROM t1 
+UNION
+SELECT id FROM t1
+) AS res;
+res
+0
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+rows_examined	sql_text
+20	SELECT 100 in (
+SELECT id FROM t1 
+UNION
+SELECT id FROM t1
+) AS res
+TRUNCATE TABLE mysql.slow_log;
+SELECT 100 in (
+SELECT id FROM t1 
+UNION ALL
+SELECT id FROM t1
+) AS res;
+res
+0
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+rows_examined	sql_text
+20	SELECT 100 in (
+SELECT id FROM t1 
+UNION ALL
+SELECT id FROM t1
+) AS res
+disconnect con2;
+connection default;
+DROP TABLE t1;
+TRUNCATE TABLE mysql.slow_log;
 End of 10.11 tests
 SET GLOBAL long_query_time = @save_long_query_time;
 SET GLOBAL log_output = @old_log_output;

--- a/mysql-test/main/log_state.test
+++ b/mysql-test/main/log_state.test
@@ -441,6 +441,57 @@ DROP TABLE t1;
 
 TRUNCATE TABLE mysql.slow_log;
 
+###########################################################################
+
+--echo #
+--echo # MDEV-37195 Rows_examined is always 0 in the slow query log 
+--echo # for queries with a subquery and degenerate select
+--echo #
+
+SET GLOBAL log_output = "TABLE";
+SET GLOBAL slow_query_log = ON;
+SET GLOBAL long_query_time = 0.0;
+
+# clear slow_log of any residual slow queries
+TRUNCATE TABLE mysql.slow_log;
+
+CREATE TABLE t1 (id INT);
+ 
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_10;
+
+connect (con2,localhost,root,,);
+--disable_ps_protocol
+
+SELECT 100 in (SELECT id FROM t1) AS res;
+
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+
+TRUNCATE TABLE mysql.slow_log;
+
+SELECT 100 in (
+    SELECT id FROM t1 
+    UNION
+    SELECT id FROM t1
+) AS res;
+
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+
+TRUNCATE TABLE mysql.slow_log;
+
+SELECT 100 in (
+    SELECT id FROM t1 
+    UNION ALL
+    SELECT id FROM t1
+) AS res;
+
+SELECT rows_examined,sql_text FROM mysql.slow_log WHERE sql_text LIKE '%SELECT 100%';
+
+disconnect con2;
+connection default;
+DROP TABLE t1;
+
+TRUNCATE TABLE mysql.slow_log;
+
 --echo End of 10.11 tests
 ###########################################################################
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -4865,7 +4865,6 @@ void JOIN::exec_inner()
     }
     /* Single select (without union) always returns 0 or 1 row */
     thd->limit_found_rows= send_records;
-    thd->set_examined_row_count(0);
     DBUG_VOID_RETURN;
   }
 


### PR DESCRIPTION
For all degenerate select queries having sub-queries in them, the field rows_examined in the slow query log is always being set to 0.

The problem is that, although sub-queries increment the rows_examined field of the thd object correctly, the degenerate outer select query is resetting the rows_examined to zero after it has finished execution, by invoking thd->set_examined_row_count(0).

The solution is to remove the thd->set_examined_row_count(0) in the degenerate select queries.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
