### PR TITLE
MDEV-36641 Implement Oracle Compatibility - INITCAP function

### DIFF
--- a/mysql-test/main/func_initcap.result
+++ b/mysql-test/main/func_initcap.result
@@ -1,0 +1,38 @@
+# Basic Functionality Tests
+SELECT INITCAP('hello world') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+SELECT INITCAP('HELLO WORLD') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+SELECT INITCAP('hello WORLD') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+# Word Boundary Tests
+SELECT INITCAP('hello,world') AS 'Expected "Hello,World"';
+Expected "Hello,World"
+Hello,World
+SELECT INITCAP('hello.world') AS 'Expected "Hello.World"';
+Expected "Hello.World"
+Hello.World
+SELECT INITCAP('hello-world') AS 'Expected "Hello-World"';
+Expected "Hello-World"
+Hello-World
+SELECT INITCAP('hello_world') AS 'Expected "Hello_World"';
+Expected "Hello_World"
+Hello_World
+# Special Character Tests
+SELECT INITCAP('hello123world') AS 'Expected "Hello123world"';
+Expected "Hello123world"
+Hello123world
+SELECT INITCAP('123Hello') AS 'Expected "123Hello"';
+Expected "123Hello"
+123Hello
+# NULL Handling Tests
+SELECT INITCAP(NULL) AS 'Expected NULL';
+Expected NULL
+NULL
+# Edge Cases Tests
+SELECT INITCAP('') AS 'Expected ""';
+Expected ""
+

--- a/mysql-test/main/func_initcap.test
+++ b/mysql-test/main/func_initcap.test
@@ -1,0 +1,22 @@
+#-- File: initcap_basic_functionality_tests.mtr
+
+--echo # Basic Functionality Tests
+SELECT INITCAP('hello world') AS 'Expected "Hello World"';
+SELECT INITCAP('HELLO WORLD') AS 'Expected "Hello World"';
+SELECT INITCAP('hello WORLD') AS 'Expected "Hello World"';
+
+--echo # Word Boundary Tests
+SELECT INITCAP('hello,world') AS 'Expected "Hello,World"';
+SELECT INITCAP('hello.world') AS 'Expected "Hello.World"';
+SELECT INITCAP('hello-world') AS 'Expected "Hello-World"';
+SELECT INITCAP('hello_world') AS 'Expected "Hello_World"';
+
+--echo # Special Character Tests
+SELECT INITCAP('hello123world') AS 'Expected "Hello123world"';
+SELECT INITCAP('123Hello') AS 'Expected "123Hello"';
+
+--echo # NULL Handling Tests
+SELECT INITCAP(NULL) AS 'Expected NULL';
+
+--echo # Edge Cases Tests
+SELECT INITCAP('') AS 'Expected ""';

