### PR TITLE
MDEV-36159 mariabackup failed after upgrade

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -2068,6 +2068,7 @@ ulonglong get_current_lsn(MYSQL *connection)
 {
 	static const char lsn_prefix[] = "\nLog sequence number ";
 	ulonglong lsn = 0;
+	msg("Getting InnoDB LSN");
 	if (MYSQL_RES *res = xb_mysql_query(connection,
 					    "SHOW ENGINE INNODB STATUS",
 					    true, false)) {
@@ -2081,5 +2082,10 @@ ulonglong get_current_lsn(MYSQL *connection)
 		}
 		mysql_free_result(res);
 	}
+	msg("InnoDB LSN: %llu, Flushing Logs", lsn);
+        /* Make sure that current LSN is written and flushed to disk. */
+	xb_mysql_query(connection, "FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS",
+		       false, false);
+	msg("Flushed Logs");
 	return lsn;
 }

--- a/mysql-test/suite/mariabackup/full_backup.test
+++ b/mysql-test/suite/mariabackup/full_backup.test
@@ -10,7 +10,7 @@ let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
 --error 1
 exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=4095 > $backup_log 2>&1;
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=10000 > $backup_log 2>&1;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir --parallel=10 --innodb-log-write-ahead-size=10000 --innodb_log_checkpoint_now=1 > $backup_log 2>&1;
 --enable_result_log
 
 # The following warning must not appear after MDEV-27343 fix

--- a/mysql-test/suite/mariabackup/partial.test
+++ b/mysql-test/suite/mariabackup/partial.test
@@ -14,7 +14,7 @@ echo # xtrabackup backup;
 
 let targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables=test.*1" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables=test.*1" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 list_files $targetdir/test *.ibd;
 list_files $targetdir/test *.new;
@@ -96,6 +96,7 @@ exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --tables-file
 --enable_result_log
 
 --echo # table t2 is skipped. Shows only t1
+--replace_result .new .ibd
 list_files $targetdir/test;
 DROP TABLE t2, t1;
 rmdir $targetdir;

--- a/mysql-test/suite/mariabackup/partial_exclude.test
+++ b/mysql-test/suite/mariabackup/partial_exclude.test
@@ -28,7 +28,7 @@ echo # xtrabackup backup;
 
 let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.*2" "--databases-exclude=db2" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.*2" "--databases-exclude=db2" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 
 COMMIT;

--- a/mysql-test/suite/mariabackup/unsupported_redo.test
+++ b/mysql-test/suite/mariabackup/unsupported_redo.test
@@ -58,7 +58,7 @@ ALTER TABLE t21 FORCE, ALGORITHM=INPLACE;
 --echo # unsupported redo log for the table t21.
 
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.t21" --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10 "--tables-exclude=test.t21" --target-dir=$targetdir --innodb_log_checkpoint_now=1;
 --enable_result_log
 --list_files $targetdir/test *.ibd
 --list_files $targetdir/test *.new


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36159*
## Description
Ever since commit 685d958e38b825ad9829be311f26729cccf37c46 (MDEV-14425) `mariadb-backup --backup` had some trouble to keep up with write workloads of the `mariadbd` server.

Debarun Banerjee found out that `mariadb-backup --backup` was copying the log in the wrong way and not pausing when it made sense to do so. This change includes his fix as well (#4178) as some dead code removal from `xtrabackup_copy_mmap_logfile()`.

Some earlier changes to the default behaviour of `mariadb-backup --backup` will be reverted, by making the configuration parameters OFF by default. These parameters were basically working around this bug:

* #3866 introduced `--innodb-log-checkpoint-now` and made it ON by default. Making the server execute a log checkpoint can be really I/O intensive.
* #3282 introduced `--innodb-log-file-mmap` and made it ON by default on Linux and FreeBSD. There are no documented semantics what should happen to a memory mapping when there are concurrent `pwrite(2)` operations by other processes. While it appears to work, it is safer to default to clearly documented semantics.

`xtrabackup_copy_logfile()`: Add a parameter early_exit. Always read a log snippet to the start of `recv_sys.buf` and assign `recv_sys.len` to the read length. We used to shift `recv_sys.buf` with `memmove()`. However, on `recv_sys_t::PREMATURE_EOF` we cannot know which part of the mini-transaction was correctly read, because that part of the `ib_logfile0` may be concurrently modified by the server. So, we will reread everything from the start of the mini-transaction.

`xtrabackup_backup_func()`: Invoke `xtrabackup_copy_logfile(true)`, allowing it to stop on every `recv_sys_t::PREMATURE_EOF`. This will also avoid repeated "Retry" messages when there is no more redo log to copy.

`get_current_lsn()`: Execute `FLUSH ENGINE LOGS` to ensure that InnoDB will complete any buffered writes to the `ib_logfile0` and ensure that everything up to the current LSN has been written.

`backup_wait_for_commit_lsn()`: Wait for as much as is really needed. This avoids an extra 5-second wait at the end of the backup.

`xtrabackup_copy_mmap_logfile()`: Remove some dead code, and add debug assertions to demonstrate that the parser can only return `recv_sys_t::OK` or `recv_sys_t::GOT_EOF`.
## Release Notes
`mariadb-backup` will default to `--innodb-log-file-mmap=OFF` and `--innodb-log-checkpoint-now=OFF`. The `mariadb-backup --backup` operation should now complete much faster.
## How can this PR be tested?
I tested this with a concurrent DDL+DML workload by starting `mariadb-backup --backup` 10 seconds into a `sysbench prepare` operation. Some regression tests were revised as well.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.