### PR TITLE
MDEV-37428 JSON_VALUE returns NULL for a key with an empty string value rather than an empty string

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -2686,4 +2686,10 @@ json_detailed('[[123],456]')
     [123],
     456
 ]
+#
+# MDEV-37428 JSON_VALUE returns NULL for a key with an empty string value rather than an empty string
+#
+SELECT JSON_VALUE(JSON_OBJECT("a", ""), '$.a') = "" AS not_null;
+not_null
+1
 # End of 10.11 Test

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -1947,4 +1947,10 @@ select json_detailed('[[123],456]');
 set @@collation_connection=@save_collation_connection;
 select json_detailed('[[123],456]');
 
+--echo #
+--echo # MDEV-37428 JSON_VALUE returns NULL for a key with an empty string value rather than an empty string
+--echo #
+
+SELECT JSON_VALUE(JSON_OBJECT("a", ""), '$.a') = "" AS not_null;
+
 --echo # End of 10.11 Test

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -109,12 +109,14 @@ bool st_append_json(String *s,
     return false;
   }
 
-  if ((str_len= json_unescape(json_cs, js, js + js_len,
-         s->charset(), (uchar *) s->end(), (uchar *) s->end() + str_len)) > 0)
-  {
+  str_len= json_unescape(json_cs, js, js + js_len, s->charset(),
+                         (uchar *) s->end(), (uchar *) s->end() + str_len);
+  if (str_len > 0)
     s->length(s->length() + str_len);
+
+  if (str_len >= 0)
     return false;
-  }
+
   if (current_thd)
   {
     if (str_len == JSON_ERROR_OUT_OF_SPACE)


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37428*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Regression from MDEV-36765 / 2b24ed87f0028180e692ba391132f55284377c02.

json_unescape can return a string length 0 without it being an error.

The regression caused this 0 length empty string to appear as an error and result in a NULL return value.

## Release Notes

Corrected regression to return empty string rather than errously returning NULL in JSON_VALUE.

## How can this PR be tested?

test case included
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.