### PR TITLE
Remove `mysqld_error_find_printf_error_used`

### DIFF
--- a/sql/sql_acl.h
+++ b/sql/sql_acl.h
@@ -64,12 +64,8 @@ extern LEX_CSTRING public_name;
 
 static inline int access_denied_error_code(int passwd_used)
 {
-#ifdef mysqld_error_find_printf_error_used
-  return 0;
-#else
   return passwd_used == 2 ? ER_ACCESS_DENIED_NO_PASSWORD_ERROR
                           : ER_ACCESS_DENIED_ERROR;
-#endif
 }
 
 /* prototypes */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5390,11 +5390,6 @@ public:
   {
     parse_error(ER_SYNTAX_ERROR);
   }
-#ifdef mysqld_error_find_printf_error_used
-  void parse_error(const char *t)
-  {
-  }
-#endif
 private:
   /*
     Only the implementation of the SIGNAL and RESIGNAL statements

--- a/sql/unireg.h
+++ b/sql/unireg.h
@@ -49,11 +49,9 @@
 #define DEFAULT_ERRMSGS           my_default_lc_messages->errmsgs->errmsgs
 #define CURRENT_THD_ERRMSGS       (current_thd)->variables.errmsgs
 
-#ifndef mysqld_error_find_printf_error_used
 #define ER_DEFAULT(X) DEFAULT_ERRMSGS[((X)-ER_ERROR_FIRST) / ERRORS_PER_RANGE][(X)% ERRORS_PER_RANGE]
 #define ER_THD(thd,X) ((thd)->variables.errmsgs[((X)-ER_ERROR_FIRST) / ERRORS_PER_RANGE][(X) % ERRORS_PER_RANGE])
 #define ER(X)         ER_THD(current_thd, (X))
-#endif
 #define ER_THD_OR_DEFAULT(thd,X) ((thd) ? ER_THD(thd, (X)) : ER_DEFAULT(X))
 
 #define SPECIAL_USE_LOCKS	1		/* Lock used databases */


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: MDEV-______*~~

## Description
This preprocessor switch is never defined.

The commit history tells that it is for a `create_mysqld_error_find_printf_error` script, of which I did not find any public mention.
I found one conversation from searching our private Corporation Slack, where Monty shares that he used it to generate `include/mysqld_error_find_printf_error.h` that surfaces erroneous `printf`s.

In any case, now that MDEV-21978 (#3360) has (re)enabled `-Wformat` that activates `printf` checks built into the compilers, we can use their attributes (e.g., GCC: `__attribute__((format(printf, …)))`) and should no longer require preprocessing replacements.

## Release Notes
N/A
(Brag about dead code removal if you like.)
## How can this PR be tested?
Can you please publish your `/tmp/my/scripts/create_mysqld_error_find_printf_error`, Monty the Great?
## PR quality check
* [x] *This is a new feature or **a refactoring**, and the PR is based against the `main` branch.*
* ~~*This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*~~
* ~~I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.~~
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.