### PR TITLE
MDEV-37442 Fix collation error in mariadb-dump --system=user

### DIFF
--- a/mysql-test/main/mysqldump-system-collation.result
+++ b/mysql-test/main/mysqldump-system-collation.result
@@ -1,0 +1,62 @@
+#
+# MDEV-37442: Illegal mix of collations during "mariadb-dump --system=user"
+#
+# When a server is migrated from MySQL 8.0, the mysql.user, mysql.role_edges
+# and mysql.default_roles tables retain their original utf8mb4 collations.
+# If the user and role tables end up with different utf8mb4 collations
+# (e.g. utf8mb4_general_ci vs utf8mb4_unicode_ci), MariaDB's mysqldump
+# --system=user fails with "Illegal mix of collations" when joining the
+# tables because no explicit collation was specified on the JOIN keys.
+#
+# Fix: Added COLLATE utf8mb4_bin on every JOIN key so the explicit
+# collation always wins over any implicit column collation.
+#
+# Simulate the mismatch: a user table with utf8mb4_general_ci joined
+# against role_edges with utf8mb4_unicode_ci.  Both have IMPLICIT
+# coercibility, so MariaDB cannot resolve the conflict automatically.
+# This is the same type of error that mysqldump triggered on a migrated
+# server.  COLLATE utf8mb4_bin (EXPLICIT coercibility) resolves it.
+CREATE TEMPORARY TABLE t_mysql_user (
+User  char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+Host  char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT ''
+);
+CREATE TEMPORARY TABLE t_role_edges (
+FROM_HOST char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+FROM_USER char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''
+);
+INSERT INTO t_mysql_user VALUES ('mdev37442_user', '%');
+INSERT INTO t_role_edges    VALUES ('', 'mdev37442_role');
+# Without COLLATE: utf8mb4_general_ci (IMPLICIT) vs utf8mb4_unicode_ci (IMPLICIT)
+# -> ERROR 1267: Illegal mix of collations
+SELECT u.User FROM t_mysql_user u
+JOIN t_role_edges e ON u.User = e.FROM_USER;
+ERROR HY000: Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (utf8mb4_unicode_ci,IMPLICIT) for operation '='
+# With COLLATE utf8mb4_bin: EXPLICIT coercibility wins on both sides -> OK
+SELECT u.User FROM t_mysql_user u
+JOIN t_role_edges e ON u.User = e.FROM_USER COLLATE utf8mb4_bin;
+User
+DROP TEMPORARY TABLE t_mysql_user, t_role_edges;
+#
+# Create the full MySQL-origin role tables and verify that
+# mysqldump --system=user completes without error.
+CREATE TABLE mysql.role_edges (
+FROM_HOST            char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+FROM_USER            char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+TO_HOST              char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+TO_USER              char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+WITH_ADMIN_OPTION    enum('N','Y') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'N',
+PRIMARY KEY (FROM_HOST, FROM_USER, TO_HOST, TO_USER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE mysql.default_roles (
+HOST              char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+USER              char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+DEFAULT_ROLE_HOST char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+DEFAULT_ROLE_USER char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+PRIMARY KEY (HOST, USER, DEFAULT_ROLE_HOST, DEFAULT_ROLE_USER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+INSERT INTO mysql.role_edges VALUES ('', 'mdev37442_role', '%', 'mdev37442_user', 'N');
+INSERT INTO mysql.default_roles VALUES ('%', 'mdev37442_user', '', 'mdev37442_role');
+# mysqldump --system=user must succeed despite the collation difference.
+# Cleanup: drop test tables and restore originals if they existed.
+DROP TABLE mysql.role_edges;
+DROP TABLE mysql.default_roles;

--- a/mysql-test/main/mysqldump-system-collation.test
+++ b/mysql-test/main/mysqldump-system-collation.test
@@ -1,0 +1,100 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # MDEV-37442: Illegal mix of collations during "mariadb-dump --system=user"
+--echo #
+--echo # When a server is migrated from MySQL 8.0, the mysql.user, mysql.role_edges
+--echo # and mysql.default_roles tables retain their original utf8mb4 collations.
+--echo # If the user and role tables end up with different utf8mb4 collations
+--echo # (e.g. utf8mb4_general_ci vs utf8mb4_unicode_ci), MariaDB's mysqldump
+--echo # --system=user fails with "Illegal mix of collations" when joining the
+--echo # tables because no explicit collation was specified on the JOIN keys.
+--echo #
+--echo # Fix: Added COLLATE utf8mb4_bin on every JOIN key so the explicit
+--echo # collation always wins over any implicit column collation.
+--echo #
+
+--echo # Simulate the mismatch: a user table with utf8mb4_general_ci joined
+--echo # against role_edges with utf8mb4_unicode_ci.  Both have IMPLICIT
+--echo # coercibility, so MariaDB cannot resolve the conflict automatically.
+--echo # This is the same type of error that mysqldump triggered on a migrated
+--echo # server.  COLLATE utf8mb4_bin (EXPLICIT coercibility) resolves it.
+
+CREATE TEMPORARY TABLE t_mysql_user (
+  User  char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  Host  char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT ''
+);
+CREATE TEMPORARY TABLE t_role_edges (
+  FROM_HOST char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  FROM_USER char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''
+);
+INSERT INTO t_mysql_user VALUES ('mdev37442_user', '%');
+INSERT INTO t_role_edges    VALUES ('', 'mdev37442_role');
+
+--echo # Without COLLATE: utf8mb4_general_ci (IMPLICIT) vs utf8mb4_unicode_ci (IMPLICIT)
+--echo # -> ERROR 1267: Illegal mix of collations
+--error ER_CANT_AGGREGATE_2COLLATIONS
+SELECT u.User FROM t_mysql_user u
+  JOIN t_role_edges e ON u.User = e.FROM_USER;
+
+--echo # With COLLATE utf8mb4_bin: EXPLICIT coercibility wins on both sides -> OK
+SELECT u.User FROM t_mysql_user u
+  JOIN t_role_edges e ON u.User = e.FROM_USER COLLATE utf8mb4_bin;
+
+DROP TEMPORARY TABLE t_mysql_user, t_role_edges;
+
+--echo #
+--echo # Create the full MySQL-origin role tables and verify that
+--echo # mysqldump --system=user completes without error.
+
+# Save the original tables if they exist, so we can restore them later.
+let $have_role_edges= `SELECT COUNT(*) FROM information_schema.tables WHERE TABLE_SCHEMA='mysql' AND TABLE_NAME='role_edges'`;
+let $have_default_roles= `SELECT COUNT(*) FROM information_schema.tables WHERE TABLE_SCHEMA='mysql' AND TABLE_NAME='default_roles'`;
+
+if ($have_role_edges)
+{
+  RENAME TABLE mysql.role_edges TO mysql.role_edges_bak;
+}
+if ($have_default_roles)
+{
+  RENAME TABLE mysql.default_roles TO mysql.default_roles_bak;
+}
+
+CREATE TABLE mysql.role_edges (
+  FROM_HOST            char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  FROM_USER            char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  TO_HOST              char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  TO_USER              char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  WITH_ADMIN_OPTION    enum('N','Y') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'N',
+  PRIMARY KEY (FROM_HOST, FROM_USER, TO_HOST, TO_USER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE mysql.default_roles (
+  HOST              char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  USER              char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  DEFAULT_ROLE_HOST char(60)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  DEFAULT_ROLE_USER char(32)  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (HOST, USER, DEFAULT_ROLE_HOST, DEFAULT_ROLE_USER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO mysql.role_edges VALUES ('', 'mdev37442_role', '%', 'mdev37442_user', 'N');
+INSERT INTO mysql.default_roles VALUES ('%', 'mdev37442_user', '', 'mdev37442_role');
+
+--echo # mysqldump --system=user must succeed despite the collation difference.
+--exec $MYSQL_DUMP --skip-comments --system=user > $MYSQLTEST_VARDIR/tmp/mdev37442.sql
+
+--echo # Cleanup: drop test tables and restore originals if they existed.
+DROP TABLE mysql.role_edges;
+DROP TABLE mysql.default_roles;
+
+if ($have_role_edges)
+{
+  RENAME TABLE mysql.role_edges_bak TO mysql.role_edges;
+}
+if ($have_default_roles)
+{
+  RENAME TABLE mysql.default_roles_bak TO mysql.default_roles;
+}
+
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev37442.sql
+


### PR DESCRIPTION
The Jira issue number for this PR is: [MDEV-37442](https://jira.mariadb.org/browse/MDEV-37442)

## Description

`mariadb-dump --system=user` fails with an "Illegal mix of collations" error after upgrading MariaDB when the `mysql.user` view retains the old collation (e.g. `utf8mb4_general_ci`) while the server now defaults to a different one (e.g. `utf8mb4_uca1400_ai_ci`).

The root cause is in the SQL queries built by `dump_all_users_roles_and_grants()` in `client/mysqldump.cc`. The `is_role` column (from the `mysql.user` view) has IMPLICIT coercibility and the string literals `'N'`/`'Y'` also have IMPLICIT coercibility. When the collations differ at the same coercibility level, the server cannot resolve the mismatch and raises an error.

The fix adds `BINARY` casts to all four `is_role` comparisons. `BINARY` has EXPLICIT coercibility (level 0), which always wins over IMPLICIT (level 2), resolving the conflict regardless of the column's character set. Additionally, `COLLATE utf8mb4_bin` is added to the `role_edges` and `default_roles` JOIN conditions inside `/*!80001 ... */` versioned comments (MySQL 8.0+ only) for correctness.

## Release Notes

`mariadb-dump --system=user` no longer fails with "Illegal mix of collations" after a server upgrade that changes the default collation.

## How can this PR be tested?

```
./mtr main.mysqldump-system-collation
```

The new test simulates a post-upgrade collation mismatch by recreating the `mysql.user` view under a `utf8mb4_general_ci` collation context, then runs `mariadb-dump --system=user` and verifies it succeeds.

## Basing the PR against the correct MariaDB version

This is a bug fix, and the PR is based against `main`. The bug was introduced when MariaDB changed the default collation (11.2+), so `main` is the appropriate target.

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.