### PR TITLE
12.1 mdev 37207 ddl dumping for multi delete isn't consistently working

### DIFF
--- a/mysql-test/main/opt_trace_store_ddls.result
+++ b/mysql-test/main/opt_trace_store_ddls.result
@@ -477,4 +477,40 @@ CREATE TABLE `t1` (
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 drop table t1;
 drop table t2;
+#
+# MDEV-37207: test multi delete of 2 tables
+# trace result should have the ddls for both the tables
+#
+create table t1(id1 int not null auto_increment primary key);
+create table t2(id2 int not null);
+insert into t1 values (1),(2);
+insert into t2 values (1),(1),(2),(2);
+delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl')) from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+ddl
+CREATE TABLE `t2` (
+  `id2` int(11) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+CREATE TABLE `t1` (
+  `id1` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id1`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+# rerun the same delete query
+# Now, trace result should have the ddls for all 2 tables,
+# even though no data is deleted
+delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl')) from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+ddl
+CREATE TABLE `t2` (
+  `id2` int(11) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+CREATE TABLE `t1` (
+  `id1` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id1`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+drop table t1, t2;
 drop database db1;

--- a/mysql-test/main/opt_trace_store_ddls.test
+++ b/mysql-test/main/opt_trace_store_ddls.test
@@ -361,4 +361,32 @@ select ddl from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
 drop table t1;
 drop table t2;
 
+--echo #
+--echo # MDEV-37207: test multi delete of 2 tables
+--echo # trace result should have the ddls for both the tables
+--echo #
+
+create table t1(id1 int not null auto_increment primary key);
+create table t2(id2 int not null);
+
+insert into t1 values (1),(2);
+insert into t2 values (1),(1),(2),(2);
+
+delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
+
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl')) from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+
+--echo # rerun the same delete query
+--echo # Now, trace result should have the ddls for all 2 tables,
+--echo # even though no data is deleted
+delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
+
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl')) from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+ 
+drop table t1, t2;
+
 drop database db1;

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -1419,6 +1419,8 @@ int multi_delete::send_data(List<Item> &values)
               }
               found++;
           }
+          else
+            error= 0; /* Clear HA_ERR_FOUND_DUPP_{KEY,UNIQUE} error */
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37207*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
    MDEV-37207: dumping tables for multi delete query doesn't work always
    
It was observed that, when doing multiple DELETE on tables:
-> if there was duplicate data to delete, then no ddls were dumped to the trace.
-> However, when tested with no data being deleted from the tables,
   then ddls of the tables were getting dumped to the trace.

The problem is that store_tables_context_in_trace() is not getting
invoked, from mysql_execute_command() in all the situations.

The reason is that multi-table DELETE returned error when it had deleted duplicate rows.
Multi-table DELETE actually finds record combinations to delete,
and when it has found let's say {t1.rowX, t2.rowY, t3.rowZ}, it will attempt to
save t1.rowX in the temptable for t1, t2.rowY in the temptable for t2 and so forth.
When saving the row to be deleted, in the temp table, it can encounter error
121 (HA_ERR_FOUND_DUPP_KEY), and it is propagated to the caller.

As a fix, I have marked that there is no error when HA_ERR_FOUND_DUPP_KEY error_code is
noticed in the multi_delete::send_data()

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
