### PR TITLE
MDEV-36861  TPC-H Query 21 takes 10X longer on 11.4 compared to 10.11

### DIFF
--- a/mysql-test/main/delete_use_source_engines.result
+++ b/mysql-test/main/delete_use_source_engines.result
@@ -1245,12 +1245,12 @@ drop table tmp;
 create table tmp as select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 explain select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 affected rows: 8
 select * from t1;
@@ -1287,16 +1287,16 @@ drop table tmp;
 create table tmp as select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 explain select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 analyze delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	1.00	100.00	100.00	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	1.00	3.12	100.00	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	1.00	100.00	100.00	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	1.00	3.12	100.00	Using where; FirstMatch(t1)
 select * from t1;
 c1	c2	c3
 1	2	2
@@ -3435,12 +3435,12 @@ drop table tmp;
 create table tmp as select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 explain select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 affected rows: 8
 select * from t1;
@@ -3477,16 +3477,16 @@ drop table tmp;
 create table tmp as select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 explain select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 analyze delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	4.00	100.00	100.00	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	1.00	3.12	25.00	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	20.00	100.00	20.00	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	25.00	3.12	1.00	Using where; FirstMatch(t1)
 select * from t1;
 c1	c2	c3
 1	2	2
@@ -5840,12 +5840,12 @@ drop table tmp;
 create table tmp as select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 explain select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 affected rows: 8
 select * from t1;
@@ -5882,16 +5882,16 @@ drop table tmp;
 create table tmp as select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 explain select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 analyze delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	4.00	100.00	100.00	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	1.00	3.12	25.00	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	27.00	100.00	14.81	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	25.00	3.12	1.00	Using where; FirstMatch(t1)
 select * from t1;
 c1	c2	c3
 1	2	2
@@ -8303,12 +8303,12 @@ drop table tmp;
 create table tmp as select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 explain select * from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c1	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c3 in (select distinct a.c1 from t1 a where t1.c2=a.c2);
 affected rows: 8
 select * from t1;
@@ -8345,12 +8345,12 @@ drop table tmp;
 create table tmp as select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 explain select * from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1); Using join buffer (flat, BNL join)
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.a.c2	1	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using where
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c2 = t1.c3) limit 1;
 affected rows: 1
 select * from t1;

