### PR TITLE
MDEV-36482: Make liburing work WITH_MSAN=ON (fix)

### DIFF
--- a/tpool/aio_liburing.cc
+++ b/tpool/aio_liburing.cc
@@ -29,11 +29,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 - 1301 USA*/
 
 namespace
 {
+using namespace tpool;
 
-class aio_uring final : public tpool::aio
+class aio_uring final : public aio
 {
 public:
-  aio_uring(tpool::thread_pool *tpool, int max_aio) : tpool_(tpool)
+  aio_uring(thread_pool *tpool, int max_aio) : tpool_(tpool)
   {
     if (const auto e= io_uring_queue_init(max_aio, &uring_, 0))
     {
@@ -71,6 +72,9 @@ public:
       }
       throw std::runtime_error("aio_uring()");
     }
+#if __has_feature(memory_sanitizer)
+    MEM_MAKE_DEFINED(&uring_, sizeof(uring_));
+#endif
     if (io_uring_ring_dontfork(&uring_) != 0)
     {
       my_printf_error(ER_UNKNOWN_ERROR,
@@ -102,7 +106,7 @@ public:
     io_uring_queue_exit(&uring_);
   }
 
-  int submit_io(tpool::aiocb *cb) final
+  int submit_io(aiocb *cb) final
   {
     cb->iov_base= cb->m_buffer;
     cb->iov_len= cb->m_len;
@@ -112,7 +116,7 @@ public:
     std::lock_guard<std::mutex> _(mutex_);
 
     io_uring_sqe *sqe= io_uring_get_sqe(&uring_);
-    if (cb->m_opcode == tpool::aio_opcode::AIO_PREAD)
+    if (cb->m_opcode == aio_opcode::AIO_PREAD)
       io_uring_prep_readv(sqe, cb->m_fh, static_cast<struct iovec *>(cb), 1,
                           cb->m_offset);
     else
@@ -159,7 +163,7 @@ private:
         abort();
       }
 
-      auto *iocb= static_cast<tpool::aiocb*>(io_uring_cqe_get_data(cqe));
+      auto *iocb= static_cast<aiocb*>(io_uring_cqe_get_data(cqe));
       if (!iocb)
         break; // ~aio_uring() told us to terminate
 
@@ -196,7 +200,7 @@ private:
 
   io_uring uring_;
   std::mutex mutex_;
-  tpool::thread_pool *tpool_;
+  thread_pool *tpool_;
   std::thread thread_;
 
   std::vector<native_file_handle> files_;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36482*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The uring_ member of the aio_uring class needed to be defined to make MSAN happy.

To make aio_uring consistent with aio_libaio in the 10.11 branch, added the "using namespace tpool" and removed tpool scoped quantifiers.

10.6 aio_uring is defined in the tpool namespace however changing that would just cause merge conflicts.

## Release Notes

nothing;

## How can this PR be tested?

msan build + test in container with --privileged:
```
root@1c914b817918:/build# ldd sql/mariadbd
	linux-vdso.so.1 (0x00007f6632caa000)
	libpcre2-8.so.0 => /msan-libs/libpcre2-8.so.0 (0x00007f662a942000)
	libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007f662a8fe000)
	liburing.so.2 => /lib/x86_64-linux-gnu/liburing.so.2 (0x00007f662a8f6000)
	libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f662a8e7000)
	libssl.so.3 => /msan-libs/libssl.so.3 (0x00007f662a723000)
	libcrypto.so.3 => /msan-libs/libcrypto.so.3 (0x00007f662a078000)
	libc++.so.1 => /msan-libs/libc++.so.1 (0x00007f6629de0000)
	libc++abi.so.1 => /msan-libs/libc++abi.so.1 (0x00007f6629d1e000)
	libunwind.so.1 => /lib/x86_64-linux-gnu/libunwind.so.1 (0x00007f6629d10000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6629c20000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f6629c0e000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6629bdf000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f66299e9000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6632cac000)
root@1c914b817918:/build# mysql-test/mtr  --suite=innodb 
innodb.alter_algorithm 'INSTANT'         w7 [ pass ]     65
innodb.alter_not_null 'COPY,STRICT'      w1 [ pass ]     85
innodb.alter_algorithm 'NOCOPY'          w8 [ pass ]     77
innodb.alter_not_null 'INPLACE,STRICT'   w5 [ pass ]     77
innodb.alter_not_null 'INPLACE,NON-STRICT' w6 [ pass ]     96
innodb.alter_not_null 'COPY,NON-STRICT'  w4 [ pass ]     96
innodb.alter_algorithm 'INPLACE'         w3 [ pass ]    128
....
root@1c914b817918:/build# grep uring mysql-test/var/1/log/mysqld.1.err
2025-08-25  3:03:17 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:18 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:19 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:22 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:24 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:27 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:29 0 [Note] InnoDB: Using liburing
2025-08-25  3:03:31 0 [Note] InnoDB: Using liburing
```


revalidation of libaio while I'm here:
```
root@1c914b817918:/build# ldd sql/mariadbd
	linux-vdso.so.1 (0x00007f6eda63e000)
	libpcre2-8.so.0 => /msan-libs/libpcre2-8.so.0 (0x00007f6ed22d8000)
	libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007f6ed2294000)
	libaio.so.1t64 => /lib/x86_64-linux-gnu/libaio.so.1t64 (0x00007f6ed228f000)
	libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f6ed2280000)
	libssl.so.3 => /msan-libs/libssl.so.3 (0x00007f6ed20bc000)
	libcrypto.so.3 => /msan-libs/libcrypto.so.3 (0x00007f6ed1a11000)
	libc++.so.1 => /msan-libs/libc++.so.1 (0x00007f6ed1779000)
	libc++abi.so.1 => /msan-libs/libc++abi.so.1 (0x00007f6ed16b7000)
	libunwind.so.1 => /lib/x86_64-linux-gnu/libunwind.so.1 (0x00007f6ed16a9000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6ed15b9000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f6ed15a7000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6ed1578000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6ed1382000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6eda640000)

root@1c914b817918:/build# mysql-test/mtr  --suite=innodb 
Logging: /source/mysql-test/mariadb-test-run.pl  --suite=innodb

innodb.alter_algorithm 'INSTANT'         w7 [ pass ]     67
innodb.alter_algorithm 'NOCOPY'          w6 [ pass ]     80
innodb.alter_not_null 'INPLACE,STRICT'   w3 [ pass ]     85
innodb.alter_not_null 'COPY,STRICT'      w2 [ pass ]     86
innodb.alter_not_null 'INPLACE,NON-STRICT' w5 [ pass ]     94
innodb.alter_not_null 'COPY,NON-STRICT'  w1 [ pass ]     97
innodb.alter_algorithm 'INPLACE'         w8 [ pass ]    129

root@1c914b817918:/build# grep 'Linux native'  mysql-test/var/1/log/mysqld.1.err
2025-08-25  3:28:47 0 [Note] InnoDB: Using Linux native AIO
2025-08-25  3:28:49 0 [Note] InnoDB: Using Linux native AIO
2025-08-25  3:28:51 0 [Note] InnoDB: Using Linux native AIO
2025-08-25  3:28:54 0 [Note] InnoDB: Using Linux native AIO
2025-08-25  3:28:57 0 [Note] InnoDB: Using Linux native AIO
2025-08-25  3:28:58 0 [Note] InnoDB: Using Linux native AIO
```

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.