### PR TITLE
WIP MDEV-35168: Potential Bug in Database Handling of NULL Values in EXIS…

### DIFF
--- a/mysql-test/main/subselect_extra.result
+++ b/mysql-test/main/subselect_extra.result
@@ -482,3 +482,26 @@ a	b
 DROP VIEW v2;
 DROP TABLE t1,t2;
 set optimizer_switch= @tmp_subselect_extra_derived;
+#
+# MDEV-35168: Potential Bug in Database Handling of NULL Values in EXISTS Clause
+#
+create table t0 (vkey int);
+insert into t0 (vkey) values (5);
+select 1 as c0
+from
+((select
+0 as c_0
+from
+t0
+) as subq_2
+right outer join t0 as ref_6
+on (subq_2.c_0 = ref_6.vkey ))
+where exists (
+select
+1
+from
+t0
+where (subq_2.c_0 <> t0.vkey));
+c0
+drop table t0;
+# End of 10.11 tests

--- a/mysql-test/main/subselect_extra.test
+++ b/mysql-test/main/subselect_extra.test
@@ -398,3 +398,27 @@ DROP VIEW v2;
 DROP TABLE t1,t2;
 
 set optimizer_switch= @tmp_subselect_extra_derived;
+
+--echo #
+--echo # MDEV-35168: Potential Bug in Database Handling of NULL Values in EXISTS Clause
+--echo #
+create table t0 (vkey int);
+insert into t0 (vkey) values (5);
+select 1 as c0
+  from
+    ((select
+            0 as c_0
+          from
+            t0
+          ) as subq_2
+      right outer join t0 as ref_6
+      on (subq_2.c_0 = ref_6.vkey ))
+  where exists (
+      select
+          1
+        from
+          t0
+        where (subq_2.c_0 <> t0.vkey));
+drop table t0;
+
+--echo # End of 10.11 tests

--- a/mysql-test/main/subselect_extra_no_semijoin.result
+++ b/mysql-test/main/subselect_extra_no_semijoin.result
@@ -484,6 +484,29 @@ a	b
 DROP VIEW v2;
 DROP TABLE t1,t2;
 set optimizer_switch= @tmp_subselect_extra_derived;
+#
+# MDEV-35168: Potential Bug in Database Handling of NULL Values in EXISTS Clause
+#
+create table t0 (vkey int);
+insert into t0 (vkey) values (5);
+select 1 as c0
+from
+((select
+0 as c_0
+from
+t0
+) as subq_2
+right outer join t0 as ref_6
+on (subq_2.c_0 = ref_6.vkey ))
+where exists (
+select
+1
+from
+t0
+where (subq_2.c_0 <> t0.vkey));
+c0
+drop table t0;
+# End of 10.11 tests
 set optimizer_switch= @subselect_extra_no_sj_tmp;
 set @optimizer_switch_for_subselect_extra_test=null;
 #

--- a/sql/item.h
+++ b/sql/item.h
@@ -2455,6 +2455,7 @@ public:
   */
   virtual bool check_index_dependence(void *arg) { return 0; }
   virtual bool check_sequence_privileges(void *arg) { return 0; }
+  virtual bool where_exists_processor(void *arg) { return 0; }
   /*============== End of Item processor list ======================*/
 
   /*

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -3505,6 +3505,12 @@ bool Item_exists_subselect::fix_fields(THD *thd, Item **ref)
 }
 
 
+bool Item_exists_subselect::where_exists_processor(void *arg)
+{
+  return walk(&Item::enumerate_field_refs_processor, true, arg);
+}
+
+
 bool Item_in_subselect::fix_fields(THD *thd_arg, Item **ref)
 {
   uint outer_cols_num;

--- a/sql/item_subselect.h
+++ b/sql/item_subselect.h
@@ -437,6 +437,7 @@ public:
   void under_not(Item_func_not *upper) override { upper_not= upper; };
 
   void set_exists_transformed() { exists_transformed= TRUE; }
+  bool where_exists_processor(void *arg) override;
 
   friend class select_exists_subselect;
   friend class subselect_uniquesubquery_engine;
@@ -783,6 +784,7 @@ public:
   void init_subq_materialization_tracker(THD *thd);
   Subq_materialization_tracker *get_materialization_tracker() const
   { return materialization_tracker; }
+  bool where_exists_processor(void *arg) override { return 0; }
 
   friend class Item_ref_null_helper;
   friend class Item_is_not_null_test;


### PR DESCRIPTION
…TS Clause

Queries of the form
```
  SELECT ... FROM (SELECT constant AS alias_N FROM t0) dt ... WHERE EXISTS
    (SELECT ... WHERE (dt.alias_N ...));
```
must force derived table `dt` to be materialized, or the `WHERE EXISTS` will not filter rows correctly.  If we allow derived table `dt` to be merged, then references to `dt.alias_N` are replaced with their constant values directly, so a `WHERE EXISTS` subquery will attempt to filter rows from the outer query based on those constant values rather than the columns' values computed during outer query evaluation.

Note that this is a WIP