### PR TITLE
MDEV-37809 : MSAN use-of-uninitialized-value in wsrep_xid_print

### DIFF
--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -719,11 +719,8 @@ static void wsrep_init_thd_for_schema(THD *thd)
 {
   thd->security_ctx->skip_grants();
   thd->system_thread= SYSTEM_THREAD_GENERIC;
-
   thd->real_id=pthread_self(); // Keep purify happy
-
-  thd->prior_thr_create_utime= thd->start_utime= thd->thr_create_utime;
-
+  thd->prior_thr_create_utime= thd->start_utime= microsecond_interval_timer();
   /* No Galera replication */
   thd->variables.wsrep_on= 0;
   /* No binlogging */

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -42,6 +42,14 @@
 #define WSREP_XID_RPL_GTID_OFFSET (WSREP_XID_SEQNO_OFFSET + sizeof(wsrep_seqno_t))
 #define WSREP_XID_GTRID_LEN_V_3 (WSREP_XID_RPL_GTID_OFFSET + sizeof(wsrep_server_gtid_t))
 
+void inline wsrep_xid_init(XID *xid)
+{
+  xid->null();
+  xid->gtrid_length= 0;
+  xid->bqual_length= 0;
+  memset(xid->data, 0, sizeof(xid->data));
+}
+
 void wsrep_xid_init(XID* xid, const wsrep::gtid& wsgtid, const wsrep_server_gtid_t& gtid)
 {
   xid->formatID= 1;
@@ -161,8 +169,6 @@ bool wsrep_get_SE_checkpoint(XID& xid)
 
 static bool wsrep_get_SE_checkpoint_common(XID& xid)
 {
-  xid.null();
-
   if (wsrep_get_SE_checkpoint(xid))
   {
     return FALSE;
@@ -186,6 +192,7 @@ template<>
 wsrep::gtid wsrep_get_SE_checkpoint()
 {
   XID xid;
+  wsrep_xid_init(&xid);
 
   if (!wsrep_get_SE_checkpoint_common(xid))
   {
@@ -199,6 +206,7 @@ template<>
 wsrep_server_gtid_t wsrep_get_SE_checkpoint()
 {
   XID xid;
+  wsrep_xid_init(&xid);
   wsrep_server_gtid_t gtid= {0,0,0};
 
   if (!wsrep_get_SE_checkpoint_common(xid))


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-37809 *

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Uninitialized value was created by an allocation of 'xid' in the stack frame

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
