### PR TITLE
MDEV-37146 mariadb-dump: Replace SHOW SLAVE STATUS usage with information_schema.SLAVE_STATUS

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6555,19 +6555,18 @@ static int do_show_slave_status(MYSQL *mysql_con,
            fmt_gtid_pos, gtid_comment_prefix, gtid_pos);
 
   print_comment(md_result_file, 0,
-                "\n--\n-- The following is the SQL position of the replication "
-                "taken from SHOW SLAVE STATUS at the time of backup.\n"
-                "-- Use this position when creating a clone of, or replacement "
-                "server, from where the backup was taken."
-                "\n-- This new server will connects to the same primary "
-                "server(s).\n--\n"
-                  // defer print similarly to do_show_master_status()
-                  "\n-- A corresponding to the below dump-slave "
-                  "CHANGE-MASTER settings to the slave gtid state is printed "
-                  "later in the file.\n");
+    "\n-- The following is the replication SQL position "
+      "taken from SHOW SLAVE STATUS at the time of backup.\n"
+    "-- Use this position when creating a clone or replacement "
+      "server from where the backup was taken."
+    "\n-- This new server will connects to the same primary server(s).\n--\n"
+    // defer print similarly to do_show_master_status()
+      "-- The replica GTID position corresponding to the below "
+        "CHANGE-MASTER settings is printed later in the file.\n"
+  );
   if (use_gtid)
     print_comment(md_result_file, 0,
-                  "\n-- Use only the MASTER_USE_GTID=slave_pos or "
+                  "-- Use only the MASTER_USE_GTID=slave_pos or "
                   "MASTER_LOG_FILE/MASTER_LOG_POS in the statements below."
                   "\n\n");
 

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6529,11 +6529,9 @@ static int do_show_slave_status(MYSQL *mysql_con,
 
   if (have_info_schema_slave_status)
   {
-    if (mysql_query_with_error_report(
-      mysql_con, &slave, have_info_schema_slave_status ?
-        "SELECT Connection_name, Master_Host, Master_Port, Relay_Master_Log_File,"
-        " Exec_Master_Log_Pos FROM information_schema.SLAVE_STATUS" :
-        "SHOW ALL SLAVES STATUS"
+    if (mysql_query_with_error_report(mysql_con, &slave,
+      "SELECT Connection_name, Master_Host, Master_Port, Relay_Master_Log_File,"
+      " Exec_Master_Log_Pos FROM information_schema.SLAVE_STATUS"
     ))
     {
       if (!ignore_errors)
@@ -6544,7 +6542,11 @@ static int do_show_slave_status(MYSQL *mysql_con,
     }
   }
   else
+  {
+    // Reuse the SHOW ALL SLAVES STATUS results from do_stop_slave_sql()
+    mysql_data_seek(slave_status_res, 0);
     slave= slave_status_res;
+  }
 
   if (get_gtid_pos(gtid_pos, false))
   {

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -174,12 +174,11 @@ static uint opt_use_gtid;
 static uint my_end_arg;
 static char * opt_mysql_unix_port=0;
 static int   first_error=0;
-/*
-  multi_source is 0 if old server or 2 if server that support multi source 
-  This is chosen this was as multi_source has 2 extra columns first in
-  SHOW ALL SLAVES STATUS.
+/**
+  `true` for 11.6 or above servers, `false` otherwise.
+  @deprecated This and its `false` branches are to be removed after 11.4's EOL.
 */
-static uint multi_source= 0;
+static bool have_info_schema_slave_status;
 static DYNAMIC_STRING extended_row;
 static DYNAMIC_STRING dynamic_where;
 static MYSQL_RES *get_table_name_result= NULL;
@@ -6471,35 +6470,28 @@ static int do_show_master_status(MYSQL *mysql_con, int consistent_binlog_pos,
 static int do_stop_slave_sql(MYSQL *mysql_con)
 {
   MYSQL_ROW row;
-  DBUG_ASSERT(
-    !slave_status_res // do_stop_slave_sql() should only be called once
-  );
+  // do_stop_slave_sql() should only be called once
+  DBUG_ASSERT(!slave_status_res);
 
   if (mysql_query_with_error_report(mysql_con, &slave_status_res,
-                                    multi_source ?
-                                    "SHOW ALL SLAVES STATUS" :
-                                    "SHOW SLAVE STATUS"))
+    have_info_schema_slave_status ?
+      "SELECT Connection_name FROM information_schema.SLAVE_STATUS"
+      // If the slave's SQL thread is not running, we don't stop (or start) it.
+      " WHERE Slave_SQL_Running <> 'No'" :
+      "SHOW ALL SLAVES STATUS"
+  ))
     return(1);
-
-  /* Loop over all slaves */
+  // Loop over all slaves
   while ((row= mysql_fetch_row(slave_status_res)))
   {
-    if (row[11 + multi_source])
+    if ((have_info_schema_slave_status ||
+        strcmp(row[/* Slave_SQL_Running */ 13], "No")))
     {
-      /* if SLAVE SQL is not running, we don't stop it */
-      if (strcmp(row[11 + multi_source], "No"))
-      {
-        char query[160];
-        if (multi_source)
-          snprintf(query, sizeof(query), "STOP SLAVE '%.80s' SQL_THREAD", row[0]);
-        else
-          strmov(query, "STOP SLAVE SQL_THREAD");
-
-        if (mysql_query_with_error_report(mysql_con, 0, query))
-        {
-          return 1;
-        }
-      }
+      char query[25 + NAME_CHAR_LEN]; // sizeof(snprintf)
+        snprintf(query, sizeof(query), "STOP SLAVE '%.*s' SQL_THREAD",
+          NAME_CHAR_LEN, row[/* Connection_name */ 0]);
+      if (mysql_query_with_error_report(mysql_con, nullptr, query))
+        return 1;
     }
   }
   return(0);
@@ -6510,10 +6502,7 @@ static int add_stop_slave(void)
   if (opt_comments)
     fprintf(md_result_file,
             "\n--\n-- stop slave statement to make a recovery dump)\n--\n\n");
-  if (multi_source)
-    fprintf(md_result_file, "STOP ALL SLAVES;\n");
-  else
-    fprintf(md_result_file, "STOP SLAVE;\n");
+  fprintf(md_result_file, "STOP ALL SLAVES;\n");
   return(0);
 }
 
@@ -6522,37 +6511,48 @@ static int add_slave_statements(void)
   if (opt_comments)
     fprintf(md_result_file,
             "\n--\n-- start slave statement to make a recovery dump)\n--\n\n");
-  if (multi_source)
-    fprintf(md_result_file, "START ALL SLAVES;\n");
-  else
-    fprintf(md_result_file, "START SLAVE;\n");
+  fprintf(md_result_file, "START ALL SLAVES;\n");
   return(0);
 }
 
-static int do_show_slave_status(MYSQL *mysql_con, int have_mariadb_gtid,
+static int do_show_slave_status(MYSQL *mysql_con,
                                 int use_gtid, char* set_gtid_pos,
                                 size_t set_gtid_pos_size)
 {
-  MYSQL_RES *UNINIT_VAR(slave);
+  MYSQL_RES *slave;
   MYSQL_ROW row;
   const char *comment_prefix=
     (opt_slave_data == MYSQL_OPT_SLAVE_DATA_COMMENTED_SQL) ? "-- " : "";
   const char *gtid_comment_prefix= (use_gtid ? comment_prefix : "-- ");
   const char *nogtid_comment_prefix= (!use_gtid ? comment_prefix : "-- ");
+  char gtid_pos[MAX_GTID_LENGTH];
 
-  if (mysql_query_with_error_report(mysql_con, &slave,
-                                    multi_source ?
-                                    "SHOW ALL SLAVES STATUS" :
-                                    "SHOW SLAVE STATUS"))
+  if (have_info_schema_slave_status)
   {
-    if (!ignore_errors)
+    if (mysql_query_with_error_report(
+      mysql_con, &slave, have_info_schema_slave_status ?
+        "SELECT Connection_name, Master_Host, Master_Port, Relay_Master_Log_File,"
+        " Exec_Master_Log_Pos FROM information_schema.SLAVE_STATUS" :
+        "SHOW ALL SLAVES STATUS"
+    ))
     {
-      /* SHOW SLAVE STATUS reports nothing and --force is not enabled */
-      fprintf(stderr, "%s: Error: Slave not set up\n", my_progname_short);
+      if (!ignore_errors)
+        // Query fails and --force is not enabled
+        fprintf(stderr, "%s: Error: Slave not set up\n", my_progname_short);
+      mysql_free_result(slave);
+      return 1;
     }
+  }
+  else
+    slave= slave_status_res;
+
+  if (get_gtid_pos(gtid_pos, false))
+  {
     mysql_free_result(slave);
     return 1;
   }
+  snprintf(set_gtid_pos, set_gtid_pos_size,
+           fmt_gtid_pos, gtid_comment_prefix, gtid_pos);
 
   print_comment(md_result_file, 0,
                 "\n--\n-- The following is the SQL position of the replication "
@@ -6560,25 +6560,11 @@ static int do_show_slave_status(MYSQL *mysql_con, int have_mariadb_gtid,
                 "-- Use this position when creating a clone of, or replacement "
                 "server, from where the backup was taken."
                 "\n-- This new server will connects to the same primary "
-                "server%s.\n--\n",
-                multi_source ? "(s)" : "");
-
-  if (multi_source)
-  {
-    char gtid_pos[MAX_GTID_LENGTH];
-    if (have_mariadb_gtid && get_gtid_pos(gtid_pos, 0))
-    {
-      mysql_free_result(slave);
-      return 1;
-    }
-    /* defer print similarly to do_show_master_status */
-    print_comment(md_result_file, 0,
+                "server(s).\n--\n"
+                  // defer print similarly to do_show_master_status()
                   "\n-- A corresponding to the below dump-slave "
                   "CHANGE-MASTER settings to the slave gtid state is printed "
                   "later in the file.\n");
-    snprintf(set_gtid_pos, set_gtid_pos_size,
-             fmt_gtid_pos, gtid_comment_prefix, gtid_pos);
-  }
   if (use_gtid)
     print_comment(md_result_file, 0,
                   "\n-- Use only the MASTER_USE_GTID=slave_pos or "
@@ -6587,41 +6573,25 @@ static int do_show_slave_status(MYSQL *mysql_con, int have_mariadb_gtid,
 
   while ((row= mysql_fetch_row(slave)))
   {
-    if (row[9 + multi_source] && row[21 + multi_source])
-    {
-      if (use_gtid)
-      {
-        if (multi_source)
-          fprintf(md_result_file, "%sCHANGE MASTER '%.80s' TO "
-                  "MASTER_USE_GTID=slave_pos;\n", gtid_comment_prefix, row[0]);
-        else
-          fprintf(md_result_file, "%sCHANGE MASTER TO "
-                  "MASTER_USE_GTID=slave_pos;\n", gtid_comment_prefix);
-      }
-
-      /* SHOW MASTER STATUS reports file and position */
-      if (multi_source)
-        fprintf(md_result_file, "%sCHANGE MASTER '%.80s' TO ",
-                nogtid_comment_prefix, row[0]);
-      else
-        fprintf(md_result_file, "%sCHANGE MASTER TO ", nogtid_comment_prefix);
-      
-      if (opt_include_master_host_port)
-      {
-        if (row[1 + multi_source])
-          fprintf(md_result_file, "MASTER_HOST='%s', ", row[1 + multi_source]);
-        if (row[3])
-          fprintf(md_result_file, "MASTER_PORT=%s, ", row[3 + multi_source]);
-      }
+    if (use_gtid)
       fprintf(md_result_file,
-              "MASTER_LOG_FILE='%s', MASTER_LOG_POS=%s;\n",
-              row[9 + multi_source], row[21 + multi_source]);
-
-      check_io(md_result_file);
-    }
+        "%sCHANGE MASTER '%.*s' TO MASTER_USE_GTID=slave_pos;\n",
+        gtid_comment_prefix, NAME_CHAR_LEN, row[/* Connection_name */ 0]);
+    fprintf(md_result_file, "%sCHANGE MASTER '%.*s' TO ",
+      nogtid_comment_prefix, NAME_CHAR_LEN, row[/* Connection_name */ 0]);
+    if (opt_include_master_host_port)
+      fprintf(md_result_file, "MASTER_HOST='%s', MASTER_PORT=%s, ",
+        row[have_info_schema_slave_status ? 1 : /* Master_Host */ 3],
+        row[have_info_schema_slave_status ? 2 : /* Master_Port */ 5]);
+    fprintf(md_result_file, "MASTER_LOG_FILE='%s', MASTER_LOG_POS=%s;\n",
+      row[have_info_schema_slave_status ? 3 : /* Relay_Master_Log_File */ 11],
+      row[have_info_schema_slave_status ? 4 : /*  Exec_Master_Log_Pos  */ 23]);
+    check_io(md_result_file);
   }
+
+  if (have_info_schema_slave_status)
+    mysql_free_result(slave);
   fprintf(md_result_file, "\n");
-  mysql_free_result(slave);
   return 0;
 }
 
@@ -6638,33 +6608,23 @@ static int do_start_slave_sql(MYSQL *mysql_con)
   if (!slave_status_res)
     DBUG_RETURN(error);
   mysql_data_seek(slave_status_res, 0);
-
+  /*
+    If SLAVE_SQL was not running but is now,
+    we start it anyway to warn the unexpected state change.
+  */
   while ((row= mysql_fetch_row(slave_status_res)))
   {
-    DBUG_PRINT("info", ("Connection: '%s'  status: '%s'",
-                        multi_source ? row[0] : "", row[11 + multi_source]));
-    if (row[11 + multi_source])
+    char query[26 + NAME_CHAR_LEN]; // sizeof(snprintf)
+    snprintf(query, sizeof(query),
+                   "START SLAVE '%.*s' SQL_THREAD",
+            NAME_CHAR_LEN, row[/* Connection_name */ 0]);
+    if ((have_info_schema_slave_status ||
+         strcmp(row[/* Slave_SQL_Running */ 13], "No")
+        ) && mysql_query_with_error_report(mysql_con, nullptr, query))
     {
-      /*
-        If SLAVE_SQL was not running but is now,
-        we start it anyway to warn the unexpected state change.
-      */
-      if (strcmp(row[11 + multi_source], "No"))
-      {
-        char query[160];
-        if (multi_source)
-          snprintf(query, sizeof(query),
-                   "START SLAVE '%.80s' SQL_THREAD", row[0]);
-        else
-          strmov(query, "START SLAVE SQL_THREAD");
-
-        if (mysql_query_with_error_report(mysql_con, 0, query))
-        {
-          fprintf(stderr, "%s: Error: Unable to start slave '%s'\n",
-                  my_progname_short, multi_source ? row[0] : "");
-          error= 1;
-        }
-      }
+      fprintf(stderr, "%s: Error: Unable to start slave '%s'\n",
+              my_progname_short, row[0]);
+      error= 1;
     }
   }
   DBUG_RETURN(error);
@@ -7687,9 +7647,10 @@ int main(int argc, char **argv)
     init_connection_pool(opt_parallel);
 
   /* Check if the server support multi source */
-  if (mysql_get_server_version(mysql) >= 100000)
+  unsigned long server_version= mysql_get_server_version(mysql);
+  if (server_version >= 100000)
   {
-    multi_source= 2;
+    have_info_schema_slave_status= server_version >= 110600;
     have_mariadb_gtid= 1;
   }
 
@@ -7757,7 +7718,6 @@ int main(int argc, char **argv)
                                                sizeof(master_set_gtid_pos)))
     goto err;
   if (opt_slave_data && do_show_slave_status(mysql,
-                                             have_mariadb_gtid,
                                              opt_use_gtid, slave_set_gtid_pos,
                                              sizeof(slave_set_gtid_pos)))
     goto err;

--- a/mysql-test/main/rpl_mysqldump_slave.result
+++ b/mysql-test/main/rpl_mysqldump_slave.result
@@ -141,14 +141,11 @@ CHANGE MASTER TO MASTER_LOG_FILE='slave-bin.000001', MASTER_LOG_POS=BINLOG_START
 
 -- CHANGE MASTER TO MASTER_LOG_FILE='slave-bin.000001', MASTER_LOG_POS=BINLOG_START;
 
---
--- The following is the SQL position of the replication taken from SHOW SLAVE STATUS at the time of backup.
--- Use this position when creating a clone of, or replacement server, from where the backup was taken.
+-- The following is the replication SQL position taken from SHOW SLAVE STATUS at the time of backup.
+-- Use this position when creating a clone or replacement server from where the backup was taken.
 -- This new server will connects to the same primary server(s).
 --
-
--- A corresponding to the below dump-slave CHANGE-MASTER settings to the slave gtid state is printed later in the file.
-
+-- The replica GTID position corresponding to the below CHANGE-MASTER settings is printed later in the file.
 -- Use only the MASTER_USE_GTID=slave_pos or MASTER_LOG_FILE/MASTER_LOG_POS in the statements below.
 
 -- CHANGE MASTER '' TO MASTER_USE_GTID=slave_pos;
@@ -204,13 +201,11 @@ CHANGE MASTER TO MASTER_LOG_FILE='slave-bin.000001', MASTER_LOG_POS=BINLOG_START
 
 -- A corresponding to the above master-data CHANGE-MASTER settings to the slave gtid state is printed as comments later in the file.
 
---
--- The following is the SQL position of the replication taken from SHOW SLAVE STATUS at the time of backup.
--- Use this position when creating a clone of, or replacement server, from where the backup was taken.
+-- The following is the replication SQL position taken from SHOW SLAVE STATUS at the time of backup.
+-- Use this position when creating a clone or replacement server from where the backup was taken.
 -- This new server will connects to the same primary server(s).
 --
-
--- A corresponding to the below dump-slave CHANGE-MASTER settings to the slave gtid state is printed later in the file.
+-- The replica GTID position corresponding to the below CHANGE-MASTER settings is printed later in the file.
 -- CHANGE MASTER '' TO MASTER_LOG_FILE='master-bin.000001', MASTER_LOG_POS=BINLOG_START;
 
 


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-37146](https://jira.mariadb.org/browse/MDEV-37146)*

## Description
`SELECT … FROM information_schema.SLAVE_STATUS` is an alternative to `SHOW SLAVE STATUS` that supports `WHERE` and column selection.
Utilizing this server-side feature allows `mariadb-dump --dump-slave` to iterate only the required data on the client side.

The main commit keeps support for pre-`information_schema.SLAVE_STATUS` ([MDEV-33526](https://jira.mariadb.org/browse/MDEV-33526) @ 11.6) via `SHOW SLAVE STATUS` by switching column indices.
On the contrary, it additionally drops `--dump-slave` and `--apply-slave-statements` support for pre-GTID & pre-multi-source (before 10.0 – long EOL).

## Release Notes
`mariadb-dump --dump-slave` now requires MariaDB 10.0 or above, and is additionally optimized for 11.6 or above.

## How can this PR be tested?
Test `mariadb-dump --dump-slave` as usual, e.g., through MTR tests `main.rpl_mysqldump_slave` & `multi_source.mariadb-dump_slave`.

## Basing the PR against the correct MariaDB version
* [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* ~~*This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*~~

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.