### PR TITLE
MDEV-37060: Zero-initialize `Log_event::server_id`

### DIFF
--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1343,7 +1343,7 @@ public:
     return thd ? thd->db.str : 0;
   }
 #else
-  Log_event() : temp_buf(0), when(0), flags(0) {}
+  Log_event() : temp_buf(0), when(0), server_id(0), flags(0) {}
   ha_checksum crc;
   /* print*() functions are used by mysqlbinlog */
   virtual bool print(FILE* file, PRINT_EVENT_INFO* print_event_info) = 0;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-37060](https://jira.mariadb.org/browse/MDEV-37060)*

## Description
MSAN found that `mariadb-binlog --force-read` reads the unknown Server ID of encrypted events.
Initializing the field with the invalid Server ID of `0` mitigates `use-of-uninitialized-value` once and for all.

## How can this PR be tested?
Run `binlog_encryption.mysqlbinlog` with MSAN
(I don’t have MSAN, but [amd64-msan-clang-20-debug](https://buildbot.mariadb.org/#/builders/866) does – [once it’s online](https://jira.mariadb.org/browse/MDBF-1076).

<details><summary>

### `Log_event` members still not initialized (excluding `WHEN_FLASHBACK_REVIEW_READY` ones)

</summary>

```c++
my_off_t log_pos;
ulong when_sec_part;
ulong exec_time;
enum_event_cache_type cache_type;
enum enum_binlog_checksum_alg checksum_alg;
ha_checksum crc;
my_bool is_flashback;
my_bool need_flashback_review;
String output_buf;
```
#### Not initialized in `MYSQL_SERVER` either
```c++
bool event_owns_temp_buf;
size_t data_written;
ulong slave_exec_mode;
Log_event_writer *writer;
```

</details>

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] ~~I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.~~
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.