### PR TITLE
MDEV-17846  Wrong result with grouping select from merged derived table

### DIFF
--- a/mysql-test/main/derived.result
+++ b/mysql-test/main/derived.result
@@ -1501,4 +1501,29 @@ SELECT * FROM v6_t;
 ERROR HY000: View 'test.v6_t' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
 DROP VIEW v1_t, v2_t, v3_t, v4_t, v5_t, v6_t;
 DROP TABLE t;
+#
+# MDEV-17846 Wrong result with grouping select from merged derived table
+#
+CREATE TABLE t1 (f1 int);
+INSERT INTO t1 VALUES (1),(2);
+CREATE TABLE t2 (f1 int, t1_f1 int);
+INSERT INTO t2 VALUES (674,1),(679,1),(684,1),(689,1),(694,1),(901,1),(608,1),
+(610,1),(299,1),(667,1),(51951034,2),(281,2),(116,2),(740,2),(974,2);
+SET optimizer_switch = 'derived_merge=off';
+SELECT  dt.tf1,
+(SELECT COUNT(dt.tf1) FROM t1 WHERE t1.f1 = dt.tf1 AND dt.tf1 = 1) AS val
+FROM (SELECT t1.f1 AS tf1, t2.f1 FROM t1 JOIN t2 ON t1.f1 = t2.t1_f1) AS dt
+GROUP BY dt.tf1;
+tf1	val
+1	10
+2	NULL
+SET optimizer_switch = 'derived_merge=on';
+SELECT  dt.tf1,
+(SELECT COUNT(dt.tf1) FROM t1 WHERE t1.f1 = dt.tf1 AND dt.tf1 = 1) AS val
+FROM (SELECT t1.f1 AS tf1, t2.f1 FROM t1 JOIN t2 ON t1.f1 = t2.t1_f1) AS dt
+GROUP BY dt.tf1;
+tf1	val
+1	10
+2	NULL
+drop table t1, t2;
 # End of 10.11 tests

--- a/mysql-test/main/derived.test
+++ b/mysql-test/main/derived.test
@@ -1292,4 +1292,30 @@ SELECT * FROM v6_t;
 DROP VIEW v1_t, v2_t, v3_t, v4_t, v5_t, v6_t;
 DROP TABLE t;
 
+
+--echo #
+--echo # MDEV-17846 Wrong result with grouping select from merged derived table
+--echo #
+
+CREATE TABLE t1 (f1 int);
+INSERT INTO t1 VALUES (1),(2);
+
+CREATE TABLE t2 (f1 int, t1_f1 int);
+INSERT INTO t2 VALUES (674,1),(679,1),(684,1),(689,1),(694,1),(901,1),(608,1),
+(610,1),(299,1),(667,1),(51951034,2),(281,2),(116,2),(740,2),(974,2);
+
+let $q=
+SELECT  dt.tf1,
+  (SELECT COUNT(dt.tf1) FROM t1 WHERE t1.f1 = dt.tf1 AND dt.tf1 = 1) AS val
+FROM (SELECT t1.f1 AS tf1, t2.f1 FROM t1 JOIN t2 ON t1.f1 = t2.t1_f1) AS dt
+GROUP BY dt.tf1;
+
+SET optimizer_switch = 'derived_merge=off';
+eval $q;
+
+SET optimizer_switch = 'derived_merge=on';
+eval $q;
+
+drop table t1, t2;
+
 --echo # End of 10.11 tests

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -5900,6 +5900,48 @@ bool is_outer_table(TABLE_LIST *table, SELECT_LEX *select)
   return TRUE;
 }
 
