### PR TITLE
WIP: Improve cardinality estimation for index lookups over columns st…

### DIFF
--- a/mysql-test/main/wip.result
+++ b/mysql-test/main/wip.result
@@ -1,0 +1,109 @@
+# Small driving table
+CREATE TABLE t1 (a INT, b INT);
+INSERT INTO t1 VALUES (1, 1), (2, 2000),(3,300);
+analyze table t1 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+# Table that will be accessed by an index lookup (`ref` access)
+CREATE TABLE t2 (a INT, b INT, KEY key_b(b));
+# All t11.b values are NULL
+INSERT INTO t2 SELECT seq/100,  NULL FROM seq_1_to_1000;
+analyze table t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	Table is already up to date
+# NULL-rejecting equality t1.b = t2.b will not return any matches
+# because all values of t2.b are NULL. So "rows" = 1 for t2 where 1 is
+# a special value meaning "very few" rows
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t2	ref	key_b	key_b	5	test.t1.b	1	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`a` = `test`.`t1`.`a` and `test`.`t2`.`b` = `test`.`t1`.`b`
+# However, rows estimation for not NULL-rejecting conditions
+# must not be affected ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
+1	SIMPLE	t2	ref	key_b	key_b	5	test.t1.b	11	100.00	Using index condition; Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`a` = `test`.`t1`.`a` and `test`.`t1`.`b` <=> `test`.`t2`.`b`
+ANALYZE SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	3.00	100.00	100.00	
+1	SIMPLE	t2	ref	key_b	key_b	5	test.t1.b	11	0.00	100.00	100.00	Using index condition; Using where
+# Test composite index for two columns. Key prefix is used for access
+CREATE TABLE t3 (a INT, b INT, KEY key_ab(a,b));
+# All t3.b values are NULL
+INSERT INTO t3 SELECT seq/100,  NULL FROM seq_1_to_1000;
+analyze table t3 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t3	analyze	status	Engine-independent statistics collected
+test.t3	analyze	status	Table is already up to date
+# NULL-rejecting equality t1.b = t3.b, same as above.
+# "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b = t3.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t3	ref	key_ab	key_ab	10	test.t1.a,test.t1.b	1	100.00	Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t3`.`a` AS `a`,`test`.`t3`.`b` AS `b` from `test`.`t1` join `test`.`t3` where `test`.`t3`.`a` = `test`.`t1`.`a` and `test`.`t3`.`b` = `test`.`t1`.`b`
+# Rows estimation for not NULL-rejecting conditions are not affected
+# ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t3	ref	key_ab	key_ab	5	test.t1.a	90	100.00	Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t3`.`a` AS `a`,`test`.`t3`.`b` AS `b` from `test`.`t1` join `test`.`t3` where `test`.`t3`.`a` = `test`.`t1`.`a`
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b <=> t3.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t3	ref	key_ab	key_ab	10	test.t1.a,test.t1.b	11	100.00	Using where; Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t3`.`a` AS `a`,`test`.`t3`.`b` AS `b` from `test`.`t1` join `test`.`t3` where `test`.`t3`.`a` = `test`.`t1`.`a` and `test`.`t1`.`b` <=> `test`.`t3`.`b`
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t3.b is NULL;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t3	ref	key_ab	key_ab	10	test.t1.a,const	11	100.00	Using where; Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t3`.`a` AS `a`,`test`.`t3`.`b` AS `b` from `test`.`t1` join `test`.`t3` where `test`.`t3`.`a` = `test`.`t1`.`a` and `test`.`t3`.`b` is null
+OLEGS: update t2 so that there are not only NULLs, collect the stats and re-test
+# Test composite index for 3 columns. Key prefix is used for access
+CREATE TABLE t4 (a INT, b INT, c INT, KEY key_abc(a,b,c));
+# All t3.b values are NULL
+INSERT INTO t4 SELECT seq/10,  NULL, seq/10 FROM seq_1_to_1000;
+analyze table t4 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t4	analyze	status	Engine-independent statistics collected
+test.t4	analyze	status	Table is already up to date
+# NULL-rejecting equality t1.b = t3.b, same as above.
+# "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t4	ref	key_abc	key_abc	10	test.t1.a,test.t1.b	1	100.00	Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t4`.`a` AS `a`,`test`.`t4`.`b` AS `b`,`test`.`t4`.`c` AS `c` from `test`.`t1` join `test`.`t4` where `test`.`t4`.`a` = `test`.`t1`.`a` and `test`.`t4`.`b` = `test`.`t1`.`b`
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b and t1.b = t4.c;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t4	ref	key_abc	key_abc	15	test.t1.a,test.t1.b,test.t1.b	1	100.00	Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t4`.`a` AS `a`,`test`.`t4`.`b` AS `b`,`test`.`t4`.`c` AS `c` from `test`.`t1` join `test`.`t4` where `test`.`t4`.`a` = `test`.`t1`.`a` and `test`.`t4`.`b` = `test`.`t1`.`b` and `test`.`t4`.`c` = `test`.`t1`.`b`
+# "rows" expected to be > 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t4	ref	key_abc	key_abc	5	test.t1.a	9	100.00	Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t4`.`a` AS `a`,`test`.`t4`.`b` AS `b`,`test`.`t4`.`c` AS `c` from `test`.`t1` join `test`.`t4` where `test`.`t4`.`a` = `test`.`t1`.`a`
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b <=> t4.c;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+1	SIMPLE	t4	ref	key_abc	key_abc	5	test.t1.a	9	100.00	Using where; Using index
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t4`.`a` AS `a`,`test`.`t4`.`b` AS `b`,`test`.`t4`.`c` AS `c` from `test`.`t1` join `test`.`t4` where `test`.`t4`.`a` = `test`.`t1`.`a` and `test`.`t1`.`b` <=> `test`.`t4`.`c`
+drop table t1, t2, t3, t4;

--- a/mysql-test/main/wip.test
+++ b/mysql-test/main/wip.test
@@ -1,0 +1,68 @@
+--source include/have_sequence.inc
+
+--echo # Small driving table
+CREATE TABLE t1 (a INT, b INT);
+INSERT INTO t1 VALUES (1, 1), (2, 2000),(3,300);
+
+analyze table t1 persistent for all;
+
+--echo # Table that will be accessed by an index lookup (`ref` access)
+CREATE TABLE t2 (a INT, b INT, KEY key_b(b));
+--echo # All t11.b values are NULL
+INSERT INTO t2 SELECT seq/100,  NULL FROM seq_1_to_1000;
+
+analyze table t2 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t2.b will not return any matches
+--echo # because all values of t2.b are NULL. So "rows" = 1 for t2 where 1 is
+--echo # a special value meaning "very few" rows
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b;
+
+--echo # However, rows estimation for not NULL-rejecting conditions
+--echo # must not be affected ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+
+ANALYZE SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+
+--echo # Test composite index for two columns. Key prefix is used for access
+CREATE TABLE t3 (a INT, b INT, KEY key_ab(a,b));
+--echo # All t3.b values are NULL
+INSERT INTO t3 SELECT seq/100,  NULL FROM seq_1_to_1000;
+
+analyze table t3 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t3.b, same as above.
+--echo # "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b = t3.b;
+
+--echo # Rows estimation for not NULL-rejecting conditions are not affected
+--echo # ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b <=> t3.b;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t3.b is NULL;
+
+--echo OLEGS: update t2 so that there are not only NULLs, collect the stats and re-test
+
+--echo # Test composite index for 3 columns. Key prefix is used for access
+CREATE TABLE t4 (a INT, b INT, c INT, KEY key_abc(a,b,c));
+
+--echo # All t3.b values are NULL
+INSERT INTO t4 SELECT seq/10,  NULL, seq/10 FROM seq_1_to_1000;
+
+analyze table t4 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t3.b, same as above.
+--echo # "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b and t1.b = t4.c;
+
+--echo # "rows" expected to be > 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b <=> t4.c;
+
+drop table t1, t2, t3, t4;
+

--- a/mysql-test/main/wip3.test
+++ b/mysql-test/main/wip3.test
@@ -1,0 +1,68 @@
+--source include/have_sequence.inc
+
+--echo # Small driving table
+CREATE TABLE t1 (a INT, b INT);
+INSERT INTO t1 VALUES (1, 1), (2, 2000),(3,300);
+
+analyze table t1 persistent for all;
+
+--echo # Table that will be accessed by an index lookup (`ref` access)
+CREATE TABLE t2 (a INT, b INT, KEY key_b(b));
+--echo # All t11.b values are NULL
+INSERT INTO t2 SELECT seq/100,  NULL FROM seq_1_to_1000;
+
+analyze table t2 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t2.b will not return any matches
+--echo # because all values of t2.b are NULL. So "rows" = 1 for t2 where 1 is
+--echo # a special value meaning "very few" rows
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b;
+
+--echo # However, rows estimation for not NULL-rejecting conditions
+--echo # must not be affected ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+
+ANALYZE SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b <=> t2.b;
+
+--echo # Test composite index for two columns. Key prefix is used for access
+CREATE TABLE t3 (a INT, b INT, KEY key_ab(a,b));
+--echo # All t3.b values are NULL
+INSERT INTO t3 SELECT seq/100,  NULL FROM seq_1_to_1000;
+
+analyze table t3 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t3.b, same as above.
+--echo # "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b = t3.b;
+
+--echo # Rows estimation for not NULL-rejecting conditions are not affected
+--echo # ("rows" > 1 is expected)
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t1.b <=> t3.b;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t3 ON t1.a = t3.a AND t3.b is NULL;
+
+--echo OLEGS: update t2 so that there are not only NULLs, collect the stats and re-test
+
+--echo # Test composite index for 3 columns. Key prefix is used for access
+CREATE TABLE t4 (a INT, b INT, c INT, KEY key_abc(a,b,c));
+
+--echo # All t3.b values are NULL
+INSERT INTO t4 SELECT seq/10,  NULL, seq/10 FROM seq_1_to_1000;
+
+analyze table t4 persistent for all;
+
+--echo # NULL-rejecting equality t1.b = t3.b, same as above.
+--echo # "rows" must be estimated to 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b = t4.b and t1.b = t4.c;
+
+--echo # "rows" expected to be > 1
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a;
+
+EXPLAIN EXTENDED SELECT * FROM t1 JOIN t4 ON t1.a = t4.a AND t1.b <=> t4.c;
+
+drop table t1, t2, t3, t4;
+

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -8950,7 +8950,8 @@ best_access_path(JOIN      *join,
             }
             else
             {
-              if (!(records= keyinfo->actual_rec_per_key(key_parts-1)))
+              if (!(records=
+                    keyinfo->rec_per_key_null_aware(key_parts-1, notnull_part)))
               {                                   /* Prefer longer keys */
                 trace_access_idx.add("rec_per_key_stats_missing", true);
                 records=
@@ -9082,7 +9083,9 @@ best_access_path(JOIN      *join,
             else
             {
               /* Check if we have statistic about the distribution */
-              if ((records= keyinfo->actual_rec_per_key(max_key_part-1)))
+              if ((records=
+                   keyinfo->rec_per_key_null_aware(max_key_part-1,
+                                                   notnull_part)))
               {
                 /* 
                   Fix for the case where the index statistics is too

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -4156,8 +4156,7 @@ void set_statistics_for_table(THD *thd, TABLE *table)
     key_info->is_statistics_from_stat_tables=
       (check_eits_preferred(thd) &&
        table->stats_is_read &&
-       key_info->read_stats->avg_frequency_is_inited() &&
-       key_info->read_stats->get_avg_frequency(0) > 0.5);
+       key_info->read_stats->avg_frequency_is_inited());
   }
 }
 

--- a/sql/structs.h
+++ b/sql/structs.h
@@ -170,8 +170,10 @@ typedef struct st_key {
   /** reference to the list of options or NULL */
   engine_option_value *option_list;
   ha_index_option_struct *option_struct;                  /* structure with parsed options */
-
+  
   double actual_rec_per_key(uint i) const;
+  double rec_per_key_null_aware(uint max_key_part,
+                                       key_part_map notnull_part) const;
 } KEY;
 
 


### PR DESCRIPTION
…oring only NULL values

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36761*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
If all values in an indexed column are NULL, index statistics for the given is empty, so the optimizer estimates the cardinality of an index lookup over this column using heuristics.  However, if the column is accessed in a NULL-rejecting condition like `t1.key_col = t2.col`, we know there will be no matches generated. On the other hand, `t1.key_col <=> t2.col` will generate matches, as this condition is not NULL-rejecting.
This commit improves cardinality estimation for such cases.

## How can this PR be tested?

`./mtr wip`

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
