### PR TITLE
MDEV-36556: MariaDB restart after upgrade fails with innodb_encrypt_tables

### DIFF
--- a/mysql-test/suite/encryption/r/recovery_memory.result
+++ b/mysql-test/suite/encryption/r/recovery_memory.result
@@ -1,3 +1,5 @@
+SET GLOBAL innodb_encrypt_tables=ON,innodb_encryption_threads=1;
+SET GLOBAL innodb_saved_page_number_debug=4,innodb_fil_make_page_dirty_debug=0;
 CREATE TABLE t1(f1 text, index idx(f1(20))) ENGINE INNODB;
 set global innodb_fast_shutdown=0;
 # restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0

--- a/mysql-test/suite/encryption/t/recovery_memory.combinations
+++ b/mysql-test/suite/encryption/t/recovery_memory.combinations
@@ -1,0 +1,4 @@
+[full_crc32]
+--innodb-checksum-algorithm=full_crc32
+[crc32]
+--innodb-checksum-algorithm=crc32

--- a/mysql-test/suite/encryption/t/recovery_memory.test
+++ b/mysql-test/suite/encryption/t/recovery_memory.test
@@ -5,6 +5,9 @@
 
 let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
 let MYSQLD_DATADIR=`select @@datadir`;
+# Encrypt the change buffer root page
+SET GLOBAL innodb_encrypt_tables=ON,innodb_encryption_threads=1;
+SET GLOBAL innodb_saved_page_number_debug=4,innodb_fil_make_page_dirty_debug=0;
 
 CREATE TABLE t1(f1 text, index idx(f1(20))) ENGINE INNODB;
 

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -1046,10 +1046,13 @@ dberr_t ibuf_upgrade_needed()
   if (!root)
     goto err_exit;
 
+  const size_t payload= fil_system.sys_space->full_crc32() ||
+    !fil_system.sys_space->crypt_data
+    ? FIL_PAGE_TYPE : FIL_PAGE_SPACE_ID;
+
   if (UNIV_LIKELY(!page_has_siblings(root->page.frame)) &&
-      UNIV_LIKELY(!memcmp(root->page.frame + FIL_PAGE_TYPE, field_ref_zero,
-                          srv_page_size -
-                          (FIL_PAGE_DATA_END + FIL_PAGE_TYPE))))
+      UNIV_LIKELY(!memcmp(root->page.frame + payload, field_ref_zero,
+                          srv_page_size - (FIL_PAGE_DATA_END + payload))))
     /* the change buffer was removed; no need to upgrade */;
   else if (page_is_comp(root->page.frame) ||
            btr_page_get_index_id(root->page.frame) != ibuf_index_id ||


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36556*
## Description
`ibuf_upgrade_needed()`: Adjust the check for the case that the InnoDB system tablespace had been created without
`innodb_checksum_algorithm=full_crc32` and `innodb_encrypt_tables` was enabled at the time the change buffer was upgraded.
## Release Notes
MariaDB Server would fail to start up after an upgrade if the InnoDB system tablespace had been created while `innodb_checksum_algorithm=full_crc32` was not in effect, and `innodb_encrypt_tables` was enabled during the upgrade.
## How can this PR be tested?
```sh
./mtr encryption.recovery_memory
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.