### PR TITLE
MDEV-37797 - main.information_schema_db fails sporadically

### DIFF
--- a/mysql-test/main/information_schema_db.result
+++ b/mysql-test/main/information_schema_db.result
@@ -215,11 +215,8 @@ connection default;
 use test;
 drop view testdb_1.v1, v2, testdb_1.v3, v4;
 drop database testdb_1;
-connection testdb_1;
 disconnect testdb_1;
-connection testdb_2;
 disconnect testdb_2;
-connection default;
 drop user testdb_1@localhost;
 drop user testdb_2@localhost;
 #
@@ -251,18 +248,18 @@ ERROR 42000: SELECT command denied to user 'mysqltest_1'@'localhost' for table `
 connection default;
 drop user mysqltest_1@localhost;
 drop database testdb_1;
-connection user1;
 disconnect user1;
-connection default;
 set global sql_mode=default;
 #
 # MDEV-20549 SQL SECURITY DEFINER does not work for INFORMATION_SCHEMA tables
 #
 create user foo@localhost;
 grant select on test.* to foo@localhost;
+connect foo,localhost,foo;
+connection default;
 create procedure rootonly() select 1;
-create sql security definer view v1d as select current_user(),user from information_schema.processlist where command!='daemon';
-create sql security invoker view v1i as select current_user(),user from information_schema.processlist where command!='daemon';
+create sql security definer view v1d as select current_user(),user from information_schema.processlist where id in($default_id, $foo_id) order by user;
+create sql security invoker view v1i as select current_user(),user from information_schema.processlist where id in($default_id, $foo_id) order by user;
 create sql security definer view v2d as select table_name from information_schema.tables where table_schema='mysql' and table_name like '%user%';
 create sql security invoker view v2i as select table_name from information_schema.tables where table_schema='mysql' and table_name like '%user%';
 create sql security definer view v3d as select schema_name from information_schema.schemata where schema_name like '%mysql%';
@@ -271,7 +268,7 @@ create sql security definer view v4d as select routine_name from information_sch
 create sql security invoker view v4i as select routine_name from information_schema.routines where routine_schema='test';
 create sql security definer view v5d as select view_definition > '' from information_schema.views where table_name='v1d';
 create sql security invoker view v5i as select view_definition > '' from information_schema.views where table_name='v1d';
-connect foo,localhost,foo;
+connection foo;
 select * from v1d;
 current_user()	user
 root@localhost	root

--- a/mysql-test/main/information_schema_db.test
+++ b/mysql-test/main/information_schema_db.test
@@ -206,13 +206,8 @@ connection default;
 use test;
 drop view testdb_1.v1, v2, testdb_1.v3, v4;
 drop database testdb_1;
-connection testdb_1;
 disconnect testdb_1;
---source include/wait_until_disconnected.inc
-connection testdb_2;
 disconnect testdb_2;
---source include/wait_until_disconnected.inc
-connection default;
 drop user testdb_1@localhost;
 drop user testdb_2@localhost;
 
@@ -243,10 +238,7 @@ show create view testdb_1.v1;
 connection default;
 drop user mysqltest_1@localhost;
 drop database testdb_1;
-connection user1;
 disconnect user1;
---source include/wait_until_disconnected.inc
-connection default;
 
 set global sql_mode=default;
 
@@ -256,9 +248,13 @@ set global sql_mode=default;
 
 create user foo@localhost;
 grant select on test.* to foo@localhost;
+let $default_id= `select connection_id()`;
+connect foo,localhost,foo;
+let $foo_id= `select connection_id()`;
+connection default;
 create procedure rootonly() select 1;
-create sql security definer view v1d as select current_user(),user from information_schema.processlist where command!='daemon';
-create sql security invoker view v1i as select current_user(),user from information_schema.processlist where command!='daemon';
+evalp create sql security definer view v1d as select current_user(),user from information_schema.processlist where id in($default_id, $foo_id) order by user;
+evalp create sql security invoker view v1i as select current_user(),user from information_schema.processlist where id in($default_id, $foo_id) order by user;
 create sql security definer view v2d as select table_name from information_schema.tables where table_schema='mysql' and table_name like '%user%';
 create sql security invoker view v2i as select table_name from information_schema.tables where table_schema='mysql' and table_name like '%user%';
 create sql security definer view v3d as select schema_name from information_schema.schemata where schema_name like '%mysql%';
@@ -267,7 +263,7 @@ create sql security definer view v4d as select routine_name from information_sch
 create sql security invoker view v4i as select routine_name from information_schema.routines where routine_schema='test';
 create sql security definer view v5d as select view_definition > '' from information_schema.views where table_name='v1d';
 create sql security invoker view v5i as select view_definition > '' from information_schema.views where table_name='v1d';
-connect foo,localhost,foo;
+connection foo;
 select * from v1d;
 select * from v1i;
 select * from v2d;


### PR DESCRIPTION
MDEV-20549 test output was affected by incompletely closed preceding connections.

Fix for similar issue was attempted by f4eb0953b136, it introduced wait_until_disconnected.inc. For an explanation of why it didn't work see bead24b7f3d commit comment.

Another fix was attempted in bead24b7f3d. It didn't help either, because connection is removed from information_schema.processlist after COM_QUIT handling.

Make test for MDEV-20549 agnostic to concurrent connections by querying information_schema.processlist only for connections that it uses.