### PR TITLE
MDEV-34902: debian-start erroneously reports issues

### DIFF
--- a/debian/additions/debian-start
+++ b/debian/additions/debian-start
@@ -22,17 +22,10 @@ MYADMIN="/usr/bin/mariadb-admin --defaults-extra-file=/etc/mysql/debian.cnf"
 # Don't run full mariadb-upgrade on every server restart, use --version-check to do it only once
 MYUPGRADE="/usr/bin/mariadb-upgrade --defaults-extra-file=/etc/mysql/debian.cnf --version-check --silent"
 MYCHECK="/usr/bin/mariadb-check --defaults-extra-file=/etc/mysql/debian.cnf"
-MYCHECK_SUBJECT="WARNING: mariadb-check has found corrupt tables"
-MYCHECK_PARAMS="--all-databases --fast --silent"
-MYCHECK_RCPT="${MYCHECK_RCPT:-root}"
-
-## Checking for corrupt, not cleanly closed (only for MyISAM and Aria engines) and upgrade needing tables.
 
 # The following commands should be run when the server is up but in background
 # where they do not block the server start and in one shell instance so that
 # they run sequentially. They are supposed not to echo anything to stdout.
-# If you want to disable the check for crashed tables comment
-# "check_for_crashed_tables" out.
 # (There may be no output to stdout inside the background process!)
 
 # Need to ignore SIGHUP, as otherwise a SIGHUP can sometimes abort the upgrade
@@ -41,7 +34,6 @@ trap "" SIGHUP
 (
   upgrade_system_tables_if_necessary;
   check_root_accounts;
-  check_for_crashed_tables;
 ) >&2 &
 
 exit 0

--- a/debian/additions/debian-start.inc.sh
+++ b/debian/additions/debian-start.inc.sh
@@ -3,50 +3,6 @@
 # This file is included by /etc/mysql/debian-start
 #
 
-## Check MyISAM and Aria unclosed tables.
-# - Requires the server to be up.
-# - Is supposed to run silently in background.
-function check_for_crashed_tables() {
-  set -e
-  set -u
-
-  # But do it in the background to not stall the boot process.
-  logger -p daemon.info -i -t"$0" "Triggering myisam-recover for all MyISAM tables and aria-recover for all Aria tables"
-
-  # Checking for $? is unreliable so the size of the output is checked.
-  # Some table handlers like HEAP do not support CHECK TABLE.
-  tempfile=$(mktemp)
-
-  # We have to use xargs in this case, because a for loop barfs on the
-  # spaces in the thing to be looped over.
-
-  # If a crashed table is encountered, the "mariadb" command will return with a status different from 0
-  set +e
-
-  LC_ALL=C $MARIADB --skip-column-names --batch -e  '
-      select concat('\''select count(*) into @discard from `'\'',
-                    TABLE_SCHEMA, '\''`.`'\'', TABLE_NAME, '\''`'\'')
-      from information_schema.TABLES where TABLE_SCHEMA<>'\''INFORMATION_SCHEMA'\'' and TABLE_SCHEMA<>'\''PERFORMANCE_SCHEMA'\'' and ( ENGINE='\''MyISAM'\'' or ENGINE='\''Aria'\'' )' | \
-    xargs -i ${MARIADB} --skip-column-names --silent --batch \
-                    --force -e "{}" &>"${tempfile}"
-  set -e
-
-  if [ -s "$tempfile" ]; then
-    (
-      /bin/echo -e "\n" \
-        "Improperly closed tables are also reported if clients are accessing\n" \
- 	"the tables *now*. A list of current connections is below.\n";
-       $MYADMIN processlist status
-    ) >> "${tempfile}"
-    # Check for presence as a dependency on mailx would require an MTA.
-    if [ -x /usr/bin/mailx ]; then
-      mailx -e -s"$MYCHECK_SUBJECT" $MYCHECK_RCPT < "$tempfile"
-    fi
-    (echo "$MYCHECK_SUBJECT"; cat "${tempfile}") | logger -p daemon.warn -i -t"$0"
-  fi
-  rm "${tempfile}"
-}
-
 ## Check for tables needing an upgrade.
 # - Requires the server to be up.
 # - Is supposed to run silently in background.

--- a/debian/control
+++ b/debian/control
@@ -610,8 +610,7 @@ Description: MariaDB database core server files
 
 Package: mariadb-server-10.6
 Architecture: any
-Suggests: mailx,
-          mariadb-test,
+Suggests: mariadb-test,
           netcat-openbsd
 Recommends: libhtml-template-perl
 Pre-Depends: adduser (>= 3.40),


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34902*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Due to table names not being escaped properly.

Also the CHECK TABLES on all tables was excessive. This was original there for MyISAM only tables that required repair. Aria and InnoDB will auto-recover.

Rather than script, take the input via the shell and attempt to push that back into SQL keeping all the quoting correclty, just use a stored procedure that is temporarly created.

## Release Notes

Change Debian's on service start check script to only `CHECK TABLE tblname FAST` on MyISAM tables.

## How can this PR be tested?

```
$ "$MARIADB" -S /tmp/build-mariadb-server-10.11.sock --skip-column-names --silent --batch --force -e '
    DELIMITER //
   CREATE OR REPLACE PROCEDURE mysql.check_myisam()
  BEGIN
  DECLARE done INT DEFAULT FALSE;
  DECLARE db TYPE OF information_schema.TABLES.TABLE_SCHEMA;
  DECLARE tbl TYPE OF information_schema.TABLES.TABLE_NAME;
  DECLARE cur CURSOR FOR SELECT TABLE_SCHEMA,TABLE_NAME FROM tlist; 
  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done=TRUE;
  CREATE TEMPORARY TABLE tlist AS SELECT TABLE_SCHEMA,TABLE_NAME FROM information_schema.TABLES WHERE ENGINE="MyISAM";
    OPEN cur;
    read_loop: LOOP
      FETCH cur INTO db, tbl;
      IF done THEN
        LEAVE read_loop;
      END IF;
      EXECUTE IMMEDIATE CONCAT("CHECK TABLE `", db, "`.`", REPLACE(tbl, "`", "``"), "` FAST");
    END LOOP;
    CLOSE cur;
    DROP TEMPORARY TABLE tlist;
  END;
  //
  DELIMITER ;
  CALL mysql.check_myisam;
  DROP PROCEDURE mysql.check_myisam;
      '
test.table@name!	check	warning	1 client is using or hasn't closed the table properly
test.table@name!	check	status	OK
test.UserTable	check	warning	1 client is using or hasn't closed the table properly
test.UserTable	check	status	OK
test.123table	check	warning	1 client is using or hasn't closed the table properly
test.123table	check	status	OK
test.user-data	check	warning	1 client is using or hasn't closed the table properly
test.user-data	check	status	OK
test.user table	check	warning	1 client is using or hasn't closed the table properly
test.user table	check	status	OK
test.select	check	warning	1 client is using or hasn't closed the table properly
test.select	check	status	OK
```

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
