### PR TITLE
Re-order zero-init variables for conversion safety

### DIFF
--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -409,7 +409,7 @@ struct LEX_MASTER_INFO
 
     host= user= password= log_file_name= ssl_key= ssl_cert= ssl_ca=
       ssl_capath= ssl_cipher= ssl_crl= ssl_crlpath= relay_log_name= NULL;
-    pos= relay_log_pos= server_id= port= connect_retry= retry_count= 0;
+    pos= relay_log_pos= server_id= retry_count= port= connect_retry= 0;
     heartbeat_period= 0;
     ssl= ssl_verify_server_cert= heartbeat_opt=
       repl_ignore_server_ids_opt= repl_do_domain_ids_opt=


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-25674](https://jira.mariadb.org/browse/MDEV-25674)*
  * cherry-picks mariadb-corporation/MariaDBEnterprise@2f8993c9ef.

## Description
In the zero-assigning chain, the variable `retry_count` from MDEV-25674 is a `ulong` placed after a `uint`.
Assigning an `unsigned long` to an `unsigned int` is not safe in LP64. Moving the `uint`s to after the `ulong`s in the chain solves this issue.

## Release Notes
N/A, probably
## How can this PR be tested?
:question:
## PR quality check
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.