### PR TITLE
MDEV-37412 Corrupted page during recovery aborts the server

### DIFF
--- a/mysql-test/suite/innodb/r/leaf_page_corrupted_during_recovery.result
+++ b/mysql-test/suite/innodb/r/leaf_page_corrupted_during_recovery.result
@@ -4,6 +4,15 @@ INSERT INTO t1 VALUES(1, 'sql'), (2, 'server'), (3, 'mariadb'),
 (4, 'mariadb'), (5, 'test1'), (6, 'test2'), (7, 'test3'),
 (8, 'test4'), (9, 'test5'), (10, 'test6'), (11, 'test7'),
 (12, 'test8');
+call mtr.add_suppression("InnoDB: Cannot apply log to \\[page id: space=[1-9], page number=0\\] of corrupted file '.*mdev_37412\\.ibd'");
+SET GLOBAL innodb_log_checkpoint_now=ON;
+CREATE TABLE mdev_37412(id INT AUTO_INCREMENT, PRIMARY KEY(id))
+STATS_PERSISTENT=0 ENGINE=InnoDB;
+# Kill the server
+# restart: --debug_dbug=+d,recv_corrupt
+SELECT * FROM mdev_37412;
+id
+DROP TABLE mdev_37412;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 12

--- a/mysql-test/suite/innodb/t/leaf_page_corrupted_during_recovery.test
+++ b/mysql-test/suite/innodb/t/leaf_page_corrupted_during_recovery.test
@@ -21,8 +21,23 @@ INSERT INTO t1 VALUES(1, 'sql'), (2, 'server'), (3, 'mariadb'),
 	(8, 'test4'), (9, 'test5'), (10, 'test6'), (11, 'test7'),
 	(12, 'test8');
 
+call mtr.add_suppression("InnoDB: Cannot apply log to \\[page id: space=[1-9], page number=0\\] of corrupted file '.*mdev_37412\\.ibd'");
+SET GLOBAL innodb_log_checkpoint_now=ON;
+--source ../include/no_checkpoint_start.inc
+CREATE TABLE mdev_37412(id INT AUTO_INCREMENT, PRIMARY KEY(id))
+			STATS_PERSISTENT=0 ENGINE=InnoDB;
+--let CLEANUP_IF_CHECKPOINT=DROP TABLE t1,mdev_37412;
+--source ../include/no_checkpoint_end.inc
+
+--let $restart_parameters=--debug_dbug=+d,recv_corrupt
+--source include/start_mysqld.inc
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN= InnoDB: Cannot apply log to \\[page id: space=[1-9], page number=0\\] of corrupted file '.*mdev_37412\\.ibd';
+--let $restart_parameters=
 let $restart_noprint=2;
 --source include/restart_mysqld.inc
+SELECT * FROM mdev_37412;
+DROP TABLE mdev_37412;
 
 let INNODB_PAGE_SIZE=`select @@innodb_page_size`;
 let MYSQLD_DATADIR=`select @@datadir`;

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3041,6 +3041,10 @@ static buf_block_t *recv_recover_page(buf_block_t *block, mtr_t &mtr,
 				      block->page.id().page_no()));
 
 		log_phys_t::apply_status a= l->apply(*block, recs.last_offset);
+		DBUG_EXECUTE_IF("recv_corrupt",
+				if (init && init->created &&
+				    (!space || space->id != 0))
+				  a= log_phys_t::APPLIED_CORRUPTED;);
 
 		switch (a) {
 		case log_phys_t::APPLIED_NO:
@@ -3112,17 +3116,9 @@ set_start_lsn:
 			mtr.discard_modifications();
 			mtr.commit();
 
-			fil_space_t* s = space
-				? space
-				: fil_space_t::get(block->page.id().space());
-
 			buf_pool.corrupted_evict(&block->page,
 						 block->page.state() &
 						 buf_page_t::LRU_MASK);
-			if (!space) {
-				s->release();
-			}
-
 			return nullptr;
 		}
 
@@ -3524,7 +3520,6 @@ inline buf_block_t *recv_sys_t::recover_low(const map::iterator &p, mtr_t &mtr,
     DBUG_LOG("ib_log", "skip log for page " << p->first
              << " LSN " << end_lsn << " < " << init.lsn);
   fil_space_t *space= fil_space_t::get(p->first.space());
-
   mtr.start();
   mtr.set_log_mode(MTR_LOG_NO_REDO);
 
@@ -3544,7 +3539,6 @@ inline buf_block_t *recv_sys_t::recover_low(const map::iterator &p, mtr_t &mtr,
     zip_size= fil_space_t::zip_size(flags);
     block= buf_page_create_deferred(p->first.space(), zip_size, &mtr, b);
     ut_ad(block == b);
-    block->page.lock.x_lock_recursive();
   }
   else
   {
@@ -3563,6 +3557,8 @@ inline buf_block_t *recv_sys_t::recover_low(const map::iterator &p, mtr_t &mtr,
     }
   }
 
+  /* Released in buf_pool_t::corrupted_evict(), recover_deferred() or below */
+  block->page.lock.x_lock_recursive();
   ut_d(mysql_mutex_lock(&mutex));
   ut_ad(&recs == &pages.find(p->first)->second);
   ut_d(mysql_mutex_unlock(&mutex));
@@ -3571,8 +3567,11 @@ inline buf_block_t *recv_sys_t::recover_low(const map::iterator &p, mtr_t &mtr,
   ut_ad(mtr.has_committed());
 
   if (space)
+  {
     space->release();
-
+    if (block)
+      block->page.lock.x_unlock();
+  }
   return block ? block : reinterpret_cast<buf_block_t*>(-1);
 }
 


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-37412*

## Description
Problem:
=======
When InnoDB encounters a corrupted page during crash recovery, server would abort due to improper handling of page locks and space references. The recovery process was not properly cleaning up resources when corruption was detected, leading to inconsistent state and server termination.

Solution:
=========
recover_low(): Move page lock recursive acquisition after deferred/non-deferred page creation logic to ensure consistent locking behavior for both code paths. Ensure proper block recursive unlock for non-deferred tablespaces

recv_recover_page(): Simplify corrupted page cleanup by removing redundant space reference handling.


## Release Notes
 Server abort when encountering corrupted pages during crash recovery. This fix prevents
unexpected server shutdowns during crash recovery when corrupted pages are encountered,
allowing the server to handle corruption more gracefully and continue recovery of non-corrupted data.

## How can this PR be tested?
./mtr innodb.leaf_page_corrupted_during_recovery

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
