### PR TITLE
MDEV-31414: Implement optional lengths for string types

### DIFF
--- a/mysql-test/main/type_varchar_no_length.result
+++ b/mysql-test/main/type_varchar_no_length.result
@@ -1,0 +1,53 @@
+# MDEV-31414: Implement optional lengths for string types
+# Test for SQL Standard T081: "Optional string types maximum length"
+# This tests the feature that allows VARCHAR, NVARCHAR and VARBINARY columns 
+# to be created without specifying a length. For flexibility, we do the following conversions
+# VARCHAR, NVARCHAR -> TEXT
+# VARBINARY -> BLOB
+#
+CREATE TABLE t1 (a VARCHAR);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (a VARBINARY);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` blob DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (a NVARCHAR);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text CHARACTER SET utf8mb3 COLLATE utf8mb3_uca1400_ai_ci DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (a VARCHAR COMPRESSED);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text /*M!100301 COMPRESSED*/ DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (id INTEGER, a VARCHAR(255));
+ALTER TABLE t1 MODIFY a VARCHAR;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) DEFAULT NULL,
+  `a` text DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (id INTEGER);
+ALTER TABLE t1 ADD a VARCHAR;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) DEFAULT NULL,
+  `a` text DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+DROP TABLE t1;

--- a/mysql-test/main/type_varchar_no_length.test
+++ b/mysql-test/main/type_varchar_no_length.test
@@ -1,0 +1,34 @@
+--echo # MDEV-31414: Implement optional lengths for string types
+--echo # Test for SQL Standard T081: "Optional string types maximum length"
+--echo # This tests the feature that allows VARCHAR, NVARCHAR and VARBINARY columns 
+--echo # to be created without specifying a length. For flexibility, we do the following conversions
+--echo # VARCHAR, NVARCHAR -> TEXT
+--echo # VARBINARY -> BLOB
+--echo #
+
+CREATE TABLE t1 (a VARCHAR);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a VARBINARY);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a NVARCHAR);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a VARCHAR COMPRESSED);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (id INTEGER, a VARCHAR(255));
+ALTER TABLE t1 MODIFY a VARCHAR;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (id INTEGER);
+ALTER TABLE t1 ADD a VARCHAR;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -2969,8 +2969,21 @@ Type_handler_varchar::Column_definition_set_attributes(
     }
     break;
   case COLUMN_DEFINITION_ROUTINE_LOCAL:
-  case COLUMN_DEFINITION_TABLE_FIELD:
     break;
+  case COLUMN_DEFINITION_TABLE_FIELD:
+    /*
+      Support SQL Standard T081: "Optional string types maximum length"
+      Allows users to specify VARCHAR fields without a length
+      In this case, has_explicit_length is false.
+      This is only allowed for types VARCHAR, VARBINARY, NVARCHAR.
+      Note that Type_handler_vector inherits from Type_handler_varchar.
+    */
+    if (this == &type_handler_varchar ||
+        this == &type_handler_varchar_compressed)
+    {
+      def->set_handler(&type_handler_blob);
+      return false;
+    }
   }
   thd->parse_error();
   return true;


### PR DESCRIPTION
Jira: https://jira.mariadb.org/browse/MDEV-31414
Adding support for SQL standard 2023's T081: `Optional string types maximum length`

This PR allows the user to not specify a length for a `VARCHAR` field. We default to making the field a `TEXT` type.

