### PR TITLE
MDEV-37308 main.failed_auth_unixsocket fails

### DIFF
--- a/mysql-test/main/failed_auth_unixsocket.result
+++ b/mysql-test/main/failed_auth_unixsocket.result
@@ -4,7 +4,7 @@ delete from mysql.global_priv where user != 'root';
 flush privileges;
 connect(localhost,USER,,test,MASTER_PORT,MASTER_SOCKET);
 ERROR 28000: Access denied for user 'USER'@'localhost'
-change_user buildbot,,;
+change_user USER,,;
 ERROR 28000: Access denied for user 'USER'@'localhost'
 replace mysql.global_priv select * from global_priv_backup;
 flush privileges;

--- a/mysql-test/main/failed_auth_unixsocket.test
+++ b/mysql-test/main/failed_auth_unixsocket.test
@@ -20,7 +20,7 @@ let $replace=Access denied for user '$USER';
 connect (fail,localhost,$USER);
 --enable_query_log
 
---replace_result $replace "Access denied for user 'USER'"
+--replace_result $USER USER
 --error ER_ACCESS_DENIED_NO_PASSWORD_ERROR
 change_user $USER;
 


### PR DESCRIPTION
Don't log the change_user result to the test result file.
