### PR TITLE
MDEV-37774: ASAN crash in Gap_time_tracker's log_time()

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2399,7 +2399,7 @@ void THD::cleanup_after_query()
   if (!in_active_multi_stmt_transaction())
     wsrep_affected_rows= 0;
 #endif /* WITH_WSREP */
-
+  gap_tracker_data.init();
   DBUG_VOID_RETURN;
 }
 


### PR DESCRIPTION
THD class has an instance of Gap_time_tracker_data, which has a
reference to "Gap_time_tracker" using "bill_to" field.
  
During clean_up_after_query, reset bill_to field to NULL.