### PR TITLE
MGL-51 Diagnostics_area does not always contain apply error info

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_vote_majority_dml.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_vote_majority_dml.result
@@ -1,0 +1,69 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 BLOB) ENGINE=InnoDB;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_3;
+SET GLOBAL wsrep_on=OFF;
+ALTER TABLE t1 MODIFY f2 LONGTEXT;
+SET GLOBAL wsrep_on=ON;
+INSERT INTO t1 VALUES (3, 'a');
+connection node_1;
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Primary
+connection node_2;
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Primary
+INSERT INTO t1 VALUES (2, 'a');
+connection node_3;
+SET SESSION wsrep_on=OFF;
+# restart
+SET SESSION wsrep_on=ON;
+INSERT INTO t1 VALUES (3, 'a');
+connection node_1;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int(11) NOT NULL,
+  `f2` blob DEFAULT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+SELECT * FROM t1;
+f1	f2
+2	a
+3	a
+connection node_2;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int(11) NOT NULL,
+  `f2` blob DEFAULT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+SELECT * FROM t1;
+f1	f2
+2	a
+3	a
+connection node_3;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int(11) NOT NULL,
+  `f2` blob DEFAULT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+SELECT * FROM t1;
+f1	f2
+2	a
+3	a
+DROP TABLE t1;
+connection node_1;
+CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+connection node_2;
+CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+connection node_3;
+CALL mtr.add_suppression("Vote 0 \\(success\\) on (.*) is inconsistent with group. Leaving cluster.");
+CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");

--- a/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.cnf
@@ -1,0 +1,5 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep-ignore-apply-errors=0
+

--- a/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.test
@@ -1,0 +1,63 @@
+#
+#  MGL-36 Inconsistency voting: If in a 3-node cluster two nodes vote
+#  identically for error the remaining node should leave
+#
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 BLOB) ENGINE=InnoDB;
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
+SET GLOBAL wsrep_on=OFF;
+ALTER TABLE t1 MODIFY f2 LONGTEXT; # Introducing schema inconsistency
+SET GLOBAL wsrep_on=ON;
+INSERT INTO t1 VALUES (3, 'a'); # Nodes 1 and 2 should fail to apply this
+
+--connection node_1
+# Wait until node #3 leaves the cluster
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_status';
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+# Wait until node #3 leaves the cluster
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_status';
+
+INSERT INTO t1 VALUES (2, 'a'); # Nodes 1 and 2 should successfully apply this
+
+--connection node_3
+SET SESSION wsrep_on=OFF;
+--source include/restart_mysqld.inc
+--source include/wait_wsrep_ready.inc
+SET SESSION wsrep_on=ON;
+
+INSERT INTO t1 VALUES (3, 'a'); # All nodes should successfully apply this
+
+# Check that consistency is restored
+--connection node_1
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+--connection node_2
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+--connection node_3
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--connection node_1
+CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+
+--connection node_2
+CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+
+--connection node_3
+CALL mtr.add_suppression("Vote 0 \\(success\\) on (.*) is inconsistent with group. Leaving cluster.");
+CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -83,9 +83,35 @@ wsrep_get_apply_format(THD* thd)
   return thd->wsrep_rgi->rli->relay_log.description_event_for_exec;
 }
 
-void wsrep_store_error(const THD* const thd,
-                       wsrep::mutable_buffer& dst,
-                       bool const include_msg)
+/* store error from rli */
+static void wsrep_store_error_rli(const THD* const thd,
+                                  wsrep::mutable_buffer& dst,
+                                  bool const include_msg)
+{
+  Slave_reporting_capability* const rli= thd->wsrep_rgi->rli;
+  if (rli && rli->last_error().number != 0)
+  {
+    auto error= rli->last_error();
+    std::ostringstream os;
+    if (include_msg)
+    {
+      os << error.message << ",";
+    }
+    os << " Error_code: " << error.number << ';';
+    std::string const err_str= os.str();
+    dst.resize(err_str.length() + 1);
+    sprintf(dst.data(), "%s", err_str.c_str());
+
+    WSREP_DEBUG("Error buffer (RLI) for thd %u seqno %lld, %zu bytes: '%s'",
+                thd->thread_id, (long long)wsrep_thd_trx_seqno(thd),
+                dst.size(), dst.size() ? dst.data() : "(null)");
+  }
+}
+
+/* store error from diagnostic area */
+static void wsrep_store_error_da(const THD* const thd,
+                                 wsrep::mutable_buffer& dst,
+                                 bool const include_msg)
 {
   Diagnostics_area::Sql_condition_iterator it=
     thd->get_stmt_da()->sql_conditions();
@@ -123,9 +149,32 @@ void wsrep_store_error(const THD* const thd,
 
   dst.resize(slider - dst.data());
 
-  WSREP_DEBUG("Error buffer for thd %llu seqno %lld, %zu bytes: '%s'",
+  WSREP_DEBUG("Error buffer (DA) for thd %llu seqno %lld, %zu bytes: '%s'",
               thd->thread_id, (long long)wsrep_thd_trx_seqno(thd),
               dst.size(), dst.size() ? dst.data() : "(null)");
+}
+
+/* store error info after applying error */
+void wsrep_store_error(const THD* const thd,
+                       wsrep::mutable_buffer& dst,
+                       bool const include_msg)
+{
+  dst.clear();
+  wsrep_store_error_da(thd, dst, include_msg);
+  if (dst.size() == 0)
+  {
+    wsrep_store_error_rli(thd, dst, include_msg);
+  }
+  if (dst.size() == 0)
+  {
+    WSREP_WARN("Failed to get apply error description from either "
+               "Relay_log_info or Diagnostics_area, will use random data.");
+    assert(0);
+    uintptr_t const data= reinterpret_cast<uintptr_t>(dst.data());
+    size_t const data_size= sizeof(data);
+    const char* const data_ptr= reinterpret_cast<const char*>(&data);
+    dst.push_back(data_ptr, data_ptr + data_size);
+  }
 }
 
 int wsrep_apply_events(THD*        thd,


### PR DESCRIPTION
It appears that some error conditions don't store error information in the Diagnostics_area. For example when table_def::compatible_with() check fails error message is stored in Relay_log_info instead. This results in optimistically identical votes and zero error buffer size breaks wsrep-lib logic as it relies on error buffer size to decide whether voting took place.
To account for this, first try to obtain error info from Diagnostics_area, then fallback to Relay_log_info. If that fails use some "random" data to distinguish this condition from success.

This requires bumping of the application protocol to 5 since vote message generation algorithm has changed.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
