### PR TITLE
MDEV-34646: Be more helpful on unknown parameter messages

### DIFF
--- a/include/my_getopt.h
+++ b/include/my_getopt.h
@@ -130,6 +130,7 @@ longlong getopt_ll_limit_value(longlong, const struct my_option *,
                                my_bool *fix);
 double getopt_double_limit_value(double num, const struct my_option *optp,
                                  my_bool *fix);
+unsigned int levenshtein_distance(const char *s1, const char *s2);
 
 ulonglong getopt_double2ulonglong(double);
 double getopt_ulonglong2double(ulonglong);

--- a/mysql-test/main/deprecated_features.result
+++ b/mysql-test/main/deprecated_features.result
@@ -1,5 +1,5 @@
 set global log_bin_trust_routine_creators=1;
-ERROR HY000: Unknown system variable 'log_bin_trust_routine_creators'
+Got one of the listed errors
 set table_type='MyISAM';
 ERROR HY000: Unknown system variable 'table_type'
 select @@table_type='MyISAM';

--- a/mysql-test/main/deprecated_features.test
+++ b/mysql-test/main/deprecated_features.test
@@ -1,4 +1,4 @@
---error ER_UNKNOWN_SYSTEM_VARIABLE
+--error ER_UNKNOWN_SYSTEM_VARIABLE,ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
 set global log_bin_trust_routine_creators=1;
 --error ER_UNKNOWN_SYSTEM_VARIABLE
 set table_type='MyISAM';

--- a/mysql-test/suite/sys_vars/r/delayed_insert_timeout_basic.result
+++ b/mysql-test/suite/sys_vars/r/delayed_insert_timeout_basic.result
@@ -59,7 +59,7 @@ SELECT @@global.delayed_insert_timeout;
 SET @@session.delayed_insert_timeout = 0;
 ERROR HY000: Variable 'delayed_insert_timeout' is a GLOBAL variable and should be set with SET GLOBAL
 SELECT @@session.dalayed_insert_timeout;
-ERROR HY000: Unknown system variable 'dalayed_insert_timeout'
+ERROR HY000: Unknown system variable 'dalayed_insert_timeout'; did you mean `delayed_insert_timeout`?
 '#----------------------FN_DYNVARS_025_06------------------------#'
 SELECT @@global.delayed_insert_timeout = VARIABLE_VALUE 
 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES 

