### PR TITLE
MDEV-37520 Failure to detect corruption during backups of Aria table

### DIFF
--- a/extra/mariabackup/aria_backup_client.cc
+++ b/extra/mariabackup/aria_backup_client.cc
@@ -400,16 +400,18 @@ bool Table::copy(ds_ctxt_t *ds, bool is_index, unsigned thread_num) {
 		for (ulonglong block= 0 ; ; block++) {
 			size_t length = m_cap.block_size;
 			if (is_index) {
-				if ((error= aria_read_index(
-							partition.m_index_file, &m_cap, block, copy_buffer) ==
-							HA_ERR_END_OF_FILE))
-					break;
+				error= aria_read_index(partition.m_index_file,
+						       &m_cap, block,
+						       copy_buffer);
 			} else {
-				if ((error= aria_read_data(
-							partition.m_data_file, &m_cap, block, copy_buffer, &length) ==
-							HA_ERR_END_OF_FILE))
-					break;
+				error= aria_read_data(partition.m_data_file,
+						      &m_cap, block,
+						      copy_buffer, &length);
 			}
+
+			if (error == HA_ERR_END_OF_FILE)
+			  break;
+
 			if (error) {
 				msg(thread_num, "error: aria_read %s failed:  %d",
 					is_index ? "index" : "data", error);

--- a/mysql-test/suite/mariabackup/aria_log_rotate_during_backup.test
+++ b/mysql-test/suite/mariabackup/aria_log_rotate_during_backup.test
@@ -34,11 +34,11 @@ CREATE TABLE test.t1(id INT, txt LONGTEXT) ENGINE=Aria;
 --source include/aria_log_control_load.inc
 CALL display_aria_log_control(@aria_log_control);
 
-
+let $backuplog= $MYSQLTEST_VARDIR/tmp/backup.log;
 --echo # Running --backup
 --let after_scanning_log_files=CALL test.populate_t1
 --disable_result_log
---exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --parallel=10  --target-dir=$targetdir  --dbug=+d,mariabackup_events 2>&1
+--exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --target-dir=$targetdir  --dbug=+d,mariabackup_events > $backuplog
 --let after_scanning_log_files=
 --enable_result_log
 
@@ -77,6 +77,7 @@ CALL display_aria_log_control(@aria_log_control);
 SELECT id, LENGTH(txt) FROM t1 ORDER BY id;
 DROP TABLE t1;
 rmdir $targetdir;
+remove_file $backuplog;
 
 DROP PROCEDURE populate_t1;
 DROP PROCEDURE display_aria_log_control;

--- a/storage/maria/ma_pagecrc.c
+++ b/storage/maria/ma_pagecrc.c
@@ -103,7 +103,7 @@ my_bool maria_page_crc_check(uchar *page,
       the CRC will be corrected at next write)
     */
     if (no_crc_val == MARIA_NO_CRC_BITMAP_PAGE &&
-        crc == 0 && _ma_check_if_zero(page, data_length))
+        crc == 0 && !_ma_check_if_zero(page, data_length))
     {
       DBUG_PRINT("warning", ("Found bitmap page that was not initialized"));
       DBUG_RETURN(0);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37520*

## Description
Problem
=======
- Mariabackup tool silently produce corrupted backups of Aria tables. Identified three issues that prevents proper detection of page corruption:

aria_read_data(), aria_read_index() does incorrect CRC validation after doing CRC check, allows corrupted pages to pass undetected.

aria_read_data(), aria_read_index() couldn't handle zero filled pages. Based on the size of
aria_pagecache_buffer_size, pages could be
in cache when backup tries to read the data from file

maria_page_crc_check(): Prevents correctly identifying and skipping zero-filled pages.

Solution:
========
This commit resolves these critical issues to ensure the integrity of Aria table backups.

Corrected CRC check: Updated the code in aria_read_data() to correctly check the return value from maria_page_crc_check(), so any CRC mismatch will now properly fail the backup and prevent corruption.

Improved zero-page handling: The aria_read_data() and aria_read_index() functions are now robust enough to tolerate and correctly process zero-filled pages.

The flawed conditional check in maria_page_crc_check() has been corrected to reliably identify zero-filled pages.

## How can this PR be tested?
./mtr mariabackup.log_aria_rotate_during_backup

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
