### PR TITLE
MDEV-35951 : Complete freeze during MW-329 test

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -12,7 +12,6 @@
 
 galera_wan : MDEV-35940 Unallowed state transition: donor -> synced in galera_wan
 galera_vote_rejoin_ddl : MDEV-35940 Unallowed state transition: donor -> synced in galera_wan
-MW-329 : MDEV-35951 Complete freeze during MW-329 test
 galera_vote_rejoin_dml : MDEV-35964 Assertion `ist_seqno >= cc_seqno' failed in galera_vote_rejoin_dml
 galera_var_notify_cmd : MDEV-37257 WSREP: Notification command failed: 1 (Operation not permitted)
 galera_var_notify_ssl_ipv6 : MDEV-37257 WSREP: Notification command failed: 1 (Operation not permitted)

--- a/mysql-test/suite/galera/r/MW-329.result
+++ b/mysql-test/suite/galera/r/MW-329.result
@@ -14,10 +14,11 @@ END|
 connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1b;
 connection node_1;
+connect node_1c, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1c;
 connection node_1b;
 connection node_1;
 DROP PROCEDURE proc_insert;
 DROP TABLE t1;
 disconnect node_1b;
-CALL mtr.add_suppression("WSREP: .* conflict state after post commit ");
-set global innodb_status_output=Default;
+disconnect node_1c;

--- a/mysql-test/suite/galera/t/MW-329.test
+++ b/mysql-test/suite/galera/t/MW-329.test
@@ -83,7 +83,19 @@ while ($count)
 
 --connection node_1
 --disable_query_log
---eval KILL CONNECTION $connection_id
+--eval KILL HARD CONNECTION $connection_id
+--enable_query_log
+--connect node_1c, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1c
+
+--disable_query_log
+# Make sure connection is killed
+while (`SELECT COUNT(*) > 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE ID = $connection_id`)
+{
+  SELECT SLEEP(1);
+--error 0,ER_NO_SUCH_THREAD,ER_QUERY_INTERRUPTED,ER_CONNECTION_KILLED
+--eval KILL HARD CONNECTION $connection_id
+}
 --enable_query_log
 
 #
@@ -101,8 +113,4 @@ DROP PROCEDURE proc_insert;
 DROP TABLE t1;
 
 --disconnect node_1b
-
-# Due to MW-330, Multiple "conflict state 3 after post commit" warnings if table is dropped while SP is running
-CALL mtr.add_suppression("WSREP: .* conflict state after post commit ");
-
-set global innodb_status_output=Default;
+--disconnect node_1c


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35951*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Better to use KILL HARD and wait until connection is really gone.

Test case changes only.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