--- a/mysql-test/suite/sys_vars/r/unknown_variable_error_message.result
+++ b/mysql-test/suite/sys_vars/r/unknown_variable_error_message.result
@@ -1,0 +1,207 @@
+set global default_storage_engine= innodb;
+set default_storage_engine= innodb;
+SET NAMES utf8;
+#
+# MDEV-34646 Be more helpful on unknown parameter messages
+#
+set innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+#
+# Verify the change in other languages
+#
+# Czech
+SET lc_messages='cs_CZ';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Danish
+SET lc_messages='da_DK';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Estonian
+SET lc_messages='et_EE';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# French
+SET lc_messages='fr_FR';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# German
+SET lc_messages='de_DE';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Georgian
+SET lc_messages='ka_GE';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Hindi
+SET lc_messages='hi_IN';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: अज्ञात सिस्टम वेरिएबल 'innobdb_lock_wait_timeout'; क्या आपका मतलब `innodb_lock_wait_timeout` था?
+# Italian
+SET lc_messages='it_IT';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Japanese
+SET lc_messages='ja_JP';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Dutch
+SET lc_messages='nl_NL';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Portuguese
+SET lc_messages='pt_PT';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Russian
+SET lc_messages='ru_RU';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Serbian
+SET lc_messages='sr_RS';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Spanish
+SET lc_messages='es_ES';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Swahili
+SET lc_messages='sw_KE';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Swedish
+SET lc_messages='sv_SE';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Ukrainian
+SET lc_messages='uk_UA';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+# Chinese
+SET lc_messages='zh_CN';
+SET innobdb_lock_wait_timeout=1000;
+ERROR HY000: 未知系统变量 'innobdb_lock_wait_timeout'；你是想输入 `innodb_lock_wait_timeout` 吗？
+#
+# Verify the change in other variables
+#
+SET lc_messages='en_US';
+SET sll_ca=0;
+ERROR HY000: Unknown system variable 'sll_ca'; did you mean `ssl_ca`?
+SET GLOBAL mx_conncetoins = 500;
+ERROR HY000: Unknown system variable 'mx_conncetoins'
+SET GLOBAL qurey_cach_size = 134217728;
+ERROR HY000: Unknown system variable 'qurey_cach_size'; did you mean `query_cache_size`?
+SET SESSION join_bufer_size = 2097152;
+ERROR HY000: Unknown system variable 'join_bufer_size'; did you mean `join_buffer_size`?
+SET SESSION sort_bufer_size = 2097152;
+ERROR HY000: Unknown system variable 'sort_bufer_size'; did you mean `sort_buffer_size`?
+SET GLOBAL max_conections = 500;
+ERROR HY000: Unknown system variable 'max_conections'; did you mean `max_connections`?
+SET SESSION tmp_table_sze = 67108864;
+ERROR HY000: Unknown system variable 'tmp_table_sze'; did you mean `tmp_table_size`?
+SET GLOBAL innodb_lok_wait_timeout = 120;
+ERROR HY000: Unknown system variable 'innodb_lok_wait_timeout'; did you mean `innodb_lock_wait_timeout`?
+SET SESSION lock_wiat_timeout = 60;
+ERROR HY000: Unknown system variable 'lock_wiat_timeout'; did you mean `lock_wait_timeout`?
+SET GLOBAL wait_tiemout = 600;
+ERROR HY000: Unknown system variable 'wait_tiemout'; did you mean `wait_timeout`?
+SET SESSION sql_mde = 'STRICT_TRANS_TABLES';
+ERROR HY000: Unknown system variable 'sql_mde'; did you mean `sql_mode`?
+SET SESSION character_set_clinet = 'utf8mb4';
+ERROR HY000: Unknown system variable 'character_set_clinet'; did you mean `character_set_client`?
+SET SESSION character_set_resuts = 'utf8mb4';
+ERROR HY000: Unknown system variable 'character_set_resuts'; did you mean `character_set_results`?
+SET GLOBAL innodb_buffer_pol_size = 134217728;
+ERROR HY000: Unknown system variable 'innodb_buffer_pol_size'; did you mean `innodb_buffer_pool_size`?
+SET GLOBAL thred_cache_size = 50;
+ERROR HY000: Unknown system variable 'thred_cache_size'; did you mean `thread_cache_size`?
+SET GLOBAL table_open_cach = 2000;
+ERROR HY000: Unknown system variable 'table_open_cach'; did you mean `table_open_cache`?
+SET GLOBAL query_cache_szie = 134217728;
+ERROR HY000: Unknown system variable 'query_cache_szie'; did you mean `query_cache_size`?
+SET SESSION max_hep_table_size = 67108864;
+ERROR HY000: Unknown system variable 'max_hep_table_size'; did you mean `max_heap_table_size`?
+#
+# Test long variables
+#
+set innobdb_lock_wait_timeout_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable=1000;
+ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable'; did you mean `innodb_lock_wait_timeout`?
+#
+# Verify not to print suggestion when the input is far from the closest variable
+# IMPORTANT: the AI generated suggestions seem to be error-prone and we currently can't get certification for languages other than English, Chinese and Hindi,
+# Answers in other languages will fall back to English when their languages can't be found in the suggestion.
+# It can improve in the future to support other languages.
+#
+# Czech
+SET lc_messages='cs_CZ';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Neznámá systémová proměnná 'xxxxxxxxxxxxxxxxxxx'
+# Danish
+SET lc_messages='da_DK';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Ukendt systemvariabel 'xxxxxxxxxxxxxxxxxxx'
+# Estonian
+SET lc_messages='et_EE';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Tundmatu süsteemne muutuja 'xxxxxxxxxxxxxxxxxxx'
+# French
+SET lc_messages='fr_FR';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Variable système 'xxxxxxxxxxxxxxxxxxx' inconnue
+# German
+SET lc_messages='de_DE';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Unbekannte Systemvariable 'xxxxxxxxxxxxxxxxxxx'
+# Georgian
+SET lc_messages='ka_GE';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: უცნობი სისტემური ცვლადი 'xxxxxxxxxxxxxxxxxxx'
+# Hindi
+SET lc_messages='hi_IN';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: अज्ञात सिस्टम वैरिएबल 'xxxxxxxxxxxxxxxxxxx'
+# Italian
+SET lc_messages='it_IT';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Variabile di sistema 'xxxxxxxxxxxxxxxxxxx' sconosciuta
+# Japanese
+SET lc_messages='ja_JP';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: 'xxxxxxxxxxxxxxxxxxx' は不明なシステム変数です。
+# Dutch
+SET lc_messages='nl_NL';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Onbekende systeem variabele 'xxxxxxxxxxxxxxxxxxx'
+# Portuguese
+SET lc_messages='pt_PT';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Variável de sistema 'xxxxxxxxxxxxxxxxxxx' desconhecida
+# Russian
+SET lc_messages='ru_RU';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Неизвестная системная переменная 'xxxxxxxxxxxxxxxxxxx'
+# Serbian
+SET lc_messages='sr_RS';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Nepoznata sistemska promenljiva 'xxxxxxxxxxxxxxxxxxx'
+# Spanish
+SET lc_messages='es_ES';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Variable de sistema 'xxxxxxxxxxxxxxxxxxx' desconocida
+# Swahili
+SET lc_messages='sw_KE';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Tofauti ya mfumo isiyojulikana 'xxxxxxxxxxxxxxxxxxx'
+# Swedish
+SET lc_messages='sv_SE';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Okänd systemvariabel: 'xxxxxxxxxxxxxxxxxxx'
+# Ukrainian
+SET lc_messages='uk_UA';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: Невідома системна змінна 'xxxxxxxxxxxxxxxxxxx'
+# Chinese
+SET lc_messages='zh_CN';
+SET xxxxxxxxxxxxxxxxxxx=1000;
+ERROR HY000: 未知系统变量 'xxxxxxxxxxxxxxxxxxx'
+set global default_storage_engine= MyISAM;

