### PR TITLE
MDEV-37360: SIGSEGV in srv_printf_innodb_monitor

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -804,9 +804,13 @@ srv_printf_innodb_monitor(
 	ibuf_print(file);
 
 #ifdef BTR_CUR_HASH_ADAPT
-	for (ulint i = 0; i < btr_ahi_parts && btr_search_enabled; ++i) {
+	for (ulint i = 0; i < btr_ahi_parts; ++i) {
 		const auto part= &btr_search_sys.parts[i];
 		part->latch.rd_lock(SRW_LOCK_CALL);
+		if (!btr_search_enabled) {
+			part->latch.rd_unlock();
+			break;
+		}
 		ut_ad(part->heap->type == MEM_HEAP_FOR_BTR_SEARCH);
 		fprintf(file, "Hash table size " ULINTPF
 			", node heap has " ULINTPF " buffer(s)\n",


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37360*
## Description
`srv_printf_innodb_monitor()`: After acquiring a latch, abort the iteration if `innodb_adaptive_hash_index=OFF`. If the adaptive hash index was disabled in a concurrently executing thread, `btr_search_sys_t::partition::clear()` would have freed `part->heap`, leading to us dereferencing a null pointer.
## Release Notes
InnoDB could crash if `innodb_adaptive_hash_index` is being disabled while `SHOW ENGINE INNODB STATUS` is executing.
## How can this PR be tested?
Concurrent connections executing the following statements:
```sql
SET GLOBAL innodb_adaptive_hash_index=ON;
SET GLOBAL innodb_adaptive_hash_index=ON;
SHOW ENGINE INNODB STATUS;
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.