### PR TITLE
MDEV-38328: Promote getting to 10k GitHub stars in server log and client prompt

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -1424,6 +1424,11 @@ int main(int argc,char *argv[])
             mysql_thread_id(&mysql), server_version_string(&mysql));
     put_info((char*) glob_buffer.ptr(),INFO_INFO);
     put_info(ORACLE_WELCOME_COPYRIGHT_NOTICE("2000"), INFO_INFO);
+#if SERVER_MATURITY_LEVEL < MariaDB_PLUGIN_MATURITY_STABLE
+    put_info("Help others discover MariaDB."
+             " Star it on GitHub: https://github.com/MariaDB/server\n",
+             INFO_INFO);
+#endif
   }
 
 #ifdef HAVE_READLINE

--- a/mysql-test/main/mysql-interactive.result
+++ b/mysql-test/main/mysql-interactive.result
@@ -10,6 +10,8 @@ Your MariaDB connection id is X
 Server version: Y
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
+Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server
+
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
 MariaDB [(none)]> delimiter $
@@ -39,6 +41,8 @@ Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is X
 Server version: Y
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server
 
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5097,11 +5097,17 @@ static int init_server_components()
     Print source revision hash, as one of the first lines, if not the
     first in error log, for troubleshooting and debugging purposes
   */
-  if (!opt_help)
+  if (!opt_help) {
     sql_print_information("Starting MariaDB %s source revision %s "
                           "server_uid %s as process %lu",
                           server_version, SOURCE_REVISION, server_uid,
                           (ulong) getpid());
+#if SERVER_MATURITY_LEVEL < MariaDB_PLUGIN_MATURITY_STABLE
+    sql_print_information("Help others discover MariaDB."
+        " Star it on GitHub: https://github.com/MariaDB/server");
+#endif
+  }
+
 
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
   /*


### PR DESCRIPTION
## Description

Ask users to give MariaDB a star by having an extra line in the MariaDB client prompt:

    Welcome to the MariaDB monitor.  Commands end with ; or \g.
    Your MariaDB connection id is 33
    Server version: 12.2.0-MariaDB-1:12.2.0 mariadb.org binary distribution

    Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

    Please help get to 10k stars at https://github.com/MariaDB/Server
    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

    MariaDB [(none)]>

Additionally, have this extra line in server logs:

    [Note] Please help get to 10k stars at https://github.com/MariaDB/server

This change is done in a way that it is easy to cherry-pick to older releases, and the text can later be changed to promote something else once MariaDB has surpassed MySQL in GitHub stars.

## Release Notes
- none

## How can this PR be tested?

* Start the server, look at logs
* Connect with the client to any server, observe the output

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