--- a/mysql-test/suite/sys_vars/t/delayed_insert_timeout_basic.test
+++ b/mysql-test/suite/sys_vars/t/delayed_insert_timeout_basic.test
@@ -95,7 +95,7 @@ SELECT @@global.delayed_insert_timeout;
 
 --Error 1229
 SET @@session.delayed_insert_timeout = 0;
---Error 1193
+--Error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
 SELECT @@session.dalayed_insert_timeout;
 
 --echo '#----------------------FN_DYNVARS_025_06------------------------#'

--- a/mysql-test/suite/sys_vars/t/unknown_variable_error_message.test
+++ b/mysql-test/suite/sys_vars/t/unknown_variable_error_message.test
@@ -1,0 +1,271 @@
+# Change storage engine to Innodb, otherwise the system variable will be different.
+--source include/have_innodb.inc
+let $default_storage_engine= `select @@global.default_storage_engine`;
+set global default_storage_engine= innodb;
+set default_storage_engine= innodb;
+
+SET NAMES utf8;
+--echo #
+--echo # MDEV-34646 Be more helpful on unknown parameter messages
+--echo #
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+set innobdb_lock_wait_timeout=1000;
+
+--echo #
+--echo # Verify the change in other languages
+--echo #
+--echo # Czech
+SET lc_messages='cs_CZ';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Danish
+SET lc_messages='da_DK';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Estonian
+SET lc_messages='et_EE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # French
+SET lc_messages='fr_FR';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # German
+SET lc_messages='de_DE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Georgian
+SET lc_messages='ka_GE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Hindi
+SET lc_messages='hi_IN';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Italian
+SET lc_messages='it_IT';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Japanese
+SET lc_messages='ja_JP';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Dutch
+SET lc_messages='nl_NL';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Portuguese
+SET lc_messages='pt_PT';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Russian
+SET lc_messages='ru_RU';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Serbian
+SET lc_messages='sr_RS';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Spanish
+SET lc_messages='es_ES';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Swahili
+SET lc_messages='sw_KE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Swedish
+SET lc_messages='sv_SE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Ukrainian
+SET lc_messages='uk_UA';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo # Chinese
+SET lc_messages='zh_CN';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET innobdb_lock_wait_timeout=1000;
+
+--echo #
+--echo # Verify the change in other variables
+--echo #
+SET lc_messages='en_US';
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET sll_ca=0;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET GLOBAL mx_conncetoins = 500;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL qurey_cach_size = 134217728;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION join_bufer_size = 2097152;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION sort_bufer_size = 2097152;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL max_conections = 500;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION tmp_table_sze = 67108864;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL innodb_lok_wait_timeout = 120;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION lock_wiat_timeout = 60;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL wait_tiemout = 600;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION sql_mde = 'STRICT_TRANS_TABLES';
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION character_set_clinet = 'utf8mb4';
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION character_set_resuts = 'utf8mb4';
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL innodb_buffer_pol_size = 134217728;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL thred_cache_size = 50;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL table_open_cach = 2000;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET GLOBAL query_cache_szie = 134217728;
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+SET SESSION max_hep_table_size = 67108864;
+
+
+--echo #
+--echo # Test long variables
+--echo #
+
+--error ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+set innobdb_lock_wait_timeout_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable_a_very_very_very_long_variable=1000;
+
+--echo #
+--echo # Verify not to print suggestion when the input is far from the closest variable
+--echo # IMPORTANT: the AI generated suggestions seem to be error-prone and we currently can't get certification for languages other than English, Chinese and Hindi,
+--echo # Answers in other languages will fall back to English when their languages can't be found in the suggestion.
+--echo # It can improve in the future to support other languages.
+--echo #
+--echo # Czech
+SET lc_messages='cs_CZ';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Danish
+SET lc_messages='da_DK';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Estonian
+SET lc_messages='et_EE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # French
+SET lc_messages='fr_FR';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # German
+SET lc_messages='de_DE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Georgian
+SET lc_messages='ka_GE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Hindi
+SET lc_messages='hi_IN';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Italian
+SET lc_messages='it_IT';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Japanese
+SET lc_messages='ja_JP';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Dutch
+SET lc_messages='nl_NL';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Portuguese
+SET lc_messages='pt_PT';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Russian
+SET lc_messages='ru_RU';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Serbian
+SET lc_messages='sr_RS';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Spanish
+SET lc_messages='es_ES';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Swahili
+SET lc_messages='sw_KE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Swedish
+SET lc_messages='sv_SE';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Ukrainian
+SET lc_messages='uk_UA';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+--echo # Chinese
+SET lc_messages='zh_CN';
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SET xxxxxxxxxxxxxxxxxxx=1000;
+
+
+# Change it back to default storage engine to avoid errors.
+eval set global default_storage_engine= $default_storage_engine;

