### PR TITLE
MDEV-22241 Revert renaming of `LEX::set_limit_rows_examined()` as it …

### DIFF
--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3600,7 +3600,7 @@ public:
     Activates enforcement of the LIMIT ROWS EXAMINED clause, if present
     in the query.
   */
-  void activate_limit_rows_examined()
+  void set_limit_rows_examined()
   {
     if (limit_rows_examined)
       limit_rows_examined_cnt= limit_rows_examined->val_uint();

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -4799,7 +4799,7 @@ void JOIN::exec_inner()
 
   if (!select_lex->outer_select() &&                            // (1)
       select_lex != select_lex->master_unit()->fake_select_lex) // (2)
-    thd->lex->activate_limit_rows_examined();
+    thd->lex->set_limit_rows_examined();
 
   if (procedure)
   {
@@ -26755,7 +26755,7 @@ JOIN_TAB::remove_duplicates()
                                   sort_field_keylength, having);
 
   if (join->select_lex != join->select_lex->master_unit()->fake_select_lex)
-    thd->lex->activate_limit_rows_examined();
+    thd->lex->set_limit_rows_examined();
   free_blobs(first_field);
   my_free(sortorder);
   DBUG_RETURN(error);

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -2180,7 +2180,7 @@ bool st_select_lex_unit::exec()
   // Handle cleanup on scope exit
   SCOPE_EXIT([this, &limit_rows_was_activated, &examined_rows]() {
     if (limit_rows_was_activated)
-      thd->lex->activate_limit_rows_examined();
+      thd->lex->set_limit_rows_examined();
     if (!saved_error)
       thd->inc_examined_row_count(examined_rows);
   });


### PR DESCRIPTION
…breaks compatibility with ColumnStore

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
