### PR TITLE
MDEV-37581: Assertion failure sql_base.cc:3927: bool open_and_process_routine

### DIFF
--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -343,7 +343,7 @@ static int open_table(THD *thd, const LEX_CSTRING *schema_name,
        (thd->get_stmt_da()->sql_errno() == ER_QUERY_INTERRUPTED));
 
   if (interrupted ||
-      !open_n_lock_single_table(thd, table_list, table_list->lock_type, flags))
+      !open_n_lock_single_table(thd, table_list, lock_type, flags))
   {
     close_thread_tables(thd);
     DBUG_RETURN(1);
@@ -805,10 +805,16 @@ int Wsrep_schema::store_view(THD* thd, const Wsrep_view& view)
 #ifdef WSREP_SCHEMA_MEMBERS_HISTORY
   TABLE* members_history_table= 0;
 #endif /* WSREP_SCHEMA_MEMBERS_HISTORY */
+  Query_tables_list query_tables_list_backup;
 
   Wsrep_schema_impl::wsrep_off wsrep_off(thd);
   Wsrep_schema_impl::binlog_off binlog_off(thd);
   Wsrep_schema_impl::sql_safe_updates sql_safe_updates(thd);
+
+  /*
+    Backup and restore the query table list changes.
+  */
+  thd->lex->reset_n_backup_query_tables_list(&query_tables_list_backup);
 
   if (trans_begin(thd, MYSQL_START_TRANS_OPT_READ_WRITE))
   {
@@ -925,6 +931,7 @@ int Wsrep_schema::store_view(THD* thd, const Wsrep_view& view)
   thd->release_transactional_locks();
 
 out_not_started:
+  thd->lex->restore_backup_query_tables_list(&query_tables_list_backup);
   DBUG_RETURN(ret);
 }
 
@@ -949,10 +956,16 @@ Wsrep_view Wsrep_schema::restore_view(THD* thd, const Wsrep_id& own_id) const {
   int proto_ver= 0;
   wsrep_cap_t capabilities= 0;
   std::vector<Wsrep_view::member> members;
+  Query_tables_list query_tables_list_backup;
 
   // we don't want causal waits for reading non-replicated private data
   int const wsrep_sync_wait_saved= thd->variables.wsrep_sync_wait;
   thd->variables.wsrep_sync_wait= 0;
+
+  /*
+    Backup and restore the query table list changes.
+  */
+  thd->lex->reset_n_backup_query_tables_list(&query_tables_list_backup);
 
   if (trans_begin(thd, MYSQL_START_TRANS_OPT_READ_ONLY)) {
     WSREP_ERROR("wsrep_schema::restore_view(): Failed to start transaction");
@@ -1068,12 +1081,14 @@ Wsrep_view Wsrep_schema::restore_view(THD* thd, const Wsrep_id& own_id) const {
       os << "Restored cluster view:\n" << ret_view;
       WSREP_INFO("%s", os.str().c_str());
     }
+    thd->lex->restore_backup_query_tables_list(&query_tables_list_backup);
     DBUG_RETURN(ret_view);
   }
   else
   {
     WSREP_ERROR("wsrep_schema::restore_view() failed.");
     Wsrep_view ret_view;
+    thd->lex->restore_backup_query_tables_list(&query_tables_list_backup);
     DBUG_RETURN(ret_view);
   }
 }
@@ -1460,6 +1475,7 @@ int Wsrep_schema::replay_transaction(THD* orig_thd,
 {
   DBUG_ENTER("Wsrep_schema::replay_transaction");
   DBUG_ASSERT(!fragments.empty());
+  Query_tables_list query_tables_list_backup;
 
   THD *thd= new THD(next_thread_id(), true);
   if (!thd)
@@ -1471,7 +1487,13 @@ int Wsrep_schema::replay_transaction(THD* orig_thd,
   thd->thread_stack= (orig_thd ? orig_thd->thread_stack : (char *) &thd);
   wsrep_assign_from_threadvars(thd);
 
+
+  /*
+    Backup and restore the query table list changes.
+  */
+  orig_thd->lex->reset_n_backup_query_tables_list(&query_tables_list_backup);
   int ret= ::replay_transaction(thd, orig_thd, rli, ws_meta, fragments);
+  orig_thd->lex->restore_backup_query_tables_list(&query_tables_list_backup);
 
   delete thd;
   DBUG_RETURN(ret);
@@ -1774,6 +1796,7 @@ void Wsrep_schema::store_allowlist(std::vector<std::string>& ip_allowlist)
   TABLE* allowlist_table= 0;
   TABLE_LIST allowlist_table_l;
   int error;
+
   Wsrep_schema_impl::init_stmt(thd);
   if (Wsrep_schema_impl::open_for_write(thd, allowlist_table_str.c_str(),
                                         &allowlist_table_l))


### PR DESCRIPTION
MDEV-37581: Assertion failure sql_base.cc:3927: bool open_and_process_routine

Issue:
The testcase galera.galera_as_slave_gtid_myisam fails with below error: mariadb-10.11-build/sql/sql_base.cc:3927: bool open_and_process_routine(THD*, Query_tables_list*, Sroutine_hash_entry*, Prelocking_strategy*, bool, Open_table_context*, bool*, bool*): Assertion `0' failed.

The error happens when  rollback is applied to replicate MyISAM tables, but the query table list (sroutines_list) is not restored to it's original value before executing this statement.

Solution:
Backup and restore the query table list to it's original value.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