--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -23,6 +23,7 @@
 #include <mysys_err.h>
 #include <my_getopt.h>
 #include <errno.h>
+#include <stdint.h>
 
 my_bool is_file_marker(const char* arg);
 typedef void (*init_func_p)(const struct my_option *option, void *variable,
@@ -200,6 +201,154 @@ void warn_deprecated(const struct my_option *optp)
   }
 }
 
+// Functions and structures to find the closest options when an unknown variable is found.
+typedef struct {
+    char **names;       // array of option names
+    size_t count;       // number of names
+    size_t max_length;  // longest name length
+} OptionNames;
+
+typedef struct {
+    char *name;       // closest option name
+    size_t distance;  // Levenstein distance to the input option
+} ClosestMatch;
+
+// Options in the optp variable are separated by "-". However, options can only 
+// use "_". Replace them with "_" to get more precise Levenshtein distance 
+// calculation.
+char *replace_dash_with_underscore(const char *str) {
+    size_t len = 0;
+    char *result = NULL;
+    if (!str) return NULL;
+    len = strlen(str);
+    result = malloc(len + 1);
+    if (!result) return NULL;
+
+    for (size_t i = 0; i < len; i++) {
+        result[i] = (str[i] == '-') ? '_' : str[i];
+    }
+    result[len] = '\0';
+
+    return result;
+}
+
+OptionNames get_option_names(const struct my_option *optp) {
+  const struct my_option *opt;
+  size_t i = 0;
+  OptionNames result;
+  result.count = 0;
+  result.max_length = 0;
+  result.names = NULL;
+
+  // Get length of opt names.
+  for (opt = optp; opt->name != NULL; opt++) {
+    size_t len = strlen(opt->name);
+    result.count++;
+    if (len > result.max_length)
+      result.max_length = len;
+  }
+
+  result.names = (char **)malloc((result.count + 1) * sizeof(char *));
+  if (!result.names) {
+    result.count = 0;
+    result.max_length = 0;
+    return result;
+  }
+
+  for (opt = optp; opt->name != NULL; opt++) {
+    result.names[i] = strdup(opt->name);
+    i++;
+  }
+  result.names[i] = NULL;
+  return result;
+}
+
+unsigned int levenshtein_distance(const char *s1, const char *s2) {
+  size_t len1 = strlen(s1);
+  size_t len2 = strlen(s2);
+  uint32_t res = 0;
+
+  uint32_t **dp = (uint32_t **)malloc((len1 + 1) * sizeof(uint32_t *));
+  for (uint32_t i = 0; i <= len1; i++) {
+    dp[i] = (uint32_t *)malloc((len2 + 1) * sizeof(uint32_t));
+  }
+
+  for (uint32_t i = 0; i <= len1; i++) dp[i][0] = i;
+  for (uint32_t j = 0; j <= len2; j++) dp[0][j] = j;
+
+  for (uint32_t i = 1; i <= len1; i++) {
+    for (uint32_t j = 1; j <= len2; j++) {
+      if (s1[i - 1] == s2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1];
+      } else {
+        uint32_t min = dp[i - 1][j];
+        if (dp[i][j - 1] < min) min = dp[i][j - 1];
+        if (dp[i - 1][j - 1] < min) min = dp[i - 1][j - 1];
+        dp[i][j] = 1 + min;
+      }
+    }
+  }
+
+  res = dp[len1][len2];
+
+  for (uint32_t i = 0; i <= len1; i++) free(dp[i]);
+  free(dp);
+
+  return res;
+}
+
+
+// Avoid using strndup here because Windows environment doesn't have this definition
+char *truncate_copy(const char *s, size_t n) {
+    size_t len = strnlen(s, n);
+    char *new_str = malloc(len + 1);
+    if (!new_str) return NULL;
+    memcpy(new_str, s, len);
+    new_str[len] = '\0';
+    return new_str;
+}
+
+
+ClosestMatch find_closest_match(const struct my_option *optp, const char *str) {
+  OptionNames opts = get_option_names(optp);
+  size_t str_len = 0;
+  size_t truncate_len = 0;
+  ClosestMatch result = {NULL, INT32_MAX};
+
+  if (opts.count == 0) return (ClosestMatch) {NULL, INT32_MAX};
+
+  // Don't find closest match for long string, because Levenshtein distance 
+  // algorithm will create O(n^2) space. Limit the size of string to avoid using 
+  // too much space.
+  str_len = strlen(str);
+  truncate_len = str_len < opts.max_length ? str_len : opts.max_length;
+
+  for (size_t i = 0; i < opts.count; i++) {
+    char *truncated = truncate_copy(str, truncate_len);
+    char *replaced_option = replace_dash_with_underscore(opts.names[i]);
+    size_t dist = levenshtein_distance(replaced_option, truncated);
+    free(replaced_option);
+    free(truncated);
+
+    if (dist < result.distance) {
+      result.name = opts.names[i];
+      result.distance = dist;
+    }
+  }
+
+  // Duplicate result name before cleanup to avoid being cleaned
+  if (result.name) {
+    result.name = strdup(result.name);
+  }
+
+  for (size_t i = 0; i < opts.count; i++) {
+    free(opts.names[i]);
+  }
+  free(opts.names);
+
+  return result;
+}
+
 /**
   Handle command line options.
   Sort options.
@@ -258,6 +407,13 @@ void warn_deprecated(const struct my_option *optp)
   @return error in case of ambiguous or unknown options,
           0 on success.
 */
