### PR TITLE
Escape `$`s in `show_slave_status.inc` error msgs

### DIFF
--- a/mysql-test/include/show_slave_status.inc
+++ b/mysql-test/include/show_slave_status.inc
@@ -86,7 +86,7 @@
 --let $_show_slave_status_items=$status_items
 if (!$status_items)
 {
-  --die Bug in test case: The mysqltest variable $status_items is not set.
+  --die Bug in test case: The mysqltest variable \$status_items is not set.
 }
 
 --let $_show_query=SHOW SLAVE STATUS
@@ -95,7 +95,7 @@ if ($all_slaves_status)
 {
   if ($slave_name)
   {
-    --die Bug in test case: Both $all_slaves_status and $slave_name are set.
+    --die Bug in test case: Both \$all_slaves_status and \$slave_name are set.
   }
   --let $_show_query=SHOW ALL SLAVES STATUS
 }


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: MDEV-______*~~

## Description
`--die` performs variable substitution like `--echo` does, so the variable names were parsed rather than mentioned verbatim.

#### Before Patch (Erroneous)
```
At line 89: Bug in test case: The mysqltest variable  is not set.
At line 98: Bug in test case: Both 1 and foobar are set.
```
#### After Patch (Intended)
```
At line 89: Bug in test case: The mysqltest variable $status_items is not set.
At line 98: Bug in test case: Both $all_slaves_status and $slave_name are set.
```

## Release Notes
N/A
Unless there are users who write their own Replication MTR tests.

## How can this PR be tested?
We are about as reliant on `include/*.inc` files as actual MTR commands.
This means the `include/*.inc`s are as eligible for unit testing as MTR commands are, right?

## PR quality check
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* ~~I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.~~
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.