### PR TITLE
MDEV-37299: Fix server crash when encryption is ON and server is read-only

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-read-only.result
+++ b/mysql-test/suite/encryption/r/innodb-read-only.result
@@ -1,4 +1,16 @@
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Success!
+SET GLOBAL innodb_encryption_threads=4;
+SELECT COUNT(*) AS encrypt_threads_running
+FROM performance_schema.threads
+WHERE NAME LIKE '%encrypt%';
+encrypt_threads_running
+4
 # restart: --innodb-read-only=1 --innodb-encrypt-tables=1
+SET GLOBAL innodb_encryption_threads=4;
+SELECT COUNT(*) AS encrypt_threads_running
+FROM performance_schema.threads
+WHERE NAME LIKE '%encrypt%';
+encrypt_threads_running
+0
 # All done

--- a/mysql-test/suite/encryption/t/innodb-read-only.test
+++ b/mysql-test/suite/encryption/t/innodb-read-only.test
@@ -25,10 +25,22 @@ if (!$success)
 }
 --echo # Success!
 
+# Server in normal mode
+SET GLOBAL innodb_encryption_threads=4;
+SELECT COUNT(*) AS encrypt_threads_running
+FROM performance_schema.threads
+WHERE NAME LIKE '%encrypt%';
+
 #
 # MDEV-11835: InnoDB: Failing assertion: free_slot != NULL on
 # restarting server with encryption and read-only
 #
 --let $restart_parameters= --innodb-read-only=1 --innodb-encrypt-tables=1
 --source include/restart_mysqld.inc
+
+# Server read-only mode
+SET GLOBAL innodb_encryption_threads=4;
+SELECT COUNT(*) AS encrypt_threads_running
+FROM performance_schema.threads
+WHERE NAME LIKE '%encrypt%';
 --echo # All done

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2108,6 +2108,9 @@ Adjust thread count for key rotation
 @param[in]	enw_cnt		Number of threads to be used */
 void fil_crypt_set_thread_cnt(const uint new_cnt)
 {
+	if (srv_read_only_mode)
+		return;
+
 	if (!fil_crypt_threads_inited) {
 		if (srv_shutdown_state != SRV_SHUTDOWN_NONE)
 			return;
@@ -2261,6 +2264,8 @@ void fil_crypt_set_encrypt_tables(ulong val)
 Init threads for key rotation */
 void fil_crypt_threads_init()
 {
+	ut_ad(!srv_read_only_mode);
+
 	if (!fil_crypt_threads_inited) {
 		pthread_cond_init(&fil_crypt_cond, nullptr);
 		pthread_cond_init(&fil_crypt_threads_cond, nullptr);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37299*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Encryption thread creation is only done when server is not in read only mode.
1. Modified srv_start to call fil_crypt_threads_init() only
    when srv_read_only_mode is not set.
2. Modified encryption.innodb-read-only to capture number of
    encryption threads created for both scenarios when
    server is not read only as well as when server is read only.

## Release Notes

This PR is a bug fix reported in MDEV-37299. 
When the server was started in read-only mode with encryption enabled,
the fix ensures that InnoDB avoids creating any encryption thread. 
No user-visible changes apart from the fix.


## How can this PR be tested?

Test encryption.innodb-read-only contains scenario that can be used to test this change.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