--- a/mysql-test/main/func_initcap_utf.result
+++ b/mysql-test/main/func_initcap_utf.result
@@ -1,0 +1,197 @@
+# Character Set Tests Setup
+SET NAMES utf8mb4;
+# Basic ASCII Tests
+SELECT INITCAP('hello world') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+SELECT INITCAP('HELLO WORLD') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+SELECT INITCAP('hello WORLD') AS 'Expected "Hello World"';
+Expected "Hello World"
+Hello World
+# Word Boundary Tests
+SELECT INITCAP('hello,world') AS 'Expected "Hello,World"';
+Expected "Hello,World"
+Hello,World
+SELECT INITCAP('hello.world') AS 'Expected "Hello.World"';
+Expected "Hello.World"
+Hello.World
+SELECT INITCAP('hello-world') AS 'Expected "Hello-World"';
+Expected "Hello-World"
+Hello-World
+SELECT INITCAP('hello_world') AS 'Expected "Hello_World"';
+Expected "Hello_World"
+Hello_World
+# Unicode Character Tests
+SELECT INITCAP('中文测试') AS 'Chinese Text';
+Chinese Text
+中文测试
+SELECT INITCAP('こんにちは世界') AS 'Japanese Text';
+Japanese Text
+こんにちは世界
+# Mixed Unicode and ASCII Tests
+SELECT INITCAP('test中文') AS 'Mixed Text';
+Mixed Text
+Test中文
+# Special Character Tests
+SELECT INITCAP('hello123world') AS 'Expected "Hello123world"';
+Expected "Hello123world"
+Hello123world
+SELECT INITCAP('123hello') AS 'Expected "123Hello"';
+Expected "123Hello"
+123Hello
+SELECT INITCAP('hello世界123') AS 'Mixed with Numbers';
+Mixed with Numbers
+Hello世界123
+# NULL and Empty String Tests
+SELECT INITCAP(NULL) AS 'Expected NULL';
+Expected NULL
+NULL
+SELECT INITCAP('') AS 'Expected ""';
+Expected ""
+
+# Extended Unicode Tests
+SELECT INITCAP('über') AS 'German Unicode';
+German Unicode
+Über
+SELECT INITCAP('français') AS 'French Unicode';
+French Unicode
+Français
+SELECT INITCAP('español') AS 'Spanish Unicode';
+Spanish Unicode
+Español
+SELECT INITCAP('çokça') AS 'Turkish Unicode';
+Turkish Unicode
+Çokça
+SELECT INITCAP('istanbul İs a bİg cIty in Asİa') AS 'Turkish Unicode';
+Turkish Unicode
+Istanbul İs A Big City In Asia
+SELECT INITCAP('İSTANBUL') AS 'Turkish İ/I Test';
+Turkish İ/I Test
+İstanbul
+# Special Case Tests
+SELECT INITCAP('école FRANÇAISE') AS 'French Mixed Case';
+French Mixed Case
+École Française
+SELECT INITCAP('ÇOKÇA türkçe') AS 'Turkish Mixed Case';
+Turkish Mixed Case
+Çokça Türkçe
+# Multi-word Special Character Tests
+SELECT INITCAP('école_française') AS 'Underscore Unicode';
+Underscore Unicode
+École_Française
+SELECT INITCAP('çokça,türkçe') AS 'Comma Separated Unicode';
+Comma Separated Unicode
+Çokça,Türkçe
+# Mixed ASCII and Unicode Tests
+SELECT INITCAP('hello über world') AS 'Mixed ASCII and Unicode';
+Mixed ASCII and Unicode
+Hello Über World
+SELECT INITCAP('HELLO ÜBER WORLD') AS 'Mixed ASCII and Unicode Upper';
+Mixed ASCII and Unicode Upper
+Hello Über World
+SELECT INITCAP('öÜtstanding älphä testiñg in ÇOKÇA') AS 'Complex Mixed Case';
+Complex Mixed Case
+Öütstanding Älphä Testiñg In Çokça
+# Test Cyrillic characters
+SELECT INITCAP('привет мир') AS 'Cyrillic Test - Expected: Привет Мир';
+Cyrillic Test - Expected: Привет Мир
+Привет Мир
+SELECT INITCAP('ПРИВЕТ МИР') AS 'Cyrillic Upper Test - Expected: Привет Мир';
+Cyrillic Upper Test - Expected: Привет Мир
+Привет Мир
+# Test Greek characters 
+SELECT INITCAP('γεια σας κόσμος') AS 'Greek Test - Expected: Γεια Σας Κόσμος';
+Greek Test - Expected: Γεια Σας Κόσμος
+Γεια Σας Κόσμος
+SELECT INITCAP('ΓΕΙΑ ΣΑΣ ΚΌΣΜΟΣ') AS 'Greek Upper Test - Expected: Γεια Σας Κόσμος';
+Greek Upper Test - Expected: Γεια Σας Κόσμος
+Γεια Σασ Κόσμοσ
+# Test mixed scripts
+SELECT INITCAP('hello привет γεια') AS 'Mixed Scripts - Expected: Hello Привет Γεια';
+Mixed Scripts - Expected: Hello Привет Γεια
+Hello Привет Γεια
+# Test existing Latin characters to ensure they still work
+SELECT INITCAP('über français español') AS 'Latin Extended - Expected: Über Français Español';
+Latin Extended - Expected: Über Français Español
+Über Français Español
+# Test Turkish collation for proper locale detection
+SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci;
+SELECT INITCAP('işık bilişim') AS 'Turkish Collation Test - Expected: İşık Bilişim';
+Turkish Collation Test - Expected: İşık Bilişim
+İşık Bilişim
+SET NAMES utf8mb4;
+# Additional European Language Tests
+SELECT INITCAP('привіт світ') AS 'Ukrainian Test - Expected: Привіт Світ';
+Ukrainian Test - Expected: Привіт Світ
+Привіт Світ
+SELECT INITCAP('witaj świecie') AS 'Polish Test - Expected: Witaj Świecie';
+Polish Test - Expected: Witaj Świecie
+Witaj Świecie
+SELECT INITCAP('ahoj světe') AS 'Czech Test - Expected: Ahoj Světe';
+Czech Test - Expected: Ahoj Světe
+Ahoj Světe
+SELECT INITCAP('zdravo svijete') AS 'Croatian Test - Expected: Zdravo Svijete';
+Croatian Test - Expected: Zdravo Svijete
+Zdravo Svijete
+SELECT INITCAP('здравей свят') AS 'Bulgarian Test - Expected: Здравей Свят';
+Bulgarian Test - Expected: Здравей Свят
+Здравей Свят
+SELECT INITCAP('olá mundo') AS 'Portuguese Test - Expected: Olá Mundo';
+Portuguese Test - Expected: Olá Mundo
+Olá Mundo
+SELECT INITCAP('hallo wereld') AS 'Dutch Test - Expected: Hallo Wereld';
+Dutch Test - Expected: Hallo Wereld
+Hallo Wereld
+SELECT INITCAP('hej världen') AS 'Swedish Test - Expected: Hej Världen';
+Swedish Test - Expected: Hej Världen
+Hej Världen
+SELECT INITCAP('hei verden') AS 'Norwegian Test - Expected: Hei Verden';
+Norwegian Test - Expected: Hei Verden
+Hei Verden
+SELECT INITCAP('hej verden') AS 'Danish Test - Expected: Hej Verden';
+Danish Test - Expected: Hej Verden
+Hej Verden
+SELECT INITCAP('halló heimur') AS 'Icelandic Test - Expected: Halló Heimur';
+Icelandic Test - Expected: Halló Heimur
+Halló Heimur
+SELECT INITCAP('hei maailma') AS 'Finnish Test - Expected: Hei Maailma';
+Finnish Test - Expected: Hei Maailma
+Hei Maailma
+SELECT INITCAP('szia világ') AS 'Hungarian Test - Expected: Szia Világ';
+Hungarian Test - Expected: Szia Világ
+Szia Világ
+SELECT INITCAP('salut lume') AS 'Romanian Test - Expected: Salut Lume';
+Romanian Test - Expected: Salut Lume
+Salut Lume
+SELECT INITCAP('zdravo svet') AS 'Serbian Test - Expected: Zdravo Svet';
+Serbian Test - Expected: Zdravo Svet
+Zdravo Svet
+SELECT INITCAP('ahoj svet') AS 'Slovak Test - Expected: Ahoj Svet';
+Slovak Test - Expected: Ahoj Svet
+Ahoj Svet
+SELECT INITCAP('zdravo svet') AS 'Slovenian Test - Expected: Zdravo Svet';
+Slovenian Test - Expected: Zdravo Svet
+Zdravo Svet
+SELECT INITCAP('sveiki pasaule') AS 'Latvian Test - Expected: Sveiki Pasaule';
+Latvian Test - Expected: Sveiki Pasaule
+Sveiki Pasaule
+SELECT INITCAP('labas pasauli') AS 'Lithuanian Test - Expected: Labas Pasauli';
+Lithuanian Test - Expected: Labas Pasauli
+Labas Pasauli
+SELECT INITCAP('tere maailm') AS 'Estonian Test - Expected: Tere Maailm';
+Estonian Test - Expected: Tere Maailm
+Tere Maailm
+SELECT INITCAP('вітаю свет') AS 'Belarusian Test - Expected: Вітаю Свет';
+Belarusian Test - Expected: Вітаю Свет
+Вітаю Свет
+SELECT INITCAP('გამარჯობა მსოფლიო') AS 'Georgian Test - Expected: გამარჯობა მსოფლიო';
+Georgian Test - Expected: გამარჯობა მსოფლიო
+Გამარჯობა Მსოფლიო
+SELECT INITCAP('բարեւ աշխարհ') AS 'Armenian Test - Expected: Բարեւ Աշխարհ';
+Armenian Test - Expected: Բարեւ Աշխարհ
+Բարեւ Աշխարհ
+SELECT INITCAP('salam dünya') AS 'Azerbaijani Test - Expected: Salam Dünya';
+Azerbaijani Test - Expected: Salam Dünya
+Salam Dünya

