### PR TITLE
MDEV-37250 buf_pool_t::shrink() assertion failure

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_buffer_pool_shrink_temporary.result
+++ b/mysql-test/suite/innodb/r/innodb_buffer_pool_shrink_temporary.result
@@ -1,0 +1,17 @@
+call mtr.add_suppression("innodb_buffer_pool_size change aborted");
+SET @b=REPEAT('0',1048576);
+CREATE TEMPORARY TABLE t (c MEDIUMTEXT) ENGINE=InnoDB;
+INSERT INTO t VALUES
+(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b);
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+SET GLOBAL innodb_buffer_pool_size=6291456;
+SET GLOBAL innodb_buffer_pool_size=16777216;
+CHECKSUM TABLE t;
+Table	Checksum
+test.t	4050893687
+DROP TEMPORARY TABLE t;

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_shrink_temporary.opt
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_shrink_temporary.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=16m

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_shrink_temporary.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_shrink_temporary.test
@@ -1,0 +1,20 @@
+--source include/have_innodb.inc
+call mtr.add_suppression("innodb_buffer_pool_size change aborted");
+SET @b=REPEAT('0',1048576);
+CREATE TEMPORARY TABLE t (c MEDIUMTEXT) ENGINE=InnoDB;
+INSERT INTO t VALUES
+(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b),(@b);
+--error 0,ER_WRONG_USAGE
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+--error 0,ER_WRONG_USAGE
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+--error 0,ER_WRONG_USAGE
+SET STATEMENT max_statement_time=0.000001 FOR
+SET GLOBAL innodb_buffer_pool_size=6291456;
+--error 0,ER_WRONG_USAGE
+SET GLOBAL innodb_buffer_pool_size=6291456;
+SET GLOBAL innodb_buffer_pool_size=16777216;
+CHECKSUM TABLE t;
+DROP TEMPORARY TABLE t;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37250*
## Description
`buf_pool_t::shrink()`: When relocating a dirty page of the temporary tablespace, reset the oldest_modification() on the discarded block, like we do for persistent pages in `buf_flush_relocate_on_flush_list()`.

`buf_pool_t::resize()`: Add debug assertions to catch this error earlier.

This bug does not seem to affect non-debug builds.
## Release Notes
N/A
## How can this PR be tested?
```sh
./mtr innodb.innodb_buffer_pool_shrink_temporary
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.