+
+// Global variables for finding the closest match of given option.
+// Use Global variable because option matching goes through several
+// rounds. We should find the closest match of all rounds.
+static ClosestMatch closest_match = {NULL, INT_MAX32};
+static ClosestMatch cur_match = {NULL, INT_MAX32};
+
 int handle_options(int *argc, char ***argv, const struct my_option *longopts,
                    my_get_one_option get_one_option)
 {
@@ -401,6 +557,12 @@ int handle_options(int *argc, char ***argv, const struct my_option *longopts,
 	  }
 	  if (!opt_found)
 	  {
+      // There are several rounds of comparisons. Choose the closest one.
+      cur_match = find_closest_match(optp, cur_arg);
+      if (cur_match.distance < closest_match.distance) {
+        closest_match.distance = cur_match.distance;
+        closest_match.name = cur_match.name;
+      }
             if (my_getopt_skip_unknown)
             {
               /* Preserve all the components of this unknown option. */
@@ -412,10 +574,32 @@ int handle_options(int *argc, char ***argv, const struct my_option *longopts,
 	    if (must_be_var)
 	    {
 	      if (my_getopt_print_errors)
-                my_getopt_error_reporter(option_is_loose ? 
-                                           WARNING_LEVEL : ERROR_LEVEL,
-                                         "%s: unknown variable '%s'",
-                                         my_progname, cur_arg);
+        {
+          // Set the threadshold to 0.3, because during the test we found out 
+          // the suggestion given by the calculation is not useful sometimes, 
+          // especially when user's input is very random, not relevant to any
+          // existing variables.
+          // Set it to 0.3 because it generally means 30% of the input variable 
+          // is different than the closest. The suggestion is only given when 
+          // user's input is close to any correct variable.
+          if (closest_match.name && (double) closest_match.distance / 
+              strlen(cur_arg) <= 0.3)
+          {
+            char *replaced_option = replace_dash_with_underscore(closest_match.name);
+            my_getopt_error_reporter(option_is_loose ? 
+                                      WARNING_LEVEL : ERROR_LEVEL,
+                                      "%s: unknown variable '%s', do you mean '%s'?",
+                                      my_progname, cur_arg, replaced_option);
+            free(replaced_option);
+            closest_match = (ClosestMatch) {NULL, INT_MAX32};
+            cur_match = (ClosestMatch) {NULL, INT_MAX32};
+          }
+          else
+            my_getopt_error_reporter(option_is_loose ? 
+                                    WARNING_LEVEL : ERROR_LEVEL,
+                                    "%s: unknown variable '%s'", 
+                                    my_progname, cur_arg);
+        }
 	      if (!option_is_loose)
 		SET_HO_ERROR_AND_CONTINUE(EXIT_UNKNOWN_VARIABLE)
 	    }

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12392,3 +12392,7 @@ ER_CANNOT_CAST_ON_IDENT1_ASSIGNMENT_FOR_OPERATION
         eng "Cannot cast '%s' as '%s' in assignment of %sQ for operation %s"
 ER_CANNOT_CAST_ON_IDENT2_ASSIGNMENT_FOR_OPERATION
         eng "Cannot cast '%s' as '%s' in assignment of %sQ.%sQ for operation %s"
+ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION
+        chi "未知系统变量 '%-.*s'；你是想输入 %.*sQ 吗？"
+        eng "Unknown system variable '%-.*s'; did you mean %.*sQ?"
+        hindi "अज्ञात सिस्टम वेरिएबल '%-.*s'; क्या आपका मतलब %.*sQ था?"

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -41,6 +41,9 @@
 #include <mysql/plugin_function.h>
 #include "sql_plugin_compat.h"
 #include "wsrep_mysqld.h"
+#include <vector>
+#include <algorithm>
+#include <string>
 
 static PSI_memory_key key_memory_plugin_mem_root;
 static PSI_memory_key key_memory_plugin_int_mem_root;
@@ -2962,6 +2965,48 @@ static void update_func_double(THD *thd, struct st_mysql_sys_var *var,
   System Variables support
 ****************************************************************************/
 
+
+std::pair<std::vector<std::string>, size_t> get_option_names(THD *thd)
+{
+  size_t max_length = 0;
+  enum_var_type m_query_scope= SHOW_OPT_SESSION;
+  SHOW_VAR *vars= enumerate_sys_vars(thd, true, m_query_scope);
+  std::vector<std::string> names;
+  for (SHOW_VAR *v = vars; v->name != nullptr; v++) {
+    names.push_back(v->name);
+    max_length = std::max(max_length, strlen(v->name));
+  }
+
+  return {names, max_length};
+}
+
+std::pair<std::string, uint32_t> find_closest_match(THD* thd,
+                                                    const std::string& str) {
+  auto [option_names, max_len] = get_option_names(thd);
+  if (option_names.empty())
+      return {"", INT_MAX};
+
+  // Don't find closest match for long string, because Levenshtein distance 
+  // algorithm will create O(n^2) space. Limit the size of string to avoid  
+  // using too much space.
+  std::string truncated_str = str.substr(0, std::min(str.size(), max_len));
+  
+  uint32_t min_distance = INT_MAX;
+  std::string closest_match = option_names[0];
+
+  for (const auto& option : option_names) {
+    uint32_t distance = levenshtein_distance(option.c_str(), 
+                                            truncated_str.c_str());
+    if (distance < min_distance) {
+      min_distance = distance;
+      closest_match = option;
+    }
+  }
+  return {closest_match, min_distance};
+}
+
+
+
 sys_var *find_sys_var(THD *thd, const char *str, size_t length,
                       bool throw_error)
 {
@@ -2983,8 +3028,28 @@ sys_var *find_sys_var(THD *thd, const char *str, size_t length,
   mysql_prlock_unlock(&LOCK_system_variables_hash);
 
   if (unlikely(!throw_error && !var))
-    my_error(ER_UNKNOWN_SYSTEM_VARIABLE, MYF(0),
-             (int) (length ? length : strlen(str)), (char*) str);
+  {
+    auto [closest_match, min_dis] = find_closest_match(thd, str);
+    // Set the threshold to 0.3, because during the test we found out the 
+    // suggestion given by the calculation is not useful sometimes, especially 
+    // when user's input is very random, not relevant to any existing variables.
+    // Set it to 0.3 because it generally means 30% of the input variable is 
+    // different than the closest. The suggestion is only given when user's 
+    // input is close to any correct variable.
+    if (static_cast<double>(min_dis) / strlen(str) <= 0.3)
+    {
+      // Variable suggestion is useful
+      my_error(ER_UNKNOWN_SYSTEM_VARIABLE_SUGGESTION, MYF(0),
+              (int) (length ? length : strlen(str)), str,
+              (int) closest_match.length(), closest_match.c_str());
+    }
+    else
+    {
+      // Variable suggestion is not useful
+      my_error(ER_UNKNOWN_SYSTEM_VARIABLE, MYF(0),
+               length ? length : strlen(str), str);
+    }
+  }
   DBUG_RETURN(var);
 }
 


### PR DESCRIPTION
## Description

The previous "unknown variable" error message did not provide details about why the input variable was invalid. For example, entering an incorrect variable name such as innobdb_lock_wait_timeout would produce the following error:

`ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout=1000'`

This commits uses Levenshtein algorithm to calculate the closest matching system variable when an invalid name is provided. Levenshtein distance represents the minimum number of single-character edits (insertions, deletions, or replacements) required to transform one string into another, effectively measuring their similarity. More details can be found here:
https://www.geeksforgeeks.org/dsa/introduction-to-levenshtein-distance/

With the improvement, the error message becomes more user-friendly. For example:

`ERROR HY000: Unknown system variable 'innobdb_lock_wait_timeout', did you mean 'innodb_lock_wait_timeout'?`

This improvement has been applied to all 19 supported languages for system variables.

Since Levenshtein algorithm use O(n^2) space to create matrix. Input variable was truncated to the longest length of options to reduce overusing of space.

Similar changes have also been applied to options when user starts the database with mariadbd.

## How can this PR be tested?

Execute the main suite in mysql-test-run.

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch_

## Backward compatibility

This is a new feature introducing more friendly error message without changing existing behaviors. It is compatible with previous versions.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.