### PR TITLE
Fix error reporting in create_libaio

### DIFF
--- a/tpool/aio_libaio.cc
+++ b/tpool/aio_libaio.cc
@@ -202,7 +202,7 @@ aio *create_libaio(thread_pool *pool, int max_io)
   if (int ret= io_setup(max_io, &ctx))
   {
     fprintf(stderr, "Warning: io_setup(%d) returned %s. See man 2 io_setup.\n",
-            max_io, strerror(ret));
+            max_io, strerror(-ret));
     return nullptr;
   }
   return new aio_libaio(ctx, pool);


### PR DESCRIPTION
The io_setup function in libaio returns a negated errno value on error,
but strerror expects a normal errno value.
