### PR TITLE
Sort output of `binlog_mysqlbinlog_warn_stop_gtid`

### DIFF
--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.inc
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.inc
@@ -52,6 +52,7 @@ if (!$read_from_remote_server)
 --echo # file should(!) result in a warning
 --echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --short-form --stop-position=binlog_f1_over_eof binlog_f1_full --result-file=$binlog_out_relpath 2>&1
 --replace_result $binlog_f1_over_eof <BINLOG_F1_OVER_EOF>
+--sorted_result
 --exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --short-form --stop-position=$binlog_f1_over_eof $binlog_f1_full --result-file=$binlog_out 2>&1
 
 --echo #
@@ -101,6 +102,7 @@ if (!$read_from_remote_server)
 --echo #    2) not prevent b2 from outputting its entire binary log
 --echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f2_over_eof binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
 --replace_result $binlog_f2_over_eof <BINLOG_F2_OVER_EOF>
+--sorted_result
 --exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f2_over_eof $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
 
 --let $server_id= `SELECT @@GLOBAL.server_id`


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-34614][]*

## Description
Hash tables don’t have a specific ordering to avoid the overhead of tracking the order. But consequentially, the output of this test from [MDEV-34614][] (#3600) may be in a different order – notably, in big-endian platforms like S390x.

This patch adds `--sort_result` to affected test cases to overcome this difference without changing the code.

(Both insertion-order and natural (Domain ID)-order make sense for these GTID filters, and *both would need more or less significant modifications to the Hash set*.)

## Release Notes
N/A (test output inconsistency)

## How can this PR be tested?
Build and run the test on [various platforms](https://buildbot.mariadb.org/#/grid?branch=refs%2Fpull%2F4200%2Fhead), namely, S390x

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

[MDEV-34614]: https://jira.mariadb.org/browse/MDEV-34614