### PR TITLE
MDEV-37366: Inconsistency detected - create sequence

### DIFF
--- a/mysql-test/suite/galera/r/MENT-2297.result
+++ b/mysql-test/suite/galera/r/MENT-2297.result
@@ -1,0 +1,27 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_1;
+SET SESSION binlog_row_image=minimal;
+CREATE SEQUENCE `seq_test` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB;
+SHOW CREATE TABLE seq_test;
+Table	Create Table
+seq_test	CREATE TABLE `seq_test` (
+  `next_not_cached_value` bigint(21) NOT NULL,
+  `minimum_value` bigint(21) NOT NULL,
+  `maximum_value` bigint(21) NOT NULL,
+  `start_value` bigint(21) NOT NULL COMMENT 'start value when sequences is created or value if RESTART is used',
+  `increment` bigint(21) NOT NULL COMMENT 'increment value',
+  `cache_size` bigint(21) unsigned NOT NULL,
+  `cycle_option` tinyint(1) unsigned NOT NULL COMMENT '0 if no cycles are allowed, 1 if the sequence should begin a new cycle when maximum_value is passed',
+  `cycle_count` bigint(21) NOT NULL COMMENT 'How many cycles have been done'
+) ENGINE=InnoDB SEQUENCE=1
+SELECT NEXT VALUE FOR seq_test;
+NEXT VALUE FOR seq_test
+1
+SELECT NEXT VALUE FOR seq_test;
+NEXT VALUE FOR seq_test
+3
+connection node_2;
+DROP SEQUENCE seq_test;

--- a/mysql-test/suite/galera/t/MENT-2297.test
+++ b/mysql-test/suite/galera/t/MENT-2297.test
@@ -1,0 +1,52 @@
+#
+# MENT-2297: Inconsistency detected - create sequence
+# Failed 'SELECT NEXT VALUE' on applier node.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/big_test.inc
+--source include/have_log_bin.inc
+
+#
+# Save original auto_increment_offset values.
+#
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+#
+# Verify there are two nodes in galera cluster.
+#
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+#
+# Create a sequence table on node1.
+#
+SET SESSION binlog_row_image=minimal;
+CREATE SEQUENCE `seq_test` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB;
+SHOW CREATE TABLE seq_test;
+
+#
+# Execute 'SELECT NEXT VALUE' which should not fail on applier node.
+#
+SELECT NEXT VALUE FOR seq_test;
+SELECT NEXT VALUE FOR seq_test;
+
+
+#
+# Verify there are two nodes in galera cluster.
+#
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+
+#
+# Cleanup
+#
+--connection node_2
+# Restore original variable values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+DROP SEQUENCE seq_test;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -7952,6 +7952,19 @@ void TABLE::mark_columns_per_binlog_row_image()
   if (file->row_logging &&
       !ha_check_storage_engine_flag(s->db_type(), HTON_NO_BINLOG_ROW_OPT))
   {
+#ifdef WITH_WSREP
+    /**
+     The marking of all columns will prevent update/set column values for the
+     sequence table. For the sequence table column bitmap sent from master is
+     used.
+    */
+    if (WSREP(thd) && wsrep_thd_is_applying(thd) &&
+        s->sequence && s->primary_key >= MAX_KEY)
+    {
+      DBUG_VOID_RETURN;
+    }
+#endif /* WITH_WSREP */
+
     /* if there is no PK, then mark all columns for the BI. */
     if (s->primary_key >= MAX_KEY)
     {


### PR DESCRIPTION
Issue:
When applying 'SELECT NEXT VALUE..' on applier node with  binlog_row_image=MINIMAL and log-binlog enabled, applier node fails with below error:
  Slave SQL: Could not execute Write_rows_v1 event on table monitor.seq_moni_num; Unknown error, Error_code: 1105; handler error No Error!; the event's master log FIRST, end_log_pos 0, Internal MariaDB error code: 1105

To reproduce run below command on the first/active node:

> CREATE SEQUENCE `seq_test` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB;
> SELECT NEXT VALUE FOR seq_test;
> SELECT NEXT VALUE FOR seq_test;

The applier node will leave the cluster after executing the 'SELECT NEXT VALUE' with below error:

ERROR] Slave SQL: Could not execute Write_rows_v1 event on table test.seq_test; Unknown error, Error_code: 1105; handler error No Error!; the event's master log FIRST, end_log_pos 0, Internal MariaDB error code: 1105
[Warning] WSREP: Event 3 Write_rows_v1 apply failed: 195, seqno 14511334511

Solution:
When binary loggging is enabled and binlog_row_image is set to 'MINIMAL', then 'SELECT NEXT VALUE' fails to apply on applier node. It fails with error HA_ERR_SEQUENCE_INVALID_DATA 195 in sequence_definition::check_and_adjust() because sequence variables like min_value, max_value, start are 0. The marking of all columns in 'TABLE::mark_columns_per_binlog_row_image()' will prevent update/set column values for the sequence table. For the sequence table column bitmap sent from master is only used.

void TABLE::mark_columns_per_binlog_row_image()
{
...
  /* if there is no PK, then mark all columns for the BI. */
  if (s->primary_key >= MAX_KEY)
  {
    bitmap_set_all(read_set);
    rpl_write_set= read_set;
  }
...
}

int Rows_log_event::update_sequence()
{
...

  if (!bitmap_is_set(table->rpl_write_set, MIN_VALUE_FIELD_NO) ||
  ...
  {
    /* This event come from a setval function executed on the master.
         Update the sequence next_number and round, like we do with setval()
    */
    ...
    return table->s->sequence->set_value(table, nextval, round, 0) > 0;
  }
...
}

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
