### PR TITLE
MDBF-801: Add github status link to full Buildbot results

### DIFF
--- a/.github/workflows/autocomment.yml
+++ b/.github/workflows/autocomment.yml
@@ -1,0 +1,18 @@
+name: Check BuildBot
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  auto-comment:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: PR Comment
+        run: |
+          gh pr comment $PRNUM --body "Hi ${{ github.event.pull_request.user.login }}, some Buildbot tests are recorded as GitHub status builder here, however for the complete list of test results see this [BuildBot URL specific to this PR](https://buildbot.mariadb.org/#/grid?branch=refs/pull/${PRNUM}/head). The most recent push to this pull request is on the left."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PRNUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDBF-801*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This enable users that submit pull requests to be able to easily see the link to the full test results of BuildBot.

As @ParadoxV5 commented when prompted about the mistake #4200 fixed, "why do no S390x builders advertise themselves to PRs?". With this, we can make it obvious rather than having users know /remember specific URL patterns.

## Release Notes

nothing

## How can this PR be tested?

See if the next PR gets a friendly GH comment.

Concept tested by @RazvanLiviuVarzaru 
https://github.com/RazvanLiviuVarzaru/buildbot-r/pull/7

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.