### PR TITLE
10.6-mdev-31744: frame_range_n_bottom assertion error

### DIFF
--- a/mysql-test/main/win.result
+++ b/mysql-test/main/win.result
@@ -4662,5 +4662,52 @@ SUM(i) OVER (ORDER BY i)
 # Clean up
 DROP TABLE t1, t2;
 #
+# MDEV-31744: Assertion `order_list->elements == 1' failure 
+# during Frame_range_n_bottom object creation
+#
+CREATE TABLE t (a int, b int, c int, d int) ENGINE=MyISAM;
+INSERT INTO t VALUES (1,1,1,1);
+CREATE VIEW v AS SELECT * FROM t;
+SELECT 
+LEAD(a)  OVER (ORDER BY b, c) AS c1,
+COUNT(*) OVER (ORDER BY d RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+FROM v;
+c1	c2
+NULL	1
+#
+# test similar query as above for Frame_range_n_top
+#
+SELECT 
+LEAD(a)  OVER (ORDER BY b, c) AS c1, 
+COUNT(*) OVER (ORDER BY d RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+FROM v;
+c1	c2
+NULL	1
+DROP TABLE t;
+DROP VIEW v;
+#
+# test queries as above but on the table instead of view 
+#
+CREATE TABLE t (a int) ENGINE=MyISAM;
+INSERT INTO t values (1), (2);
+SELECT 
+COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+COUNT(*) OVER (ORDER BY a RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+from t;
+c1	c2
+1	2
+2	1
+#
+# similar query on table with Frame_range_n_top
+#
+SELECT 
+COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+COUNT(*) OVER (ORDER BY a RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+from t;
+c1	c2
+1	1
+2	2
+DROP TABLE t;
+#
 # End of 10.6 tests
 #

--- a/mysql-test/main/win.test
+++ b/mysql-test/main/win.test
@@ -3056,5 +3056,54 @@ EXECUTE IMMEDIATE "SELECT SUM(i) OVER (ORDER BY i) FROM t1 NATURAL JOIN t2";
 DROP TABLE t1, t2;
 
 --echo #
+--echo # MDEV-31744: Assertion `order_list->elements == 1' failure 
+--echo # during Frame_range_n_bottom object creation
+--echo #
+
+CREATE TABLE t (a int, b int, c int, d int) ENGINE=MyISAM;
+INSERT INTO t VALUES (1,1,1,1);
+CREATE VIEW v AS SELECT * FROM t;
+ 
+SELECT 
+  LEAD(a)  OVER (ORDER BY b, c) AS c1,
+  COUNT(*) OVER (ORDER BY d RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+FROM v;
+
+--echo #
+--echo # test similar query as above for Frame_range_n_top
+--echo #
+
+SELECT 
+  LEAD(a)  OVER (ORDER BY b, c) AS c1, 
+  COUNT(*) OVER (ORDER BY d RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+FROM v;
+
+DROP TABLE t;
+DROP VIEW v;
+
+--echo #
+--echo # test queries as above but on the table instead of view 
+--echo #
+
+CREATE TABLE t (a int) ENGINE=MyISAM;
+INSERT INTO t values (1), (2);
+
+SELECT 
+  COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+  COUNT(*) OVER (ORDER BY a RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+from t;
+
+--echo #
+--echo # similar query on table with Frame_range_n_top
+--echo #
+
+SELECT 
+  COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+  COUNT(*) OVER (ORDER BY a RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+from t;
+
+DROP TABLE t;
+
+--echo #
 --echo # End of 10.6 tests
 --echo #

--- a/mysql-test/suite/encryption/r/tempfiles_encrypted.result
+++ b/mysql-test/suite/encryption/r/tempfiles_encrypted.result
@@ -4668,6 +4668,53 @@ SUM(i) OVER (ORDER BY i)
 # Clean up
 DROP TABLE t1, t2;
 #
+# MDEV-31744: Assertion `order_list->elements == 1' failure 
+# during Frame_range_n_bottom object creation
+#
+CREATE TABLE t (a int, b int, c int, d int) ENGINE=MyISAM;
+INSERT INTO t VALUES (1,1,1,1);
+CREATE VIEW v AS SELECT * FROM t;
+SELECT 
+LEAD(a)  OVER (ORDER BY b, c) AS c1,
+COUNT(*) OVER (ORDER BY d RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+FROM v;
+c1	c2
+NULL	1
+#
+# test similar query as above for Frame_range_n_top
+#
+SELECT 
+LEAD(a)  OVER (ORDER BY b, c) AS c1, 
+COUNT(*) OVER (ORDER BY d RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+FROM v;
+c1	c2
+NULL	1
+DROP TABLE t;
+DROP VIEW v;
+#
+# test queries as above but on the table instead of view 
+#
+CREATE TABLE t (a int) ENGINE=MyISAM;
+INSERT INTO t values (1), (2);
+SELECT 
+COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+COUNT(*) OVER (ORDER BY a RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) AS c2
+from t;
+c1	c2
+1	2
+2	1
+#
+# similar query on table with Frame_range_n_top
+#
+SELECT 
+COUNT(*) OVER (ORDER BY 'abc', a) AS c1,
+COUNT(*) OVER (ORDER BY a RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS c2
+from t;
+c1	c2
+1	1
+2	2
+DROP TABLE t;
+#
 # End of 10.6 tests
 #
 #


### PR DESCRIPTION
MDEV-31744: Assertion with COUNT(*) OVER (ORDER BY const RANGE BETWEEN...)

When the query uses several Window Functions:
 SELECT 
   WIN_FUNC1() OVER (ORDER BY 'const', col1), 
   WIN_FUNC2() OVER (ORDER BY col1 RANGE BETWEEN CURRENT ROW 
                                                 AND 5 FOLLOWING)
compare_window_funcs_by_window_specs() will try to get the Window Specs to
reuse the ORDER BY lists. If the lists produce the same order (like above)
Window Spec of the WIN_FUNC2 will reuse the ORDER BY list of WIN_FUNC1.

However, WIN_FUNC2 has a RANGE-type window frame. It expects to get 
ORDER BY list with one element, which it will use to compute frame bounds.
Proving it with ORDER BY list from WIN_FUNC1 ('const', col1) was caused an 
assertion failure

The fix is to: 
- use the original ORDER BY list when constructing RANGE-type frames
- fix an apparent typo bug in compare_window_funcs_by_window_specs():
  assignment
    win_spec1->save_order_list= win_spec2->order_list;
    saved the order list from the wrong spec. Instead, take one from win_spec1.