### PR TITLE
MDEV-30692: conf_to_src incompatible with CHARSET_INFO changes (postfix)

### DIFF
--- a/strings/conf_to_src.c
+++ b/strings/conf_to_src.c
@@ -482,7 +482,7 @@ main(int argc, char **argv  __attribute__((unused)))
       if ( (!simple_cs_is_full(cs)) && (cs->cs_name.str))
       {
         snprintf(filename, sizeof filename, "%s/%.*s.xml",
-                 argv[1], cs->csname.length, cs->csname.str);
+                 argv[1], (int) cs->cs_name.length, cs->cs_name.str);
         my_read_charset_file(filename);
       }
       cs->state|= MY_CS_LOADED;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30692*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Caused by MDEV-30577 when the CHARSET_INFO structure changed.

As hinted by clang:

error: no member named 'csname' in 'struct charset_info_st'; did you mean 'cs_name'?

Because the target conf_to_src has the properties EXCLUDE_FROM_DEFAULT_BUILD it hasn't been noticed.

## Release Notes

nothing - convenience not distributed executable

## How can this PR be tested?

explicitly build the target and it will compile:
```
cmake --build . --target conf_to_src
```

Run codebase under static analyser.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

10.6 faults also exist, but I'm not concerned.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