--- a/mysql-test/main/func_initcap_utf.test
+++ b/mysql-test/main/func_initcap_utf.test
@@ -1,0 +1,97 @@
+--source include/have_utf8mb4.inc
+
+--echo # Character Set Tests Setup
+SET NAMES utf8mb4;
+
+--echo # Basic ASCII Tests
+SELECT INITCAP('hello world') AS 'Expected "Hello World"';
+SELECT INITCAP('HELLO WORLD') AS 'Expected "Hello World"';
+SELECT INITCAP('hello WORLD') AS 'Expected "Hello World"';
+
+--echo # Word Boundary Tests
+SELECT INITCAP('hello,world') AS 'Expected "Hello,World"';
+SELECT INITCAP('hello.world') AS 'Expected "Hello.World"';
+SELECT INITCAP('hello-world') AS 'Expected "Hello-World"';
+SELECT INITCAP('hello_world') AS 'Expected "Hello_World"';
+
+--echo # Unicode Character Tests
+SELECT INITCAP('中文测试') AS 'Chinese Text';
+SELECT INITCAP('こんにちは世界') AS 'Japanese Text';
+
+--echo # Mixed Unicode and ASCII Tests
+SELECT INITCAP('test中文') AS 'Mixed Text';
+
+--echo # Special Character Tests
+SELECT INITCAP('hello123world') AS 'Expected "Hello123world"';
+SELECT INITCAP('123hello') AS 'Expected "123Hello"';
+SELECT INITCAP('hello世界123') AS 'Mixed with Numbers';
+
+--echo # NULL and Empty String Tests
+SELECT INITCAP(NULL) AS 'Expected NULL';
+SELECT INITCAP('') AS 'Expected ""';
+
+--echo # Extended Unicode Tests
+SELECT INITCAP('über') AS 'German Unicode';
+SELECT INITCAP('français') AS 'French Unicode';
+SELECT INITCAP('español') AS 'Spanish Unicode';
+SELECT INITCAP('çokça') AS 'Turkish Unicode';
+SELECT INITCAP('istanbul İs a bİg cIty in Asİa') AS 'Turkish Unicode';
+SELECT INITCAP('İSTANBUL') AS 'Turkish İ/I Test';
+
+--echo # Special Case Tests
+SELECT INITCAP('école FRANÇAISE') AS 'French Mixed Case';
+SELECT INITCAP('ÇOKÇA türkçe') AS 'Turkish Mixed Case';
+
+--echo # Multi-word Special Character Tests
+SELECT INITCAP('école_française') AS 'Underscore Unicode';
+SELECT INITCAP('çokça,türkçe') AS 'Comma Separated Unicode';
+
+--echo # Mixed ASCII and Unicode Tests
+SELECT INITCAP('hello über world') AS 'Mixed ASCII and Unicode';
+SELECT INITCAP('HELLO ÜBER WORLD') AS 'Mixed ASCII and Unicode Upper';
+SELECT INITCAP('öÜtstanding älphä testiñg in ÇOKÇA') AS 'Complex Mixed Case';
+
+--echo # Test Cyrillic characters
+SELECT INITCAP('привет мир') AS 'Cyrillic Test - Expected: Привет Мир';
+SELECT INITCAP('ПРИВЕТ МИР') AS 'Cyrillic Upper Test - Expected: Привет Мир';
+
+--echo # Test Greek characters 
+SELECT INITCAP('γεια σας κόσμος') AS 'Greek Test - Expected: Γεια Σας Κόσμος';
+SELECT INITCAP('ΓΕΙΑ ΣΑΣ ΚΌΣΜΟΣ') AS 'Greek Upper Test - Expected: Γεια Σας Κόσμος';
+
+--echo # Test mixed scripts
+SELECT INITCAP('hello привет γεια') AS 'Mixed Scripts - Expected: Hello Привет Γεια';
+
+--echo # Test existing Latin characters to ensure they still work
+SELECT INITCAP('über français español') AS 'Latin Extended - Expected: Über Français Español';
+
+--echo # Test Turkish collation for proper locale detection
+SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci;
+SELECT INITCAP('işık bilişim') AS 'Turkish Collation Test - Expected: İşık Bilişim';
+SET NAMES utf8mb4;
+
+--echo # Additional European Language Tests
+SELECT INITCAP('привіт світ') AS 'Ukrainian Test - Expected: Привіт Світ';
+SELECT INITCAP('witaj świecie') AS 'Polish Test - Expected: Witaj Świecie';
+SELECT INITCAP('ahoj světe') AS 'Czech Test - Expected: Ahoj Světe';
+SELECT INITCAP('zdravo svijete') AS 'Croatian Test - Expected: Zdravo Svijete';
+SELECT INITCAP('здравей свят') AS 'Bulgarian Test - Expected: Здравей Свят';
+SELECT INITCAP('olá mundo') AS 'Portuguese Test - Expected: Olá Mundo';
+SELECT INITCAP('hallo wereld') AS 'Dutch Test - Expected: Hallo Wereld';
+SELECT INITCAP('hej världen') AS 'Swedish Test - Expected: Hej Världen';
+SELECT INITCAP('hei verden') AS 'Norwegian Test - Expected: Hei Verden';
+SELECT INITCAP('hej verden') AS 'Danish Test - Expected: Hej Verden';
+SELECT INITCAP('halló heimur') AS 'Icelandic Test - Expected: Halló Heimur';
+SELECT INITCAP('hei maailma') AS 'Finnish Test - Expected: Hei Maailma';
+SELECT INITCAP('szia világ') AS 'Hungarian Test - Expected: Szia Világ';
+SELECT INITCAP('salut lume') AS 'Romanian Test - Expected: Salut Lume';
+SELECT INITCAP('zdravo svet') AS 'Serbian Test - Expected: Zdravo Svet';
+SELECT INITCAP('ahoj svet') AS 'Slovak Test - Expected: Ahoj Svet';
+SELECT INITCAP('zdravo svet') AS 'Slovenian Test - Expected: Zdravo Svet';
+SELECT INITCAP('sveiki pasaule') AS 'Latvian Test - Expected: Sveiki Pasaule';
+SELECT INITCAP('labas pasauli') AS 'Lithuanian Test - Expected: Labas Pasauli';
+SELECT INITCAP('tere maailm') AS 'Estonian Test - Expected: Tere Maailm';
+SELECT INITCAP('вітаю свет') AS 'Belarusian Test - Expected: Вітаю Свет';
+SELECT INITCAP('გამარჯობა მსოფლიო') AS 'Georgian Test - Expected: გამარჯობა მსოფლიო';
+SELECT INITCAP('բարեւ աշխարհ') AS 'Armenian Test - Expected: Բարեւ Աշխարհ';
+SELECT INITCAP('salam dünya') AS 'Azerbaijani Test - Expected: Salam Dünya';

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -2394,6 +2394,19 @@ protected:
 };
 
 
