### PR TITLE
MDEV-35224 ASAN error in mariadb client with \c

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2876,7 +2876,10 @@ static void fix_history(String *final_command)
     ptr++;
   }
   if (total_lines > 1)			
+  {
+    fixed_buffer.append('\0');
     add_history(fixed_buffer.ptr());
+  }
 }
 
 /*	


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Mariadb monitor when a line is cancelled, provided its more than one line, passes that text to the
add_history of libedit. This string that has been
passed however isn't null terminated resulting
in an ASAN error within the libedit code.

fix_history where the add_history is called
is called by the com_clear, associated with
the \c command, and com_go. An additional null
character onto the end of the string in the
com_go case harmless.

## Release Notes

not noteworthy

## How can this PR be tested?

compile under asan.
Enter two lines followed by \c into the monitor.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
