### PR TITLE
MDEV-31053 UUID(size) should be disallowed

### DIFF
--- a/plugin/type_inet/mysql-test/type_inet/type_inet4.result
+++ b/plugin/type_inet/mysql-test/type_inet/type_inet4.result
@@ -2017,3 +2017,12 @@ DROP TABLE t1;
 #
 # End of 10.10 tests
 #
+#
+# Begin 10.11 tests
+#
+#
+# MDEV-31053 UUID(size) should be disallowed
+#
+CREATE TABLE t1 (a INET4(24));
+ERROR HY000: Type 'inet4' does not accept length nor precision values
+# End 10.11 tests

--- a/plugin/type_inet/mysql-test/type_inet/type_inet4.test
+++ b/plugin/type_inet/mysql-test/type_inet/type_inet4.test
@@ -1479,3 +1479,15 @@ DROP TABLE t1;
 --echo #
 --echo # End of 10.10 tests
 --echo #
+
+--echo #
+--echo # Begin 10.11 tests
+--echo #
+
+--echo #
+--echo # MDEV-31053 UUID(size) should be disallowed
+--echo #
+--error ER_NO_LENGTH_PRECISION_ALLOWED
+CREATE TABLE t1 (a INET4(24));
+
+--echo # End 10.11 tests

--- a/plugin/type_inet/sql_type_inet.h
+++ b/plugin/type_inet/sql_type_inet.h
@@ -44,6 +44,15 @@ public:
     return !only_zero_bytes(m_buffer, sizeof(m_buffer));
   }
   static const Name &default_value();
+  static bool allowed(const Lex_field_type_st &attr,
+                      const Name& name)
+  {
+    /*
+      Inet6 support allows length at least, for the case
+      CREATE TABLE t1 (id int NOT NULL PRIMARY KEY, a INET6(6) DEFAULT '::10');
+    */
+    return false;  // no error, is allowed
+  }
 };
 
 
@@ -59,6 +68,16 @@ public:
   bool ascii_to_fbt(const char *str, size_t str_length);
   size_t to_string(char *dst, size_t dstsize) const;
   static const Name &default_value();
+  static bool allowed(const Lex_field_type_st &attr,
+                      const Name& name)
+  {
+    if (attr.length() || attr.dec()) {
+      my_error(ER_NO_LENGTH_PRECISION_ALLOWED, MYF(0), name.ptr());
+      return true;
+    }
+
+    return false;  // no error, is allowed
+  }
 };
 
 typedef Type_handler_fbt<Inet4> Type_handler_inet4;

--- a/plugin/type_uuid/mysql-test/type_uuid/type_uuid.result
+++ b/plugin/type_uuid/mysql-test/type_uuid/type_uuid.result
@@ -3202,3 +3202,12 @@ Warnings:
 Warning	1292	Incorrect uuid value: ''
 Warning	1292	Incorrect uuid value: ''
 DROP TABLE t1;
+#
+# Begin 10.11 tests
+#
+#
+# MDEV-31053 UUID(size) should be disallowed
+#
+CREATE TABLE t1 (a UUID(24));
+ERROR HY000: Type 'uuid' does not accept length nor precision values
+# End 10.11 tests

--- a/plugin/type_uuid/mysql-test/type_uuid/type_uuid.test
+++ b/plugin/type_uuid/mysql-test/type_uuid/type_uuid.test
@@ -1697,3 +1697,15 @@ INSERT INTO t1 VALUES ('00000000-0000-0000-0000-000000000000');
 SELECT * FROM t1 WHERE a IN ('','00000000-0000-0000-0000-000000000001');
 SELECT * FROM t1 WHERE a='';
 DROP TABLE t1;
+
+--echo #
+--echo # Begin 10.11 tests
+--echo #
+
+--echo #
+--echo # MDEV-31053 UUID(size) should be disallowed
+--echo #
+--error ER_NO_LENGTH_PRECISION_ALLOWED
+CREATE TABLE t1 (a UUID(24));
+
+--echo # End 10.11 tests

--- a/plugin/type_uuid/sql_type_uuid.h
+++ b/plugin/type_uuid/sql_type_uuid.h
@@ -311,6 +311,16 @@ public:
     return rc;
   }
 
+  static bool allowed(const Lex_field_type_st &attr,
+                      const Name& name)
+  {
+    if (attr.length() || attr.dec()) {
+      my_error(ER_NO_LENGTH_PRECISION_ALLOWED, MYF(0), name.ptr());
+      return true;
+    }
+
+    return false;  // no error, is allowed
+  }
 };
 
 class Type_collection_uuid: public Type_collection

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -10758,3 +10758,5 @@ ER_CM_OPTION_MISSING_REQUIREMENT
         eng "CHANGE MASTER TO option '%s=%s' is missing requirement %s"
 ER_SLAVE_STATEMENT_TIMEOUT 70100
         eng "Slave log event execution was interrupted (slave_max_statement_time exceeded)"
+ER_NO_LENGTH_PRECISION_ALLOWED
+       eng "Type '%s' does not accept length nor precision values"

--- a/sql/sql_type_fixedbin.h
+++ b/sql/sql_type_fixedbin.h
@@ -1217,6 +1217,18 @@ public:
     const Record_addr tmp(NULL, Bit_addr(true));
     return new (table->in_use->mem_root) Field_fbt(&empty_clex_str, tmp);
   }
+
+  bool Column_definition_set_attributes(THD *thd,
+                                        Column_definition *def,
+                                        const Lex_field_type_st &attr,
+                                        column_definition_type_t type) const override
+  {
+    if (FbtImpl::allowed(attr, singleton()->name()))
+      return true;
+    return Type_handler::Column_definition_set_attributes(thd, def,
+                                                          attr, type);
+  }
+
   // Fix attributes after the parser
   bool Column_definition_fix_attributes(Column_definition *c) const override
   {


### PR DESCRIPTION
Emits an error when creating a table with either a UUID or ipv4 column having a nonzero length.  Specifying lengths has no effect for these types:
```
  CREATE TABLE t1 (id UUID(24), ..., ip ipv4(4), ... );
```
ipv6 columns having nonzero lengths are permitted, for example in the case of
```
  CREATE TABLE t1 (a INET6(6) DEFAULT '::10');
```
Specifying length zero for uuid, ipv4 has the same behavior as specifying no explicit length.  Since these types are plugins, the lengths cannot be rejected by the grammar at lexing; rather they are rejected at a later parsing step if they are nonzero.
