### PR TITLE
MDEV-31887: wrong result with split optimization

### DIFF
--- a/mysql-test/main/derived_split_innodb.result
+++ b/mysql-test/main/derived_split_innodb.result
@@ -1002,5 +1002,46 @@ set statement optimizer_switch='split_materialized=off' for $query;
 a	b	name	total_amt
 1	NULL	A	10
 DROP TABLE t1,t2;
+#
+# MDEV-37407 Wrong result with ORDER BY LIMIT
+# Both, with and without split_materialized should
+# produce the same results
+#
+CREATE TABLE t1
+(a varchar(35), b varchar(4), KEY (a))
+ENGINE=InnoDB;
+INSERT INTO t1 VALUES
+('Albania','AXA'), ('Australia','AUS'), ('Myanmar','MMR'),
+('Bahamas','BS'), ('Brazil','BRA'), ('Barbados','BRB');
+CREATE TABLE t2
+(a varchar(4), b varchar(50), PRIMARY KEY (b,a), KEY (a))
+ENGINE=InnoDB;
+INSERT INTO t2 VALUES
+('AUS','Anglican'), ('MMR','Baptist'), ('BS','Anglican'),
+('BS','Baptist'), ('BS','Methodist'), ('BRB','Methodist'),
+('BRA','Baptist'), ('USA','Baptist');
+ANALYZE TABLE t1 PERSISTENT FOR ALL;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+ANALYZE TABLE t2 PERSISTENT FOR ALL;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+set optimizer_switch='split_materialized=off';
+SELECT t1.a
+FROM (SELECT a FROM t2 GROUP BY a ORDER BY a, COUNT(DISTINCT b) LIMIT 1) dt
+JOIN t1 ON
+dt.a=t1.b
+WHERE t1.a LIKE 'B%';
+a
+set optimizer_switch='split_materialized=on';
+SELECT t1.a
+FROM (SELECT a FROM t2 GROUP BY a ORDER BY a, COUNT(DISTINCT b) LIMIT 1) dt
+JOIN t1 ON
+dt.a=t1.b
+WHERE t1.a LIKE 'B%';
+a
+DROP TABLE t1,t2;
 # End of 10.11 tests
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/mysql-test/main/derived_split_innodb.test
+++ b/mysql-test/main/derived_split_innodb.test
@@ -620,5 +620,46 @@ evalp set statement optimizer_switch='split_materialized=off' for $query;
 
 DROP TABLE t1,t2;
 
+--echo #
+--echo # MDEV-37407 Wrong result with ORDER BY LIMIT
+--echo # Both, with and without split_materialized should
+--echo # produce the same results
+--echo #
+
+CREATE TABLE t1
+  (a varchar(35), b varchar(4), KEY (a))
+ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES
+('Albania','AXA'), ('Australia','AUS'), ('Myanmar','MMR'),
+('Bahamas','BS'), ('Brazil','BRA'), ('Barbados','BRB');
+ 
+CREATE TABLE t2
+  (a varchar(4), b varchar(50), PRIMARY KEY (b,a), KEY (a))
+ENGINE=InnoDB;
+
+INSERT INTO t2 VALUES
+('AUS','Anglican'), ('MMR','Baptist'), ('BS','Anglican'),
+('BS','Baptist'), ('BS','Methodist'), ('BRB','Methodist'),
+('BRA','Baptist'), ('USA','Baptist');
+
+ANALYZE TABLE t1 PERSISTENT FOR ALL;
+ANALYZE TABLE t2 PERSISTENT FOR ALL;
+
+let $q=
+SELECT t1.a
+FROM (SELECT a FROM t2 GROUP BY a ORDER BY a, COUNT(DISTINCT b) LIMIT 1) dt
+     JOIN t1 ON
+     dt.a=t1.b
+WHERE t1.a LIKE 'B%';
+
+set optimizer_switch='split_materialized=off';
+eval $q;
+ 
+set optimizer_switch='split_materialized=on';
+eval $q;
+ 
+DROP TABLE t1,t2;
+
 --echo # End of 10.11 tests
 SET GLOBAL innodb_stats_persistent=@save_innodb_stats_persistent;

--- a/mysql-test/main/group_min_max_innodb.result
+++ b/mysql-test/main/group_min_max_innodb.result
@@ -323,7 +323,7 @@ JOIN t1 ON dt.a=t1.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	#	Using where
 1	PRIMARY	<derived2>	ref	key0	key0	6	test.t1.b	#	
-2	DERIVED	t2	range	a	a	58	NULL	#	Using index for group-by; Using temporary; Using filesort
+2	DERIVED	t2	index	NULL	a	6	NULL	#	Using index; Using temporary; Using filesort
 SELECT t1.a
 FROM (SELECT a FROM t2 GROUP BY a ORDER BY COUNT(DISTINCT b) LIMIT 1) dt
 JOIN t1 ON dt.a=t1.b;

--- a/sql/opt_split.cc
+++ b/sql/opt_split.cc
@@ -355,6 +355,7 @@ struct SplM_field_ext_info: public SplM_field_info
        with available statistics.
     10. The select doesn't use WITH ROLLUP (This limitation can probably be
        lifted)
+    11. The select doesn't have ORDER BY with LIMIT
 
   @retval
     true   if the answer is positive
@@ -386,6 +387,9 @@ bool JOIN::check_for_splittable_materialized()
       select_lex->window_specs.head()->partition_list->first;
   }
   if (!partition_list)
+    return false;
+
+  if (select_lex->order_list.elements > 0 && !unit->lim.is_unlimited()) //!(11)
     return false;
 
   Json_writer_object trace_wrapper(thd);


### PR DESCRIPTION
Don't let Split-Materialized optimization to happen when the sub-query
has an ORDER BY with LIMIT