### PR TITLE
MDEV-37553: Assertion failure lsn - get_flushed_lsn(std::memory_order_relaxed) < capacity()

### DIFF
--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -909,7 +909,8 @@ ATTRIBUTE_COLD void log_t::append_prepare_wait(bool late, bool ex) noexcept
     const bool is_pmem{is_mmap()};
     if (is_pmem)
     {
-      ut_ad(lsn - get_flushed_lsn(std::memory_order_relaxed) < capacity());
+      ut_ad(lsn - get_flushed_lsn(std::memory_order_relaxed) < capacity() ||
+            overwrite_warned);
       persist(lsn);
     }
 #endif


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-37553*
## Description
`log_t::append_prepare_wait()`: Relax the debug assertion in case log_overwrite_warning() has been called. In this case, the contents of `log_sys.buf` (and the `ib_logfile0`) is basically unrecoverable garbage, and it does not matter which write was last persisted.

This assertion would easily fail in the 11.4 branch in the test `encryption.innochecksum` after merging MDEV-36024.
## Release Notes
N/A
## How can this PR be tested?
On two systems that I have access to, 8f30f028c548fee7c8cdde61cdd84f500fa6af50 (a merge of 10.11 to 11.4) would crash in the test `encryption.innochecksum` when this change is absent, and pass when this change is present.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.