### PR TITLE
MDEV-36385 Fix slave_parallel_threads_basic test in view-protocol mode

### DIFF
--- a/mysql-test/suite/sys_vars/r/slave_parallel_threads_basic.result
+++ b/mysql-test/suite/sys_vars/r/slave_parallel_threads_basic.result
@@ -1,6 +1,6 @@
 SET @save_slave_parallel_threads= @@GLOBAL.slave_parallel_threads;
-SELECT IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
-IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*)))
+SELECT IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) AS ProcessCheck FROM information_schema.processlist WHERE user = "system user";
+ProcessCheck
 OK
 SELECT @@GLOBAL.slave_parallel_threads as 'must be 20 because of .cnf';
 must be 20 because of .cnf
@@ -16,7 +16,7 @@ SET GLOBAL slave_parallel_threads= 10;
 SELECT @@GLOBAL.slave_parallel_threads;
 @@GLOBAL.slave_parallel_threads
 10
-SELECT IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
-IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*)))
+SELECT IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) AS ProcessCheck FROM information_schema.processlist WHERE user = "system user";
+ProcessCheck
 OK
 SET GLOBAL slave_parallel_threads = @save_slave_parallel_threads;

--- a/mysql-test/suite/sys_vars/t/slave_parallel_threads_basic.test
+++ b/mysql-test/suite/sys_vars/t/slave_parallel_threads_basic.test
@@ -4,7 +4,7 @@ SET @save_slave_parallel_threads= @@GLOBAL.slave_parallel_threads;
 
 # Check that we don't spawn worker threads at server startup, when no
 # slave is configured (MDEV-5289).
-SELECT IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
+SELECT IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) AS ProcessCheck FROM information_schema.processlist WHERE user = "system user";
 
 SELECT @@GLOBAL.slave_parallel_threads as 'must be 20 because of .cnf';
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
@@ -16,6 +16,6 @@ SELECT @@GLOBAL.slave_parallel_threads as 'must be 0 because of default';
 SET GLOBAL slave_parallel_threads= 10;
 SELECT @@GLOBAL.slave_parallel_threads;
 # Check that we don't spawn worker threads when no slave is started.
-SELECT IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
+SELECT IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) AS ProcessCheck FROM information_schema.processlist WHERE user = "system user";
 
 SET GLOBAL slave_parallel_threads = @save_slave_parallel_threads;


### PR DESCRIPTION
## Description

Add explicit column aliases to `SELECT` statements in `slave_parallel_threads_basic` to ensure consistent column names across both normal and view-protocol modes.

The test `sys_vars.slave_parallel_threads_basic.test` was failing in view-protocol mode due to different column naming behavior. Without an explicit column alias, view-protocol mode generates an automatic name (`Name_exp_1`) while normal mode uses the full expression as the column name.

## Release Notes

N/A

## How can this PR be tested?

Execute the test `slave_parallel_threads_basic` in view-protocol mode using `./build/mysql-test/mysql-test-run.pl --force --parallel=auto --skip-rpl --view-protocol sys_vars.slave_parallel_threads_basic`. 

**Before this change**

The test fails like so:
```
==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
worker[01] mysql-test-run: WARNING: running this script as _root_ will cause some tests to be skipped
sys_vars.slave_parallel_threads_basic    [ fail ]
        Test ended at 2025-07-30 20:57:36

CURRENT_TEST: sys_vars.slave_parallel_threads_basic
--- /quick-rebuilds/mariadb/mysql-test/suite/sys_vars/r/slave_parallel_threads_basic.result 2025-07-30 20:57:14.885187447 +0000
+++ /quick-rebuilds/mariadb/mysql-test/suite/sys_vars/r/slave_parallel_threads_basic.reject 2025-07-30 20:57:36.515713109 +0000
@@ -1,6 +1,6 @@
 SET @save_slave_parallel_threads= @@GLOBAL.slave_parallel_threads;
 SELECT IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
-IF(COUNT(*) < 20, "OK", CONCAT("Found too many system user processes: ", COUNT(*)))
+Name_exp_1
 OK
 SELECT @@GLOBAL.slave_parallel_threads as 'must be 20 because of .cnf';
 must be 20 because of .cnf
@@ -17,6 +17,6 @@
 @@GLOBAL.slave_parallel_threads
 10
 SELECT IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*))) FROM information_schema.processlist WHERE user = "system user";
-IF(COUNT(*) < 10, "OK", CONCAT("Found too many system user processes: ", COUNT(*)))
+Name_exp_1
 OK
 SET GLOBAL slave_parallel_threads = @save_slave_parallel_threads;

Result length mismatch

 - saving '/quick-rebuilds/build/mysql-test/var/log/sys_vars.slave_parallel_threads_basic/' to '/quick-rebuilds/build/mysql-test/var/log/sys_vars.slave_parallel_threads_basic/'
--------------------------------------------------------------------------
```

**After this change**

The test passes in both normal and view-protocol mode:
```
==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
worker[01] mysql-test-run: WARNING: running this script as _root_ will cause some tests to be skipped
sys_vars.slave_parallel_threads_basic    [ pass ]      5
--------------------------------------------------------------------------
```

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.
