### PR TITLE
MDEV-36701 command line client doesn't check session_track informatio…

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3199,20 +3199,17 @@ static int reconnect(void)
 }
 
 #ifndef EMBEDDED_LIBRARY
-static void status_info_cb(void *data, enum enum_mariadb_status_info type, ...)
+static void status_info_cb(void *data, enum enum_mariadb_status_info type,
+  enum enum_session_state_type state_type, MARIADB_CONST_STRING *val)
 {
-  va_list ap;
-  va_start(ap, type);
-  if (type == SESSION_TRACK_TYPE && va_arg(ap, int) == SESSION_TRACK_SCHEMA)
+  if (type == SESSION_TRACK_TYPE && state_type == SESSION_TRACK_SCHEMA)
   {
-    MARIADB_CONST_STRING *val= va_arg(ap, MARIADB_CONST_STRING *);
     my_free(current_db);
     if (val->length)
       current_db= my_strndup(PSI_NOT_INSTRUMENTED, val->str, val->length, MYF(MY_FAE));
     else
       current_db= NULL;
   }
-  va_end(ap);
 }
 #else
 #define mysql_optionsv(A,B,C,D) do { } while(0)


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Corrects clang Wvargs warning:

client/mysql.cc:3205:16: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]

Because there is only one mode we are interested in that is tested before the varargs this is safe to do.

## Release Notes

nothing

## How can this PR be tested?

look for compile warnings under recent clang (msan builder or macos)

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