+class Create_func_initcap : public Create_func_arg1
+{
+public:
+  Item *create_1_arg(THD *thd, Item *arg1) override;
+
+  static Create_func_initcap s_singleton;
+
+protected:
+  Create_func_initcap() = default;
+  ~Create_func_initcap() override = default;
+};
+
+
 class Create_func_space : public Create_func_arg1
 {
 public:
@@ -4183,6 +4196,13 @@ Create_func_instr::create_2_arg(THD *thd, Item *arg1, Item *arg2)
   return new (thd->mem_root) Item_func_locate(thd, arg1, arg2);
 }
 
+Create_func_initcap Create_func_initcap::s_singleton;
+
+Item*
+Create_func_initcap::create_1_arg(THD *thd, Item *arg1)
+{
+  return new (thd->mem_root) Item_func_initcap(thd, arg1);
+}
 
 Create_func_is_free_lock Create_func_is_free_lock::s_singleton;
 
@@ -6421,6 +6441,7 @@ const Native_func_registry func_array[] =
   { { STRING_WITH_LEN("GREATEST") }, BUILDER(Create_func_greatest)},
   { { STRING_WITH_LEN("HEX") }, BUILDER(Create_func_hex)},
   { { STRING_WITH_LEN("IFNULL") }, BUILDER(Create_func_ifnull)},
