### PR TITLE
MDEV-37120 Improve timeout log message clarity for empty binlog state

### DIFF
--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -964,7 +964,8 @@ int Repl_semi_sync_master::commit_trx(const char *trx_wait_binlog_name,
          * semi-sync was turned off then on, so on debug builds, we track
          * the number of times semi-sync turned off at binlogging, and compare
          * to the current value. */
-        DBUG_ASSERT(rpl_semi_sync_master_off_times > thd->expected_semi_sync_offs);
+        DBUG_ASSERT(rpl_semi_sync_master_off_times >
+                    thd->expected_semi_sync_offs);
 
         break;
       }
@@ -1033,10 +1034,11 @@ int Repl_semi_sync_master::commit_trx(const char *trx_wait_binlog_name,
       if (wait_result != 0)
       {
         /* This is a real wait timeout. */
-        sql_print_warning("Timeout waiting for reply of binlog (file: %s, pos: %lu), "
-                          "semi-sync up to file %s, position %lu.",
+        sql_print_warning("Timeout waiting for reply of binlog (file: %s, pos:"
+                          " %lu), last semi-sync at file %s, position %lu.",
                           trx_wait_binlog_name, (ulong)trx_wait_binlog_pos,
-                          m_reply_file_name, (ulong)m_reply_file_pos);
+                          (m_reply_file_name[0] == '\0') ? "(none)" :
+                           m_reply_file_name, (ulong)m_reply_file_pos);
         rpl_semi_sync_master_wait_timeouts++;
 
         /* switch semi-sync off */


### PR DESCRIPTION
## Description

This PR addresses issue where semi-sync replication timeout log messages were confusing when no previous successful replication had occurred.

The fix involves:

1. Replacing empty file name with "(none)" when displaying semi-sync position
2. Changing "semi-sync up to file" to "last semi-sync at file" for better semantic accuracy

## How can this PR be tested?

Run the semi-sync replication test and check log messages:

```
build/mysql-test/mtr rpl.rpl_semi_sync
```

Look for timeout warning messages in the error log to verify they now show "(none)" instead of an empty file name.

```
> cat build/mysql-test/var/log/mysqld.1.err
...
2025-08-21 17:15:28 8 [Warning] Timeout waiting for reply of binlog (file: master-bin.000001, pos: 484), last semi-sync at file (none), position 0.
...
```

## Results from my testing

1. Before changes

   ```
   [2025-08-21, 10:02:36.397 AM] 2025-08-21 16:56:32 8 [Warning] Timeout waiting for reply of binlog (file: master-bin.000001, pos: 484), semi-sync up to file , position 0.
   ```
2. After Changes
   * filename would indicate "(none)" (when empty previously)
   * "semi-sync up to" replaced with "last semi-sync at"

   ```
   2025-08-21 17:15:28 8 [Warning] Timeout waiting for reply of binlog (file: master-bin.000001, pos: 484), last semi-sync at file (none), position 0.
   ```

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.