### PR TITLE
MDEV-37504 MemorySanitizer: use-of-uninitialized-value myrocks::Rdb_key_def::pack_field

### DIFF
--- a/storage/rocksdb/mysql-test/rocksdb/include/bulk_load_unsorted.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/include/bulk_load_unsorted.inc
@@ -1,4 +1,6 @@
 --source include/have_partition.inc
+--source include/not_msan_with_debug.inc
+--source include/no_msan_without_big.inc
 --source include/count_sessions.inc
 
 SET rocksdb_bulk_load_size=3;

--- a/storage/rocksdb/mysql-test/rocksdb/t/unique_check.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/unique_check.test
@@ -1,4 +1,5 @@
 --source include/have_rocksdb.inc
+--source include/not_msan.inc
 --source include/have_debug_sync.inc
 
 if (`SELECT $CURSOR_PROTOCOL != 0`)

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2713,7 +2713,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
 */
 
 void Rdb_key_def::make_unpack_unknown(
-    const Rdb_collation_codec *codec MY_ATTRIBUTE((__unused__)),
+    const Rdb_collation_codec *,
     const Field *const field, Rdb_pack_field_context *const pack_ctx) {
   pack_ctx->writer->write(field->ptr, field->pack_length());
 }
@@ -2727,9 +2727,9 @@ void Rdb_key_def::make_unpack_unknown(
 */
 
 void Rdb_key_def::dummy_make_unpack_info(
-    const Rdb_collation_codec *codec MY_ATTRIBUTE((__unused__)),
-    const Field *field MY_ATTRIBUTE((__unused__)),
-    Rdb_pack_field_context *pack_ctx MY_ATTRIBUTE((__unused__))) {
+    const Rdb_collation_codec *,
+    const Field *,
+    Rdb_pack_field_context *) {
   // Do nothing
 }
 
@@ -2762,7 +2762,7 @@ int Rdb_key_def::unpack_unknown(Rdb_field_packing *const fpi,
 */
 
 void Rdb_key_def::make_unpack_unknown_varchar(
-    const Rdb_collation_codec *const codec MY_ATTRIBUTE((__unused__)),
+    const Rdb_collation_codec *,
     const Field *const field, Rdb_pack_field_context *const pack_ctx) {
   const auto f = static_cast<const Field_varstring *>(field);
   uint len = f->length_bytes == 1 ? (uint)*f->ptr : uint2korr(f->ptr);

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3380,6 +3380,11 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         m_skip_func = Rdb_key_def::skip_variable_space_pad;
         m_pack_func = Rdb_key_def::pack_with_varchar_space_pad;
         m_make_unpack_info_func = Rdb_key_def::dummy_make_unpack_info;
+#if __has_feature(memory_sanitizer)
+        // dummy_make_unpack_info doesn't use arguments but MSAN expects
+        // them to be initialized.
+        m_charset_codec = nullptr;
+#endif
         m_segment_size = get_segment_size_from_collation(cs);
         m_max_image_len =
             (max_image_len_before_chunks / (m_segment_size - 1) + 1) *
@@ -3453,6 +3458,15 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
                                       : Rdb_key_def::make_unpack_unknown;
         m_unpack_func = is_varchar ? Rdb_key_def::unpack_unknown_varchar
                                    : Rdb_key_def::unpack_unknown;
+#if __has_feature(memory_sanitizer)
+       // Rdb_key_def::make_unpack_info_unknown and
+       // Rdb_key_def::make_unpack_unknown_varchar when called
+       // via m_make_unpack_info_func do not make use of the m_charset_codec
+       // provided as an argument. MemorySanitizer doesn't make the logical
+       // there is no risk in m_charset_codec being uninitialized. Therefore we
+       // initialize to make MemorySanitizer satisified.
+       m_charset_codec = nullptr;
+#endif
       } else {
         // Same as above: we don't know how to restore the value from its
         // mem-comparable form.


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37504*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Correct MSAN errors in a few of the rocksdb tests.

Some rocksdb test either timed out or was slow so adjust these for the msan case.

## Release Notes

nothing.

## How can this PR be tested?

rocksdb.issue896 + rocksdb.type_char_indexes_collation

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.