### PR TITLE
MDEV-37633 Connect UDF functions push empty string warning.

### DIFF
--- a/storage/connect/bsonudf.cpp
+++ b/storage/connect/bsonudf.cpp
@@ -294,8 +294,11 @@ my_bool BJNX::ParseJpath(PGLOBAL g)
 	if (Parsed)
 		return false;                       // Already done
 	else if (!Jpath)
+	{
 		//	Jpath = Name;
+		snprintf(g->Message, sizeof(g->Message), MSG(ARG_IS_NULL));
 		return true;
+	}
 
 	if (trace(1))
 		htrc("ParseJpath %s\n", SVP(Jpath));

--- a/storage/connect/encas.h
+++ b/storage/connect/encas.h
@@ -318,3 +318,4 @@
     case MSG_XPATH_CNTX_ERR:  p = "Unable to create new XPath context";                      break;
     case MSG_XPATH_EVAL_ERR:  p = "Unable to evaluate xpath location '%s'";                  break;
     case MSG_XPATH_NOT_SUPP:  p = "Unsupported Xpath for column %s";                         break;
+    case MSG_ARG_IS_NULL:     p = "Argument is NULL";                                        break;

--- a/storage/connect/engmsg.h
+++ b/storage/connect/engmsg.h
@@ -324,3 +324,4 @@
 #define MSG_XPATH_EVAL_ERR  "Unable to evaluate xpath location '%s'"
 #define MSG_XPATH_NOT_SUPP  "Unsupported Xpath for column %s"
 #define MSG_ZERO_DIVIDE     "Zero divide in expression"
+#define MSG_ARG_IS_NULL     "Argument is NULL"

--- a/storage/connect/jsonudf.cpp
+++ b/storage/connect/jsonudf.cpp
@@ -98,7 +98,10 @@ my_bool JSNX::SetJpath(PGLOBAL g, char *path, my_bool jb)
 {
 	// Check Value was allocated
 	if (!Value)
+	{
+		snprintf(g->Message, sizeof(g->Message), MSG(NO_MEMORY));
 		return true;
+	}
 
 	Value->SetNullable(true);
 	Jpath = path;
@@ -217,8 +220,11 @@ my_bool JSNX::ParseJpath(PGLOBAL g)
 	if (Parsed)
 		return false;                       // Already done
 	else if (!Jpath)
+	{
 		//	Jpath = Name;
+		snprintf(g->Message, sizeof(g->Message), MSG(ARG_IS_NULL));
 		return true;
+	}
 
 	if (trace(1))
 		htrc("ParseJpath %s\n", SVP(Jpath));

--- a/storage/connect/msgid.h
+++ b/storage/connect/msgid.h
@@ -324,3 +324,4 @@
 #define MSG_FIX_OVFLW_TIMES    522
 #define MSG_FIX_UNFLW_ADD      523
 #define MSG_FIX_UNFLW_TIMES    524
+#define MSG_ARG_IS_NULL        525

--- a/storage/connect/mysql-test/connect/r/bson_udf.result
+++ b/storage/connect/mysql-test/connect/r/bson_udf.result
@@ -352,7 +352,7 @@ SELECT BsonGet_String(NULL json_, NULL);
 BsonGet_String(NULL json_, NULL)
 NULL
 Warnings:
-Warning	1105	
+Warning	1105	Argument is NULL
 /* NULL WARNING */
 SELECT department, BsonGet_String(Bson_Make_Object(department, Bson_Array_Grp(salary) "Json_salaries"),'salaries.[+]') Sumsal FROM t3 GROUP BY department;
 department	Sumsal

--- a/storage/connect/mysql-test/connect/r/json_udf.result
+++ b/storage/connect/mysql-test/connect/r/json_udf.result
@@ -346,7 +346,7 @@ SELECT JsonGet_String(NULL json_, NULL);
 JsonGet_String(NULL json_, NULL)
 NULL
 Warnings:
-Warning	1105	
+Warning	1105	Argument is NULL
 SELECT department, JsonGet_String(Json_Make_Object(department, Json_Array_Grp(salary) "Json_salaries"),'salaries.[+]') Sumsal FROM t3 GROUP BY department;
 department	Sumsal
 0021	28500.000000


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37633*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

BsonGet_String and JsonGet_String with a NULL argument push an empty string warning which is the default contents of g->Message.

In push_warning in the server, there is a Debug assertion that the string doesn't end in \n. This looks before the last null of the string, which in this case is before the buffer. This results in a UBSAN error as its a pointer overflow/underflow.

Correct by adding an "Argument is NULL" as the warning message.

Also corrected the JsonGet_String to error if the Value failed to allocate a buffer in its constructor.

## Release Notes

Per MDEV.

## How can this PR be tested?

mtr tests connect.json_udf  connect.bson_udf, especially under UBSAN


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
