### PR TITLE
MDEV-37477: decimal_digits_t trips GCC -Wconversion

### DIFF
--- a/sql/item.h
+++ b/sql/item.h
@@ -1980,12 +1980,12 @@ public:
   /**
     TIME or DATETIME precision of the item: 0..6
   */
-  uint time_precision(THD *thd)
+  decimal_digits_t time_precision(THD *thd)
   {
     return const_item() ? type_handler()->Item_time_precision(thd, this) :
                           MY_MIN(decimals, TIME_SECOND_PART_DIGITS);
   }
-  uint datetime_precision(THD *thd)
+  decimal_digits_t datetime_precision(THD *thd)
   {
     return const_item() ? type_handler()->Item_datetime_precision(thd, this) :
                           MY_MIN(decimals, TIME_SECOND_PART_DIGITS);

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -1116,8 +1116,8 @@ protected:
   inline void fix_decimals()
   {
     DBUG_ASSERT(result_type() == DECIMAL_RESULT);
-    if (decimals == NOT_FIXED_DEC)
-      set_if_smaller(decimals, max_length - 1);
+    if (decimals == NOT_FIXED_DEC && decimals >= max_length)
+      decimals= decimal_digits_t(max_length - 1);
   }
 
 public:
@@ -1505,7 +1505,8 @@ public:
   {
     return args[0]->type_handler()->Item_func_unsigned_fix_length_and_dec(this);
   }
-  decimal_digits_t decimal_precision() const override { return max_length; }
+  decimal_digits_t decimal_precision() const override
+  { return decimal_digits_t(max_length); }
   void print(String *str, enum_query_type query_type) override;
   Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_unsigned>(thd, this); }
