### PR TITLE
MDEV-37939 Add function context to division by zero warnings

### DIFF
--- a/mysql-test/main/func_math.result
+++ b/mysql-test/main/func_math.result
@@ -45,9 +45,9 @@ select log(exp(10)),exp(log(sqrt(10))*2),log(-1),log(NULL),log(1,1),log(3,9),log
 log(exp(10))	exp(log(sqrt(10))*2)	log(-1)	log(NULL)	log(1,1)	log(3,9)	log(-1,2)	log(NULL,2)
 10	10.000000000000002	NULL	NULL	NULL	2	NULL	NULL
 Warnings:
-Warning	1365	Division by 0
-Warning	1365	Division by 0
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function log.
+Warning	3047	Invalid argument error: 1 in function log.
+Warning	3047	Invalid argument error: -1 in function log.
 explain extended select log(exp(10)),exp(log(sqrt(10))*2),log(-1),log(NULL),log(1,1),log(3,9),log(-1,2),log(NULL,2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
@@ -57,8 +57,8 @@ select ln(exp(10)),exp(ln(sqrt(10))*2),ln(-1),ln(0),ln(NULL);
 ln(exp(10))	exp(ln(sqrt(10))*2)	ln(-1)	ln(0)	ln(NULL)
 10	10.000000000000002	NULL	NULL	NULL
 Warnings:
-Warning	1365	Division by 0
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function ln.
+Warning	3047	Invalid argument error: 0 in function ln.
 explain extended select ln(exp(10)),exp(ln(sqrt(10))*2),ln(-1),ln(0),ln(NULL);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
@@ -68,8 +68,8 @@ select log2(8),log2(15),log2(-2),log2(0),log2(NULL);
 log2(8)	log2(15)	log2(-2)	log2(0)	log2(NULL)
 3	3.9068905956085187	NULL	NULL	NULL
 Warnings:
-Warning	1365	Division by 0
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log2.
+Warning	3047	Invalid argument error: 0 in function log2.
 explain extended select log2(8),log2(15),log2(-2),log2(0),log2(NULL);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
@@ -79,8 +79,8 @@ select log10(100),log10(18),log10(-4),log10(0),log10(NULL);
 log10(100)	log10(18)	log10(-4)	log10(0)	log10(NULL)
 2	1.255272505103306	NULL	NULL	NULL
 Warnings:
-Warning	1365	Division by 0
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -4 in function log10.
+Warning	3047	Invalid argument error: 0 in function log10.
 explain extended select log10(100),log10(18),log10(-4),log10(0),log10(NULL);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
@@ -239,27 +239,27 @@ select ln(-1);
 ln(-1)
 NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function ln.
 select log10(-1);
 log10(-1)
 NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function log10.
 select log2(-1);
 log2(-1)
 NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function log2.
 select log(2,-1);
 log(2,-1)
 NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -1 in function log.
 select log(-2,1);
 log(-2,1)
 NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 set sql_mode='';
 select round(111,-10);
 round(111,-10)

--- a/mysql-test/main/func_math_div_zero.result
+++ b/mysql-test/main/func_math_div_zero.result
@@ -1,0 +1,238 @@
+#
+# MDEV-37939: Use correct error for invalid logarithm arguments
+#
+# LOG/LN/LOG2/LOG10 now emit function-specific domain warnings
+# instead of ER_DIVISION_BY_ZERO, since these functions do not
+# perform division.
+#
+#
+# Test valid inputs first (before any warning-producing statements)
+# This ensures SHOW WARNINGS is truly empty
+#
+SET SESSION sql_mode='ERROR_FOR_DIVISION_BY_ZERO';
+SELECT LOG(10);
+LOG(10)
+2.302585092994046
+SELECT LN(2.718);
+LN(2.718)
+0.999896315728952
+SELECT LOG2(8);
+LOG2(8)
+3
+SELECT LOG10(100);
+LOG10(100)
+2
+SELECT LOG(2, 8);
+LOG(2, 8)
+3
+SHOW WARNINGS;
+Level	Code	Message
+# Should be empty - valid inputs produce no warnings
+#
+# Test sql_mode='' behavior (before any warnings are produced)
+#
+SET SESSION sql_mode='';
+SELECT LOG(-1);
+LOG(-1)
+NULL
+SHOW WARNINGS;
+Level	Code	Message
+# Should be empty - no warning when sql_mode doesn't include ERROR_FOR_DIVISION_BY_ZERO
+SELECT LN(-1);
+LN(-1)
+NULL
+SHOW WARNINGS;
+Level	Code	Message
+#
+# Now test warning-producing cases
+#
+SET SESSION sql_mode='ERROR_FOR_DIVISION_BY_ZERO';
+#
+# LOG family should report function-specific domain warnings
+#
+SELECT LOG(-1);
+LOG(-1)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -1 in function log.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -1 in function log.
+SELECT LOG(0);
+LOG(0)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: 0 in function log.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: 0 in function log.
+SELECT LN(0);
+LN(0)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: 0 in function ln.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: 0 in function ln.
+SELECT LN(-5);
+LN(-5)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -5 in function ln.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -5 in function ln.
+SELECT LOG2(-1);
+LOG2(-1)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -1 in function log2.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -1 in function log2.
+SELECT LOG10(-1);
+LOG10(-1)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -1 in function log10.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -1 in function log10.
+# Two-argument LOG: invalid second argument
+SELECT LOG(2, -1);
+LOG(2, -1)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -1 in function log.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -1 in function log.
+# Two-argument LOG: invalid base (negative)
+SELECT LOG(-2, 10);
+LOG(-2, 10)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: -2 in function log.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: -2 in function log.
+# Two-argument LOG: base = 1 (invalid - would cause log(1)=0 in denominator)
+SELECT LOG(1, 10);
+LOG(1, 10)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: 1 in function log.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3047	Invalid argument error: 1 in function log.
+#
+# Division operations should report ER_DIVISION_BY_ZERO (1365)
+#
+# Division - integer
+SELECT 1/0;
+1/0
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# Division - real/float
+SELECT 1.0/0.0;
+1.0/0.0
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# Division - decimal
+SELECT CAST(1 AS DECIMAL(10,2)) / CAST(0 AS DECIMAL(10,2));
+CAST(1 AS DECIMAL(10,2)) / CAST(0 AS DECIMAL(10,2))
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# Division - with string arguments
+SELECT '1'/'0';
+'1'/'0'
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# Integer DIV
+SELECT 5 DIV 0;
+5 DIV 0
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# Integer DIV - with string arguments
+SELECT '5' DIV '0';
+'5' DIV '0'
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD - integer
+SELECT 5 MOD 0;
+5 MOD 0
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD - real/float
+SELECT 5.5e0 MOD 0.0e0;
+5.5e0 MOD 0.0e0
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD - decimal
+SELECT CAST(5 AS DECIMAL(10,2)) MOD CAST(0 AS DECIMAL(10,2));
+CAST(5 AS DECIMAL(10,2)) MOD CAST(0 AS DECIMAL(10,2))
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD - with string arguments
+SELECT '5' MOD '0';
+'5' MOD '0'
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD function syntax
+SELECT MOD(5, 0);
+MOD(5, 0)
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0
+# MOD function - decimal
+SELECT MOD(5.5, 0.0);
+MOD(5.5, 0.0)
+NULL
+Warnings:
+Warning	1365	Division by 0
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1365	Division by 0

--- a/mysql-test/main/func_math_div_zero.test
+++ b/mysql-test/main/func_math_div_zero.test
@@ -1,0 +1,123 @@
+--echo #
+--echo # MDEV-37939: Use correct error for invalid logarithm arguments
+--echo #
+--echo # LOG/LN/LOG2/LOG10 now emit function-specific domain warnings
+--echo # instead of ER_DIVISION_BY_ZERO, since these functions do not
+--echo # perform division.
+--echo #
+
+--echo #
+--echo # Test valid inputs first (before any warning-producing statements)
+--echo # This ensures SHOW WARNINGS is truly empty
+--echo #
+SET SESSION sql_mode='ERROR_FOR_DIVISION_BY_ZERO';
+
+SELECT LOG(10);
+SELECT LN(2.718);
+SELECT LOG2(8);
+SELECT LOG10(100);
+SELECT LOG(2, 8);
+SHOW WARNINGS;
+--echo # Should be empty - valid inputs produce no warnings
+
+--echo #
+--echo # Test sql_mode='' behavior (before any warnings are produced)
+--echo #
+SET SESSION sql_mode='';
+
+SELECT LOG(-1);
+SHOW WARNINGS;
+--echo # Should be empty - no warning when sql_mode doesn't include ERROR_FOR_DIVISION_BY_ZERO
+
+SELECT LN(-1);
+SHOW WARNINGS;
+
+--echo #
+--echo # Now test warning-producing cases
+--echo #
+SET SESSION sql_mode='ERROR_FOR_DIVISION_BY_ZERO';
+
+--echo #
+--echo # LOG family should report function-specific domain warnings
+--echo #
+SELECT LOG(-1);
+SHOW WARNINGS;
+
+SELECT LOG(0);
+SHOW WARNINGS;
+
+SELECT LN(0);
+SHOW WARNINGS;
+
+SELECT LN(-5);
+SHOW WARNINGS;
+
+SELECT LOG2(-1);
+SHOW WARNINGS;
+
+SELECT LOG10(-1);
+SHOW WARNINGS;
+
+--echo # Two-argument LOG: invalid second argument
+SELECT LOG(2, -1);
+SHOW WARNINGS;
+
+--echo # Two-argument LOG: invalid base (negative)
+SELECT LOG(-2, 10);
+SHOW WARNINGS;
+
+--echo # Two-argument LOG: base = 1 (invalid - would cause log(1)=0 in denominator)
+SELECT LOG(1, 10);
+SHOW WARNINGS;
+
+--echo #
+--echo # Division operations should report ER_DIVISION_BY_ZERO (1365)
+--echo #
+
+--echo # Division - integer
+SELECT 1/0;
+SHOW WARNINGS;
+
+--echo # Division - real/float
+SELECT 1.0/0.0;
+SHOW WARNINGS;
+
+--echo # Division - decimal
+SELECT CAST(1 AS DECIMAL(10,2)) / CAST(0 AS DECIMAL(10,2));
+SHOW WARNINGS;
+
+--echo # Division - with string arguments
+SELECT '1'/'0';
+SHOW WARNINGS;
+
+--echo # Integer DIV
+SELECT 5 DIV 0;
+SHOW WARNINGS;
+
+--echo # Integer DIV - with string arguments
+SELECT '5' DIV '0';
+SHOW WARNINGS;
+
+--echo # MOD - integer
+SELECT 5 MOD 0;
+SHOW WARNINGS;
+
+--echo # MOD - real/float
+SELECT 5.5e0 MOD 0.0e0;
+SHOW WARNINGS;
+
+--echo # MOD - decimal
+SELECT CAST(5 AS DECIMAL(10,2)) MOD CAST(0 AS DECIMAL(10,2));
+SHOW WARNINGS;
+
+--echo # MOD - with string arguments
+SELECT '5' MOD '0';
+SHOW WARNINGS;
+
+--echo # MOD function syntax
+SELECT MOD(5, 0);
+SHOW WARNINGS;
+
+--echo # MOD function - decimal
+SELECT MOD(5.5, 0.0);
+SHOW WARNINGS;

--- a/mysql-test/suite/gcol/r/gcol_supported_sql_funcs_innodb.result
+++ b/mysql-test/suite/gcol/r/gcol_supported_sql_funcs_innodb.result
@@ -274,13 +274,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 select * from t1;
 a	b
 -2	NULL
 2	0.693147
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 drop table t1;
 set sql_warnings = 0;
 # LOG()
@@ -297,14 +297,14 @@ insert into t1 values (2,65536,default);
 insert into t1 values (10,100,default);
 insert into t1 values (1,100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 select * from t1;
 a	b	c
 1	100	NULL
 10	100	2
 2	65536	16
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 drop table t1;
 set sql_warnings = 0;
 set sql_warnings = 1;
@@ -318,13 +318,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 select * from t1;
 a	b
 -2	NULL
 2	0.693147
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 drop table t1;
 set sql_warnings = 0;
 # LOG2()
@@ -339,13 +339,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (65536,default);
 insert into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 select * from t1;
 a	b
 -100	NULL
 65536	16
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 drop table t1;
 set sql_warnings = 0;
 # LOG10()
@@ -361,14 +361,14 @@ insert into t1 values (2,default);
 insert into t1 values (100,default);
 insert into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 select * from t1;
 a	b
 -100	NULL
 100	2
 2	0.30103
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 drop table t1;
 set sql_warnings = 0;
 # -

--- a/mysql-test/suite/gcol/r/gcol_supported_sql_funcs_myisam.result
+++ b/mysql-test/suite/gcol/r/gcol_supported_sql_funcs_myisam.result
@@ -274,13 +274,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 select * from t1;
 a	b
 -2	NULL
 2	0.693147
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 drop table t1;
 set sql_warnings = 0;
 # LOG()
@@ -297,14 +297,14 @@ insert into t1 values (2,65536,default);
 insert into t1 values (10,100,default);
 insert into t1 values (1,100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 select * from t1;
 a	b	c
 1	100	NULL
 10	100	2
 2	65536	16
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 drop table t1;
 set sql_warnings = 0;
 set sql_warnings = 1;
@@ -318,13 +318,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 select * from t1;
 a	b
 -2	NULL
 2	0.693147
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 drop table t1;
 set sql_warnings = 0;
 # LOG2()
@@ -339,13 +339,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (65536,default);
 insert into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 select * from t1;
 a	b
 -100	NULL
 65536	16
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 drop table t1;
 set sql_warnings = 0;
 # LOG10()
@@ -361,14 +361,14 @@ insert into t1 values (2,default);
 insert into t1 values (100,default);
 insert into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 select * from t1;
 a	b
 -100	NULL
 100	2
 2	0.30103
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 drop table t1;
 set sql_warnings = 0;
 # -

--- a/mysql-test/suite/vcol/r/vcol_supported_sql_funcs.result
+++ b/mysql-test/suite/vcol/r/vcol_supported_sql_funcs.result
@@ -274,13 +274,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert ignore into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 select * from t1;
 a	b
 2	0.693147
 -2	NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function ln.
 drop table t1;
 set sql_warnings = 0;
 # LOG()
@@ -297,14 +297,14 @@ insert into t1 values (2,65536,default);
 insert ignore into t1 values (10,100,default);
 insert into t1 values (1,100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 select * from t1;
 a	b	c
 2	65536	16
 10	100	2
 1	100	NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: 1 in function log.
 drop table t1;
 set sql_warnings = 0;
 set sql_warnings = 1;
@@ -318,13 +318,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (2,default);
 insert ignore into t1 values (-2,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 select * from t1;
 a	b
 2	0.693147
 -2	NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -2 in function log.
 drop table t1;
 set sql_warnings = 0;
 # LOG2()
@@ -339,13 +339,13 @@ t1	CREATE TABLE `t1` (
 insert into t1 values (65536,default);
 insert ignore into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 select * from t1;
 a	b
 65536	16
 -100	NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log2.
 drop table t1;
 set sql_warnings = 0;
 # LOG10()
@@ -361,14 +361,14 @@ insert into t1 values (2,default);
 insert ignore into t1 values (100,default);
 insert into t1 values (-100,default);
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 select * from t1;
 a	b
 2	0.30103
 100	2
 -100	NULL
 Warnings:
-Warning	1365	Division by 0
+Warning	3047	Invalid argument error: -100 in function log10.
 drop table t1;
 set sql_warnings = 0;
 # -

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -783,6 +783,19 @@ void Item_udf_func::fix_num_length_and_dec()
 #endif
 
 
+double Item_func::signal_log_domain_error(double value)
+{
+  THD *thd= current_thd;
+  if (thd->variables.sql_mode & MODE_ERROR_FOR_DIVISION_BY_ZERO)
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                        ER_STD_INVALID_ARGUMENT,
+                        ER_THD(thd, ER_STD_INVALID_ARGUMENT),
+                        ErrConvDouble(value).ptr(), func_name());
+  null_value= 1;
+  return 0.0;
+}
+
+
 void Item_func::signal_divide_by_null()
 {
   THD *thd= current_thd;
@@ -2020,10 +2033,7 @@ double Item_func_ln::val_real()
   if ((null_value= args[0]->null_value))
     return 0.0;
   if (value <= 0.0)
-  {
-    signal_divide_by_null();
-    return 0.0;
-  }
+    return signal_log_domain_error(value);
   return log(value);
 }
 
@@ -2036,27 +2046,23 @@ double Item_func_ln::val_real()
 double Item_func_log::val_real()
 {
   DBUG_ASSERT(fixed());
-  double value= args[0]->val_real();
+  double base= args[0]->val_real();
   if ((null_value= args[0]->null_value))
     return 0.0;
-  if (value <= 0.0)
-  {
-    signal_divide_by_null();
-    return 0.0;
-  }
   if (arg_count == 2)
   {
-    double value2= args[1]->val_real();
+    double value= args[1]->val_real();
     if ((null_value= args[1]->null_value))
       return 0.0;
-    if (value2 <= 0.0 || value == 1.0)
-    {
-      signal_divide_by_null();
-      return 0.0;
-    }
-    return log(value2) / log(value);
+    if (base <= 0.0 || base == 1.0)
+      return signal_log_domain_error(base);
+    if (value <= 0.0)
+      return signal_log_domain_error(value);
+    return log(value) / log(base);
   }
-  return log(value);
+  if (base <= 0.0)
+    return signal_log_domain_error(base);
+  return log(base);
 }
 
 double Item_func_log2::val_real()
@@ -2067,10 +2073,7 @@ double Item_func_log2::val_real()
   if ((null_value=args[0]->null_value))
     return 0.0;
   if (value <= 0.0)
-  {
-    signal_divide_by_null();
-    return 0.0;
-  }
+    return signal_log_domain_error(value);
   return log(value) / M_LN2;
 }
 
@@ -2081,10 +2084,7 @@ double Item_func_log10::val_real()
   if ((null_value= args[0]->null_value))
     return 0.0;
   if (value <= 0.0)
-  {
-    signal_divide_by_null();
-    return 0.0;
-  }
+    return signal_log_domain_error(value);
   return log10(value);
 }
 

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -249,8 +249,10 @@ public:
     return null_value;
   }
   String *val_str_from_val_str_ascii(String *str, String *str2);
-
+protected:
   void signal_divide_by_null();
+  double signal_log_domain_error(double value);
+public:
   friend class udf_handler;
   Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   { return tmp_table_field_from_field_type(root, table); }


### PR DESCRIPTION
JIRA: https://jira.mariadb.org/browse/MDEV-37939

  Summary
  - Add contextual “Division by 0 in function” warnings for LOG/LN/LOG2/LOG10
  - Keep warning code ER_DIVISION_BY_ZERO (1365) unchanged
  - Add a regression test for LOG-family warnings vs generic division warnings

  Testing
  - MTR_BINDIR=../build ./mariadb-test-run.pl --suite=main --record func_math_div_zero
  - MTR_BINDIR=../build ./mariadb-test-run.pl --suite=main func_math_div_zero