### PR TITLE
MDEV-37103 innodb_immediate_scrub_data_uncompressed=ON may break innodb_undo_log_truncate=ON

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2696,23 +2696,30 @@ fil_io_t fil_space_t::io(const IORequest &type, os_offset_t offset, size_t len,
 
 		while (node->size <= p) {
 			p -= node->size;
-			node = UT_LIST_GET_NEXT(chain, node);
-			if (!node) {
+			if (!UT_LIST_GET_NEXT(chain, node)) {
 fail:
-				if (type.type != IORequest::READ_ASYNC) {
+				switch (type.type) {
+				case IORequest::READ_ASYNC:
+					/* Read-ahead may be requested for
+					non-existing pages. Ignore such
+					requests. */
+					break;
+				default:
 					fil_invalid_page_access_msg(
 						node->name,
 						offset, len,
 						type.is_read());
-				}
 #ifndef DBUG_OFF
 io_error:
 #endif
-				set_corrupted();
+					set_corrupted();
+				}
+
 				err = DB_CORRUPTION;
 				node = nullptr;
 				goto release;
 			}
+			node = UT_LIST_GET_NEXT(chain, node);
 		}
 
 		offset = os_offset_t{p} << srv_page_size_shift;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37103*
## Description
The test `innodb.undo_truncate` occasionally demonstrates a race condition where scrubbing is writing zeroes to a freed undo page, and `innodb_undo_log_truncate=ON` truncating the same tablespace. The truncation is an exception to the rule that InnoDB tablespace file sizes can only grow, never shrink.

Currently the `fil_space_t::size` and `fil_node_t::size` are protected by `fil_system.mutex`, which used to be a highly contended resource. We do not want to revert back to acquiring the mutex in `fil_space_t::io()` because that would introduce an obvious scalability bottleneck.

In fact, during or slightly after the time `fil_space_t::io()` is assessing the size, the size may be changed by another thread. A concurrent increase of the size is not a problem, but shrinking the size may be. That is, if an undo tablespace file was shrunk just after our check, we could initiate an out-of-bounds write. This write would extend the file, possibly making it sparse. InnoDB should not access such out-of-bounds pages before the tablespace has been expanded to that size again. The information on the expected file size is persisted in the first page of the file. Any extra NUL bytes after the file payload should not matter.

`fil_space_t::flush_freed()`: Do not try to scrub pages of the undo tablespace in order to prevent a race condition between `io()` and undo tablespace truncation.

`fil_space_t::io()`: Prevent a null pointer dereference when reporting an out-of-bounds access to the non-first file of the system or temporary tablespace. Do not invoke `set_corrupted()` after an out-of-bounds asynchronous read.
## Release Notes
InnoDB could crash when `innodb_immediate_scrub_data_uncompressed=ON` and `innodb_undo_log_truncate=ON` were enabled at the same time.
## How can this PR be tested?
The test `innodb.undo_truncate` covers this. Alas, this race condition is very rare, and we failed to reproduce the failure outside some Buildbot workers.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.