### PR TITLE
MDEV-33817/MDEV-37170 fixup: Remove evex512

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -25,12 +25,6 @@
 #else
 # include <cpuid.h>
 # ifdef __APPLE__ /* AVX512 states are not enabled in XCR0 */
-# elif __GNUC__ >= 15
-#  define TARGET "pclmul,avx10.1,vpclmulqdq"
-#  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
-# elif __GNUC__ >= 14 || (defined __clang_major__ && __clang_major__ >= 18)
-#  define TARGET "pclmul,evex512,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
-#  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
 # elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 9)
 /* clang 8 does not support _xgetbv(), which we also need */
 #  define TARGET "pclmul,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37170*
## Description
It turns out that there is no need to use the `evex512` target attribute that had been introduced in GCC 14 and clang 18, and will be removed in GCC 16.

At the time when the `evex512` attribute was introduced, Intel had an idea to release products with AVX10.1-256, supporting the AVX512 instruction set but limited to 256-bit registers.  The `evex512` attribute would have been needed to "opt in" to the 512-bit instruction variants (using the EVEX instruction prefix). Later on, Intel revised its plans to make AVX10.1 always 512-bit.

This follows up #3270, #4081, #4170.
## Release Notes
N/A
## How can this PR be tested?
I have tested this on https://godbolt.org. On our CI we do have some hosts that support AVX512 and will run this code.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.