### PR TITLE
MDEV-37852 mytop: fix connection to localhost if a port is specified

### DIFF
--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# $Id: mytop,v 1.99-maria6 2019/10/22 14:53:51 jweisbuch Exp $
+# $Id: mytop,v 1.99-maria8 2025/07/16 17:59:26 jweisbuch Exp $
 
 =pod
 
@@ -21,7 +21,7 @@ use Socket;
 use List::Util qw(min max);
 use File::Basename;
 
-$main::VERSION = "1.99-maria6";
+$main::VERSION = "1.99-maria8";
 my $path_for_script = dirname($0);
 
 $| = 1;
@@ -256,7 +256,11 @@ if (eval {DBI->install_driver("MariaDB")}) {
 
 if ($config{socket} and -S $config{socket})
 {
-  $dsn .= "${prefix}_socket=$config{socket}";
+    $dsn .= "${prefix}_socket=$config{socket}";
+}
+elsif($config{host} eq "localhost")
+{
+    $dsn .= "host=$config{host}";
 }
 else
 {


### PR DESCRIPTION
## Description
mytop fails to execute when no settings are specified (or host=localhost and port=3306 which are the default for mytop)  and DBD-MariaDB is used with the error "Connection error: port cannot be specified when host is localhost or embedded".

It's because DBD-MariaDB (unlike DBD-mysql) doesn't accept a port parameter if the host is "localhost" : https://github.com/perl5-dbi/DBD-MariaDB/blob/a005081c0f98d564e4256068d5dda22362293e49/dbdimp.c#L1511.

## Release Notes
This is a fix for Debian bug #1109394.
The correction is to only pass the port parameter to DBD if the host is not "localhost".

I tested it and it doesn't break mytop when used with DBD-mysql (which works the same if the port is specified or not for the host "localhost").

## How can this PR be tested?
Executing mytop on an OS with DBD-MariaDB, a MariaDB server accessible from "localhost" and no hostname/port specified (or localhost/3306) in ~/.mytop or ~/.my.cnf config files should return a fatal error before the fix and work after.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
