### PR TITLE
Draft: MDEV-38045: Implement implicit query block names for optimizer hints

### DIFF
--- a/mysql-test/main/opt_hints.result
+++ b/mysql-test/main/opt_hints.result
@@ -439,6 +439,18 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t2	ref	f1	f1	8	test.t3.f1,test.t3.f2	2	50.00	Using where; FirstMatch(t3)
 Warnings:
 Note	1003	update /*+ BKA(`t2`@`select#2`) NO_BNL(`t1`@`select#2`) NO_RANGE_OPTIMIZATION(`t3`@`select#1` `PRIMARY`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f2` = `test`.`t3`.`f2` and `test`.`t3`.`f1` > 30 and `test`.`t3`.`f1` < 33 and `test`.`t3`.`f2` between `test`.`t3`.`f1` and `test`.`t1`.`f2` and `test`.`t3`.`f2` + 1 >= `test`.`t3`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
+# Same as above but addressing tables with QB name
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t3 PRIMARY) BKA(t2@QB1) NO_BNL(t1@QB1)*/ t3
+SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
+(SELECT /*+ QB_NAME(QB1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
+t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	range	PRIMARY,f2_idx,f3_idx	f2_idx	4	NULL	2	100.00	Using index condition; Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	3	3.33	Using where
+1	PRIMARY	t2	ref	f1	f1	8	test.t3.f1,test.t3.f2	2	50.00	Using where; FirstMatch(t3)
+Warnings:
+Note	1003	update /*+ BKA(`t2`@`QB1`) NO_BNL(`t1`@`QB1`) NO_RANGE_OPTIMIZATION(`t3`@`select#1` `PRIMARY`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f2` = `test`.`t3`.`f2` and `test`.`t3`.`f1` > 30 and `test`.`t3`.`f1` < 33 and `test`.`t3`.`f2` between `test`.`t3`.`f1` and `test`.`t1`.`f2` and `test`.`t3`.`f2` + 1 >= `test`.`t3`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
 # Turn off range access for all keys.
 EXPLAIN EXTENDED UPDATE /*+ NO_RANGE_OPTIMIZATION(t3) */ t3
 SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
@@ -450,6 +462,31 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t3	eq_ref	PRIMARY,f2_idx,f3_idx	PRIMARY	4	test.t2.f1	1	100.00	Using where; End temporary
 Warnings:
 Note	1003	update /*+ NO_RANGE_OPTIMIZATION(`t3`@`select#1`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t2`.`f1` and `test`.`t3`.`f1` = `test`.`t2`.`f1` and `test`.`t3`.`f2` = `test`.`t2`.`f2` and `test`.`t2`.`f1` > 30 and `test`.`t2`.`f1` < 33 and `test`.`t2`.`f2` between `test`.`t2`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t2`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
+# Multi-table UPDATE with a derived table
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt)*/ t3,
+(SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	ALL	PRIMARY,f2_idx	NULL	NULL	NULL	56	100.00	
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t3.f1	8	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
+2	DERIVED	t2	index	f1	f1	8	NULL	28	100.00	Using where; Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ update /*+ NO_RANGE_OPTIMIZATION(`t2`@`dt`) */ `test`.`t3` join (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`f1` AS `f1`,`test`.`t1`.`f2` AS `f2` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`f1` > `test`.`t2`.`f1`) `dt` set `test`.`t3`.`f3` = 'mnbv' where `dt`.`f1` = `test`.`t3`.`f1`
+# Multi-table UPDATE with a derived table and both table-level and
+# query block-level hints
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt) NO_BNL(@dt)*/ t3,
+(SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	ALL	PRIMARY,f2_idx	NULL	NULL	NULL	56	100.00	
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t3.f1	8	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
+2	DERIVED	t2	index	f1	f1	8	NULL	28	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ update /*+ NO_BNL(@`dt`) NO_RANGE_OPTIMIZATION(`t2`@`dt`) */ `test`.`t3` join (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`f1` AS `f1`,`test`.`t1`.`f2` AS `f2` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`f1` > `test`.`t2`.`f1`) `dt` set `test`.`t3`.`f3` = 'mnbv' where `dt`.`f1` = `test`.`t3`.`f1`
 EXPLAIN EXTENDED DELETE FROM t3
 WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
 (SELECT /*+ QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
@@ -500,7 +537,7 @@ Warnings:
 Note	1003	(insert into `test`.`t3`(f1,f2,f3) select /*+ NO_ICP(`t5`@`select#1`) */ `test`.`t4`.`x` AS `x`,`test`.`t5`.`y` AS `y`,'filler' AS `filler` from `test`.`t4` join `test`.`t4` `t5` where `test`.`t4`.`y` = 8 and `test`.`t5`.`x` between 7 and <cache>(8 + 0))
 # Turn off ICP for a particular table and a key
 EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
-(SELECT /*+ QB_NAME(qb1) NO_ICP(t5@QB1 x_idx)*/ t4.x, t5.y, 'filler' FROM t4, t4 t5
+(SELECT /*+ NO_ICP(t5@QB1 x_idx) QB_NAME(qb1) */ t4.x, t5.y, 'filler' FROM t4, t4 t5
 WHERE t4.y = 8 AND t5.x BETWEEN 7 AND t4.y+0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t4	ref	y_idx	y_idx	5	const	1	100.00	
@@ -550,15 +587,14 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 Warnings:
 Warning	4219	Hint QB_NAME(`qb1`) is ignored as conflicting/duplicated
 Note	1003	select /*+ QB_NAME(`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t2`
-# Should issue warning
-EXPLAIN EXTENDED SELECT /*+ BKA(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
+# QB_NAME may appear after the hint, but the hint is still resolved
+EXPLAIN EXTENDED SELECT /*+ NO_BNL(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
-1	SIMPLE	t2	ALL	f1	NULL	NULL	NULL	28	25.00	Using where; Using join buffer (flat, BNL join)
+1	SIMPLE	t2	ALL	f1	NULL	NULL	NULL	28	25.00	Using where
 Warnings:
-Warning	4220	Query block name `qb1` is not found for BKA hint
-Note	1003	select /*+ QB_NAME(`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`f1` = `test`.`t1`.`f1` and `test`.`t2`.`f2` between `test`.`t1`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t1`.`f1` + 1
+Note	1003	select /*+ QB_NAME(`qb1`) NO_BNL(@`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`f1` = `test`.`t1`.`f1` and `test`.`t2`.`f2` between `test`.`t1`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t1`.`f1` + 1
 # Should not crash
 PREPARE stmt1 FROM "SELECT /*+ BKA(t2) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1";

--- a/mysql-test/main/opt_hints.test
+++ b/mysql-test/main/opt_hints.test
@@ -248,11 +248,31 @@ SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
   (SELECT /*+ BKA(t2) NO_BNL(t1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
     t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
 
+--echo # Same as above but addressing tables with QB name
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t3 PRIMARY) BKA(t2@QB1) NO_BNL(t1@QB1)*/ t3
+  SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
+  (SELECT /*+ QB_NAME(QB1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
+    t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+
 --echo # Turn off range access for all keys.
 EXPLAIN EXTENDED UPDATE /*+ NO_RANGE_OPTIMIZATION(t3) */ t3
 SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
   (SELECT t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
     t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+
+--echo # Multi-table UPDATE with a derived table
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt)*/ t3,
+  (SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+
+--echo # Multi-table UPDATE with a derived table and both table-level and
+--echo # query block-level hints
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt) NO_BNL(@dt)*/ t3,
+  (SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
 
 EXPLAIN EXTENDED DELETE FROM t3
 WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
@@ -282,7 +302,7 @@ EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
 
 --echo # Turn off ICP for a particular table and a key
 EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
-  (SELECT /*+ QB_NAME(qb1) NO_ICP(t5@QB1 x_idx)*/ t4.x, t5.y, 'filler' FROM t4, t4 t5
+  (SELECT /*+ NO_ICP(t5@QB1 x_idx) QB_NAME(qb1) */ t4.x, t5.y, 'filler' FROM t4, t4 t5
    WHERE t4.y = 8 AND t5.x BETWEEN 7 AND t4.y+0);
 
 --echo # Make sure ICP is expected to be used when there are no hints
@@ -308,8 +328,8 @@ EXPLAIN EXTENDED REPLACE INTO t3(f1, f2, f3)
 
 --echo # Should issue warning
 EXPLAIN EXTENDED SELECT /*+ QB_NAME(qb1) QB_NAME(qb1 ) */ * FROM t2;
---echo # Should issue warning
-EXPLAIN EXTENDED SELECT /*+ BKA(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
+--echo # QB_NAME may appear after the hint, but the hint is still resolved
+EXPLAIN EXTENDED SELECT /*+ NO_BNL(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1;
 
 --echo # Should not crash

--- a/mysql-test/main/opt_hints_impl_qb_name,MERGE_OFF.rdiff
+++ b/mysql-test/main/opt_hints_impl_qb_name,MERGE_OFF.rdiff
@@ -1,0 +1,374 @@
+--- main/opt_hints_impl_qb_name.result
++++ main/opt_hints_impl_qb_name.reject
+@@ -11,107 +11,122 @@
+ explain extended select /*+ no_bnl(t2@dt)*/ * from
+ (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+ # More than one reference to a single QB
+ explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+ (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
++2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(`t2`@`dt`) NO_INDEX(`t1`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) NO_INDEX(`t1`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+ # QB-level hint
+ explain extended select /*+ no_bnl(@dt)*/ * from
+ (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+ # Index-level hints
+ # Without the hint 'range' index access would be chosen
+ explain extended select /*+ no_index(t1@`T`)*/ * from
+ (select * from t1 where a < 3) t;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
++2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_INDEX(`t1`@`T`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`T`) */ `t`.`a` AS `a`,`t`.`b` AS `b`,`t`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`T`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t`
+ # Without the hint 'range' index access would be chosen
+ explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+ (select * from t1 where a > 100 and a < 120) as t1;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	1.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
++2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	1.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_RANGE_OPTIMIZATION(`t1`@`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` > 100 and `test`.`t1`.`a` < 120
++Note	1003	/* select#1 */ select /*+ NO_RANGE_OPTIMIZATION(`t1`@`t1`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` > 100 and `test`.`t1`.`a` < 120) `t1`
+ # Regular and derived tables share same name but the hint is applied correctly
+ explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+ (select * from t1 where a < 3) as t1;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
++2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	select /*+ INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
++Note	1003	/* select#1 */ select /*+ INDEX(`t1`@`t1` `idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1`
+ explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+ (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+-1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
++1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	3	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition
++2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	select /*+ NO_INDEX(`t1`@`t2` `idx_a`) INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`t2` `idx_a`) INDEX(`t1`@`t1` `idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c`,`t2`.`a` AS `a`,`t2`.`b` AS `b`,`t2`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1` join (/* select#3 */ select /*+ QB_NAME(`t2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t2`
+ explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+ (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+-1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
++1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
++2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_INDEX(`t1`@`t1` `idx_a`,`idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`t1` `idx_a`,`idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c`,`t2`.`a` AS `a`,`t2`.`b` AS `b`,`t2`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t2`
+ # Nested derived tables
+ explain extended select /*+ no_bnl(t1@dt2)*/ * from
+ (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	/* select#1 */ select /*+ NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
++Note	1003	/* select#1 */ select /*+ NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+ explain extended select /*+ no_index(t1@DT2)*/ * from
+ (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`DT2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`DT2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`DT2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`DT2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+ # Explicit QB name overrides the implicit one
+ explain extended select /*+ no_index(t1@dt2)*/ * from
+ (select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+-2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+ Warnings:
+-Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+ # Both hints are applied
+ explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+ (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+-2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
++3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+ Warnings:
+-Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1`) NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
++Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1`) NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+ # Nested derived tables with ambiguous names, hint is ignored
+ explain extended select /*+ no_index(t1@t1)*/* from
+ (select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+ Warning	4256	Query block name `t1` is ambiguous for NO_INDEX hint
+-Note	1003	/* select#1 */ select `t1`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `t1`
++Note	1003	/* select#1 */ select `t1`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t1`) `t1`
+ # The hint cannot be applied to a derived table with UNION
+ explain extended select /*+ no_index(t2@t1)*/* from
+ (select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+@@ -137,20 +152,23 @@
+ explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+ (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	Using temporary
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	insert into `test`.`t2` select /*+ NO_BNL(`t2`@`dt`) */ sql_buffer_result `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	insert into `test`.`t2` /* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+ # MERGE/NO_MERGE hints are resolved early and so do not support
+ # implicit QB names. Warning is expected
+ explain extended select /*+ no_merge(@dt)*/ * from
+ (select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+ Warnings:
+ Warning	4220	Query block name `dt` is not found for NO_MERGE hint
+-Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select `dt1`.`a` AS `a`,`dt1`.`b` AS `b`,`dt1`.`c` AS `c` from (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt1`) `dt`
+ # Multiple levels of nested derived tables, all hints are applied
+ explain extended
+ select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+@@ -176,55 +194,61 @@
+ select * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select `cte`.`count(*)` AS `count(*)` from `cte`
+ explain extended
+ with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+ select /*+ no_bnl(t1@cte)*/ * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_BNL(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+ explain extended
+ with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+ select /*+ no_bnl(@cte)*/ * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+ explain extended
+ with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+ select /*+ no_index(t1@cte)*/ * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+ explain extended
+ with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+ select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+-2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+ 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) NO_INDEX(`t1`@`dt1`) */ `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) NO_INDEX(`t1`@`dt1`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+ explain extended
+ with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+ select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	300	100.00	
+-2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	3	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
++3	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1` `idx_a`) NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1` `idx_a`) NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+ # Ambiguity: multiple occurencies of `cte`, the hint is ignored
+ explain extended
+ with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+@@ -233,15 +257,17 @@
+ select * from cte where cnt < 100;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ 4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+-5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++5	DERIVED	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++6	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+ Warnings:
+ Warning	4256	Query block name `cte` is ambiguous for NO_BNL hint
+-Note	1003	with cte as (/* select#2 */ select count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
++Note	1003	with cte as (/* select#2 */ select count(0) AS `cnt` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1` having `cnt` > 10)/* select#1 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+ # However, if CTE occurencies have different aliases, the hint can be applied
+ explain extended
+ with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+@@ -250,14 +276,16 @@
+ select * from cte where cnt < 100;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+ 1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+-2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
++3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ 4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+-5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
++5	DERIVED	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ 5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
++6	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+ NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+ Warnings:
+-Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte1`) */ count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte1`) */ `cte1`.`cnt` AS `cnt` from `cte` `cte1` where `cte1`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
++Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte1`) */ count(0) AS `cnt` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1` having `cnt` > 10)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte1`) */ `cte1`.`cnt` AS `cnt` from `cte` `cte1` where `cte1`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+ # ======================================
+ # Test views
+ create view v1 as select * from t1 where a < 100;
+@@ -306,11 +334,12 @@
+ explain extended select /*+ index(t2@v1) */ * from v1,
+ (select a from v1 where b > 5) dt;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	range	idx_a,idx_ab	idx_ab	5	NULL	99	90.20	Using where; Using index
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where; Using join buffer (flat, BNL join)
++1	PRIMARY	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where
++1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	99	100.00	Using join buffer (flat, BNL join)
++2	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	99	90.20	Using where; Using index
+ Warnings:
+ Warning	4256	Query block name `v1` is ambiguous for INDEX hint
+-Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`b` > 5 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
++Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`dt`.`a` AS `a` from `test`.`t1` join (/* select#2 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`b` > 5 and `test`.`t1`.`a` < 100) `dt` where `test`.`t1`.`a` < 100
+ # Implicit QB names are not supported inside views
+ create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+ (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+@@ -325,26 +354,29 @@
+ # Addressing a single table
+ explain extended select /*+ no_bnl(t2@dt) */* from v5;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+-1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
++1	PRIMARY	<derived3>	ref	key0	key0	5	test.t1.a	100	100.00	
++3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt` where `dt`.`a` = `test`.`t1`.`a`
+ # Addressing the whole derived table
+ explain extended select /*+ no_bnl(@dt) */* from v5;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+-1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
++1	PRIMARY	<derived3>	ref	key0	key0	5	test.t1.a	100	100.00	
++3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(@`dt`) */ `dt`.`a` AS `a` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt` where `dt`.`a` = `test`.`t1`.`a`
+ # Derived tables inside views can be addressed by their aliases
+ explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
++1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
++3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
++3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+ Warnings:
+-Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
++Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+ drop view v1, v2, v3, v4, v5;
+ # ======================================
+ # Not supported for DML, check presence of warnings
+@@ -364,11 +396,12 @@
+ where t2.a in
+ (select * from (select a from t1 where a > 10) dt where dt.a > 20);
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	90.00	Using where
+-1	PRIMARY	t1	ref	idx_a,idx_ab	idx_a	5	test.t2.a	1	100.00	Using index; FirstMatch(t2)
++1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	80.00	Using where
++1	PRIMARY	<derived3>	eq_ref	distinct_key	distinct_key	5	test.t2.a	1	100.00	
++3	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	84	100.00	Using where; Using index
+ Warnings:
+ Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+-Note	1003	delete  from `test`.`t2` using (`test`.`t1`) where `test`.`t1`.`a` = `test`.`t2`.`a` and `test`.`t2`.`a` > 20 and `test`.`t2`.`a` > 10
++Note	1003	/* select#1 */ delete  from `test`.`t2` using (/* select#3 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` > 10 and `test`.`t1`.`a` > 20) `dt` where `dt`.`a` = `test`.`t2`.`a` and `test`.`t2`.`a` > 20
+ # ======================================
+ # Objects in triggers and stored functions must not be visible for hints
+ create table t3 (a int, b int);

--- a/mysql-test/main/opt_hints_impl_qb_name.combinations
+++ b/mysql-test/main/opt_hints_impl_qb_name.combinations
@@ -1,0 +1,5 @@
+[MERGE_ON]
+optimizer_switch=derived_merge=on
+
+[MERGE_OFF]
+optimizer_switch=derived_merge=off

--- a/mysql-test/main/opt_hints_impl_qb_name.result
+++ b/mysql-test/main/opt_hints_impl_qb_name.result
@@ -1,0 +1,401 @@
+create table t1 (a int, b int, c char(20), key idx_a(a), key idx_ab(a, b));
+insert into t1 select seq, seq, 'filler' from seq_1_to_100;
+create table t2 as select * from t1;
+analyze table t1,t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	Table is already up to date
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+# Table-level hint
+explain extended select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# More than one reference to a single QB
+explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) NO_INDEX(`t1`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# QB-level hint
+explain extended select /*+ no_bnl(@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# Index-level hints
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_index(t1@`T`)*/ * from
+(select * from t1 where a < 3) t;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`T`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+(select * from t1 where a > 100 and a < 120) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	1.00	Using where
+Warnings:
+Note	1003	select /*+ NO_RANGE_OPTIMIZATION(`t1`@`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` > 100 and `test`.`t1`.`a` < 120
+# Regular and derived tables share same name but the hint is applied correctly
+explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
+explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`t2` `idx_a`) INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
+explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`t1` `idx_a`,`idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
+# Nested derived tables
+explain extended select /*+ no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+explain extended select /*+ no_index(t1@DT2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`DT2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`DT2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Explicit QB name overrides the implicit one
+explain extended select /*+ no_index(t1@dt2)*/ * from
+(select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Both hints are applied
+explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1`) NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Nested derived tables with ambiguous names, hint is ignored
+explain extended select /*+ no_index(t1@t1)*/* from
+(select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Warning	4256	Query block name `t1` is ambiguous for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `t1`
+# The hint cannot be applied to a derived table with UNION
+explain extended select /*+ no_index(t2@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+explain extended select /*+ no_index(t1@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+# Test INSERT..SELECT
+explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	Using temporary
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	insert into `test`.`t2` select /*+ NO_BNL(`t2`@`dt`) */ sql_buffer_result `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# MERGE/NO_MERGE hints are resolved early and so do not support
+# implicit QB names. Warning is expected
+explain extended select /*+ no_merge(@dt)*/ * from
+(select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_MERGE hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# Multiple levels of nested derived tables, all hints are applied
+explain extended
+select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+select /*+ no_merge(du) */ * from (
+select /*+ no_merge(dt) */ * from (
+select t1.* from t1, t2 where t1.a > t2.a
+) dt
+) du
+) dv;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+4	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+4	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_MERGE(`dt`@`select#3`) NO_MERGE(`du`@`select#2`) NO_MERGE(`dv`@`select#1`) NO_BNL(`t2`@`dt`) */ `dv`.`a` AS `a`,`dv`.`b` AS `b`,`dv`.`c` AS `c` from (/* select#2 */ select `du`.`a` AS `a`,`du`.`b` AS `b`,`du`.`c` AS `c` from (/* select#3 */ select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#4 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`) `du`) `dv`
+# ======================================
+# Test CTEs
+# By default BNL and index access to t1 are used.
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) NO_INDEX(`t1`@`dt1`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	300	100.00	
+2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1` `idx_a`) NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+# Ambiguity: multiple occurencies of `cte`, the hint is ignored
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4256	Query block name `cte` is ambiguous for NO_BNL hint
+Note	1003	with cte as (/* select#2 */ select count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# However, if CTE occurencies have different aliases, the hint can be applied
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte1)*/ * from cte as cte1 where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte1`) */ count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte1`) */ `cte1`.`cnt` AS `cnt` from `cte` `cte1` where `cte1`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# ======================================
+# Test views
+create view v1 as select * from t1 where a < 100;
+# Default execution plan
+explain extended select *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+explain extended
+select /*+ index(t1@v1 idx_ab) no_index(t1@`v2`)*/ *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	99.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) NO_INDEX(`t1`@`v2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+# Nested views
+create view v2 as select * from v1 where a < 300;
+# Default execution plan
+explain extended select * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+# Addressing an object inside a nested view
+explain extended select /*+ index(t1@`v1` idx_ab)*/ * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	99	100.00	Using index condition
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+create view v3 as select * from t1 union select * from t2;
+# Unable to apply the hint to a view with UNION
+explain extended select /*+ no_index(t1@v3) */ * from v3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `v3` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `v3`.`a` AS `a`,`v3`.`b` AS `b`,`v3`.`c` AS `c` from `test`.`v3`
+# Ambiguity: view `v1` appears two times - should warn and ignore hint
+explain extended select /*+ index(t2@v1) */ * from v1,
+(select a from v1 where b > 5) dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_ab	5	NULL	99	90.20	Using where; Using index
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Warning	4256	Query block name `v1` is ambiguous for INDEX hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`b` > 5 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+# Implicit QB names are not supported inside views
+create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+Warnings:
+Warning	4242	Implicit query block names are ignored for hints specified within VIEWs
+show create view v4;
+View	Create View	character_set_client	collation_connection
+v4	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v4` AS select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (`t1` join `t2`) where `t1`.`a` > `t2`.`a`) `dt`	latin1	latin1_swedish_ci
+# However, a derived table inside a view can be addressed from outer query
+create view v5 as select dt.a from
+t1, (select t1.* from t1, t2 where t1.a > t2.a) as dt where t1.a=dt.a;
+# Addressing a single table
+explain extended select /*+ no_bnl(t2@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
+# Addressing the whole derived table
+explain extended select /*+ no_bnl(@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
+# Derived tables inside views can be addressed by their aliases
+explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+drop view v1, v2, v3, v4, v5;
+# ======================================
+# Not supported for DML, check presence of warnings
+explain extended
+update /*+ no_range_optimization(t1@dt)*/ t2,
+(select a from t1 where a > 10) dt
+set b=1 where t2.a = dt.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t2.a	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	92	100.00	Using where; Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_RANGE_OPTIMIZATION hint
+Note	1003	/* select#1 */ update `test`.`t2` join (/* select#2 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` > 10) `dt` set `test`.`t2`.`b` = 1 where `dt`.`a` = `test`.`t2`.`a`
+explain extended
+delete /*+ no_index(t1@dt)*/ from t2
+where t2.a in
+(select * from (select a from t1 where a > 10) dt where dt.a > 20);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	90.00	Using where
+1	PRIMARY	t1	ref	idx_a,idx_ab	idx_a	5	test.t2.a	1	100.00	Using index; FirstMatch(t2)
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	delete  from `test`.`t2` using (`test`.`t1`) where `test`.`t1`.`a` = `test`.`t2`.`a` and `test`.`t2`.`a` > 20 and `test`.`t2`.`a` > 10
+# ======================================
+# Objects in triggers and stored functions must not be visible for hints
+create table t3 (a int, b int);
+# Trigger with derived table inside
+create trigger tr1 before insert on t3
+for each row
+begin
+set new.b = (select max(a) from
+(select a from t1 where a < new.a) dt);
+end|
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ max(a) from t3 where a<2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select max(NULL) AS `max(a)` from `test`.`t3` where 0
+# Stored function with derived table inside
+create function get_max(p_a int) returns int
+return (select max(a) from
+(select a from t1 where a < p_a) dt);
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ a, get_max(a) from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`get_max`(`test`.`t1`.`a`) AS `get_max(a)` from `test`.`t1`
+drop function get_max;
+drop table t1, t2, t3;

--- a/mysql-test/main/opt_hints_impl_qb_name.test
+++ b/mysql-test/main/opt_hints_impl_qb_name.test
@@ -1,0 +1,238 @@
+--source include/have_sequence.inc
+
+create table t1 (a int, b int, c char(20), key idx_a(a), key idx_ab(a, b));
+
+insert into t1 select seq, seq, 'filler' from seq_1_to_100;
+
+create table t2 as select * from t1;
+
+analyze table t1,t2 persistent for all;
+
+--echo # Table-level hint
+explain extended select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # More than one reference to a single QB
+explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # QB-level hint
+explain extended select /*+ no_bnl(@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # Index-level hints
+--echo # Without the hint 'range' index access would be chosen
+explain extended select /*+ no_index(t1@`T`)*/ * from
+  (select * from t1 where a < 3) t;
+
+--echo # Without the hint 'range' index access would be chosen
+explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+  (select * from t1 where a > 100 and a < 120) as t1;
+
+--echo # Regular and derived tables share same name but the hint is applied correctly
+explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1;
+
+explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+
+explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+
+--echo # Nested derived tables
+explain extended select /*+ no_bnl(t1@dt2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+explain extended select /*+ no_index(t1@DT2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+--echo # Explicit QB name overrides the implicit one
+explain extended select /*+ no_index(t1@dt2)*/ * from
+  (select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+
+--echo # Both hints are applied
+explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+--disable_ps_protocol
+# PS protocol is disabled because the warning is genererated only during
+# PREPARE step of a statement. When the QB name cannot be resolved the hint
+# is discarded, so it is not present during EXECUTE step. The same applies
+# not only to implicit but also to explicit QB names.
+
+--echo # Nested derived tables with ambiguous names, hint is ignored
+explain extended select /*+ no_index(t1@t1)*/* from
+  (select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+
+--echo # The hint cannot be applied to a derived table with UNION
+explain extended select /*+ no_index(t2@t1)*/* from
+  (select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+
+explain extended select /*+ no_index(t1@t1)*/* from
+  (select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+
+--echo # Test INSERT..SELECT
+explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # MERGE/NO_MERGE hints are resolved early and so do not support
+--echo # implicit QB names. Warning is expected
+explain extended select /*+ no_merge(@dt)*/ * from
+  (select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+
+--echo # Multiple levels of nested derived tables, all hints are applied
+explain extended
+select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+  select /*+ no_merge(du) */ * from (
+      select /*+ no_merge(dt) */ * from (
+        select t1.* from t1, t2 where t1.a > t2.a
+    ) dt
+  ) du
+) dv;
+
+--enable_ps_protocol
+
+--echo # ======================================
+--echo # Test CTEs
+--echo # By default BNL and index access to t1 are used.
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(t1@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+
+
+--disable_ps_protocol
+# See the comment above for why PS protocol is disabled
+
+--echo # Ambiguity: multiple occurencies of `cte`, the hint is ignored
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte where cnt > 10
+union
+select * from cte where cnt < 100;
+
+--echo # However, if CTE occurencies have different aliases, the hint can be applied
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte1)*/ * from cte as cte1 where cnt > 10
+union
+select * from cte where cnt < 100;
+
+--enable_ps_protocol
+
+--echo # ======================================
+--echo # Test views
+create view v1 as select * from t1 where a < 100;
+
+--echo # Default execution plan
+explain extended select *
+  from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+
+explain extended
+  select /*+ index(t1@v1 idx_ab) no_index(t1@`v2`)*/ *
+  from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+
+--echo # Nested views
+create view v2 as select * from v1 where a < 300;
+
+--echo # Default execution plan
+explain extended select * from v2;
+
+--echo # Addressing an object inside a nested view
+explain extended select /*+ index(t1@`v1` idx_ab)*/ * from v2;
+
+create view v3 as select * from t1 union select * from t2;
+
+--disable_ps_protocol
+# See the comment above for why PS protocol is disabled
+
+--echo # Unable to apply the hint to a view with UNION
+explain extended select /*+ no_index(t1@v3) */ * from v3;
+
+--echo # Ambiguity: view `v1` appears two times - should warn and ignore hint
+explain extended select /*+ index(t2@v1) */ * from v1,
+   (select a from v1 where b > 5) dt;
+
+--enable_ps_protocol
+
+--echo # Implicit QB names are not supported inside views
+create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+show create view v4;
+
+--echo # However, a derived table inside a view can be addressed from outer query
+create view v5 as select dt.a from
+    t1, (select t1.* from t1, t2 where t1.a > t2.a) as dt where t1.a=dt.a;
+
+--echo # Addressing a single table
+explain extended select /*+ no_bnl(t2@dt) */* from v5;
+--echo # Addressing the whole derived table
+explain extended select /*+ no_bnl(@dt) */* from v5;
+
+--echo # Derived tables inside views can be addressed by their aliases
+explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+
+drop view v1, v2, v3, v4, v5;
+
+--echo # ======================================
+--echo # Not supported for DML, check presence of warnings
+
+--disable_ps_protocol
+explain extended
+update /*+ no_range_optimization(t1@dt)*/ t2,
+   (select a from t1 where a > 10) dt
+set b=1 where t2.a = dt.a;
+
+explain extended
+delete /*+ no_index(t1@dt)*/ from t2
+where t2.a in
+   (select * from (select a from t1 where a > 10) dt where dt.a > 20);
+
+--echo # ======================================
+--echo # Objects in triggers and stored functions must not be visible for hints
+create table t3 (a int, b int);
+
+--echo # Trigger with derived table inside
+delimiter |;
+create trigger tr1 before insert on t3
+for each row
+begin
+  set new.b = (select max(a) from
+    (select a from t1 where a < new.a) dt);
+end|
+delimiter ;|
+
+--echo # Warning expected
+explain extended select /*+ no_index(t1@dt) */ max(a) from t3 where a<2;
+
+--echo # Stored function with derived table inside
+create function get_max(p_a int) returns int
+return (select max(a) from
+    (select a from t1 where a < p_a) dt);
+
+--echo # Warning expected
+explain extended select /*+ no_index(t1@dt) */ a, get_max(a) from t1;
+
+--enable_ps_protocol
+drop function get_max;
+drop table t1, t2, t3;

--- a/sql/opt_hints.cc
+++ b/sql/opt_hints.cc
@@ -15,10 +15,12 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "my_global.h"
+#include "opt_hints_structs.h"
 #include "sql_class.h"
 #include "sql_lex.h"
 #include "sql_select.h"
 #include "opt_hints.h"
+#include "opt_trace.h"
 
 /**
   Information about hints. Must be in sync with opt_hints_enum.
@@ -30,32 +32,34 @@
   can control wishful form of the hint name.
 */
 
+using hrs= hint_resolution_stage;
+
 struct st_opt_hint_info opt_hint_info[]=
 {
-  // hint_type                             check_upper   has_args     irregular
-  {{STRING_WITH_LEN("BKA")},                   true,      false,        false},
-  {{STRING_WITH_LEN("BNL")},                   true,      false,        false},
-  {{STRING_WITH_LEN("ICP")},                   true,      false,        false},
-  {{STRING_WITH_LEN("MRR")},                   true,      false,        false},
-  {{STRING_WITH_LEN("NO_RANGE_OPTIMIZATION")}, true,      false,        false},
-  {{STRING_WITH_LEN("QB_NAME")},               false,     false,        false},
-  {{STRING_WITH_LEN("MAX_EXECUTION_TIME")},    false,     true,         false},
-  {{STRING_WITH_LEN("SEMIJOIN")},              false,     true,         false},
-  {{STRING_WITH_LEN("SUBQUERY")},              false,     true,         false},
-  {{STRING_WITH_LEN("JOIN_PREFIX")},           false,     true,         true},
-  {{STRING_WITH_LEN("JOIN_SUFFIX")},           false,     true,         true},
-  {{STRING_WITH_LEN("JOIN_ORDER")},            false,     true,         true},
-  {{STRING_WITH_LEN("JOIN_FIXED_ORDER")},      false,     true,         false},
-  {{STRING_WITH_LEN("DERIVED_CONDITION_PUSHDOWN")}, false, false, false},
-  {{STRING_WITH_LEN("MERGE")}, true, false, false},
-  {{STRING_WITH_LEN("SPLIT_MATERIALIZED")}, false, false, false},
-  {{STRING_WITH_LEN("INDEX")},                 false,     true,         false},
-  {{STRING_WITH_LEN("JOIN_INDEX")},            false,     true,         false},
-  {{STRING_WITH_LEN("GROUP_INDEX")},           false,     true,         false},
-  {{STRING_WITH_LEN("ORDER_INDEX")},           false,     true,         false},
-  {{STRING_WITH_LEN("ROWID_FILTER")},          false,     true,         false},
-  {{STRING_WITH_LEN("INDEX_MERGE")}, false, false, false},
-  {null_clex_str, 0, 0, 0}
+  // hint_type                             check_upper   has_args     irregular     resolution_stage
+  {{STRING_WITH_LEN("BKA")},                   true,      false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("BNL")},                   true,      false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("ICP")},                   true,      false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("MRR")},                   true,      false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("NO_RANGE_OPTIMIZATION")}, true,      false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("QB_NAME")},               false,     false,        false,        hrs::EARLY},
+  {{STRING_WITH_LEN("MAX_EXECUTION_TIME")},    false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("SEMIJOIN")},              false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("SUBQUERY")},              false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("JOIN_PREFIX")},           false,     true,         true,         hrs::LATE},
+  {{STRING_WITH_LEN("JOIN_SUFFIX")},           false,     true,         true,         hrs::LATE},
+  {{STRING_WITH_LEN("JOIN_ORDER")},            false,     true,         true,         hrs::LATE},
+  {{STRING_WITH_LEN("JOIN_FIXED_ORDER")},      false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("DERIVED_CONDITION_PUSHDOWN")}, false, false,       false,        hrs::LATE},
+  {{STRING_WITH_LEN("MERGE")},                 true,      false,        false,        hrs::EARLY},
+  {{STRING_WITH_LEN("SPLIT_MATERIALIZED")},    false,     false,        false,        hrs::LATE},
+  {{STRING_WITH_LEN("INDEX")},                 false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("JOIN_INDEX")},            false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("GROUP_INDEX")},           false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("ORDER_INDEX")},           false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("ROWID_FILTER")},          false,     true,         false,        hrs::LATE},
+  {{STRING_WITH_LEN("INDEX_MERGE")},           false,     false,        false,        hrs::LATE},
+  {null_clex_str, 0, 0, 0, hrs::LATE}
 };
 
 /**
@@ -83,7 +87,6 @@ int cmp_lex_string(const LEX_CSTRING &s, const LEX_CSTRING &t,
   return cs->coll->strnncollsp(cs, (const uchar*)s.str, s.length,
                                    (const uchar*)t.str, t.length);
 }
-
 
 /*
   This is a version of push_warning_printf() guaranteeing no escalation of
@@ -137,7 +140,9 @@ void print_warn(THD *thd, uint err_code, opt_hints_enum hint_type,
   str.append(opt_hint_info[hint_type].hint_type);
 
   /* ER_WARN_UNKNOWN_QB_NAME with two arguments */
-  if (err_code == ER_WARN_UNKNOWN_QB_NAME)
+  if (err_code == ER_WARN_UNKNOWN_QB_NAME ||
+      err_code == ER_WARN_AMBIGUOUS_QB_NAME ||
+      err_code == ER_WARN_IMPLICIT_QB_NAME_FOR_UNION)
   {
     String qb_name_str;
     append_identifier(thd, &qb_name_str, qb_name_arg->str, qb_name_arg->length);
@@ -287,6 +292,95 @@ static Opt_hints_qb *find_hints_by_select_number(Parse_context *pc,
   return qb;
 }
 
+/**
+   Helper function to find_qb_hints whereby it matches a qb_name to
+   an alias of a derived table, view or CTE used in the current query.
+   For example, for query
+     `select * from (select ... from t1 ...) as DT`
+   and given qb_name "DT", this function will return the query block
+   corresponding to the derived table DT, just like if the name was specified
+   explicitly using the QB_NAME hint:
+     `select * from (select / *+ QB_NAME(DT) * / ... from t1 ...) as DT`
+
+   For query
+     `select * from v1, v1 as v2 where v1.a = v2.a and v1.a < 3`
+   and given qb_name "v2", this function will return the query block
+   corresponding to the view v2.
+
+   For query
+     `with lda as (select ... from t1 ...)
+      select * from lda`
+   and given qb_name "lda", this function will return the query block
+   corresponding to the CTE "lda", just like if the name was specified
+   explicitly using the QB_NAME hint:
+     `with lda as (select / *+ QB_NAME(lda) * / ... from t1 ...)
+      select * from lda`
+
+   Note: Implicit QB names are only supported for SELECTs. DML operations
+   (UPDATE, DELETE, INSERT) only support explicit QB names. This is caused by
+   the fact that Sql_cmd_dml::prepare() resolves both early and late hints
+   at the same time.
+
+   @return the pair: - result code
+                     - matching query block hints object, if it exists,
+                       and NULL otherwise
+ */
+
+enum class implicit_qb_result
+{
+  OK,        // Found exactly one match, success
+  // Failure statuses:
+  NOT_FOUND, // No matches found
+  AMBIGUOUS, // More than one alias matches qb_name in the current query
+  UNION      // DT/view/CTE has UNION/EXCEPT/INTERSECT inside
+             // (i.e., multiple query blocks), so the hint cannot be resolved
+             // unambiguously
+};
+
+static std::pair<implicit_qb_result, Opt_hints_qb*>
+find_hints_by_implicit_qb_name(Parse_context *pc, const Lex_ident_sys &qb_name)
+{
+  Opt_hints_qb *qb= nullptr;
+
+  // Traverse the global table list to find all derived tables and views
+  for (TABLE_LIST *tbl= pc->thd->lex->query_tables; tbl; tbl= tbl->next_global)
+  {
+    // Skip if neither a derived table nor a view
+    if (tbl->is_non_derived())
+      continue;
+
+    // Check if the alias equals the implicit QB name
+    if (cmp_lex_string(tbl->alias, qb_name, system_charset_info))
+      continue;  // not a match, continue to next table
+
+    /*
+      If `qb` was already set before, this means there are multiple tables with
+      same alias in the query. The name cannot be resolved unambiguously.
+    */
+    if (qb)
+      return {implicit_qb_result::AMBIGUOUS, nullptr};
+
+    SELECT_LEX *child_select= tbl->get_unit()->first_select();
+    /*
+      Check if the derived table/view does not contain UNION, because
+      implicit QB names for UNIONs are ambiguous - we do not know which SELECT
+      should the hint be applied to. So we only support implicit names
+      for single-SELECT derived tables/views.
+    */
+    if (child_select->next_select())
+      return {implicit_qb_result::UNION, nullptr};
+
+    Parse_context child_ctx(pc, child_select);
+    /*
+      qb should be set only this one time.  Ambiguous references to
+      the same query block will fail on subsequent iterations (see above).
+    */
+    qb= get_qb_hints(&child_ctx);
+  }
+
+  return {(qb ? implicit_qb_result::OK : implicit_qb_result::NOT_FOUND), qb};
+}
+
 
 /**
   Find existing Opt_hints_qb object, print warning
@@ -316,13 +410,37 @@ Opt_hints_qb *find_qb_hints(Parse_context *pc,
   if (qb_by_name == nullptr)
     qb_by_number= find_hints_by_select_number(pc, qb_name);
 
+  Opt_hints_qb *qb_by_implicit_name= nullptr;
+  if (qb_by_name == nullptr && qb_by_number == nullptr)
+  {
+    std::pair<implicit_qb_result, Opt_hints_qb*> find_res=
+      find_hints_by_implicit_qb_name(pc, qb_name);
+    if (find_res.first == implicit_qb_result::AMBIGUOUS)
+    {
+      // Warn on ambiguous derived table name
+      print_warn(pc->thd, ER_WARN_AMBIGUOUS_QB_NAME,
+                 hint_type, hint_state, &qb_name,
+                 nullptr, nullptr, nullptr);
+      return nullptr;
+    }
+    if (find_res.first == implicit_qb_result::UNION)
+    {
+      print_warn(pc->thd, ER_WARN_IMPLICIT_QB_NAME_FOR_UNION,
+                 hint_type, hint_state, &qb_name,
+                 nullptr, nullptr, nullptr);
+      return nullptr;
+    }
+    qb_by_implicit_name= find_res.second;
+  }
+
   // C++-style comment here, otherwise compiler warns of /* within comment.
   // We don't allow implicit query block names to be specified for hints local
   // to a view (e.g. CREATE VIEW v1 AS SELECT /*+ NO_ICP(@`select#2` t1) ...
   // because of select numbering issues.  When we're ready to fix that, then we
   // can remove this gate.
+  // Implicit QB naming using DT/view aliases is also not supported inside views
   if (pc->thd->lex->sql_command == SQLCOM_CREATE_VIEW &&
-      qb_by_number)
+      (qb_by_number || qb_by_implicit_name))
   {
     print_warn(pc->thd, ER_WARN_NO_IMPLICIT_QB_NAMES_IN_VIEW,
                hint_type, hint_state, &qb_name,
@@ -330,10 +448,21 @@ Opt_hints_qb *find_qb_hints(Parse_context *pc,
     return nullptr;
   }
 
-  Opt_hints_qb *qb= qb_by_name ? qb_by_name : qb_by_number;
+  Opt_hints_qb *qb= qb_by_name ? qb_by_name :
+                    (qb_by_number ? qb_by_number : qb_by_implicit_name);
   if (qb == nullptr)
+  {
     print_warn(pc->thd, ER_WARN_UNKNOWN_QB_NAME, hint_type, hint_state,
                &qb_name, NULL, NULL, NULL);
+  }
+  else if (qb == qb_by_implicit_name && qb->get_name().length == 0)
+  {
+    /*
+      If the block is addressed by an implicit name, assign a name to the block,
+      so it is properly printed in warnings
+    */
+    qb->set_name(qb_name);
+  }
 
   return qb;
 }
@@ -1656,7 +1785,7 @@ bool is_compound_hint(opt_hints_enum type_arg)
 /*
   @brief
     Perform "Hint Resolution" for Optimizer Hints (see opt_hints.h for
-    definition)
+    definition) for both early and late stages.
 
   @detail
     Hints use "Explain select numbering", so this must be called after the
@@ -1668,13 +1797,53 @@ bool is_compound_hint(opt_hints_enum type_arg)
 
 void LEX::resolve_optimizer_hints()
 {
+  resolve_early_optimizer_hints();
+  resolve_late_optimizer_hints();
+}
+
+/*
+  Perform Hint Resolution for Optimizer Hints in early stage.
+
+  This function processes only those hints that have to be resolved
+  in the early stage (before opening tables), and skips others.
+  The function does not clean up the list of SELECT_LEX'es to be resolved,
+  because resolve_late_optimizer_hints() is expected to be called after.
+  The stage when a certain hint type should be resolved is specified in
+  opt_hint_info[].
+
+  Also see description of resolve_optimizer_hints().
+*/
+
+void LEX::resolve_early_optimizer_hints()
+{
+  resolve_optimizer_hints_for_stage(hint_resolution_stage::EARLY);
+}
+
+/*
+  Perform Hint Resolution for Optimizer Hints in late stage.
+
+  This function processes only those hints that have to be resolved
+  in the late stage (after opening tables), and skips others. The function
+  cleans up the list of SELECT_LEX'es to be resolved after completion.
+  The stage when a certain hint type should be resolved is specified in
+  opt_hint_info[].
+
+  Also see description of resolve_optimizer_hints().
+*/
+
+void LEX::resolve_late_optimizer_hints()
+{
+  resolve_optimizer_hints_for_stage(hint_resolution_stage::LATE);
+}
+
+// Helper function for be called from the three functions above
+void LEX::resolve_optimizer_hints_for_stage(hint_resolution_stage stage)
+{
+  if (selects_for_hint_resolution.is_empty())
+    return;
+
   Query_arena *arena, backup;
   arena= thd->activate_stmt_arena_if_needed(&backup);
-  SCOPE_EXIT([&] () mutable {
-    selects_for_hint_resolution.empty();
-    if (arena)
-      thd->restore_active_arena(arena, &backup);
-  });
 
   List_iterator<SELECT_LEX> it(selects_for_hint_resolution);
   SELECT_LEX *sel;
@@ -1682,10 +1851,16 @@ void LEX::resolve_optimizer_hints()
   {
     if (!sel->parsed_optimizer_hints)
       continue;
-    Parse_context pc(thd, sel);
+    Parse_context pc(thd, sel, stage);
     sel->parsed_optimizer_hints->resolve(&pc);
   }
+
+  if (stage == hint_resolution_stage::LATE)
+    selects_for_hint_resolution.empty(); // Don't clean up in early stage
+  if (arena)
+    thd->restore_active_arena(arena, &backup);
 }
+
 
 #ifndef DBUG_OFF
 static char dbug_print_hint_buf[64];

--- a/sql/opt_hints.h
+++ b/sql/opt_hints.h
@@ -113,6 +113,7 @@
 
 #include <functional>
 #include "my_config.h"
+#include "opt_hints_structs.h"
 #include "sql_alloc.h"
 #include "sql_list.h"
 #include "mem_root_array.h"
@@ -138,6 +139,9 @@ struct st_opt_hint_info
   bool irregular_hint;    // true if hint requires some special handling.
                           // Currently it's used only for join order hints
                           // since they need a special printing procedure.
+  hint_resolution_stage resolution_stage; // Stage when this hint type has to
+                          // be resolved: early (before opening tables) or late
+                          // (after opening tables).
 };
 
 typedef Optimizer_hint_parser Parser;

--- a/sql/opt_hints_parser.cc
+++ b/sql/opt_hints_parser.cc
@@ -53,11 +53,15 @@ void append_table_name(THD *thd, String *str, const LEX_CSTRING &table_name,
 
 static const Lex_ident_sys null_ident_sys;
 
-Parse_context::Parse_context(THD *thd, st_select_lex *select)
+
+Parse_context::Parse_context(THD *thd, st_select_lex *select,
+                             hint_resolution_stage stage)
 : thd(thd),
   mem_root(thd->mem_root),
-  select(select)
+  select(select),
+  resolution_stage(stage)
 {}
+
 
 Parse_context::Parse_context(Parse_context *pc, st_select_lex *select)
 : thd(pc->thd),
@@ -294,6 +298,16 @@ void Parser::push_warning_syntax_error(THD *thd, uint start_lineno)
                       msg, txt.ptr(), start_lineno + lineno());
 }
 
+/*
+  Returns true if the hint of `hint_type` should be resolved in
+  the current stage. Current stage is specified in `pc->resolution_stage`.
+*/
+bool Parser::is_appropriate_resolution_stage(opt_hints_enum hint_type,
+                                             Parse_context *pc)
+{
+  return pc->resolution_stage == opt_hint_info[hint_type].resolution_stage;
+}
+
 
 bool
 Parser::Table_name_list_container::add(Optimizer_hint_parser *p,
@@ -411,6 +425,9 @@ bool Parser::Table_level_hint::resolve(Parse_context *pc) const
     DBUG_ASSERT(0);
     return true;
   }
+
+  if (!is_appropriate_resolution_stage(hint_type, pc))
+    return false;
 
   if (const At_query_block_name_opt_table_name_list &
           at_query_block_name_opt_table_name_list= *this)
@@ -624,6 +641,9 @@ bool Parser::Index_level_hint::resolve(Parse_context *pc) const
     return true;
   }
 
+  if (!is_appropriate_resolution_stage(hint_type, pc))
+    return false;
+
   const Hint_param_table_ext &table_ext= *this;
   const Lex_ident_sys qb_name_sys= table_ext.Query_block_name::
                                    to_ident_sys(pc->thd);
@@ -775,6 +795,10 @@ Return value:
 */
 bool Parser::Qb_name_hint::resolve(Parse_context *pc) const
 {
+  const opt_hints_enum hint_type= QB_NAME_HINT_ENUM;
+  if (!is_appropriate_resolution_stage(hint_type, pc))
+    return false;
+
   Opt_hints_qb *qb= pc->select->opt_hints_qb;
 
   DBUG_ASSERT(qb);
@@ -784,7 +808,7 @@ bool Parser::Qb_name_hint::resolve(Parse_context *pc) const
   if (qb->get_name().str ||                        // QB name is already set
       qb->get_parent()->find_by_name(qb_name_sys)) // Name is already used
   {
-    print_warn(pc->thd, ER_WARN_CONFLICTING_HINT, QB_NAME_HINT_ENUM, true,
+    print_warn(pc->thd, ER_WARN_CONFLICTING_HINT, hint_type, true,
                &qb_name_sys, nullptr, nullptr, nullptr);
     return false;
   }
@@ -841,6 +865,9 @@ Return value:
 */
 bool Parser::Semijoin_hint::resolve(Parse_context *pc) const
 {
+  if (!is_appropriate_resolution_stage(SEMIJOIN_HINT_ENUM, pc))
+    return false;
+
   const Semijoin_hint_type &semijoin_hint_type= *this;
   bool hint_state; // true - SEMIJOIN(), false - NO_SEMIJOIN()
   if (semijoin_hint_type.id() == TokenID::keyword_SEMIJOIN)
@@ -957,6 +984,9 @@ Return value:
 */
 bool Parser::Subquery_hint::resolve(Parse_context *pc) const
 {
+  if (!is_appropriate_resolution_stage(SUBQUERY_HINT_ENUM, pc))
+    return false;
+
   Opt_hints_qb *qb;
   if (const At_query_block_name_subquery_strategy &
           at_query_block_name_subquery_strategy= *this)
@@ -1072,6 +1102,9 @@ void Parser::Subquery_hint::append_args(THD *thd, String *str) const
 */
 bool Parser::Max_execution_time_hint::resolve(Parse_context *pc) const
 {
+  if (!is_appropriate_resolution_stage(MAX_EXEC_TIME_HINT_ENUM, pc))
+    return false;
+
   const Unsigned_Number& hint_arg= *this;
   const ULonglong_null time_ms= hint_arg.get_ulonglong();
 
@@ -1141,6 +1174,9 @@ bool Parser::Join_order_hint::resolve(Parse_context *pc)
     DBUG_ASSERT(0);
     return true;
   }
+
+  if (!is_appropriate_resolution_stage(hint_type, pc))
+    return false;
 
   Opt_hints_qb *qb= nullptr;
   Lex_ident_sys qb_name;
@@ -1283,6 +1319,20 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
   if (!get_qb_hints(pc))
     return true;
 
+  /*
+    QB_NAME hints are resolved first so following hints can be attached to
+    the pre-configured query blocks
+  */
+  for (Hint_list::iterator li= this->begin(); li != this->end(); ++li)
+  {
+    Parser::Hint &hint= *li;
+    if (const Qb_name_hint &qb_hint= hint)
+    {
+      if (qb_hint.resolve(pc))
+        return true;
+    }
+  }
+
   for (Hint_list::iterator li= this->begin(); li != this->end(); ++li)
   {
     Parser::Hint &hint= *li;
@@ -1294,11 +1344,6 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
     else if (const Index_level_hint &index_hint= hint)
     {
       if (index_hint.resolve(pc))
-        return true;
-    }
-    else if (const Qb_name_hint &qb_hint= hint)
-    {
-      if (qb_hint.resolve(pc))
         return true;
     }
     else if (const Max_execution_time_hint &max_hint= hint)
@@ -1320,6 +1365,11 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
     {
       if (join_order_hint.resolve(pc))
         return true;
+    }
+    else if (const Qb_name_hint &qb_hint __attribute__((unused)) = hint)
+    {
+      // QB_NAME hints have been resolved earlier
+      continue;
     }
     else {
       DBUG_ASSERT(0);

--- a/sql/opt_hints_parser.h
+++ b/sql/opt_hints_parser.h
@@ -19,6 +19,7 @@
 */
 
 #include "lex_ident_sys.h"
+#include "opt_hints_structs.h"
 #include "simple_tokenizer.h"
 #include "sql_list.h"
 #include "sql_string.h"
@@ -29,47 +30,15 @@ class st_select_lex;
 class Opt_hints_qb;
 
 /**
-  Hint types, MAX_HINT_ENUM should be always last.
-  This enum should be synchronized with opt_hint_info
-  array(see opt_hints.cc).
-*/
-enum opt_hints_enum
-{
-  BKA_HINT_ENUM= 0,
-  BNL_HINT_ENUM,
-  ICP_HINT_ENUM,
-  MRR_HINT_ENUM,
-  NO_RANGE_HINT_ENUM,
-  QB_NAME_HINT_ENUM,
-  MAX_EXEC_TIME_HINT_ENUM,
-  SEMIJOIN_HINT_ENUM,
-  SUBQUERY_HINT_ENUM,
-  JOIN_PREFIX_HINT_ENUM,
-  JOIN_SUFFIX_HINT_ENUM,
-  JOIN_ORDER_HINT_ENUM,
-  JOIN_FIXED_ORDER_HINT_ENUM,
-  DERIVED_CONDITION_PUSHDOWN_HINT_ENUM,
-  MERGE_HINT_ENUM,
-  SPLIT_MATERIALIZED_HINT_ENUM,
-  INDEX_HINT_ENUM,
-  JOIN_INDEX_HINT_ENUM,
-  GROUP_INDEX_HINT_ENUM,
-  ORDER_INDEX_HINT_ENUM,
-  ROWID_FILTER_HINT_ENUM,
-  INDEX_MERGE_HINT_ENUM,
-  MAX_HINT_ENUM // This one must be the last in the list
-};
-
-
-/**
   Environment data for the name resolution phase
 */
 struct Parse_context {
-  THD * const thd;              ///< Current thread handler
-  MEM_ROOT *mem_root;           ///< Current MEM_ROOT
-  st_select_lex * select;       ///< Current SELECT_LEX object
+  THD * const thd;
+  MEM_ROOT *mem_root;
+  st_select_lex * select;
+  hint_resolution_stage resolution_stage;
 
-  Parse_context(THD *thd, st_select_lex *select);
+  Parse_context(THD *thd, st_select_lex *select, hint_resolution_stage stage);
   Parse_context(Parse_context *pc, st_select_lex *select);
 };
 
@@ -994,6 +963,8 @@ private:
     bool resolve(Parse_context *pc) const;
   };
 
+  static bool is_appropriate_resolution_stage(opt_hints_enum hint_type,
+                                              Parse_context *pc);
 public:
   /*
     The main rule:

--- a/sql/opt_hints_structs.h
+++ b/sql/opt_hints_structs.h
@@ -1,0 +1,59 @@
+#ifndef OPT_HINTS_STRUCTS_H
+#define OPT_HINTS_STRUCTS_H
+/*
+   Copyright (c) 2026, MariaDB
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA
+*/
+
+/**
+  Hint types, MAX_HINT_ENUM should be always last.
+  This enum should be synchronized with opt_hint_info
+  array(see opt_hints.cc).
+*/
+enum opt_hints_enum
+{
+  BKA_HINT_ENUM= 0,
+  BNL_HINT_ENUM,
+  ICP_HINT_ENUM,
+  MRR_HINT_ENUM,
+  NO_RANGE_HINT_ENUM,
+  QB_NAME_HINT_ENUM,
+  MAX_EXEC_TIME_HINT_ENUM,
+  SEMIJOIN_HINT_ENUM,
+  SUBQUERY_HINT_ENUM,
+  JOIN_PREFIX_HINT_ENUM,
+  JOIN_SUFFIX_HINT_ENUM,
+  JOIN_ORDER_HINT_ENUM,
+  JOIN_FIXED_ORDER_HINT_ENUM,
+  DERIVED_CONDITION_PUSHDOWN_HINT_ENUM,
+  MERGE_HINT_ENUM,
+  SPLIT_MATERIALIZED_HINT_ENUM,
+  INDEX_HINT_ENUM,
+  JOIN_INDEX_HINT_ENUM,
+  GROUP_INDEX_HINT_ENUM,
+  ORDER_INDEX_HINT_ENUM,
+  ROWID_FILTER_HINT_ENUM,
+  INDEX_MERGE_HINT_ENUM,
+  MAX_HINT_ENUM // This one must be the last in the list
+};
+
+enum class hint_resolution_stage
+{
+  EARLY, // Hints resolved in the first order
+  LATE   // Hints resolved in the second order, after EARLY hints
+};
+
+#endif /* OPT_HINTS_STRUCTS_H */

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12388,3 +12388,7 @@ ER_SLAVE_INCOMPATIBLE_TABLE_DEF
         eng "Table structure for binlog event is not compatible with the table definition on this slave: %s"
 ER_UNSUPPORTED_DATA_TYPE_ATTRIBUTE
         eng "Data type '%-.64s' doesn't support %s attribute."
+ER_WARN_AMBIGUOUS_QB_NAME
+	eng "Query block name %s is ambiguous for %s hint"
+ER_WARN_IMPLICIT_QB_NAME_FOR_UNION
+	eng "Implicit query block name %s is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for %s hint"

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -42,6 +42,7 @@
 #include "sql_class.h"                // enum enum_column_usage
 #include "select_handler.h"
 #include "rpl_master_info_file.h"     // Master_info_file
+#include "opt_hints_structs.h"
 
 /* Used for flags of nesting constructs */
 #define SELECT_NESTING_MAP_SIZE 64
@@ -3839,6 +3840,8 @@ public:
 
   void handle_parsed_optimizer_hints_in_last_select();
   void resolve_optimizer_hints();
+  void resolve_early_optimizer_hints();
+  void resolve_late_optimizer_hints();
   bool discard_optimizer_hints_in_last_select();
 
   bool is_in_sf_or_trg();
@@ -5068,6 +5071,9 @@ private:
     create_info.set(options);
     return main_select_push() || check_create_options(options);
   }
+
+  void resolve_optimizer_hints_for_stage(hint_resolution_stage stage);
+
 public:
   bool stmt_create_function_start(const DDL_options_st &options)
   {

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3539,7 +3539,6 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
   */
   lex->first_lists_tables_same();
   lex->fix_first_select_number();
-  lex->resolve_optimizer_hints();
   /* should be assigned after making first tables same */
   all_tables= lex->query_tables;
   /* set context for commands which do not use setup_tables */
@@ -4588,6 +4587,7 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
 
     unit->set_limit(select_lex);
 
+    lex->resolve_early_optimizer_hints();
     if (!(res=open_and_lock_tables(thd, all_tables, TRUE, 0)))
     {
       MYSQL_INSERT_SELECT_START(thd->query());
@@ -4674,6 +4674,7 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
       select_lex->table_list.first= second_table;
       select_lex->context.table_list=
         select_lex->context.first_name_resolution_table= second_table;
+      lex->resolve_late_optimizer_hints();
       res= mysql_insert_select_prepare(thd, result);
       Write_record write;
       if (!res &&
@@ -6130,8 +6131,10 @@ static bool execute_sqlcom_select(THD *thd, TABLE_LIST *all_tables)
                                      (ulonglong) thd->variables.select_limit);
   }
 
+  lex->resolve_early_optimizer_hints();
   if (!(res= open_and_lock_tables(thd, all_tables, TRUE, 0)))
   {
+    lex->resolve_late_optimizer_hints();
     if (lex->describe)
     {
       /*

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -1560,10 +1560,12 @@ static int mysql_test_select(Prepared_statement *stmt,
     goto error;
   }
 
+  lex->resolve_early_optimizer_hints();
   if (open_normal_and_derived_tables(thd, tables,  MYSQL_OPEN_FORCE_SHARED_MDL,
                                      DT_INIT | DT_PREPARE))
     goto error;
 
+  lex->resolve_late_optimizer_hints();
   thd->lex->used_tables= 0;                        // Updated by setup_fields
 
   /*
@@ -2304,7 +2306,6 @@ static bool check_prepared_statement(Prepared_statement *stmt)
 
   lex->first_lists_tables_same();
   lex->fix_first_select_number();
-  lex->resolve_optimizer_hints();
   tables= lex->query_tables;
 
   /* set context for commands which do not use setup_tables */

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -34748,7 +34748,7 @@ bool Sql_cmd_dml::prepare(THD *thd)
   MYSQL_DML_START(thd);
 
   lex->context_analysis_only|= CONTEXT_ANALYSIS_ONLY_DERIVED;
-
+  lex->resolve_optimizer_hints();
   if (open_tables_for_query(thd, lex->query_tables, &table_count, 0,
                             get_dml_prelocking_strategy()))
   {

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1375,6 +1375,7 @@ mysqld_show_create(THD *thd, TABLE_LIST *table_list)
   if (mysqld_show_create_get_fields(thd, table_list, &field_list, &buffer))
     goto exit;
 
+  thd->lex->resolve_optimizer_hints();
   if (protocol->send_result_set_metadata(&field_list,
                                          Protocol::SEND_NUM_ROWS |
                                          Protocol::SEND_EOF))

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -559,6 +559,7 @@ bool mysql_create_view(THD *thd, TABLE_LIST *views,
 
   /* prepare select to resolve all fields */
   lex->context_analysis_only|= CONTEXT_ANALYSIS_ONLY_VIEW;
+  lex->resolve_optimizer_hints();
   if (unit->prepare(unit->derived, 0, 0))
   {
     /*
@@ -568,7 +569,6 @@ bool mysql_create_view(THD *thd, TABLE_LIST *views,
     res= TRUE;
     goto err;
   }
-
   /* view list (list of view fields names) */
   if (lex->view_list.elements)
   {


### PR DESCRIPTION
## Description
This patch implements support for implicit query block (QB) names in optimizer hints, allowing hints to reference query blocks and tables within derived tables, views and CTEs without requiring explicit QB_NAME hints.

Examples.
```
-- Addressing a table inside a derived table using implicit QB name
select /*+ no_index(t1@dt) */ *
  from (select * from t1 where a > 10) as DT;
-- this is an equivalent to:
select /*+ no_index(t1@dt) */ * from
  (select /*+ qb_name(dt)*/ * from t1 where a > 10) as DT;
-- Addressing a query block corresponding to the derived table
select /*+ no_bnl(@dt) */ *
  from (select * from t1, t2 where t.1.a > t2.a) as DT;

-- View
create view v1 as select * from t1 where a > 10 and b > 100;
-- referencing a table inside a view by implicit QB name: 
select /*+ index_merge(t1@v1 idx_a, idx_b) */ *
  from v1, t2 where v1.a = t2.a;
-- equivalent to:
create view v1 as select /*+ qb_name(qb_v1) */ *
  from t1 where a > 10 and b > 100;
select /*+ index_merge(t1@qb_v1 idx_a, idx_b) */ *
  from v1, t2 where v1.a = t2.a;

-- CTE
with aless100 as (select a from t1 where b <100)
  select /*+ index(t1@aless100) */ * from aless100;
-- equivalent to:
with aless100 as (select /*+ qb_name(aless100) */ a from t1 where b <100)
  select /*+ index(t1@aless100) */ * from aless100;
```
Key changes:

1. Two-stage hint resolution
   - Introduced hint_resolution_stage enum (EARLY/LATE) to control when different hint types are resolved:
     - EARLY stage: before opening tables (QB_NAME, MERGE hints)
     - LATE stage: after opening tables (all other hints)

2. Implicit QB name support
   - Derived table/view/CTE aliases can now be used as implicit query block names in hint syntax: @alias, table@alias
   - Derived tables inside views can be addressed from outer queries using their aliases

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-38045*

## Release Notes

## How can this PR be tested?
`./mtr opt_hints_impl_qb_name`

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
