### PR TITLE
MDEV-37296 ALTER TABLE allows adding unique hash key with duplicate values

### DIFF
--- a/mysql-test/suite/innodb/r/alter_copy_bulk.result
+++ b/mysql-test/suite/innodb/r/alter_copy_bulk.result
@@ -112,3 +112,25 @@ SET innodb_lock_wait_timeout=default;
 DROP TABLE t1;
 DROP TABLE IF EXISTS t2;
 # restart
+#
+#  MDEV-37296 ALTER TABLE allows adding unique hash key
+#		with duplicate values
+#
+CREATE TABLE t (pk INT PRIMARY KEY, a INT, b TEXT) ENGINE=InnoDB;
+INSERT INTO t VALUES (5,3,'foo'), (1,NULL,'bar'), (3,3,'foo');
+ALTER TABLE t ADD UNIQUE (a,b);
+ERROR 23000: Duplicate entry '3-foo' for key 'a'
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `pk` int(11) NOT NULL,
+  `a` int(11) DEFAULT NULL,
+  `b` text DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+SELECT * FROM t;
+pk	a	b
+1	NULL	bar
+3	3	foo
+5	3	foo
+DROP TABLE t;

--- a/mysql-test/suite/innodb/t/alter_copy_bulk.test
+++ b/mysql-test/suite/innodb/t/alter_copy_bulk.test
@@ -130,3 +130,15 @@ SET innodb_lock_wait_timeout=default;
 DROP TABLE t1;
 DROP TABLE IF EXISTS t2;
 --source include/restart_mysqld.inc
+
+--echo #
+--echo #  MDEV-37296 ALTER TABLE allows adding unique hash key
+--echo #		with duplicate values
+--echo #
+CREATE TABLE t (pk INT PRIMARY KEY, a INT, b TEXT) ENGINE=InnoDB;
+INSERT INTO t VALUES (5,3,'foo'), (1,NULL,'bar'), (3,3,'foo');
+--error ER_DUP_ENTRY
+ALTER TABLE t ADD UNIQUE (a,b);
+SHOW CREATE TABLE t;
+SELECT * FROM t;
+DROP TABLE t;

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -2171,6 +2171,11 @@ struct dict_table_t {
                       (as part of rolling back TRUNCATE) */
   dberr_t rename_tablespace(span<const char> new_name, bool replace) const;
 
+  /** Whether the table is eligible to do bulk insert operation
+  @param trx transaction which tries to do bulk insert
+  @retval true if table can do bulk insert
+  @retval false otherwise */
+  bool can_bulk_insert(const trx_t &trx) const noexcept;
 private:
 	/** Initialize instant->field_map.
 	@param[in]	table	table definition to copy from */

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2619,6 +2619,21 @@ static uint64_t row_parse_int(const byte *data, size_t len,
   return 0;
 }
 
+inline bool dict_table_t::can_bulk_insert(const trx_t &trx) const noexcept
+{
+  if (is_temporary() || versioned() || has_spatial_index())
+    return false;
+  /* Bulk insert is not compatible with HA_CHECK_UNIQUE_AFTER_WRITE.
+  Refuse bulk insert if HA_KEY_ALG_LONG_HASH indexes exist.
+  handler::ha_check_long_uniques() assumes that all data
+  passed to ha_innobase::write_row() is available immediately. */
+  if (const char *s= v_col_names)
+    for (auto n= n_v_cols; n--; s+= strlen(s) + 1)
+      if (!strncmp(s, C_STRING_WITH_LEN("DB_ROW_HASH_")))
+        return false; /* make_long_hash_field_name() */
+  return !trx.check_foreigns || (foreign_set.empty() && referenced_set.empty());
+}
+
 /***************************************************************//**
 Tries to insert an entry into a clustered index, ignoring foreign key
 constraints. If a record with the same unique key is found, the other
@@ -2824,12 +2839,7 @@ avoid_bulk:
 		/* If foreign key exist and foreign key is enabled
 		then avoid using bulk insert for copy algorithm */
 		if (innodb_alter_copy_bulk
-		    && !index->table->is_temporary()
-		    && !index->table->versioned()
-		    && !index->table->has_spatial_index()
-		    && (!trx->check_foreigns
-                        || (index->table->foreign_set.empty()
-                            && index->table->referenced_set.empty()))) {
+		    && index->table->can_bulk_insert(*trx)) {
 			ut_ad(page_is_empty(block->page.frame));
 			/* This code path has been executed at the
 			start of the alter operation. Consecutive


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37296*

## Description
Problem:
=======
- During copy algorithm, InnoDB fails to detect the duplicate key error for unique hash key blob index. Unique HASH index treated as virtual index inside InnoDB. So bulk insert operation doesn't detect the duplicate key error while building the index.

Solution:
========
- Avoid bulk insert operation when table does have unique hash key blob index.

has_unique_blob(): Check whether the table has any unique blob index

dict_table_t::unique_blob : Indicates that table has long unique blob column

## Release Notes
Avoid the bulk insert operation for copy algorithm When table has unique blob index.

## How can this PR be tested?
./mtr innodb.alter_copy_bulk

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.