+  { { STRING_WITH_LEN("INITCAP") }, BUILDER(Create_func_initcap)},
   { { STRING_WITH_LEN("INSTR") }, BUILDER(Create_func_instr)},
   { { STRING_WITH_LEN("ISNULL") }, BUILDER(Create_func_isnull)},
   { { STRING_WITH_LEN("IS_FREE_LOCK") }, BUILDER(Create_func_is_free_lock)},

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -633,6 +633,23 @@ public:
 };
 
 
+class Item_func_initcap :public Item_str_func
+{
+  String tmp_value;
+public:
+  Item_func_initcap(THD *thd, Item *a): Item_str_func(thd, a) {}
+  String *val_str(String *) override;
+  bool fix_length_and_dec(THD *thd) override;
+  LEX_CSTRING func_name_cstring() const override
+  {
+    static LEX_CSTRING name= {STRING_WITH_LEN("initcap") };
+    return name;
+  }
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_func_initcap>(thd, this); }
+};
+
+
 class Item_func_insert :public Item_str_func
 {
   String tmp_value;


### PR DESCRIPTION
INITCAP() implementation returns char, with the first letter of each word in uppercase, all other letters in lowercase. Words are delimited by white space or characters that are not alphanumeric.

The return value is the same data type as char. The database sets the case of the initial characters based on the binary mapping defined for the underlying character set.

Examples

The following example capitalizes each word in the string:

Input:
```
SELECT INITCAP('hello world')
```

Output:
```
Hello World
```
Summary of changes in files:

Code:

* sql/item_create.cc:
  * Register the INITCAP function
* sql/item_strfunc.cc:
  * Implement the INITCAP function
* sql/item_strfunc.h:
  * Define the INITCAP function

Unit Test(s):

* mysql-test/main/initcap_functionality.test
* mysql-test/main/initcap_functionality_utf.test

Copyright:

All new code of the whole pull request, including one or several files that are either
new files or modified ones, are contributed under the BSD-new license.
I am contributing on behalf of my employer Amazon Web Services, Inc.