--- a/mysql-test/main/derived_cond_pushdown.result
+++ b/mysql-test/main/derived_cond_pushdown.result
@@ -22862,10 +22862,11 @@ WHERE t1.valint1 = dt.valint1 AND
 t1.valdate = dt.maxdate AND
 t1.valint1 IN (SELECT * FROM t2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	21	Using where; Start temporary
-1	PRIMARY	t1	ref	valint1,valint1_2	valint1	5	test.t2.a	2	Using index condition; Using where; End temporary
-1	PRIMARY	<derived2>	ref	key0	key0	11	test.t1.valdate,test.t1.valint1	1	
-2	LATERAL DERIVED	t	ref	valint1,valint1_2	valint1	5	test.t2.a	2	Using index condition
+1	PRIMARY	<subquery3>	ALL	distinct_key	NULL	NULL	NULL	21	
+1	PRIMARY	t1	ref	valint1,valint1_2	valint1	5	test.t2.a	2	Using index condition; Using where
+1	PRIMARY	<derived2>	ref	key0	key0	11	test.t1.valdate,test.t1.valint1	5	
+3	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	21	Using where
+2	DERIVED	t	index	valint1,valint1_2	valint1_2	11	NULL	100	Using index; Using temporary; Using filesort
 SELECT t1.valdouble, t1.valint1
 FROM t1,
 (SELECT max(t.valdate) AS maxdate, t.valint1 FROM t1 t GROUP BY t.valint1)

--- a/mysql-test/main/innodb_ext_key.result
+++ b/mysql-test/main/innodb_ext_key.result
@@ -384,15 +384,15 @@ EXPLAIN
 SELECT a FROM t1 AS t, t2 as t2_out 
 WHERE t2_out.c = t.a AND t.b IN (SELECT b FROM t1, t2 WHERE b = t.b);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	index	b	b	7	NULL	10	Using index; Start temporary
-1	PRIMARY	t	ref	a,b	b	3	test.t1.b	2	Using index
-1	PRIMARY	t2	index	NULL	PRIMARY	4	NULL	11	Using index; End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t	index	a,b	b	7	NULL	10	Using index
 1	PRIMARY	t2_out	eq_ref	PRIMARY	PRIMARY	4	test.t.a	1	Using index
+1	PRIMARY	t1	ref	b	b	3	test.t.b	2	Using index; Start temporary
+1	PRIMARY	t2	index	NULL	PRIMARY	4	NULL	11	Using index; End temporary; Using join buffer (flat, BNL join)
 SELECT a FROM t1 AS t, t2 as t2_out 
 WHERE t2_out.c = t.a AND t.b IN (SELECT b FROM t1, t2 WHERE b = t.b);
 a
 24
-Last_query_cost	0.120558
+Last_query_cost	0.140303
 DROP TABLE t1,t2;
 #
 # LP Bug #923236: hash join + extended_keys = on 

--- a/mysql-test/main/subselect3.result
+++ b/mysql-test/main/subselect3.result
@@ -1167,8 +1167,8 @@ set @@optimizer_switch='firstmatch=off,materialization=off';
 set @@max_heap_table_size= 16384;
 explain select count(*) from t0 A, t0 B, t0 C, t0 D where D.a in (select a from t1 E where a+1 < 10000 + A.a + B.a +C.a+D.a);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	E	ALL	NULL	NULL	NULL	NULL	5	Start temporary
-1	PRIMARY	A	ALL	NULL	NULL	NULL	NULL	10	Using join buffer (flat, BNL join)
+1	PRIMARY	A	ALL	NULL	NULL	NULL	NULL	10	
+1	PRIMARY	E	ALL	NULL	NULL	NULL	NULL	5	Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	B	ALL	NULL	NULL	NULL	NULL	10	Using join buffer (flat, BNL join)
 1	PRIMARY	C	ALL	NULL	NULL	NULL	NULL	10	Using where; Using join buffer (flat, BNL join)
 1	PRIMARY	D	ALL	NULL	NULL	NULL	NULL	10	Using where; End temporary; Using join buffer (flat, BNL join)
@@ -1437,7 +1437,7 @@ WHERE cona.postalStripped='T2H3B2'
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	cona	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where; Start temporary
 1	PRIMARY	c	eq_ref	PRIMARY	PRIMARY	4	test.cona.idContact	1	100.00	Using where
-1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.c.idObj	1	50.00	Using index; End temporary
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.c.idObj	1	100.00	Using index; End temporary
 Warnings:
 Note	1003	select `test`.`a`.`idIndividual` AS `idIndividual` from `test`.`t1` `a` semi join (`test`.`t3` `cona` join `test`.`t2` `c`) where `test`.`cona`.`postalStripped` = 'T2H3B2' and `test`.`a`.`idIndividual` = `test`.`c`.`idObj` and `test`.`c`.`idContact` = `test`.`cona`.`idContact`
 SELECT a.idIndividual FROM t1 a 

--- a/mysql-test/main/subselect3_jcl6.result
+++ b/mysql-test/main/subselect3_jcl6.result
@@ -1046,10 +1046,10 @@ update t22 set c = '2005-12-08 15:58:27' where a = 255;
 explain select t21.* from t21,t22 where t21.a = t22.a and 
 t22.a in (select t12.a from t11, t12 where t11.a in(255,256) and t11.a = t12.a and t11.c is null) and t22.c is null order by t21.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t11	ALL	NULL	NULL	NULL	NULL	8	Using where; Start temporary; Using temporary; Using filesort
-1	PRIMARY	t12	hash_ALL	NULL	#hash#$hj	4	test.t11.a	8	Using where; Using join buffer (flat, BNLH join)
-1	PRIMARY	t22	hash_ALL	NULL	#hash#$hj	4	test.t11.a	26	Using where; End temporary; Using join buffer (incremental, BNLH join)
-1	PRIMARY	t21	hash_ALL	NULL	#hash#$hj	4	test.t11.a	26	Using where; Using join buffer (incremental, BNLH join)
+1	PRIMARY	t21	ALL	NULL	NULL	NULL	NULL	26	Using where; Using temporary; Using filesort
+1	PRIMARY	t11	hash_ALL	NULL	#hash#$hj	4	test.t21.a	8	Using where; Start temporary; Using join buffer (flat, BNLH join)
+1	PRIMARY	t12	hash_ALL	NULL	#hash#$hj	4	test.t21.a	8	Using where; Using join buffer (incremental, BNLH join)
+1	PRIMARY	t22	hash_ALL	NULL	#hash#$hj	4	test.t21.a	26	Using where; End temporary; Using join buffer (incremental, BNLH join)
 select t21.* from t21,t22 where t21.a = t22.a and 
 t22.a in (select t12.a from t11, t12 where t11.a in(255,256) and t11.a = t12.a and t11.c is null) and t22.c is null order by t21.a;
 a	b	c
@@ -1274,14 +1274,14 @@ insert into t0 values(1,1);
 explain select * from t0, t3 where t3.a in (select a from t2) and (t3.a < 10 or t3.a >30);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t0	system	NULL	NULL	NULL	NULL	1	
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	10	Using where; Start temporary
-1	PRIMARY	t3	ref	a	a	5	test.t2.a	10	End temporary; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+1	PRIMARY	t3	ALL	a	NULL	NULL	NULL	1000	Using where
+1	PRIMARY	t2	hash_ALL	NULL	#hash#$hj	5	test.t3.a	10	Using where; FirstMatch(t3); Using join buffer (flat, BNLH join)
 create table t4 as select a as x, a as y from t1;
 explain select * from t0, t3 where (t3.a, t3.b) in (select x,y from t4) and (t3.a < 10 or t3.a >30);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t0	system	NULL	NULL	NULL	NULL	1	
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	10	Using where; Start temporary
-1	PRIMARY	t3	ref	a	a	5	test.t4.x	10	Using where; End temporary; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+1	PRIMARY	t3	ALL	a	NULL	NULL	NULL	1000	Using where
+1	PRIMARY	t4	hash_ALL	NULL	#hash#$hj	10	test.t3.a,test.t3.b	10	Using where; FirstMatch(t3); Using join buffer (flat, BNLH join)
 drop table t0,t1,t2,t3,t4;
 #
 # LooseScan with ref access
@@ -1440,7 +1440,7 @@ WHERE cona.postalStripped='T2H3B2'
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	cona	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where; Start temporary
 1	PRIMARY	c	eq_ref	PRIMARY	PRIMARY	4	test.cona.idContact	1	100.00	Using where; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.c.idObj	1	50.00	Using index; End temporary
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.c.idObj	1	100.00	Using index; End temporary
 Warnings:
 Note	1003	select `test`.`a`.`idIndividual` AS `idIndividual` from `test`.`t1` `a` semi join (`test`.`t3` `cona` join `test`.`t2` `c`) where `test`.`cona`.`postalStripped` = 'T2H3B2' and `test`.`a`.`idIndividual` = `test`.`c`.`idObj` and `test`.`c`.`idContact` = `test`.`cona`.`idContact`
 SELECT a.idIndividual FROM t1 a 

--- a/mysql-test/main/subselect4.result
+++ b/mysql-test/main/subselect4.result
@@ -1252,9 +1252,10 @@ EXPLAIN
 SELECT * FROM (t2 LEFT JOIN t1 ON t1.c1) LEFT JOIN t3 on t3.c1 WHERE 's' IN (SELECT c1 FROM t2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t1	system	NULL	NULL	NULL	NULL	0	Const row not found
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; End temporary
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	3	Using join buffer (flat, BNL join)
 1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	3	Using where
+2	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
 SELECT * FROM (t2 LEFT JOIN t1 ON t1.c1) LEFT JOIN t3 on t3.c1 WHERE 's' IN (SELECT c1 FROM t2);
 c1	c1	c1
 EXPLAIN

--- a/mysql-test/main/subselect_sj.result
+++ b/mysql-test/main/subselect_sj.result
@@ -763,16 +763,16 @@ explain extended
 select a from t1
 where a in (select c from t2 where d >= some(select e from t3 where b=e));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	6	100.00	Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	7	16.67	Using where; End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	7	100.00	
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	6	16.67	Using where; Start temporary; End temporary
 3	DEPENDENT SUBQUERY	t3	ALL	NULL	NULL	NULL	NULL	4	100.00	Using where
 Warnings:
 Note	1276	Field or reference 'test.t1.b' of SELECT #3 was resolved in SELECT #1
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t1`.`a` = `test`.`t2`.`c` and <nop>(<expr_cache><`test`.`t2`.`d`,`test`.`t1`.`b`>(<in_optimizer>(`test`.`t2`.`d`,<exists>(/* select#3 */ select `test`.`t3`.`e` from `test`.`t3` where `test`.`t1`.`b` = `test`.`t3`.`e` and <cache>(`test`.`t2`.`d`) >= `test`.`t3`.`e`))))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t2`.`c` = `test`.`t1`.`a` and <nop>(<expr_cache><`test`.`t2`.`d`,`test`.`t1`.`b`>(<in_optimizer>(`test`.`t2`.`d`,<exists>(/* select#3 */ select `test`.`t3`.`e` from `test`.`t3` where `test`.`t1`.`b` = `test`.`t3`.`e` and <cache>(`test`.`t2`.`d`) >= `test`.`t3`.`e`))))
 show warnings;
 Level	Code	Message
 Note	1276	Field or reference 'test.t1.b' of SELECT #3 was resolved in SELECT #1
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t1`.`a` = `test`.`t2`.`c` and <nop>(<expr_cache><`test`.`t2`.`d`,`test`.`t1`.`b`>(<in_optimizer>(`test`.`t2`.`d`,<exists>(/* select#3 */ select `test`.`t3`.`e` from `test`.`t3` where `test`.`t1`.`b` = `test`.`t3`.`e` and <cache>(`test`.`t2`.`d`) >= `test`.`t3`.`e`))))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t2`.`c` = `test`.`t1`.`a` and <nop>(<expr_cache><`test`.`t2`.`d`,`test`.`t1`.`b`>(<in_optimizer>(`test`.`t2`.`d`,<exists>(/* select#3 */ select `test`.`t3`.`e` from `test`.`t3` where `test`.`t1`.`b` = `test`.`t3`.`e` and <cache>(`test`.`t2`.`d`) >= `test`.`t3`.`e`))))
 select a from t1
 where a in (select c from t2 where d >= some(select e from t3 where b=e));
 a
@@ -2178,10 +2178,10 @@ INSERT INTO t5 VALUES (7,0),(9,0);
 explain
 SELECT * FROM t3 WHERE t3.a IN (SELECT t5.a FROM t2, t4, t5 WHERE t2.c = t5.a AND t2.b = t5.b);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t5	index	a	a	10	NULL	2	Using where; Using index; Start temporary
+1	PRIMARY	t5	index	a	a	10	NULL	2	Using where; Using index; LooseScan
 1	PRIMARY	t2	ref	b	b	5	test.t5.b	1	Using where
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	15	Using where; End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	FirstMatch(t5)
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	15	Using where; Using join buffer (flat, BNL join)
 SELECT * FROM t3 WHERE t3.a IN (SELECT t5.a FROM t2, t4, t5 WHERE t2.c = t5.a AND t2.b = t5.b);
 a
 0
@@ -2573,10 +2573,10 @@ SELECT a, b, d FROM t1, t2
 WHERE ( b, d ) IN
 ( SELECT b, d FROM t1 as t3, t2 as t4 WHERE b = c );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t3	index	b	b	5	NULL	10	Using where; Using index; Start temporary
-1	PRIMARY	t4	ref	c	c	5	test.t3.b	1	
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	8	
 1	PRIMARY	t1	ALL	b	NULL	NULL	NULL	10	Using where; Using join buffer (flat, BNL join)
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	8	Using where; End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t4	ref	c	c	5	test.t1.b	1	Using where
+1	PRIMARY	t3	ref	b	b	5	test.t1.b	2	Using index; FirstMatch(t1)
 SELECT a, b, d FROM t1, t2
 WHERE ( b, d ) IN
 ( SELECT b, d FROM t1 as t3, t2 as t4 WHERE b = c );
@@ -3034,9 +3034,9 @@ EXPLAIN EXTENDED
 SELECT * FROM t1, t2 WHERE pk IN ( SELECT pk FROM t1 LEFT JOIN t3 ON (c1 = c3 ) ) ORDER BY c2, c1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t2	system	NULL	NULL	NULL	NULL	1	100.00	Using temporary; Using filesort
-1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	5	100.00	Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t1.pk	1	100.00	
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	10.00	Using where; End temporary
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	5	100.00	
+1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t1.pk	1	100.00	Start temporary
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	50.00	Using where; End temporary
 Warnings:
 Note	1003	select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`c1` AS `c1`,'x' AS `c2` from `test`.`t1` semi join (`test`.`t1` left join `test`.`t3` on(`test`.`t1`.`c1` = `test`.`t3`.`c3`)) where `test`.`t1`.`pk` = `test`.`t1`.`pk` order by 'x',`test`.`t1`.`c1`
 DROP TABLE t1,t2,t3;

--- a/mysql-test/main/subselect_sj2.result
+++ b/mysql-test/main/subselect_sj2.result
@@ -108,8 +108,9 @@ test.t3	analyze	status	Engine-independent statistics collected
 test.t3	analyze	status	OK
 explain select * from t3 where b in (select a from t0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	#	Using where; Start temporary
-1	PRIMARY	t3	ref	b	b	5	test.t0.a	#	End temporary
+1	PRIMARY	t3	ALL	b	NULL	NULL	NULL	#	
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	#	
+2	MATERIALIZED	t0	ALL	NULL	NULL	NULL	NULL	#	
 select * from t3 where b in (select A.a+B.a from t0 A, t0 B where B.a<5);
 a	b	pk1	pk2
 0	0	0	0

--- a/mysql-test/main/subselect_sj2_jcl6.result
+++ b/mysql-test/main/subselect_sj2_jcl6.result
@@ -117,8 +117,8 @@ test.t3	analyze	status	Engine-independent statistics collected
 test.t3	analyze	status	OK
 explain select * from t3 where b in (select a from t0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	#	Using where; Start temporary
-1	PRIMARY	t3	ref	b	b	5	test.t0.a	#	End temporary; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+1	PRIMARY	t3	ALL	b	NULL	NULL	NULL	#	Using where
+1	PRIMARY	t0	hash_ALL	NULL	#hash#$hj	5	test.t3.b	#	Using where; FirstMatch(t3); Using join buffer (flat, BNLH join)
 select * from t3 where b in (select A.a+B.a from t0 A, t0 B where B.a<5);
 a	b	pk1	pk2
 0	0	0	0
@@ -1154,10 +1154,10 @@ WHERE alias5.b = alias4.b
 AND ( alias5.b >= alias3.b OR alias5.c != alias3.c )
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	alias4	index	PRIMARY,c	c	4	NULL	#	Using where; Using index; Start temporary
-1	PRIMARY	alias5	eq_ref	PRIMARY	PRIMARY	4	test.alias4.b	#	Using join buffer (flat, BKA join); Key-ordered scan
+1	PRIMARY	alias1	ALL	NULL	NULL	NULL	NULL	#	
+1	PRIMARY	alias4	range	PRIMARY,c	c	4	NULL	#	Using where; Using index; Start temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	alias5	eq_ref	PRIMARY	PRIMARY	4	test.alias4.b	#	Using join buffer (incremental, BKA join); Key-ordered scan
 1	PRIMARY	alias3	hash_ALL	PRIMARY	#hash#$hj	4	test.alias4.c	#	Using where; End temporary; Using join buffer (incremental, BNLH join)
-1	PRIMARY	alias1	ALL	NULL	NULL	NULL	NULL	#	Using join buffer (incremental, BNL join)
 1	PRIMARY	alias2	ALL	NULL	NULL	NULL	NULL	#	Using join buffer (incremental, BNL join)
 SELECT COUNT(*) FROM t1 AS alias1, t1 AS alias2, t2 AS alias3
 WHERE alias3.d IN (
@@ -1175,10 +1175,10 @@ WHERE alias5.b = alias4.b
 AND ( alias5.b >= alias3.b OR alias3.c != alias5.c )
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	alias4	index	PRIMARY,c	c	4	NULL	#	Using where; Using index; Start temporary
-1	PRIMARY	alias5	eq_ref	PRIMARY	PRIMARY	4	test.alias4.b	#	Using join buffer (flat, BKA join); Key-ordered scan
+1	PRIMARY	alias1	ALL	NULL	NULL	NULL	NULL	#	
+1	PRIMARY	alias4	range	PRIMARY,c	c	4	NULL	#	Using where; Using index; Start temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	alias5	eq_ref	PRIMARY	PRIMARY	4	test.alias4.b	#	Using join buffer (incremental, BKA join); Key-ordered scan
 1	PRIMARY	alias3	hash_ALL	PRIMARY	#hash#$hj	4	test.alias4.c	#	Using where; End temporary; Using join buffer (incremental, BNLH join)
-1	PRIMARY	alias1	ALL	NULL	NULL	NULL	NULL	#	Using join buffer (incremental, BNL join)
 1	PRIMARY	alias2	ALL	NULL	NULL	NULL	NULL	#	Using join buffer (incremental, BNL join)
 SELECT COUNT(*) FROM t1 AS alias1, t1 AS alias2, t2 AS alias3
 WHERE alias3.d IN (

--- a/mysql-test/main/subselect_sj2_mat.result
+++ b/mysql-test/main/subselect_sj2_mat.result
@@ -110,8 +110,9 @@ test.t3	analyze	status	Engine-independent statistics collected
 test.t3	analyze	status	OK
 explain select * from t3 where b in (select a from t0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	#	Using where; Start temporary
-1	PRIMARY	t3	ref	b	b	5	test.t0.a	#	End temporary
+1	PRIMARY	t3	ALL	b	NULL	NULL	NULL	#	
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	#	
+2	MATERIALIZED	t0	ALL	NULL	NULL	NULL	NULL	#	
 select * from t3 where b in (select A.a+B.a from t0 A, t0 B where B.a<5);
 a	b	pk1	pk2
 0	0	0	0
@@ -1561,9 +1562,9 @@ EXPLAIN EXTENDED
 SELECT * FROM t1 LEFT JOIN t2 ON ( b1 = a2 ) 
 WHERE ( b1, b1 )  IN ( SELECT a4, b4 FROM t3, t4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Start temporary
-1	PRIMARY	t1	ref	idx	idx	2	test.t4.a4	1	100.00	Using index
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	16.67	End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	Start temporary
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ref	idx	idx	2	test.t4.a4	1	33.33	Using index; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (flat, BNL join)
 Warnings:
 Note	1003	select `test`.`t1`.`a1` AS `a1`,`test`.`t1`.`b1` AS `b1`,`test`.`t2`.`a2` AS `a2`,`test`.`t2`.`b2` AS `b2` from `test`.`t1` semi join (`test`.`t3` join `test`.`t4`) left join `test`.`t2` on(`test`.`t2`.`a2` = `test`.`t4`.`a4`) where `test`.`t4`.`b4` = `test`.`t4`.`a4` and `test`.`t1`.`b1` = `test`.`t4`.`a4`
@@ -1579,9 +1580,9 @@ EXPLAIN EXTENDED
 SELECT * FROM t1 LEFT JOIN t2 ON ( b1 = a2 ) 
 WHERE ( b1, b1 )  IN ( SELECT a4, b4 FROM t3, t4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Start temporary
-1	PRIMARY	t1	ref	idx	idx	2	test.t4.a4	1	100.00	Using index
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	16.67	End temporary; Using join buffer (flat, BNL join)
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	Start temporary
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ref	idx	idx	2	test.t4.a4	1	33.33	Using index; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (flat, BNL join)
 Warnings:
 Note	1003	select `test`.`t1`.`a1` AS `a1`,`test`.`t1`.`b1` AS `b1`,`test`.`t2`.`a2` AS `a2`,`test`.`t2`.`b2` AS `b2` from `test`.`t1` semi join (`test`.`t3` join `test`.`t4`) left join `test`.`t2` on(`test`.`t2`.`a2` = `test`.`t4`.`a4`) where `test`.`t4`.`b4` = `test`.`t4`.`a4` and `test`.`t1`.`b1` = `test`.`t4`.`a4`
@@ -1846,15 +1847,16 @@ explain
 SELECT t2.id FROM t2,t1
 WHERE  t2.id IN (SELECT t3.ref_id FROM t3,t1 where t3.id = t1.id) and t2.id = t1.id;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	14	Using where; Start temporary
-1	PRIMARY	t2	eq_ref	PRIMARY	PRIMARY	4	test.t3.ref_id	1	Using where; Using index
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t3.id	1	Using index; End temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t3.ref_id	1	Using where; Using index
+1	PRIMARY	t2	index	PRIMARY	PRIMARY	4	NULL	30	Using index
+1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t2.id	1	Using index
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
+2	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	14	
+2	MATERIALIZED	t1	eq_ref	PRIMARY	PRIMARY	4	test.t3.id	1	Using index
 SELECT t2.id FROM t2,t1
 WHERE  t2.id IN (SELECT t3.ref_id FROM t3,t1 where t3.id = t1.id) and t2.id = t1.id;
 id
-11
 10
+11
 set optimizer_switch='materialization=off';
 SELECT t2.id FROM t2,t1
 WHERE  t2.id IN (SELECT t3.ref_id FROM t3,t1 where t3.id = t1.id) and t2.id = t1.id;
@@ -1951,16 +1953,17 @@ AND t3.id_product IN (SELECT id_product FROM t2 t2_3 WHERE t2_3.id_t2 = 18 OR t2
 AND t3.id_product IN (SELECT id_product FROM t2 t2_4 WHERE t2_4.id_t2 = 34 OR t2_4.id_t2 = 23) 
 AND t3.id_product IN (SELECT id_product FROM t2 t2_5 WHERE t2_5.id_t2 = 29 OR t2_5.id_t2 = 28 OR t2_5.id_t2 = 26);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t2_2	ref	id_t2,id_product	id_t2	5	const	12	Using where; Start temporary
-1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2_2.id_product	1	Using where; Using index; End temporary
-1	PRIMARY	t4	eq_ref	PRIMARY	PRIMARY	8	test.t3.id_product,const	1	Using where; Using index
+1	PRIMARY	t1	index	NULL	PRIMARY	8	NULL	73	Using index
+1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t1.id_product	1	Using index
+1	PRIMARY	t4	eq_ref	PRIMARY	PRIMARY	8	test.t1.id_product,const	1	Using where; Using index
 1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
+1	PRIMARY	<subquery3>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
 1	PRIMARY	<subquery4>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
 1	PRIMARY	<subquery5>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
 1	PRIMARY	<subquery6>	eq_ref	distinct_key	distinct_key	4	func	1	Using where
 1	PRIMARY	t5	ALL	NULL	NULL	NULL	NULL	18	Using where; Using join buffer (flat, BNL join)
-1	PRIMARY	t1	index	NULL	PRIMARY	8	NULL	73	Using where; Using index; Using join buffer (flat, BNL join)
 2	MATERIALIZED	t2_1	ALL	id_t2,id_product	NULL	NULL	NULL	223	Using where
+3	MATERIALIZED	t2_2	ref	id_t2,id_product	id_t2	5	const	12	
 4	MATERIALIZED	t2_3	range	id_t2,id_product	id_t2	5	NULL	33	Using index condition; Using where
 5	MATERIALIZED	t2_4	range	id_t2,id_product	id_t2	5	NULL	18	Using index condition; Using where
 6	MATERIALIZED	t2_5	range	id_t2,id_product	id_t2	5	NULL	31	Using index condition; Using where

--- a/mysql-test/main/subselect_sj_jcl6.result
+++ b/mysql-test/main/subselect_sj_jcl6.result
@@ -2184,10 +2184,10 @@ INSERT INTO t5 VALUES (7,0),(9,0);
 explain
 SELECT * FROM t3 WHERE t3.a IN (SELECT t5.a FROM t2, t4, t5 WHERE t2.c = t5.a AND t2.b = t5.b);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t5	index	a	a	10	NULL	2	Using where; Using index; Start temporary
-1	PRIMARY	t2	ref	b	b	5	test.t5.b	1	Using where; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using join buffer (incremental, BNL join)
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	15	Using where; End temporary; Using join buffer (incremental, BNL join)
+1	PRIMARY	t5	index	a	a	10	NULL	2	Using where; Using index; LooseScan
+1	PRIMARY	t2	ref	b	b	5	test.t5.b	1	Using where
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	FirstMatch(t5)
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	15	Using where; Using join buffer (flat, BNL join)
 SELECT * FROM t3 WHERE t3.a IN (SELECT t5.a FROM t2, t4, t5 WHERE t2.c = t5.a AND t2.b = t5.b);
 a
 0
@@ -2579,10 +2579,10 @@ SELECT a, b, d FROM t1, t2
 WHERE ( b, d ) IN
 ( SELECT b, d FROM t1 as t3, t2 as t4 WHERE b = c );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t3	index	b	b	5	NULL	10	Using where; Using index; Start temporary
-1	PRIMARY	t4	ref	c	c	5	test.t3.b	1	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-1	PRIMARY	t1	ALL	b	NULL	NULL	NULL	10	Using where; Using join buffer (incremental, BNL join)
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	8	Using where; End temporary; Using join buffer (incremental, BNL join)
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	8	
+1	PRIMARY	t1	ALL	b	NULL	NULL	NULL	10	Using where; Using join buffer (flat, BNL join)
+1	PRIMARY	t4	ref	c	c	5	test.t1.b	1	Using where
+1	PRIMARY	t3	ref	b	b	5	test.t1.b	2	Using index; FirstMatch(t1)
 SELECT a, b, d FROM t1, t2
 WHERE ( b, d ) IN
 ( SELECT b, d FROM t1 as t3, t2 as t4 WHERE b = c );
@@ -3040,9 +3040,9 @@ EXPLAIN EXTENDED
 SELECT * FROM t1, t2 WHERE pk IN ( SELECT pk FROM t1 LEFT JOIN t3 ON (c1 = c3 ) ) ORDER BY c2, c1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t2	system	NULL	NULL	NULL	NULL	1	100.00	Using temporary; Using filesort
-1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	5	100.00	Start temporary
-1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t1.pk	1	100.00	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	10.00	Using where; End temporary; Using join buffer (incremental, BNL join)
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	5	100.00	
+1	PRIMARY	t1	eq_ref	PRIMARY	PRIMARY	4	test.t1.pk	1	100.00	Start temporary; Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	2	50.00	Using where; End temporary; Using join buffer (incremental, BNL join)
 Warnings:
 Note	1003	select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`c1` AS `c1`,'x' AS `c2` from `test`.`t1` semi join (`test`.`t1` left join `test`.`t3` on(`test`.`t1`.`c1` = `test`.`t3`.`c3`)) where `test`.`t1`.`pk` = `test`.`t1`.`pk` order by 'x',`test`.`t1`.`c1`
 DROP TABLE t1,t2,t3;

--- a/mysql-test/main/subselect_sj_mat.result
+++ b/mysql-test/main/subselect_sj_mat.result
@@ -1140,10 +1140,11 @@ create index it1a on t1(a);
 explain extended
 select a from t1 where a in (select c from t2 where d >= 20);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where; Start temporary
-1	PRIMARY	t1	ref	it1a	it1a	4	test.t2.c	1	16.67	Using index; End temporary
+1	PRIMARY	t1	index	it1a	it1a	4	NULL	7	100.00	Using index
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	100.00	
+2	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
 Warnings:
-Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t1`.`a` = `test`.`t2`.`c` and `test`.`t2`.`d` >= 20
+Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t2`.`d` >= 20
 select a from t1 where a in (select c from t2 where d >= 20);
 a
 2
@@ -1154,10 +1155,11 @@ insert into t2 values (1,10);
 explain extended
 select a from t1 where a in (select c from t2 where d >= 20);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	7	100.00	Using where; Start temporary
-1	PRIMARY	t1	ref	it1a	it1a	4	test.t2.c	1	14.29	Using index; End temporary
+1	PRIMARY	t1	index	it1a	it1a	4	NULL	7	100.00	Using index
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	100.00	
+2	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	7	100.00	Using where
 Warnings:
-Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t1`.`a` = `test`.`t2`.`c` and `test`.`t2`.`d` >= 20
+Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` semi join (`test`.`t2`) where `test`.`t2`.`d` >= 20
 select a from t1 where a in (select c from t2 where d >= 20);
 a
 2
@@ -1208,7 +1210,7 @@ select a from t1
 where a in (select c from t2 where d >= some(select e from t3 where b=e));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	7	100.00	Start temporary
-1	PRIMARY	t1	ref	it1a,iab	iab	4	test.t2.c	1	9.41	Using where; Using index; End temporary
+1	PRIMARY	t1	ref	it1a,iab	iab	4	test.t2.c	1	65.88	Using where; Using index; End temporary
 3	DEPENDENT SUBQUERY	t3	ALL	NULL	NULL	NULL	NULL	4	100.00	Using where
 Warnings:
 Note	1276	Field or reference 'test.t1.b' of SELECT #3 was resolved in SELECT #1

--- a/mysql-test/suite/gcol/r/gcol_select_innodb.result
+++ b/mysql-test/suite/gcol/r/gcol_select_innodb.result
@@ -699,8 +699,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -753,8 +753,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -808,8 +808,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -871,8 +871,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1, t3.i1
@@ -926,8 +926,8 @@ WHERE t4.c1 < 'o' and t4.i1 < (t2.i1 + 1)
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY	PRIMARY	4	test.t4.i1	1	Using where
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using where; End temporary; Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1

--- a/mysql-test/suite/gcol/r/gcol_select_myisam.result
+++ b/mysql-test/suite/gcol/r/gcol_select_myisam.result
@@ -1325,8 +1325,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY,v_idx	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -1380,8 +1380,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY,v_idx,v_idx2	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -1437,8 +1437,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY,v_idx2	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1
@@ -1503,8 +1503,8 @@ WHERE t4.c1 < 'o'
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY,v_idx	PRIMARY	4	test.t4.i1	1	Using where; End temporary
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1, t3.i1
@@ -1558,8 +1558,8 @@ WHERE t4.c1 < 'o' and t4.i1 < (t2.i1 + 1)
 )
 AND t1.i1 <= t3.i2_key;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	Using join buffer (flat, BNL join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Start temporary; Using join buffer (flat, BNL join)
 1	PRIMARY	t3	eq_ref	PRIMARY,v_idx	PRIMARY	4	test.t4.i1	1	Using where
 1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	5	Using where; End temporary; Using join buffer (flat, BNL join)
 SELECT /*+ NO_SEMIJOIN(@subq1) */ t1.c1, t2.i1

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -3711,7 +3711,8 @@ bool Duplicate_weedout_picker::check_qep(JOIN *join,
 
     if (first_tab == join->const_tables)
     {
-      first_weedout_table_rec_count= 1.0;
+      first_weedout_table_rec_count=
+                                 join->positions[first_tab].prefix_record_count;
       temptable_rec_size= 0;
       dups_cost= 0.0;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36861*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

    MDEV-36861  TPC-H Query 21 takes 10X longer on 11.4 compared to 10.11
    
    commit b66cdbd1eaee changed the cost model from row based
    to millisecond based.  Part of the commit touched
    Duplicate_weedout_picker::check_qep() and subtly changed how
    the cost calculation was done for the case where the first non-constant
    table in the join is one converted into a semijoin.  Previous to this commit
    the starting number of rows for determining the cost was
    join->positions[first_tab].prefix_record_count.  After this commit
    the number of rows was estimated to be 1.  This commit reverts that
    change.
    
    A number of test result files have reverted to the query plans prior to
    the above commit.

## Release Notes
Semi-join transformations may cause poor join ordering due to bug estimating the number rows.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
