### PR TITLE
MDEV-30354 Fix JSON escaping in optimizer trace

### DIFF
--- a/mysql-test/main/opt_trace_json_escape.result
+++ b/mysql-test/main/opt_trace_json_escape.result
@@ -1,0 +1,160 @@
+# Testing JSON escaping in optimizer trace output
+set optimizer_trace="enabled=on";
+# Test 1: Simple double quotes
+SELECT LENGTH("a");
+LENGTH("a")
+1
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select octet_length('a') AS `LENGTH(\"a\")`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}
+# Test 2: Nested quotes
+SELECT LENGTH("a\"b");
+LENGTH("a\"b")
+3
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select octet_length('a\"b') AS `LENGTH(\"a\\\"b\")`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}
+# Test 3: Special characters with quotes
+SELECT LENGTH("a\n\"b\t\"c");
+LENGTH("a\n\"b\t\"c")
+7
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select octet_length('a\\n\"b\\t\"c') AS `LENGTH(\"a\\n\\\"b\\t\\\"c\")`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}
+# Test 4: New line
+SELECT COLUMN_JSON(COLUMN_CREATE("foo", "New
+line" AS CHAR));
+COLUMN_JSON(COLUMN_CREATE("foo", "New
+line" AS CHAR))
+{"foo":"New\u000Aline"}
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select column_json(column_create('foo','New\\nline' AS char charset latin1 collate latin1_swedish_ci )) AS `COLUMN_JSON(COLUMN_CREATE(\"foo\", \"New\nline\" AS CHAR))`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}
+# Test 5: Backslashes
+SELECT LENGTH("a\\b");
+LENGTH("a\\b")
+3
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select octet_length('a\\\\b') AS `LENGTH(\"a\\\\b\")`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}
+# Test 6: JSON functions
+SELECT JSON_EXTRACT('{"key":"value"}', "$.key");
+JSON_EXTRACT('{"key":"value"}', "$.key")
+"value"
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+valid_json	trace
+1	{
+  "steps": [
+    {
+      "join_preparation": {
+        "select_id": 1,
+        "steps": [
+          {
+            "expanded_query": "select json_extract('{\"key\":\"value\"}','$.key') AS `JSON_EXTRACT('{\"key\":\"value\"}', \"$.key\")`"
+          }
+        ]
+      }
+    },
+    {
+      "join_optimization": {
+        "select_id": 1,
+        "steps": []
+      }
+    }
+  ]
+}

--- a/mysql-test/main/opt_trace_json_escape.test
+++ b/mysql-test/main/opt_trace_json_escape.test
@@ -1,0 +1,32 @@
+--echo # Testing JSON escaping in optimizer trace output
+
+#
+# MDEV-30354: Fix JSON escaping in optimizer trace output
+#
+
+set optimizer_trace="enabled=on";
+
+--echo # Test 1: Simple double quotes
+SELECT LENGTH("a");
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+
+--echo # Test 2: Nested quotes
+SELECT LENGTH("a\"b");
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+
+--echo # Test 3: Special characters with quotes
+SELECT LENGTH("a\n\"b\t\"c");
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+
+--echo # Test 4: New line
+SELECT COLUMN_JSON(COLUMN_CREATE("foo", "New
+line" AS CHAR));
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+
+--echo # Test 5: Backslashes
+SELECT LENGTH("a\\b");
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;
+
+--echo # Test 6: JSON functions
+SELECT JSON_EXTRACT('{"key":"value"}', "$.key");
+SELECT json_valid(trace) AS valid_json, trace FROM information_schema.optimizer_trace;

--- a/sql/opt_trace.cc
+++ b/sql/opt_trace.cc
@@ -126,7 +126,23 @@ void opt_trace_print_expanded_query(THD *thd, SELECT_LEX *select_lex,
     The output is not very pretty lots of back-ticks, the output
     is as the one in explain extended , lets try to improved it here.
   */
-  writer->add("expanded_query", str.c_ptr_safe(), str.length());
+
+  StringBuffer<1024> escaped_str(system_charset_info);
+  escaped_str.alloc(str.length() * 2 + 1);
+  // Use json_escape function to properly escape the query string 
+  int result = json_escape(str.charset(),
+                          (const uchar*)str.ptr(),
+                          (const uchar*)str.ptr() + str.length(),
+                          &my_charset_utf8mb4_bin,
+                          (uchar*)escaped_str.ptr(),
+                          (uchar*)escaped_str.ptr() + escaped_str.alloced_length());
+  
+  if (result >= 0) {
+    escaped_str.length(result);
+    writer->add("expanded_query", escaped_str.c_ptr_safe(), escaped_str.length());
+  } else {
+    writer->add("expanded_query", str.c_ptr_safe(), str.length());
+  }
 }
 
 void opt_trace_disable_if_no_security_context_access(THD *thd)


### PR DESCRIPTION
# Description

Currently, when using optimizer trace, the expanded_query field can produce invalid JSON when queries contain special characters like quotes or backslashes. This makes the JSON output invalid and difficult to parse programmatically.

This PR modifies the expanded_query output to properly escape special characters using json_escape(), ensuring valid JSON output while maintaining readability.

It also includes MTR tests to verify the fix.

# How can this PR be tested?

Enable optimizer trace and run queries with special characters:
```
SET optimizer_trace='enabled=on';
SELECT LENGTH("a");
SELECT json_valid(trace), trace FROM information_schema.optimizer_trace;
```
Before change:
```
{
            "expanded_query": "select octet_length('a') AS `LENGTH("a")`"
}
```
After change:
```
{
            "expanded_query": "select octet_length('a') AS `LENGTH(\"a\")`"
}
```

Additional test cases:

- Nested quotes: `SELECT LENGTH("a\"b");`
```
{
    "expanded_query": "select octet_length('a\"b') AS `LENGTH(\"a\\\"b\")`"
}
```
- Special characters with quotes: `SELECT LENGTH("a\n\"b\t\"c");`

```
{
    "expanded_query": "select octet_length('a\\n\"b\\t\"c') AS `LENGTH(\"a\\n\\\"b\\t\\\"c\")`"
}
```
- New line: 
```
SELECT COLUMN_JSON(COLUMN_CREATE("foo", "New
line" AS CHAR));
```
```
{
    "expanded_query": "select column_json(column_create('foo','New\\nline' AS char charset latin1 collate latin1_swedish_ci )) AS `COLUMN_JSON(COLUMN_CREATE(\"foo\", \"New\nline\" AS CHAR))`"}
```
# Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.