### PR TITLE
MDEV-37411: Clear warnings for io_setup failure

### DIFF
--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -4546,8 +4546,6 @@ sub extract_warning_lines ($$) {
      qr|table.*is full|,
      qr/\[ERROR\] (mysqld|mariadbd): \Z/,  # Warning from Aria recovery
      qr|Linux Native AIO|, # warning that aio does not work on /dev/shm
-     qr|InnoDB: io_setup\(\) attempt|,
-     qr|InnoDB: io_setup\(\) failed with EAGAIN|,
      qr|io_uring_queue_init\(\) failed with|,
      qr|InnoDB: io_uring failed: falling back to libaio|,
      qr/InnoDB: Failed to set O_DIRECT on file/,

--- a/tpool/aio_libaio.cc
+++ b/tpool/aio_libaio.cc
@@ -193,7 +193,8 @@ aio *create_libaio(thread_pool *pool, int max_io)
   memset(&ctx, 0, sizeof ctx);
   if (int ret= io_setup(max_io, &ctx))
   {
-    fprintf(stderr, "io_setup(%d) returned %d\n", max_io, ret);
+    fprintf(stderr, "Warning: io_setup(%d) returned %s. See man 2 io_setup.\n",
+            max_io, strerror(ret));
     return nullptr;
   }
   return new aio_libaio(ctx, pool);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37411*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Where io_setup fails, this is a serious issue, normally because of the lack of fs.aio-max-nr configured in the kernel. We adjust the error message to be a Warning, because like "native AIO failed: falling back to innodb_use_native_aio=OFF", its user actionable.

A default configuation of the server and indeed raising innodb_write_io_threads and innodb_read_io_threads couldn't exceed the default fs.aio-max-nr value. If a user is constructing multipe instances of MariaDB that exceed this value then they should be seeing the warning and taking action.

There are CI environments, as Otto points on on Launchpad, that have insufficient fs.aio-max-nr configure to run mtr in parallel. This however a genuine distro problem and to resolve.

For us, and our developers, we'd rather see the warning so we can fix CI and dev instances that are insufficiently configured.

The io_setup man page as a very short but descript set of causes for the io_setup failures. Its safer to refer to this, now with a strerror description rather than a number.

The mtr suppressions are removed because a while ago when the errors where moved out of InnoDB and recently the server could never generate a warning of these forms.

## Release Notes

Upgrading a warning is barely mentionable.

## How can this PR be tested?

Run in a limited environment like launchpad and see the mtr errors.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
