### PR TITLE
MDEV-37541 Race of rolling back and committing transaction to binlog

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_mdev37541.result
+++ b/mysql-test/suite/binlog/r/binlog_mdev37541.result
@@ -8,14 +8,17 @@ insert into t_x values (1);
 drop temporary table tt_tmp;
 insert into t1 values (99, "gotta log first");
 SET DEBUG_SYNC= 'reset';
-SET DEBUG_SYNC= "before_group_commit_queue WAIT_FOR trx1_go";
+SET DEBUG_SYNC= "before_group_commit_queue SIGNAL trx1_at_log WAIT_FOR trx1_go";
 ROLLBACK;
-connection default;
+connect trx2_commit,localhost,root,,;
 insert into t1 values (99, "second best in binlog");
+connection default;
+SET DEBUG_SYNC= "now WAIT_FOR trx1_at_log";
+SET DEBUG_SYNC= "now SIGNAL trx1_go";
+connection trx2_commit;
 select * from t1;
 a	b
 99	second best in binlog
-SET DEBUG_SYNC= "now SIGNAL trx1_go";
 # Prove the logging order is Trx1, Trx2
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
@@ -25,13 +28,14 @@ master-bin.000001	#	Table_map	#	#	table_id: # (test.t_x)
 master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
-master-bin.000001	#	Query	#	#	use `test`; insert into t1 values (99, "second best in binlog")
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
 master-bin.000001	#	Annotate_rows	#	#	insert into t1 values (99, "gotta log first")
 master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
 master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Query	#	#	ROLLBACK
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; insert into t1 values (99, "second best in binlog")
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 drop table t_x, t1;
 disconnect trx1_rollback;
+disconnect trx2_commit;
 # end of the tests

--- a/mysql-test/suite/binlog/r/binlog_mdev37541.result
+++ b/mysql-test/suite/binlog/r/binlog_mdev37541.result
@@ -1,0 +1,37 @@
+create table t1 (a int primary key, b text) engine=innodb;
+connect trx1_rollback,localhost,root,,;
+CREATE TABLE t_x (a int) engine=MEMORY;
+SET binlog_format=row;
+CREATE TEMPORARY TABLE tt_tmp ( id INT ) ENGINE = Memory;
+BEGIN;
+insert into t_x values (1);
+drop temporary table tt_tmp;
+insert into t1 values (99, "gotta log first");
+SET DEBUG_SYNC= 'reset';
+SET DEBUG_SYNC= "before_group_commit_queue WAIT_FOR trx1_go";
+ROLLBACK;
+connection default;
+insert into t1 values (99, "second best in binlog");
+select * from t1;
+a	b
+99	second best in binlog
+SET DEBUG_SYNC= "now SIGNAL trx1_go";
+# Prove the logging order is Trx1, Trx2
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Annotate_rows	#	#	insert into t_x values (1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t_x)
+master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; insert into t1 values (99, "second best in binlog")
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Annotate_rows	#	#	insert into t1 values (99, "gotta log first")
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	ROLLBACK
+drop table t_x, t1;
+disconnect trx1_rollback;
+# end of the tests

--- a/mysql-test/suite/binlog/t/binlog_mdev37541.test
+++ b/mysql-test/suite/binlog/t/binlog_mdev37541.test
@@ -1,0 +1,36 @@
+--source include/have_innodb.inc
+--source include/have_binlog_format_mixed.inc
+
+create table t1 (a int primary key, b text) engine=innodb;
+
+connect(trx1_rollback,localhost,root,,);
+CREATE TABLE t_x (a int) engine=MEMORY;
+
+--let $master_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_start=query_get_value(SHOW MASTER STATUS, Position, 1)
+SET binlog_format=row;
+CREATE TEMPORARY TABLE tt_tmp ( id INT ) ENGINE = Memory;
+BEGIN;
+  insert into t_x values (1);
+  drop temporary table tt_tmp;
+  insert into t1 values (99, "gotta log first");
+
+SET DEBUG_SYNC= 'reset';
+SET DEBUG_SYNC= "before_group_commit_queue WAIT_FOR trx1_go";
+
+--send ROLLBACK
+
+# trx2_commit
+connection default;
+insert into t1 values (99, "second best in binlog");
+select * from t1;
+
+SET DEBUG_SYNC= "now SIGNAL trx1_go";
+
+--echo # Prove the logging order is Trx1, Trx2
+--source include/show_binlog_events.inc
+
+drop table t_x, t1;
+disconnect trx1_rollback;
+
+--echo # end of the tests

--- a/mysql-test/suite/binlog/t/binlog_mdev37541.test
+++ b/mysql-test/suite/binlog/t/binlog_mdev37541.test
@@ -16,21 +16,34 @@ BEGIN;
   insert into t1 values (99, "gotta log first");
 
 SET DEBUG_SYNC= 'reset';
-SET DEBUG_SYNC= "before_group_commit_queue WAIT_FOR trx1_go";
+SET DEBUG_SYNC= "before_group_commit_queue SIGNAL trx1_at_log WAIT_FOR trx1_go";
 
 --send ROLLBACK
 
-# trx2_commit
-connection default;
-insert into t1 values (99, "second best in binlog");
-select * from t1;
+connect(trx2_commit,localhost,root,,);
+--send insert into t1 values (99, "second best in binlog")
 
+connection default;
+
+# Make sure ROLLBACK is in the binlogging phase ..
+SET DEBUG_SYNC= "now WAIT_FOR trx1_at_log";
+# .. and the contender trx2 in the locking phase ..
+let $wait_condition=
+  select count(*) = 1 from information_schema.innodb_trx
+  where trx_state = "LOCK WAIT" and trx_query like "%insert into t1 values%";
+source include/wait_condition.inc;
+# .. when both provided unfreeze the trx:s ..
 SET DEBUG_SYNC= "now SIGNAL trx1_go";
 
+connection trx2_commit;
+reap;
+select * from t1;
+
+# .. to observe proper binlogging.
 --echo # Prove the logging order is Trx1, Trx2
 --source include/show_binlog_events.inc
 
 drop table t_x, t1;
 disconnect trx1_rollback;
-
+disconnect trx2_commit;
 --echo # end of the tests

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2306,11 +2306,18 @@ int ha_rollback_trans(THD *thd, bool all)
     if (is_real_trans)                          /* not a statement commit */
       thd->stmt_map.close_transient_cursors();
 
+    int err;
+    if (has_binlog_hton(ha_info) &&
+        (err= binlog_hton->rollback(binlog_hton, thd, all)))
+    {
+      my_error(ER_ERROR_DURING_COMMIT, MYF(0), err);
+      error= 1;
+    }
     for (; ha_info; ha_info= ha_info_next)
     {
-      int err;
       handlerton *ht= ha_info->ht();
-      if ((err= ht->rollback(ht, thd, all)))
+
+      if (ht != binlog_hton && (err= ht->rollback(ht, thd, all)))
       {
         // cannot happen
         my_error(ER_ERROR_DURING_ROLLBACK, MYF(0), err);

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8235,6 +8235,7 @@ end:
 bool
 MYSQL_BIN_LOG::write_transaction_to_binlog_events(group_commit_entry *entry)
 {
+  DEBUG_SYNC(entry->thd, "before_group_commit_queue");
   int is_leader= queue_for_group_commit(entry);
 #ifdef WITH_WSREP
   /* commit order was released in queue_for_group_commit() call,


### PR DESCRIPTION
This is the 1st of two commits to demonstrate the failure which is
that a rolling back transaction while serializes its completion in
Engine before a contender transaction the two are logged into binary
log in reverse order.<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
