### PR TITLE
MDEV-37776: connect engine Debian packaging shouldn't depend explictly on libxml2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -803,8 +803,7 @@ Description: Backup tool for MariaDB server
 
 Package: mariadb-plugin-connect
 Architecture: any
-Depends: libxml2,
-         mariadb-server (= ${server:Version}),
+Depends: mariadb-server (= ${server:Version}),
          unixodbc,
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37776*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The dependency on libxml2 will be populated by its shlibs:Depends directive.

Thanks Simon Chopin for pointing out the error of our ways and I'm counting this as the review/author.

ref: https://bugs.launchpad.net/ubuntu/+source/libxml2/+bug/2125555

## Release Notes

Probably not user visible.

## How can this PR be tested?

Install tests on Ubuntu 25.10.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.