### PR TITLE
MDEV-37555 - Fix server_audit rwlock Performance Schema instrumentation

### DIFF
--- a/plugin/server_audit/server_audit.c
+++ b/plugin/server_audit/server_audit.c
@@ -562,8 +562,8 @@ static struct st_mysql_show_var audit_status[]=
 };
 
 #ifdef HAVE_PSI_INTERFACE
-static PSI_mutex_key key_LOCK_operations;
-static PSI_mutex_info mutex_key_list[]=
+static PSI_rwlock_key key_LOCK_operations;
+static PSI_rwlock_info rwlock_key_list[]=
 {
   { &key_LOCK_operations, "SERVER_AUDIT_plugin::lock_operations",
     PSI_FLAG_GLOBAL}
@@ -2662,7 +2662,7 @@ static int server_audit_init(void *p __attribute__((unused)))
   logger_init_mutexes();
 #ifdef HAVE_PSI_INTERFACE
   if (PSI_server)
-    PSI_server->register_mutex("server_audit", mutex_key_list, 1);
+    PSI_server->register_rwlock("server_audit", rwlock_key_list, 1);
 #endif
   mysql_prlock_init(key_LOCK_operations, &lock_operations);
   flogger_mutex_init(key_LOCK_operations, &lock_atomic, MY_MUTEX_INIT_FAST);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The server_audit plugin rwlock isn't instrumented correctly in Performance Schema.

Commit 1d80e8e updated lock_operations to a rwlock from a mutex but didn't
update the PS instrumentation setup accordingly.

We update the PS setup accordingly so the lock is correctly instrumented in
performance_schema.rwlock_instances.

**Before changes (lock does not show up in mutex_instances or rwlock_instances)**
```
MariaDB [(none)]> SELECT * FROM performance_schema.setup_instruments WHERE NAME LIKE '%server_audit%';
+--------------------------------------------------------------------+---------+-------+
| NAME                                                               | ENABLED | TIMED |
+--------------------------------------------------------------------+---------+-------+
| wait/synch/mutex/server_audit/SERVER_AUDIT_plugin::lock_operations | YES     | YES   |
+--------------------------------------------------------------------+---------+-------+

MariaDB [(none)]> select * from performance_schema.mutex_instances where name like '%server_audit%';
Empty set (0.001 sec)

MariaDB [(none)]> select * from performance_schema.rwlock_instances where name like '%server_audit%';
Empty set (0.002 sec)
```

**After changes (lock shows up in rwlock_instances)**
```
MariaDB [(none)]> SELECT * FROM performance_schema.setup_instruments WHERE NAME LIKE '%server_audit%';
+---------------------------------------------------------------------+---------+-------+
| NAME                                                                | ENABLED | TIMED |
+---------------------------------------------------------------------+---------+-------+
| wait/synch/rwlock/server_audit/SERVER_AUDIT_plugin::lock_operations | YES     | YES   |
+---------------------------------------------------------------------+---------+-------+
1 row in set (0.002 sec)


MariaDB [(none)]> select * from performance_schema.rwlock_instances where name like '%server_audit%';
+---------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| NAME                                                                | OBJECT_INSTANCE_BEGIN | WRITE_LOCKED_BY_THREAD_ID | READ_LOCKED_BY_COUNT |
+---------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| wait/synch/rwlock/server_audit/SERVER_AUDIT_plugin::lock_operations |       140238222358208 |                      NULL |                    7 |
+---------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
1 row in set (0.002 sec)
```

## Release Notes

The server audit plugin lock is now instrumented in the rwlock_instances Performance Schema table.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.