### PR TITLE
MDEV-31740 InnoDB statistics column length validation failed

### DIFF
--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -2518,7 +2518,8 @@ name	dl
 # Check that mysql_upgrade can be run on mysqldump
 # of mysql schema from previous versions
 #
-call mtr.add_suppression("innodb_(table|index)_stats has length mismatch in the column name table_name");
+call mtr.add_suppression("InnoDB: Fetch of persistent statistics requested for table `mysql`\\.`gtid_slave_pos` but the required system tables mysql\\.innodb_table_stats and mysql\\.innodb_index_stats are not present or have unexpected structure");
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_table_stats\\.table_name");
 call mtr.add_suppression("Column count of mysql.proc is wrong. Expected 21, found 20.");
 #
 # Upgrade from version 5.5

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -526,7 +526,8 @@ SELECT * FROM mysql.plugin WHERE name='unix_socket';
 --echo #
 
 # The warning appears during mysql_upgrade, before the schema becomes consistent
-call mtr.add_suppression("innodb_(table|index)_stats has length mismatch in the column name table_name");
+call mtr.add_suppression("InnoDB: Fetch of persistent statistics requested for table `mysql`\\.`gtid_slave_pos` but the required system tables mysql\\.innodb_table_stats and mysql\\.innodb_index_stats are not present or have unexpected structure");
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_table_stats\\.table_name");
 # This comes from opening 10.6 sys.host_summary view that uses sys.format_time function,
 # on still inconsistent mysql.proc, in older versions
 call mtr.add_suppression("Column count of mysql.proc is wrong. Expected 21, found 20.");

--- a/mysql-test/suite/innodb/r/innodb_stats.result
+++ b/mysql-test/suite/innodb/r/innodb_stats.result
@@ -530,3 +530,16 @@ INDEX_TYPE	BTREE
 COMMENT	
 INDEX_COMMENT	
 IGNORED	NO
+#
+#  MDEV-31740 InnoDB statistics column length validation failed
+#
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_table_stats\\.last_update");
+ALTER TABLE mysql.innodb_table_stats MODIFY LAST_UPDATE DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP();
+CREATE TABLE t (a INT KEY)Engine=InnoDB STATS_PERSISTENT=1;
+FOUND 1 /InnoDB: Unexpected length of mysql\.innodb_table_stats\.last_update/ in mysqld.1.err
+ALTER TABLE mysql.innodb_table_stats MODIFY last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP();
+CREATE TABLE t2(a INT KEY)ENGINE=InnoDB STATS_PERSISTENT= 1;
+SELECT table_name FROM mysql.innodb_table_stats;
+table_name
+t2
+DROP TABLE t, t2;

--- a/mysql-test/suite/innodb/r/innodb_stats_create_on_corrupted.result
+++ b/mysql-test/suite/innodb/r/innodb_stats_create_on_corrupted.result
@@ -1,6 +1,6 @@
 call mtr.add_suppression("InnoDB: Table .*innodb_index_stats.* not found");
 call mtr.add_suppression("InnoDB: Fetch of persistent statistics requested for table .*");
-call mtr.add_suppression("InnoDB: Table mysql\\.innodb_index_stats has length mismatch in the column name stat_description\\. Please run mariadb-upgrade");
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_index_stats\\.stat_description");
 call mtr.add_suppression("InnoDB: Column stat_description in table mysql\\.innodb_index_stats is VARCHAR");
 ALTER TABLE mysql.innodb_index_stats RENAME TO mysql.innodb_index_stats_;
 CREATE TABLE test_ps_create_on_corrupted

--- a/mysql-test/suite/innodb/t/innodb_stats.test
+++ b/mysql-test/suite/innodb/t/innodb_stats.test
@@ -3,6 +3,7 @@
 #
 
 -- source include/have_innodb.inc
+-- source include/not_embedded.inc
 
 -- disable_warnings
 -- disable_query_log
@@ -63,3 +64,17 @@ CREATE TABLE test_innodb_stats (
 -- disable_query_log
 DROP TABLE test_innodb_stats;
 set @@use_stat_tables= @save_use_stat_tables;
+--enable_query_log
+--echo #
+--echo #  MDEV-31740 InnoDB statistics column length validation failed
+--echo #
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_table_stats\\.last_update");
+ALTER TABLE mysql.innodb_table_stats MODIFY LAST_UPDATE DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP();
+CREATE TABLE t (a INT KEY)Engine=InnoDB STATS_PERSISTENT=1;
+let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN=InnoDB: Unexpected length of mysql\\.innodb_table_stats\\.last_update;
+--source include/search_pattern_in_file.inc
+ALTER TABLE mysql.innodb_table_stats MODIFY last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP();
+CREATE TABLE t2(a INT KEY)ENGINE=InnoDB STATS_PERSISTENT= 1;
+SELECT table_name FROM mysql.innodb_table_stats;
+DROP TABLE t, t2;

--- a/mysql-test/suite/innodb/t/innodb_stats_create_on_corrupted.test
+++ b/mysql-test/suite/innodb/t/innodb_stats_create_on_corrupted.test
@@ -12,7 +12,7 @@
 
 call mtr.add_suppression("InnoDB: Table .*innodb_index_stats.* not found");
 call mtr.add_suppression("InnoDB: Fetch of persistent statistics requested for table .*");
-call mtr.add_suppression("InnoDB: Table mysql\\.innodb_index_stats has length mismatch in the column name stat_description\\. Please run mariadb-upgrade");
+call mtr.add_suppression("InnoDB: Unexpected length of mysql\\.innodb_index_stats\\.stat_description");
 call mtr.add_suppression("InnoDB: Column stat_description in table mysql\\.innodb_index_stats is VARCHAR");
 
 -- vertical_results

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -430,12 +430,12 @@ dict_table_schema_check(
 
 		/* check length for exact match */
 		if (req_schema->columns[i].len != table->cols[j].len) {
-			sql_print_warning("InnoDB: Table %s has"
-					  " length mismatch in the"
-					  " column name %s."
-					  " Please run mariadb-upgrade",
-					  req_schema->table_name_sql,
-					  req_schema->columns[i].name);
+			snprintf(errstr, errstr_sz,
+				 "Unexpected length of %s.%s. Please run "
+				 "mariadb-upgrade or ALTER TABLE",
+				 req_schema->table_name_sql,
+				 req_schema->columns[i].name);
+			return DB_ERROR;
 		}
 
 		/*


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31740*

## Description
When there's a column length mismatch in the InnoDB
statistics tables (innodb_table_stats or innodb_index_stats),
consecutive access of statistics table throws error message
and uses transient statistics.
    
This change makes it easier for users to understand and
resolve the issue when the statistics tables have been
modified or corrupted.

## Release Notes
Users will now see a clear error message with specific instructions
when there's a column length mismatch in the statistics tables

This change is backward compatible and only affects the error reporting behavior
when there's a schema mismatch in the statistics tables.

## How can this PR be tested?
./mtr --suite=innodb

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