+/**
+  @brief  check to see if we need to wrap this in an Item_outer_ref
+
+  @description
+    If an outer field is resolved in a grouping select then it
+    is replaced for an Item_outer_ref object. Otherwise an
+    Item_field object is used.
+    The new Item_outer_ref object is saved in the inner_refs_list of
+    the outer select. Here it is only created. It can be fixed only
+    after the original field has been fixed and this is done in the
+    fix_inner_refs() function.
+    Called only from Item_field::fix_outer_field, where *reference type
+    will be applicable.
+  @returns
+    false  normal execution
+    true   error
+*/
+static inline bool inner_refs_check(THD *thd,
+                             Name_resolution_context *last_checked_context,
+                             Name_resolution_context *context,
+                             SELECT_LEX *select,
+                             enum_parsing_place place,
+                             Item **reference)
+{
+  Item::Type ref_type= (*reference)->type();
+  if (!last_checked_context->select_lex->having_fix_field &&
+      select->group_list.elements &&
+      (place == SELECT_LIST || place == IN_HAVING))
+  {
+    DBUG_ASSERT(ref_type == Item::REF_ITEM || ref_type == Item::FIELD_ITEM);
+    Item_outer_ref *rf;
+    if (!(rf= new (thd->mem_root)
+                  Item_outer_ref(thd, context,(Item_ident*) (*reference))))
+      return true;
+    thd->change_item_tree(reference, rf);
+    if (select->inner_refs_list.push_back(rf, thd->mem_root))
+      return true;
+    rf->in_sum_func= thd->lex->in_sum_func;
+  }
+  return false;
+}
+
 
 /**
   Resolve the name of an outer select column reference.
@@ -6071,27 +6113,9 @@ Item_field::fix_outer_field(THD *thd, Field **from_field, Item **reference)
             prev_subselect_item->const_item_cache= 0;
           }
           set_field(*from_field);
-          if (!last_checked_context->select_lex->having_fix_field &&
-              select->group_list.elements &&
-              (place == SELECT_LIST || place == IN_HAVING))
-          {
-            Item_outer_ref *rf;
-            /*
-              If an outer field is resolved in a grouping select then it
-              is replaced for an Item_outer_ref object. Otherwise an
-              Item_field object is used.
-              The new Item_outer_ref object is saved in the inner_refs_list of
-              the outer select. Here it is only created. It can be fixed only
-              after the original field has been fixed and this is done in the
-              fix_inner_refs() function.
-            */
-            ;
-            if (!(rf= new (thd->mem_root) Item_outer_ref(thd, context, this)))
-              return -1;
-            thd->change_item_tree(reference, rf);
-            select->inner_refs_list.push_back(rf, thd->mem_root);
-            rf->in_sum_func= thd->lex->in_sum_func;
-          }
+          if (inner_refs_check(thd, last_checked_context, context, select,
+                               place, reference))
+            return -1;
           /*
             A reference is resolved to a nest level that's outer or the same as
             the nest level of the enclosing set function : adjust the value of
@@ -6125,6 +6149,11 @@ Item_field::fix_outer_field(THD *thd, Field **from_field, Item **reference)
                             ((ref_type == REF_ITEM || ref_type == FIELD_ITEM) ?
                              (Item_ident*) (*reference) :
                              0), false);
+
+          if (inner_refs_check(thd, last_checked_context, context, select,
+                               place, reference))
+            return -1;
+
           if (thd->lex->in_sum_func &&
               last_checked_context->select_lex->parent_lex ==
               context->select_lex->parent_lex &&

--- a/sql/item.h
+++ b/sql/item.h
@@ -6631,7 +6631,7 @@ public:
   bool found_in_select_list;
   bool found_in_group_by;
   Item_outer_ref(THD *thd, Name_resolution_context *context_arg,
-                 Item_field *outer_field_arg):
+                 Item_ident *outer_field_arg):
     Item_direct_ref(thd, context_arg, 0, outer_field_arg->table_name,
                     outer_field_arg->field_name),
     outer_ref(outer_field_arg), in_sum_func(0),


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-17846*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

When a grouping select referring to a derived table has an outer reference within it's select list, that outer reference isn't properly fixed.  It isn't added to    outer_context->select_lex->inner_refs_list for later resolution during JOIN::prepare.
As it is not fixed, the Item pointer arrays associated with the temporary table filled during the join process are now incorrect and we end up with an incorrect join->outer_ref_cond evaluation and potentially a wrong result.


## Release Notes
Wrong result with grouping select from merged derived table

## How can this PR be tested?

mtr main.derived

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