@@ -1516,7 +1517,8 @@ class Item_decimal_typecast :public Item_func
 {
   my_decimal decimal_value;
 public:
-  Item_decimal_typecast(THD *thd, Item *a, uint len, decimal_digits_t dec)
+  Item_decimal_typecast(THD *thd, Item *a,
+                        decimal_digits_t len, decimal_digits_t dec)
    :Item_func(thd, a)
   {
     decimals= dec;

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -549,7 +549,7 @@ class Item_func_seconds_hybrid: public Item_func_numhybrid
 public:
   Item_func_seconds_hybrid(THD *thd): Item_func_numhybrid(thd) {}
   Item_func_seconds_hybrid(THD *thd, Item *a): Item_func_numhybrid(thd, a) {}
-  void fix_length_and_dec_generic(uint dec)
+  void fix_length_and_dec_generic(decimal_digits_t dec)
   {
     DBUG_ASSERT(dec <= TIME_SECOND_PART_DIGITS);
     decimals= dec;
@@ -724,7 +724,8 @@ class Item_func_curtime :public Item_timefunc
   MYSQL_TIME ltime;
   query_id_t last_query_id;
 public:
-  Item_func_curtime(THD *thd, uint dec): Item_timefunc(thd), last_query_id(0)
+  Item_func_curtime(THD *thd, decimal_digits_t dec):
+    Item_timefunc(thd), last_query_id(0)
   { decimals= dec; }
   bool fix_fields(THD *, Item **) override;
   bool fix_length_and_dec() override
@@ -747,7 +748,8 @@ public:
 class Item_func_curtime_local :public Item_func_curtime
 {
 public:
-  Item_func_curtime_local(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
+  Item_func_curtime_local(THD *thd, decimal_digits_t dec):
+    Item_func_curtime(thd, dec) {}
   LEX_CSTRING func_name_cstring() const override
   {
     static LEX_CSTRING name= {STRING_WITH_LEN("curtime") };
@@ -762,7 +764,8 @@ public:
 class Item_func_curtime_utc :public Item_func_curtime
 {
 public:
-  Item_func_curtime_utc(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
+  Item_func_curtime_utc(THD *thd, decimal_digits_t dec):
+    Item_func_curtime(thd, dec) {}
   LEX_CSTRING func_name_cstring() const override
   {
     static LEX_CSTRING name= {STRING_WITH_LEN("utc_time") };
@@ -828,7 +831,8 @@ class Item_func_now :public Item_datetimefunc
   MYSQL_TIME ltime;
   query_id_t last_query_id;
 public:
-  Item_func_now(THD *thd, uint dec): Item_datetimefunc(thd), last_query_id(0)
+  Item_func_now(THD *thd, decimal_digits_t dec):
+    Item_datetimefunc(thd), last_query_id(0)
   { decimals= dec; }
   bool fix_fields(THD *, Item **) override;
   bool fix_length_and_dec() override
@@ -850,7 +854,8 @@ public:
 class Item_func_now_local :public Item_func_now
 {
 public:
-  Item_func_now_local(THD *thd, uint dec): Item_func_now(thd, dec) {}
+  Item_func_now_local(THD *thd, decimal_digits_t dec):
+    Item_func_now(thd, dec) {}
   LEX_CSTRING func_name_cstring() const override
   {
     static LEX_CSTRING name= {STRING_WITH_LEN("current_timestamp") };
@@ -867,7 +872,7 @@ public:
 class Item_func_now_utc :public Item_func_now
 {
 public:
-  Item_func_now_utc(THD *thd, uint dec): Item_func_now(thd, dec) {}
+  Item_func_now_utc(THD *thd, decimal_digits_t dec): Item_func_now(thd, dec) {}
   LEX_CSTRING func_name_cstring() const override
   {
     static LEX_CSTRING name= {STRING_WITH_LEN("utc_timestamp") };
@@ -892,7 +897,8 @@ public:
 class Item_func_sysdate_local :public Item_func_now
 {
 public:
-  Item_func_sysdate_local(THD *thd, uint dec): Item_func_now(thd, dec) {}
+  Item_func_sysdate_local(THD *thd, decimal_digits_t dec):
+    Item_func_now(thd, dec) {}
   bool const_item() const override { return 0; }
   LEX_CSTRING func_name_cstring() const override
   {
@@ -1365,7 +1371,7 @@ public:
 class Item_time_typecast :public Item_timefunc
 {
 public:
-  Item_time_typecast(THD *thd, Item *a, uint dec_arg):
+  Item_time_typecast(THD *thd, Item *a, decimal_digits_t dec_arg):
     Item_timefunc(thd, a) { decimals= dec_arg; }
   LEX_CSTRING func_name_cstring() const override
   {
@@ -1391,7 +1397,7 @@ public:
 class Item_datetime_typecast :public Item_datetimefunc
 {
 public:
-  Item_datetime_typecast(THD *thd, Item *a, uint dec_arg):
+  Item_datetime_typecast(THD *thd, Item *a, decimal_digits_t dec_arg):
     Item_datetimefunc(thd, a) { decimals= dec_arg; }
   LEX_CSTRING func_name_cstring() const override
   {
@@ -1451,8 +1457,8 @@ public:
   bool fix_length_and_dec() override
   {
     THD *thd= current_thd;
-    uint dec0= args[0]->datetime_precision(thd);
-    uint dec1= Interval_DDhhmmssff::fsp(thd, args[1]);
+    decimal_digits_t dec0= args[0]->datetime_precision(thd);
+    decimal_digits_t dec1= Interval_DDhhmmssff::fsp(thd, args[1]);
     fix_attributes_datetime(MY_MAX(dec0, dec1));
     set_maybe_null();
     return false;
@@ -1520,8 +1526,8 @@ public:
   bool fix_length_and_dec() override
   {
     THD *thd= current_thd;
-    uint dec= MY_MAX(args[0]->time_precision(thd),
-                     args[1]->time_precision(thd));
+    decimal_digits_t dec= MY_MAX(args[0]->time_precision(thd),
+                                 args[1]->time_precision(thd));
     fix_attributes_time(dec);
     set_maybe_null();
     return FALSE;
@@ -1693,7 +1699,8 @@ public:
 class Func_handler_date_add_interval
 {
 protected:
-  static uint interval_dec(const Item *item, interval_type int_type)
+  static decimal_digits_t interval_dec(const Item *item,
+                                       interval_type int_type)
   {
     if (int_type == INTERVAL_MICROSECOND ||
         (int_type >= INTERVAL_DAY_MICROSECOND &&
@@ -1730,8 +1737,9 @@ class Func_handler_date_add_interval_datetime:
 public:
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
-    uint dec= MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
-                     interval_dec(item->arguments()[1], int_type(item)));
+    decimal_digits_t dec=
+      MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
+             interval_dec(item->arguments()[1], int_type(item)));
     item->fix_attributes_datetime(dec);
     return false;
   }
@@ -1789,8 +1797,9 @@ class Func_handler_date_add_interval_time:
 public:
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
-    uint dec= MY_MAX(item->arguments()[0]->time_precision(current_thd),
-                     interval_dec(item->arguments()[1], int_type(item)));
+    decimal_digits_t dec=
+      MY_MAX(item->arguments()[0]->time_precision(current_thd),
+             interval_dec(item->arguments()[1], int_type(item)));
     item->fix_attributes_time(dec);
     return false;
   }
@@ -1814,8 +1823,9 @@ class Func_handler_date_add_interval_string:
 public:
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
-    uint dec= MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
-                     interval_dec(item->arguments()[1], int_type(item)));
+    decimal_digits_t dec=
+      MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
+             interval_dec(item->arguments()[1], int_type(item)));
     item->Type_std_attributes::set(
       Type_temporal_attributes_not_fixed_dec(MAX_DATETIME_WIDTH, dec, false),
       DTCollation(item->default_charset(),
@@ -1856,8 +1866,8 @@ public:
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
     THD *thd= current_thd;
-    uint dec0= item->arguments()[0]->datetime_precision(thd);
-    uint dec1= Interval_DDhhmmssff::fsp(thd, item->arguments()[1]);
+    decimal_digits_t dec0= item->arguments()[0]->datetime_precision(thd);
+    decimal_digits_t dec1= Interval_DDhhmmssff::fsp(thd, item->arguments()[1]);
     item->fix_attributes_datetime(MY_MAX(dec0, dec1));
     return false;
   }
@@ -1890,8 +1900,8 @@ public:
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
     THD *thd= current_thd;
-    uint dec0= item->arguments()[0]->time_precision(thd);
-    uint dec1= Interval_DDhhmmssff::fsp(thd, item->arguments()[1]);
+    decimal_digits_t dec0= item->arguments()[0]->time_precision(thd);
+    decimal_digits_t dec1= Interval_DDhhmmssff::fsp(thd, item->arguments()[1]);
     item->fix_attributes_time(MY_MAX(dec0, dec1));
     return false;
   }
@@ -1922,9 +1932,10 @@ public:
   { }
   bool fix_length_and_dec(Item_handled_func *item) const override
   {
-    uint dec0= item->arguments()[0]->decimals;
-    uint dec1= Interval_DDhhmmssff::fsp(current_thd, item->arguments()[1]);
-    uint dec= MY_MAX(dec0, dec1);
+    decimal_digits_t dec0= item->arguments()[0]->decimals;
+    decimal_digits_t dec1=
+      Interval_DDhhmmssff::fsp(current_thd, item->arguments()[1]);
+    decimal_digits_t dec= MY_MAX(dec0, dec1);
     item->Type_std_attributes::set(
       Type_temporal_attributes_not_fixed_dec(MAX_DATETIME_WIDTH, dec, false),
       DTCollation(item->default_charset(),

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -703,7 +703,7 @@ Interval_DDhhmmssff::push_warning_wrong_or_truncated_value(THD *thd,
 }
 
 
-uint Interval_DDhhmmssff::fsp(THD *thd, Item *item)
+decimal_digits_t Interval_DDhhmmssff::fsp(THD *thd, Item *item)
 {
   switch (item->cmp_type()) {
   case INT_RESULT:

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -1495,7 +1495,7 @@ class Interval_DDhhmmssff: public Temporal
   }
 public:
   // Get fractional second precision from an Item
-  static uint fsp(THD *thd, Item *item);
+  static decimal_digits_t fsp(THD *thd, Item *item);
   /*
     Maximum useful HOUR value:
     TIMESTAMP'0001-01-01 00:00:00' + '87649415:59:59' = '9999-12-31 23:59:59'


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37477*
## Description
In commit fa7d4abf164b37d0f98012ff7e906ebe7de8f1ed when the 16-bit type alias `decimal_digits_t` was introduced, some incompatible use of the 32-bit `uint` data type was overlooked.

Only for converting `Item_result_field::max_length` (`uint`), we will use explicit conversion.
## Release Notes
N/A. This is expected to have no impact on the generated code.
## How can this PR be tested?
Apply the following patch to enable `-Wconversion` for the affected code:
```diff
diff --git a/storage/innobase/handler/ha_innodb.cc b/storage/innobase/handler/ha_innodb.cc
index 9a136cbc178..b6f33d13528 100644
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -28,6 +28,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 /** @file ha_innodb.cc */
 
+#define MYSQL_SERVER
 #include "univ.i"
 
 /* Include necessary SQL headers */
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.