### PR TITLE
MDEV-32067 InnoDB linear read ahead had better be logical

### DIFF
--- a/mysql-test/main/analyze_stmt_prefetch_count.result
+++ b/mysql-test/main/analyze_stmt_prefetch_count.result
@@ -32,7 +32,8 @@ set @pages_prefetch_read_count= cast(json_value(@js,'$.pages_prefetch_read_count
 select @pages_accessed > 1000 and @pages_accessed < 1500;
 @pages_accessed > 1000 and @pages_accessed < 1500
 1
-set @total_read = (@pages_read_count + @pages_prefetch_read_count);
+set @corrected_pages_read_count = greatest(0, @pages_read_count - @pages_prefetch_read_count);
+set @total_read = (@corrected_pages_read_count + @pages_prefetch_read_count);
 set @low_ok= @pages_accessed*0.75 < @total_read;
 set @high_ok= @total_read < @pages_accessed*1.50;
 select @low_ok, @high_ok;

--- a/mysql-test/main/analyze_stmt_prefetch_count.test
+++ b/mysql-test/main/analyze_stmt_prefetch_count.test
@@ -49,7 +49,10 @@ set @pages_prefetch_read_count= cast(json_value(@js,'$.pages_prefetch_read_count
 
 select @pages_accessed > 1000 and @pages_accessed < 1500;
 
-set @total_read = (@pages_read_count + @pages_prefetch_read_count);
+# Correct for double-counting: pages_read_count includes waits for prefetched pages
+# Calculate actual synchronous reads by subtracting prefetch waits from total reads
+set @corrected_pages_read_count = greatest(0, @pages_read_count - @pages_prefetch_read_count);
+set @total_read = (@corrected_pages_read_count + @pages_prefetch_read_count);
 set @low_ok= @pages_accessed*0.75 < @total_read;
 set @high_ok= @total_read < @pages_accessed*1.50;
 

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -6641,7 +6641,8 @@ ha_rows ha_partition::multi_range_read_info_const(uint keyno,
                                                   RANGE_SEQ_IF *seq,
                                                   void *seq_init_param,
                                                   uint n_ranges, uint *bufsz,
-                                                  uint *mrr_mode, ha_rows limit,
+                                                  uint *mrr_mode, page_range *pr,
+                                                  ha_rows limit,
                                                   Cost_estimate *cost)
 {
   int error;
@@ -6702,7 +6703,9 @@ ha_rows ha_partition::multi_range_read_info_const(uint keyno,
                                     &m_partition_part_key_multi_range_hld[i],
                                     m_part_mrr_range_length[i],
                                     &m_mrr_buffer_size[i],
-                                    &tmp_mrr_mode, limit, &part_cost);
+                                    &tmp_mrr_mode, pr, limit, &part_cost);
+      if (pr)
+        *pr= {0, 0};
       if (tmp_rows == HA_POS_ERROR)
       {
         m_part_spec= save_part_spec;

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -6641,7 +6641,8 @@ ha_rows ha_partition::multi_range_read_info_const(uint keyno,
                                                   RANGE_SEQ_IF *seq,
                                                   void *seq_init_param,
                                                   uint n_ranges, uint *bufsz,
-                                                  uint *mrr_mode, ha_rows limit,
+                                                  uint *mrr_mode, page_range *pr,
+                                                  ha_rows limit,
                                                   Cost_estimate *cost)
 {
   int error;
@@ -6702,7 +6703,8 @@ ha_rows ha_partition::multi_range_read_info_const(uint keyno,
                                     &m_partition_part_key_multi_range_hld[i],
                                     m_part_mrr_range_length[i],
                                     &m_mrr_buffer_size[i],
-                                    &tmp_mrr_mode, limit, &part_cost);
+                                    &tmp_mrr_mode, pr, limit, &part_cost);
+      *pr= {0, 0};
       if (tmp_rows == HA_POS_ERROR)
       {
         m_part_spec= save_part_spec;

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -957,7 +957,8 @@ public:
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param,
                                       uint n_ranges, uint *bufsz,
-                                      uint *mrr_mode, ha_rows limit,
+                                      uint *mrr_mode, page_range *pr,
+                                      ha_rows limit,
                                       Cost_estimate *cost) override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz,

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -4469,17 +4469,27 @@ public:
     too?
   */
   virtual ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
-                                              void *seq_init_param, 
+                                              void *seq_init_param,
                                               uint n_ranges, uint *bufsz,
-                                              uint *mrr_mode, ha_rows limit,
+                                              uint *mrr_mode, page_range *pr,
+                                              ha_rows limit,
                                               Cost_estimate *cost);
   virtual ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
-                                        uint key_parts, uint *bufsz, 
+                                        uint key_parts, uint *bufsz,
                                         uint *mrr_mode, Cost_estimate *cost);
   virtual int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
-                                    uint n_ranges, uint mrr_mode, 
+                                    uint n_ranges, uint mrr_mode,
                                     HANDLER_BUFFER *buf);
   virtual int multi_range_read_next(range_id_t *range_info);
+
+  /**
+    Advise the engine of the leaf-page extent that an upcoming range scan
+    is estimated to touch, so it can prefetch accordingly. Called just
+    before multi_range_read_init(). The range is a hint only; @c
+    scan_range->first_page / last_page are the first and last leaf pages
+    reported by records_in_range() (UNUSED_PAGE_NO if unknown).
+  */
+  virtual void advise_page_range(const page_range *scan_range) {}
 private:
   inline void calculate_costs(Cost_estimate *cost, uint keyno,
                               uint ranges, uint multi_row_ranges, uint flags,

--- a/sql/multi_range_read.cc
+++ b/sql/multi_range_read.cc
@@ -131,6 +131,7 @@ ha_rows
 handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                      void *seq_init_param, uint n_ranges_arg,
                                      uint *bufsz, uint *flags,
+                                     page_range *pr,
                                      ha_rows top_limit,
                                      Cost_estimate *cost)
 {
@@ -191,6 +192,12 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
 
   /* Default MRR implementation doesn't need buffer */
   *bufsz= 0;
+
+  /* Basically it should give the union of page extents of
+  every range in the scan. Initialize with unused_page_range
+  until the first range reports; If it is unused_page_range then
+  widened the search to whole tablespace .*/
+  page_range range_covering_all= unused_page_range;
 
   seq_it= seq->init(seq_init_param, n_ranges, *flags);
   while (!seq->next(seq_it, &range))
@@ -253,6 +260,19 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
           DBUG_RETURN(HA_POS_ERROR);
         break;
       }
+      /* Fold this range's extent into range_covering_all. */
+      if (pages.first_page == UNUSED_PAGE_NO ||
+          pages.last_page == UNUSED_PAGE_NO)
+        range_covering_all= {0, UNUSED_PAGE_NO};
+      else if (range_covering_all.first_page == UNUSED_PAGE_NO)
+        /* first positioned range */
+        range_covering_all= pages;
+      else if (range_covering_all.last_page != UNUSED_PAGE_NO)
+      {
+        set_if_smaller(range_covering_all.first_page, pages.first_page);
+        set_if_bigger(range_covering_all.last_page, pages.last_page);
+      }
+
       if (pages.first_page == UNUSED_PAGE_NO)
       {
         /*
@@ -372,6 +392,8 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
 
   if (total_rows != HA_POS_ERROR)
   {
+    if (pr)
+      *pr= range_covering_all;
     set_if_smaller(total_rows, max_rows);
     *flags |= HA_MRR_USE_DEFAULT_IMPL;
     calculate_costs(cost, keyno, n_ranges,
@@ -1102,7 +1124,6 @@ int Mrr_ordered_rndpos_reader::get_next(range_id_t *range_info)
 /****************************************************************************
  * Top-level DS-MRR implementation functions (the ones called by storage engine)
  ***************************************************************************/
-
 /**
   DS-MRR: Initialize and start MRR scan
 
@@ -1142,7 +1163,7 @@ int DsMrr_impl::dsmrr_init(handler *h_arg, RANGE_SEQ_IF *seq_funcs,
   is_mrr_assoc= !MY_TEST(mode & HA_MRR_NO_ASSOCIATION);
 
   strategy_exhausted= FALSE;
-  
+
   /* By default, have do-nothing buffer manager */
   buf_manager.arg= this;
   buf_manager.reset_buffer_sizes= do_nothing;
@@ -1781,18 +1802,20 @@ ha_rows DsMrr_impl::dsmrr_info(uint keyno, uint n_ranges, uint rows,
 
 ha_rows DsMrr_impl::dsmrr_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                      void *seq_init_param, uint n_ranges,
-                                     uint *bufsz, uint *flags, ha_rows limit,
+                                     uint *bufsz, uint *flags, page_range *pr,
+                                     ha_rows limit,
                                      Cost_estimate *cost)
 {
   ha_rows rows;
   uint def_flags= *flags;
   uint def_bufsz= *bufsz;
   /* Get cost/flags/mem_usage of default MRR implementation */
-  rows= primary_file->handler::multi_range_read_info_const(keyno, seq, 
+  rows= primary_file->handler::multi_range_read_info_const(keyno, seq,
                                                            seq_init_param,
-                                                           n_ranges, 
-                                                           &def_bufsz, 
+                                                           n_ranges,
+                                                           &def_bufsz,
                                                            &def_flags,
+                                                           pr,
                                                            limit,
                                                            cost);
   if (rows == HA_POS_ERROR)

--- a/sql/multi_range_read.cc
+++ b/sql/multi_range_read.cc
@@ -131,6 +131,7 @@ ha_rows
 handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                      void *seq_init_param, uint n_ranges_arg,
                                      uint *bufsz, uint *flags,
+                                     page_range *pr,
                                      ha_rows top_limit,
                                      Cost_estimate *cost)
 {
@@ -191,6 +192,15 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
 
   /* Default MRR implementation doesn't need buffer */
   *bufsz= 0;
+
+  if (pr)
+    *pr= unused_page_range;
+
+  /* Basically it should give the union of page extents of
+  every range in the scan. Initialize with unused_page_range
+  until the first range reports; If it is unused_page_range then
+  widened the search to whole tablespace .*/
+  page_range range_covering_all= unused_page_range;
 
   seq_it= seq->init(seq_init_param, n_ranges, *flags);
   while (!seq->next(seq_it, &range))
@@ -253,6 +263,19 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
           DBUG_RETURN(HA_POS_ERROR);
         break;
       }
+      /* Fold this range's extent into range_covering_all. */
+      if (pages.first_page == UNUSED_PAGE_NO ||
+          pages.last_page == UNUSED_PAGE_NO)
+        range_covering_all= {0, UNUSED_PAGE_NO};
+      else if (range_covering_all.first_page == UNUSED_PAGE_NO)
+        /* first positioned range */
+        range_covering_all= pages;
+      else if (range_covering_all.last_page != UNUSED_PAGE_NO)
+      {
+        set_if_smaller(range_covering_all.first_page, pages.first_page);
+        set_if_bigger(range_covering_all.last_page, pages.last_page);
+      }
+
       if (pages.first_page == UNUSED_PAGE_NO)
       {
         /*
@@ -372,6 +395,8 @@ handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
 
   if (total_rows != HA_POS_ERROR)
   {
+    if (pr)
+      *pr= range_covering_all;
     set_if_smaller(total_rows, max_rows);
     *flags |= HA_MRR_USE_DEFAULT_IMPL;
     calculate_costs(cost, keyno, n_ranges,
@@ -1102,7 +1127,6 @@ int Mrr_ordered_rndpos_reader::get_next(range_id_t *range_info)
 /****************************************************************************
  * Top-level DS-MRR implementation functions (the ones called by storage engine)
  ***************************************************************************/
-
 /**
   DS-MRR: Initialize and start MRR scan
 
@@ -1142,7 +1166,7 @@ int DsMrr_impl::dsmrr_init(handler *h_arg, RANGE_SEQ_IF *seq_funcs,
   is_mrr_assoc= !MY_TEST(mode & HA_MRR_NO_ASSOCIATION);
 
   strategy_exhausted= FALSE;
-  
+
   /* By default, have do-nothing buffer manager */
   buf_manager.arg= this;
   buf_manager.reset_buffer_sizes= do_nothing;
@@ -1781,18 +1805,20 @@ ha_rows DsMrr_impl::dsmrr_info(uint keyno, uint n_ranges, uint rows,
 
 ha_rows DsMrr_impl::dsmrr_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                      void *seq_init_param, uint n_ranges,
-                                     uint *bufsz, uint *flags, ha_rows limit,
+                                     uint *bufsz, uint *flags, page_range *pr,
+                                     ha_rows limit,
                                      Cost_estimate *cost)
 {
   ha_rows rows;
   uint def_flags= *flags;
   uint def_bufsz= *bufsz;
   /* Get cost/flags/mem_usage of default MRR implementation */
-  rows= primary_file->handler::multi_range_read_info_const(keyno, seq, 
+  rows= primary_file->handler::multi_range_read_info_const(keyno, seq,
                                                            seq_init_param,
-                                                           n_ranges, 
-                                                           &def_bufsz, 
+                                                           n_ranges,
+                                                           &def_bufsz,
                                                            &def_flags,
+                                                           pr,
                                                            limit,
                                                            cost);
   if (rows == HA_POS_ERROR)

--- a/sql/multi_range_read.h
+++ b/sql/multi_range_read.h
@@ -557,10 +557,11 @@ class DsMrr_impl
 public:
   typedef void (handler::*range_check_toggle_func_t)(bool on);
 
-  void init(handler *h_arg, TABLE *table_arg)
+  void init(handler *h_arg, TABLE *table_arg, ha_rows limit= HA_POS_ERROR)
   {
     primary_file= h_arg; 
     table= table_arg;
+    limit_hint= limit;
   }
   int dsmrr_init(handler *h_arg, RANGE_SEQ_IF *seq_funcs, 
                  void *seq_init_param, uint n_ranges, uint mode, 
@@ -571,11 +572,15 @@ public:
   ha_rows dsmrr_info(uint keyno, uint n_ranges, uint keys, uint key_parts, 
                      uint *bufsz, uint *flags, Cost_estimate *cost);
 
-  ha_rows dsmrr_info_const(uint keyno, RANGE_SEQ_IF *seq, 
+  ha_rows dsmrr_info_const(uint keyno, RANGE_SEQ_IF *seq,
                             void *seq_init_param, uint n_ranges, uint *bufsz,
-                           uint *flags, ha_rows limit, Cost_estimate *cost);
+                           uint *flags, page_range *pr, ha_rows limit,
+                           Cost_estimate *cost);
 
   int dsmrr_explain_info(uint mrr_mode, char *str, size_t size);
+  void set_limit(ha_rows limit) { limit_hint= limit; }
+  ha_rows get_limit() const { return limit_hint; }
+
 private:
   /* Buffer to store (key, range_id) pairs */
   Lifo_buffer *key_buffer= nullptr;
@@ -635,7 +640,10 @@ private:
     is_mrr_assoc==FALSE
   */
   Forward_lifo_buffer rowid_buffer;
-  
+
+  /* LIMIT value */
+  ha_rows limit_hint= HA_POS_ERROR;
+
   bool choose_mrr_impl(uint keyno, ha_rows rows, uint *flags, uint *bufsz, 
                        Cost_estimate *cost);
   bool get_disk_sweep_mrr_cost(uint keynr, ha_rows rows, uint flags,

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -346,7 +346,8 @@ static ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
                                   bool index_only,
                                   SEL_ARG *tree, bool update_tbl_stats, 
                                   uint *mrr_flags, uint *bufsize,
-                                  Cost_estimate *cost, bool *is_ror_scan);
+                                  Cost_estimate *cost, page_range *pr,
+                                  bool *is_ror_scan);
 
 QUICK_RANGE_SELECT *get_quick_select(PARAM *param,uint index,
                                      SEL_ARG *key_tree, uint mrr_flags, 
@@ -2302,6 +2303,7 @@ public:
   uint     key_idx; /* key number in PARAM::key */
   uint     mrr_flags; 
   uint     mrr_buf_size;
+  page_range pgrange= unused_page_range;
 
   TRP_RANGE(SEL_ARG *key_arg, uint idx_arg, uint mrr_flags_arg)
    : key(key_arg), key_idx(idx_arg), mrr_flags(mrr_flags_arg)
@@ -2318,6 +2320,7 @@ public:
     {
       quick->records= records;
       quick->read_time= read_cost;
+      quick->mrr_pages_range= pgrange;
     }
     DBUG_RETURN(quick);
   }
@@ -7943,6 +7946,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
   ha_rows UNINIT_VAR(best_records);              /* protected by key_to_read */
   uint    UNINIT_VAR(best_mrr_flags),            /* protected by key_to_read */
           UNINIT_VAR(best_buf_size);             /* protected by key_to_read */
+  page_range best_page_range= unused_page_range;
   TRP_RANGE* read_plan= NULL;
   DBUG_ENTER("get_key_scans_params");
   THD *thd= param->thd;
@@ -7991,9 +7995,11 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
     Json_writer_object trace_idx(thd);
     trace_idx.add("index", param->table->key_info[keynr].name);
 
+    page_range pr= unused_page_range;
+
     found_records= check_quick_select(param, idx, limit, read_index_only,
                                       key, for_range_access, &mrr_flags,
-                                      &buf_size, &cost, &is_ror_scan);
+                                      &buf_size, &cost, &pr, &is_ror_scan);
 
     const index_merge_behavior ihb= index_merge_hint(param->table,  // do this before check_quick_select?
                                                      keynr,
@@ -8063,6 +8069,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
       best_idx= idx;
       best_mrr_flags= mrr_flags;
       best_buf_size=  buf_size;
+      best_page_range= pr;
       using_table_scan= 0;
       trace_idx.add("chosen", true);
     }
@@ -8093,6 +8100,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
       read_plan->is_ror= tree->ror_scans_map.is_set(best_idx);
       read_plan->read_cost= read_time;
       read_plan->mrr_buf_size= best_buf_size;
+      read_plan->pgrange= best_page_range;
       DBUG_PRINT("info",
                  ("Returning range plan for key %s, cost %g, records %lu",
                   param->table->key_info[param->real_keynr[best_idx]].name.str,
@@ -12432,6 +12440,7 @@ ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
                            bool index_only,
                            SEL_ARG *tree, bool update_tbl_stats, 
                            uint *mrr_flags, uint *bufsize, Cost_estimate *cost,
+                           page_range *pr,
                            bool *is_ror_scan)
 {
   SEL_ARG_RANGE_SEQ seq;
@@ -12491,7 +12500,8 @@ ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
   */
   if (!param->table->pos_in_table_list->is_materialized_derived())
     rows= file->multi_range_read_info_const(keynr, &seq_if, (void*)&seq, 0,
-                                            bufsize, mrr_flags, limit, cost);
+                                            bufsize, mrr_flags, pr, limit,
+                                            cost);
   param->quick_rows[keynr]= rows;
   if (rows != HA_POS_ERROR)
   {
@@ -13637,6 +13647,9 @@ int QUICK_RANGE_SELECT::reset()
   if (!mrr_buf_desc)
     empty_buf.buffer= empty_buf.buffer_end= empty_buf.end_of_used_area= NULL;
 
+  /* Hand the optimizer-estimated leaf-page extent of this scan to the
+  engine so it can drive read-ahead (see ha_innobase::advise_page_range). */
+  file->advise_page_range(&mrr_pages_range);
   error= file->multi_range_read_init(&seq_funcs, (void*)this,
                                      (uint)ranges.elements, mrr_flags,
                                      mrr_buf_desc? mrr_buf_desc: &empty_buf);

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -346,7 +346,8 @@ static ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
                                   bool index_only,
                                   SEL_ARG *tree, bool update_tbl_stats, 
                                   uint *mrr_flags, uint *bufsize,
-                                  Cost_estimate *cost, bool *is_ror_scan);
+                                  Cost_estimate *cost, page_range *pr,
+                                  bool *is_ror_scan);
 
 QUICK_RANGE_SELECT *get_quick_select(PARAM *param,uint index,
                                      SEL_ARG *key_tree, uint mrr_flags, 
@@ -2302,6 +2303,7 @@ public:
   uint     key_idx; /* key number in PARAM::key */
   uint     mrr_flags; 
   uint     mrr_buf_size;
+  page_range pgrange;
 
   TRP_RANGE(SEL_ARG *key_arg, uint idx_arg, uint mrr_flags_arg)
    : key(key_arg), key_idx(idx_arg), mrr_flags(mrr_flags_arg)
@@ -2318,6 +2320,7 @@ public:
     {
       quick->records= records;
       quick->read_time= read_cost;
+      quick->mrr_pages_range= pgrange;
     }
     DBUG_RETURN(quick);
   }
@@ -7943,6 +7946,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
   ha_rows UNINIT_VAR(best_records);              /* protected by key_to_read */
   uint    UNINIT_VAR(best_mrr_flags),            /* protected by key_to_read */
           UNINIT_VAR(best_buf_size);             /* protected by key_to_read */
+  page_range best_page_range;
   TRP_RANGE* read_plan= NULL;
   DBUG_ENTER("get_key_scans_params");
   THD *thd= param->thd;
@@ -7991,9 +7995,11 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
     Json_writer_object trace_idx(thd);
     trace_idx.add("index", param->table->key_info[keynr].name);
 
+    page_range pr;
+
     found_records= check_quick_select(param, idx, limit, read_index_only,
                                       key, for_range_access, &mrr_flags,
-                                      &buf_size, &cost, &is_ror_scan);
+                                      &buf_size, &cost, &pr, &is_ror_scan);
 
     const index_merge_behavior ihb= index_merge_hint(param->table,  // do this before check_quick_select?
                                                      keynr,
@@ -8063,6 +8069,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
       best_idx= idx;
       best_mrr_flags= mrr_flags;
       best_buf_size=  buf_size;
+      best_page_range= pr;
       using_table_scan= 0;
       trace_idx.add("chosen", true);
     }
@@ -8093,6 +8100,7 @@ static TRP_RANGE *get_key_scans_params(PARAM *param, SEL_TREE *tree,
       read_plan->is_ror= tree->ror_scans_map.is_set(best_idx);
       read_plan->read_cost= read_time;
       read_plan->mrr_buf_size= best_buf_size;
+      read_plan->pgrange= best_page_range;
       DBUG_PRINT("info",
                  ("Returning range plan for key %s, cost %g, records %lu",
                   param->table->key_info[param->real_keynr[best_idx]].name.str,
@@ -12432,6 +12440,7 @@ ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
                            bool index_only,
                            SEL_ARG *tree, bool update_tbl_stats, 
                            uint *mrr_flags, uint *bufsize, Cost_estimate *cost,
+                           page_range *pr,
                            bool *is_ror_scan)
 {
   SEL_ARG_RANGE_SEQ seq;
@@ -12491,7 +12500,8 @@ ha_rows check_quick_select(PARAM *param, uint idx, ha_rows limit,
   */
   if (!param->table->pos_in_table_list->is_materialized_derived())
     rows= file->multi_range_read_info_const(keynr, &seq_if, (void*)&seq, 0,
-                                            bufsize, mrr_flags, limit, cost);
+                                            bufsize, mrr_flags, pr, limit,
+                                            cost);
   param->quick_rows[keynr]= rows;
   if (rows != HA_POS_ERROR)
   {
@@ -13637,6 +13647,9 @@ int QUICK_RANGE_SELECT::reset()
   if (!mrr_buf_desc)
     empty_buf.buffer= empty_buf.buffer_end= empty_buf.end_of_used_area= NULL;
 
+  /* Hand the optimizer-estimated leaf-page extent of this scan to the
+  engine so it can drive read-ahead (see ha_innobase::advise_page_range). */
+  file->advise_page_range(&mrr_pages_range);
   error= file->multi_range_read_init(&seq_funcs, (void*)this,
                                      (uint)ranges.elements, mrr_flags,
                                      mrr_buf_desc? mrr_buf_desc: &empty_buf);

--- a/sql/opt_range.h
+++ b/sql/opt_range.h
@@ -1361,6 +1361,7 @@ protected:
   QUICK_RANGE_SEQ_CTX qr_traversal_ctx;
 public:
   uint mrr_flags; /* Flags to be used with MRR interface */
+  page_range mrr_pages_range= unused_page_range;
 protected:
   uint mrr_buf_size; /* copy from thd->variables.mrr_buff_size */  
   HANDLER_BUFFER *mrr_buf_desc; /* the handler buffer */

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -7373,7 +7373,8 @@ int ha_connect::multi_range_read_next(range_id_t *range_info)
 ha_rows ha_connect::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                void *seq_init_param,
                                                uint n_ranges, uint *bufsz,
-                                                uint *flags, ha_rows limit,
+                                                uint *flags, page_range* pr, 
+                                                ha_rows limit,
                                                 Cost_estimate *cost)
 {
   /*
@@ -7388,7 +7389,7 @@ ha_rows ha_connect::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
     *flags|= HA_MRR_USE_DEFAULT_IMPL;
 
   ha_rows rows= ds_mrr.dsmrr_info_const(keyno, seq, seq_init_param, n_ranges,
-                                        bufsz, flags, limit, cost);
+                                        bufsz, flags, pr, limit, cost);
   xp->g->Mrr= !(*flags & HA_MRR_USE_DEFAULT_IMPL);
   return rows;
 } // end of multi_range_read_info_const

--- a/storage/connect/ha_connect.h
+++ b/storage/connect/ha_connect.h
@@ -498,7 +498,7 @@ int index_prev(uchar *buf) override;
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param,
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, ha_rows limit,
+                                      uint *flags, page_range*, ha_rows limit,
                                       Cost_estimate *cost) override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz,

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1105,8 +1105,91 @@ static inline void btr_ahi_inc_searches_btree(const mtr_t &mtr) noexcept
 }
 #endif /* BTR_CUR_HASH_ADAPT */
 
+btr_ra_result btr_read_ahead_collect(btr_read_ahead_t *ra,
+                                     const dict_index_t *index,
+                                     const rec_t *rec, bool descending,
+                                     uint32_t stop_page) noexcept
+{
+  ut_ad(ra->n < ra->capacity);
+  mem_heap_t *heap= nullptr;
+  rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+  rec_offs_init(offsets_);
+  rec_offs *offsets= rec_get_offsets(rec, index, offsets_, 0,
+                                     ULINT_UNDEFINED, &heap);
+  btr_ra_result res;
+  for (;;)
+  {
+    const uint32_t child= btr_node_ptr_get_child_page_no(rec, offsets);
+    ra->pages[ra->n++]= child;
+    ra->l1_child= child;
+    if (child == stop_page)
+    {
+      res= BTR_RA_STOP;
+      break;
+    }
+    if (ra->n == ra->capacity)
+    {
+      res= BTR_RA_FULL;
+      break;
+    }
+    rec= descending
+      ? page_rec_get_prev_const(rec) : page_rec_get_next_const(rec);
+    if (!rec ||
+        (descending ? page_rec_is_infimum(rec) : page_rec_is_supremum(rec)))
+    {
+      res= BTR_RA_EDGE;
+      break;
+    }
+    offsets= rec_get_offsets(rec, index, offsets_, 0, ULINT_UNDEFINED, &heap);
+  }
+  if (heap)
+    mem_heap_free(heap);
+  return res;
+}
+
+const rec_t *btr_read_ahead_resume_rec(const buf_block_t *block,
+                                       const dict_index_t *index,
+                                       uint32_t resume_child,
+                                       bool descending) noexcept
+{
+  const page_t *page= block->page.frame;
+  const rec_t *rec= descending
+    ? page_rec_get_prev_const(page_get_supremum_rec(page))
+    : page_rec_get_next_const(page_get_infimum_rec(page));
+
+  if (resume_child == FIL_NULL)
+    return rec;
+
+  /* Locate the last read child page from the records */
+  mem_heap_t *heap= nullptr;
+  rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+  rec_offs_init(offsets_);
+  const rec_t *result= nullptr;
+
+  while (rec &&
+         !(descending ? page_rec_is_infimum(rec) : page_rec_is_supremum(rec)))
+  {
+    rec_offs *offsets= rec_get_offsets(rec, index, offsets_, 0,
+                                       ULINT_UNDEFINED, &heap);
+    const bool found=
+      btr_node_ptr_get_child_page_no(rec, offsets) == resume_child;
+    rec= descending
+      ? page_rec_get_prev_const(rec) : page_rec_get_next_const(rec);
+    if (found)
+    {
+      result= rec;
+      break;
+    }
+  }
+
+  if (heap)
+    mem_heap_free(heap);
+  return result;
+}
+
 dberr_t btr_cur_t::search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
-                               btr_latch_mode latch_mode, mtr_t *mtr)
+                               btr_latch_mode latch_mode, mtr_t *mtr,
+                               btr_read_ahead_t *read_ahead)
 {
   ut_ad(index()->is_btree());
 
@@ -1273,7 +1356,7 @@ dberr_t btr_cur_t::search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
 
   page_cur.block= block;
   ut_ad(block == mtr->at_savepoint(block_savepoint));
-  const bool not_first_access{buf_page_make_young_if_needed(&block->page)};
+  buf_page_make_young_if_needed(&block->page);
 #ifdef UNIV_ZIP_DEBUG
   if (const page_zip_des_t *page_zip= buf_block_get_page_zip(block))
     ut_a(page_zip_validate(page_zip, block->page.frame, index()));
@@ -1471,6 +1554,16 @@ release_tree:
   offsets= rec_get_offsets(page_cur.rec, index(), offsets, 0, ULINT_UNDEFINED,
                            &heap);
 
+  /* Logical read-ahead at PAGE_LEVEL=1, collect the child page
+  numbers that the scan is about to visit. */
+  if (read_ahead && page_level == 1 &&
+      read_ahead->n < read_ahead->capacity)
+  {
+    read_ahead->l1_page= block->page.id().page_no();
+    btr_read_ahead_collect(read_ahead, index(), page_cur.rec,
+                           mode == PAGE_CUR_L || mode == PAGE_CUR_LE);
+  }
+
   ut_ad(block == mtr->at_savepoint(block_savepoint));
 
   switch (latch_mode) {
@@ -1558,9 +1651,6 @@ release_tree:
     case BTR_SEARCH_PREV: /* btr_pcur_move_to_prev() */
       ut_ad(rw_latch == RW_S_LATCH);
 
-      if (!not_first_access)
-        buf_read_ahead_linear(page_id);
-
       if (page_has_prev(block->page.frame) &&
           page_rec_is_first(page_cur.rec, block->page.frame))
       {
@@ -1594,8 +1684,6 @@ release_tree:
     case BTR_MODIFY_LEAF:
     case BTR_SEARCH_LEAF:
       rw_latch= rw_lock_type_t(latch_mode);
-      if (!not_first_access)
-        buf_read_ahead_linear(page_id);
       break;
     case BTR_MODIFY_TREE:
       ut_ad(rw_latch == RW_X_LATCH);
@@ -1893,7 +1981,8 @@ search_loop:
 }
 
 dberr_t btr_cur_t::open_leaf(bool first, dict_index_t *index,
-                             btr_latch_mode latch_mode, mtr_t *mtr)
+                             btr_latch_mode latch_mode, mtr_t *mtr,
+                             btr_read_ahead_t *read_ahead)
 {
   ulint n_blocks= 0;
   mem_heap_t *heap= nullptr;
@@ -2062,13 +2151,15 @@ index_locked:
                              &heap);
     page= btr_node_ptr_get_child_page_no(page_cur.rec, offsets);
 
+    if (read_ahead && l == 1 && read_ahead->n < read_ahead->capacity)
+    {
+      read_ahead->l1_page= block->page.id().page_no();
+      btr_read_ahead_collect(read_ahead, index, page_cur.rec, !first, FIL_NULL);
+    }
+
     ut_ad(latch_mode != BTR_MODIFY_TREE || upper_rw_latch == RW_X_LATCH);
 
-    if (latch_mode != BTR_MODIFY_TREE)
-    {
-      if (!height && first && first_access)
-        buf_read_ahead_linear(page_id_t(block->page.id().space(), page));
-    }
+    if (latch_mode != BTR_MODIFY_TREE);
     else if (btr_cur_need_opposite_intention(block->page, index->is_clust(),
                                              lock_intention,
                                              node_ptr_max_size, compress_limit,
@@ -6531,9 +6622,9 @@ btr_copy_blob_prefix(
 	ulint	copied_len	= 0;
 	THD*	thd{current_thd};
 
-	for (mtr_t mtr{thd ? thd_to_trx(thd) : nullptr};;) {
+	for (mtr_t mtr{thd ? thd_to_trx(thd) : nullptr};;
+	     offset = FIL_PAGE_DATA) {
 		buf_block_t*	block;
-		const page_t*	page;
 		const byte*	blob_header;
 		ulint		part_len;
 		ulint		copy_len;
@@ -6542,16 +6633,14 @@ btr_copy_blob_prefix(
 
 		block = buf_page_get(id, 0, RW_S_LATCH, &mtr);
 		if (!block || btr_check_blob_fil_page_type(*block, "read")) {
+func_exit:
 			mtr.commit();
 			return copied_len;
 		}
-		if (!buf_page_make_young_if_needed(&block->page)) {
-			buf_read_ahead_linear(id);
-		}
 
-		page = buf_block_get_frame(block);
+		buf_page_make_young_if_needed(&block->page);
 
-		blob_header = page + offset;
+		blob_header= block->page.frame + offset;
 		part_len = btr_blob_get_part_len(blob_header);
 		copy_len = ut_min(part_len, len - copied_len);
 
@@ -6559,14 +6648,13 @@ btr_copy_blob_prefix(
 		       blob_header + BTR_BLOB_HDR_SIZE, copy_len);
 		copied_len += copy_len;
 
-		id.set_page_no(btr_blob_get_next_page_no(blob_header));
+		const uint32_t next{btr_blob_get_next_page_no(blob_header)};
+		if (next == FIL_NULL || copy_len != part_len) {
+			MEM_CHECK_DEFINED(buf, copied_len);
+			goto func_exit;
+		}
 
 		mtr_commit(&mtr);
-
-		if (id.page_no() == FIL_NULL || copy_len != part_len) {
-			MEM_CHECK_DEFINED(buf, copied_len);
-			return(copied_len);
-		}
 
 		/* On other BLOB pages except the first the BLOB header
 		always is at the page data start: */
@@ -6574,6 +6662,7 @@ btr_copy_blob_prefix(
 		offset = FIL_PAGE_DATA;
 
 		ut_ad(copied_len <= len);
+		id.set_page_no(next);
 	}
 }
 

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2581,6 +2581,68 @@ buf_block_t *buf_pool_t::unzip(buf_page_t *b, buf_pool_t::hash_chain &chain)
   return block;
 }
 
+/** Applies a random read-ahead in buf_pool if there are at least a threshold
+value of accessed pages from the random read-ahead area. Does not read any
+page, not even the one at the position (space, offset), if the read-ahead
+mechanism is not activated. NOTE: the calling thread may own latches on
+pages: to avoid deadlocks this function must be written such that it cannot
+end up waiting for these latches!
+@param[in]	page_id		page id of a page which the current thread
+wants to access
+@return number of page read requests issued */
+TRANSACTIONAL_TARGET
+static void buf_read_ahead_random(const page_id_t page_id) noexcept
+{
+  if (!srv_random_read_ahead || page_id.space() >= SRV_TMP_SPACE_ID)
+    /* Disable the read-ahead for temporary tablespace */
+    return;
+
+  if (srv_startup_is_before_trx_rollback_phase)
+    /* No read-ahead to avoid thread deadlocks */
+    return;
+
+  if (page_id == page_id_t(TRX_SYS_SPACE, TRX_SYS_PAGE_NO))
+    return;
+
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
+    return;
+
+  fil_space_t* space= fil_space_t::get(page_id.space());
+  if (!space)
+    return;
+
+
+  const uint32_t buf_read_ahead_area= buf_pool.read_ahead_area;
+  ulint count= 5 + buf_read_ahead_area / 8;
+  const page_id_t low= page_id - (page_id.page_no() % buf_read_ahead_area);
+  page_id_t high= low + buf_read_ahead_area;
+  high.set_page_no(std::min(high.page_no(), space->last_page_number()));
+
+  /* Count how many blocks in the area have been recently accessed,
+  that is, reside near the start of the LRU list. */
+
+  for (page_id_t i= low; i < high; ++i)
+  {
+    bool ok= false;
+    {
+      buf_pool_t::hash_chain &chain=
+        buf_pool.page_hash.cell_get(i.fold());
+      transactional_shared_lock_guard<page_hash_latch> g
+        {buf_pool.page_hash.lock_get(chain)};
+      if (const buf_page_t *bpage= buf_pool.page_hash.get(i, chain))
+        if (bpage->is_accessed() && buf_page_peek_if_young(bpage))
+          ok= true;
+    }
+    if (ok && !--count)
+    {
+      buf_read_ahead_random(space, low, high);
+      break;
+    }
+  }
+
+  space->release();
+}
+
 buf_block_t *buf_pool_t::page_fix(const page_id_t id,
                                   dberr_t *err, trx_t *trx,
                                   buf_pool_t::page_fix_conflicts c) noexcept

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -379,126 +379,133 @@ static void buf_read_release(buf_block_t *block) noexcept
 }
 
 ATTRIBUTE_NOINLINE
-/** Free a buffer block if needed, and update the read-ahead count.
-@param block  block to be freed
+/** Update the read-ahead count.
 @param count  number of blocks that were read ahead
 @return count*/
-static size_t buf_read_release_count(buf_block_t *block, size_t count) noexcept
+static size_t buf_read_ahead_count(size_t count) noexcept
 {
-  if (block || count)
-  {
-    mysql_mutex_lock(&buf_pool.mutex);
-    if (block)
-      buf_LRU_block_free_non_file_page(block);
-    if (count)
-    {
-      /* Read ahead is considered one I/O operation for the purpose of
-      LRU policy decision. */
-      buf_LRU_stat_inc_io();
-      buf_pool.stat.n_ra_pages_read+= count;
-    }
-    mysql_mutex_unlock(&buf_pool.mutex);
-  }
+  if (count == 0)
+    return 0;
+  
+  mysql_mutex_lock(&buf_pool.mutex);
+  /* Read ahead is considered one I/O operation for the purpose of
+  LRU policy decision. */
+  buf_LRU_stat_inc_io();
+  buf_pool.stat.n_ra_pages_read+= count;
+  mysql_mutex_unlock(&buf_pool.mutex);
 
-  if (count)
-    if (THD *thd= current_thd)
-      if (trx_t *trx= thd_to_trx(thd))
-        if (ha_handler_stats *stats= trx->active_handler_stats)
-          stats->pages_prefetched+= count;
+  if (THD *thd= current_thd)
+    if (trx_t *trx= thd_to_trx(thd))
+      if (ha_handler_stats *stats= trx->active_handler_stats)
+        stats->pages_prefetched+= count;
   return count;
 }
 
-/** Applies a random read-ahead in buf_pool if there are at least a threshold
-value of accessed pages from the random read-ahead area. Does not read any
-page, not even the one at the position (space, offset), if the read-ahead
-mechanism is not activated. NOTE: the calling thread may own latches on
-pages: to avoid deadlocks this function must be written such that it cannot
-end up waiting for these latches!
-@param[in]	page_id		page id of a page which the current thread
-wants to access
-@return number of page read requests issued */
-TRANSACTIONAL_TARGET
-ulint buf_read_ahead_random(const page_id_t page_id) noexcept
+/** Apply a random read-ahead of pages.
+@param space    tablespace
+@param low      first page to attempt to read
+@param high     last page to attempt to read */
+void buf_read_ahead_random(fil_space_t *space, page_id_t low,
+                           page_id_t high) noexcept
 {
-  if (!srv_random_read_ahead || page_id.space() >= SRV_TMP_SPACE_ID)
-    /* Disable the read-ahead for temporary tablespace */
-    return 0;
+  const size_t zip_size{space->zip_size()};
+  size_t count{0};
 
-  if (srv_startup_is_before_trx_rollback_phase)
-    /* No read-ahead to avoid thread deadlocks */
-    return 0;
-
-  if (os_aio_pending_reads_approx() >
-      buf_pool.curr_size() / BUF_READ_AHEAD_PEND_LIMIT)
-    return 0;
-
-  fil_space_t* space= fil_space_t::get(page_id.space());
-  if (!space)
-    return 0;
-
-  const uint32_t buf_read_ahead_area= buf_pool.read_ahead_area;
-  ulint count= 5 + buf_read_ahead_area / 8;
-  const page_id_t low= page_id - (page_id.page_no() % buf_read_ahead_area);
-  page_id_t high= low + buf_read_ahead_area;
-  high.set_page_no(std::min(high.page_no(), space->last_page_number()));
-
-  /* Count how many blocks in the area have been recently accessed,
-  that is, reside near the start of the LRU list. */
-
-  for (page_id_t i= low; i < high; ++i)
-  {
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
-    transactional_shared_lock_guard<page_hash_latch> g
-      {buf_pool.page_hash.lock_get(chain)};
-    if (const buf_page_t *bpage= buf_pool.page_hash.get(i, chain))
-      if (bpage->is_accessed() && buf_page_peek_if_young(bpage) && !--count)
-        goto read_ahead;
-  }
-
-no_read_ahead:
-  space->release();
-  return 0;
-
-read_ahead:
-  if (space->is_stopping())
-    goto no_read_ahead;
-
-  /* Read all the suitable blocks within the area */
-  buf_block_t *block= nullptr;
-  unsigned zip_size{space->zip_size()};
-  if (UNIV_LIKELY(!zip_size))
-  {
-  allocate_block:
-    if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
-      goto no_read_ahead;
-  }
-  else if (recv_recovery_is_on())
-  {
-    zip_size|= 1;
-    goto allocate_block;
-  }
-
-  /* Read all the suitable blocks within the area */
   for (page_id_t i= low; i < high; ++i)
   {
     if (space->is_stopping())
       break;
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
     space->reacquire();
-    if (reinterpret_cast<buf_page_t*>(-1) ==
-        buf_read_page_low(i, zip_size, nullptr, chain, space, block, nullptr))
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
+    if (buf_pool.page_hash_contains(i, chain))
     {
-      count++;
-      ut_ad(!block);
-      if ((UNIV_LIKELY(!zip_size) || (zip_size & 1)) &&
-          UNIV_UNLIKELY(!(block= buf_read_acquire())))
-        break;
+skip:
+      space->release();
+      return;
     }
+
+    buf_block_t *block= nullptr;
+    if (UNIV_LIKELY(!zip_size))
+    {
+allocate_block:
+      if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
+        goto skip;
+    }
+    else if (recv_recovery_is_on())
+      goto allocate_block;
+
+    if (!buf_read_page_low(i, zip_size, nullptr, chain, space, block))
+      ut_ad(!block);
+    else
+      buf_read_release(block);
+
+    count++;
   }
 
-  space->release();
+  if (count)
+  {
+    DBUG_PRINT("ib_buf", ("random read-ahead %zu pages from %s: %u",
+               count, space->chain.start->name, low.page_no()));
+    buf_read_ahead_count(count);
+  }
+}
 
-  return buf_read_release_count(block, count);
+/** Read ahead a page if it is not yet in the buffer pool.
+@param space    tablespace
+@param page     page to read ahead */
+void buf_read_ahead_one(fil_space_t *space, uint32_t page) noexcept
+{
+  if (srv_startup_is_before_trx_rollback_phase)
+    return;
+  /* Unlike buf_read_ahead_undo(), we do not re-check space->is_stopping():
+  this is used for user index/table tablespaces, which are not shrunk under a
+  live scan (DROP/TRUNCATE are blocked by space->acquire() below). A stale
+  last_page_number() at worst yields one page read that fails and is evicted. */
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
+    return;
+
+  page_id_t id{space->id, page};
+  auto &page_hash= buf_pool.page_hash;
+  auto& chain= page_hash.cell_get(id.fold());
+  page_hash_latch &hash_lock= page_hash.lock_get(chain);
+
+  hash_lock.lock_shared();
+  buf_page_t *b= page_hash.get(id, chain);
+  hash_lock.unlock_shared();
+  if (b)
+    return;
+  if (space->last_page_number() < page || !space->acquire())
+    return;
+
+  const size_t zip_size{space->zip_size()};
+  buf_block_t *block=
+    zip_size ? nullptr : buf_LRU_get_free_block(have_no_mutex);
+
+  if (buf_page_t *bpage=
+        buf_page_init_for_read(id, zip_size, chain, block))
+  {
+    const bool exist(uintptr_t(bpage) & 1);
+    bpage= reinterpret_cast<buf_page_t*>(uintptr_t(bpage) & ~uintptr_t{1});
+    if (exist)
+    {
+      bpage->unfix();
+      goto func_exit;
+    }
+    const ulint len{zip_size ? zip_size : srv_page_size};
+    if (UNIV_LIKELY(space->io(IORequest(IORequest::READ_ASYNC),
+                              os_offset_t{page} * len, len,
+                              zip_size ? bpage->zip.data : bpage->frame,
+                              bpage).err == DB_SUCCESS))
+    {
+      buf_read_ahead_count(1);
+      return;
+    }
+    buf_pool.corrupted_evict(bpage, buf_page_t::READ_FIX);
+  }
+  else
+func_exit:
+    buf_read_release(block);
+  space->release();
 }
 
 buf_block_t *buf_read_page(const page_id_t page_id, dberr_t *err,
@@ -580,42 +587,31 @@ void buf_read_page_background(const page_id_t page_id, fil_space_t *space,
   }
 }
 
-/** Applies linear read-ahead if in the buf_pool the page is a border page of
+/** Apply linear read-ahead if an undo log page is a border page of
 a linear read-ahead area and all the pages in the area have been accessed.
-Does not read any page if the read-ahead mechanism is not activated. Note
-that the algorithm looks at the 'natural' adjacent successor and
-predecessor of the page, which on the leaf level of a B-tree are the next
-and previous page in the chain of leaves. To know these, the page specified
-in (space, offset) must already be present in the buf_pool. Thus, the
-natural way to use this function is to call it when a page in the buf_pool
-is accessed the first time, calling this function just after it has been
-bufferfixed.
-NOTE 1: as this function looks at the natural predecessor and successor
-fields on the page, what happens, if these are not initialized to any
-sensible value? No problem, before applying read-ahead we check that the
-area to read is within the span of the space, if not, read-ahead is not
-applied. An uninitialized value may result in a useless read operation, but
-only very improbably.
-NOTE 2: the calling thread may own latches on pages: to avoid deadlocks this
-function must be written such that it cannot end up waiting for these
-latches!
-@param[in]	page_id		page id; see NOTE 3 above
+Does not read any page if the read-ahead mechanism is not activated.
+@param space     undo tablespace or fil_system.space, or nullptr
+@param id        undo page identifier
 @return number of page read requests issued */
-ulint buf_read_ahead_linear(const page_id_t page_id) noexcept
+TRANSACTIONAL_TARGET
+ulint buf_read_ahead_undo(fil_space_t *space, const page_id_t page_id) noexcept
 {
-  /* check if readahead is disabled.
-  Disable the read ahead logic for temporary tablespace */
-  if (!srv_read_ahead_threshold || page_id.space() >= SRV_TMP_SPACE_ID)
+  if (!srv_read_ahead_threshold)
     return 0;
 
   if (srv_startup_is_before_trx_rollback_phase)
     /* No read-ahead to avoid thread deadlocks */
     return 0;
 
-  if (os_aio_pending_reads_approx() >
-      buf_pool.curr_size() / BUF_READ_AHEAD_PEND_LIMIT)
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
     return 0;
 
+  /* Prevent race condition with undo tablespace truncation by checking
+  if the space is being truncated (STOPPING_READS flag set) */
+  if (!space->acquire())
+    return 0;
+
+  ut_ad(!space->zip_size());
   const uint32_t buf_read_ahead_area= buf_pool.read_ahead_area;
   const page_id_t low= page_id - (page_id.page_no() % buf_read_ahead_area);
   const page_id_t high_1= low + (buf_read_ahead_area - 1);
@@ -625,35 +621,46 @@ ulint buf_read_ahead_linear(const page_id_t page_id) noexcept
   const bool descending= page_id != low;
 
   if (!descending && page_id != high_1)
-    /* This is not a border page of the area */
-    return 0;
-
-  fil_space_t *space= fil_space_t::get(page_id.space());
-  if (!space)
-    return 0;
-
-  if (high_1.page_no() > space->last_page_number())
   {
-    /* The area is not whole. */
-fail:
+    /* This is not a border page of the area */
     space->release();
     return 0;
   }
 
-  if (trx_sys_hdr_page(page_id))
-    /* If it is an ibuf bitmap page or trx sys hdr, we do no
-    read-ahead, as that could break the ibuf page access order */
-    goto fail;
+  ulint count;
+
+  /* Re-check if space is being truncated before
+  using last_page_number(). This prevents race
+  where acquire() succeeded but truncation started
+  before we check the page bounds. */
+  if (space->is_stopping())
+  {
+    space->release();
+    return 0;
+  }
+
+  if (high_1.page_no() > space->last_page_number())
+  {
+    /* The area is not whole. */
+  fail:
+    count= 0;
+    space->release();
+    return count;
+  }
 
   /* How many out of order accessed pages can we ignore
   when working out the access pattern for linear readahead */
-  ulint count= std::min<ulint>(buf_pool_t::READ_AHEAD_PAGES -
-                               srv_read_ahead_threshold,
-                               uint32_t{buf_pool.read_ahead_area});
+  count= std::min<ulint>(buf_pool_t::READ_AHEAD_PAGES -
+                         srv_read_ahead_threshold,
+                         uint32_t{buf_pool.read_ahead_area});
   page_id_t new_low= low, new_high_1= high_1;
   unsigned prev_accessed= 0;
   for (page_id_t i= low; i <= high_1; ++i)
   {
+    /* Check if space is being truncated during
+    access pattern analysis */
+    if (space->is_stopping())
+      goto fail;
     buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
     page_hash_latch &hash_lock= buf_pool.page_hash.lock_get(chain);
     /* It does not make sense to use transactional_lock_guard here,
@@ -738,41 +745,93 @@ failed:
   }
 
   /* If we got this far, read-ahead can be sensible: do it */
-  buf_block_t *block= nullptr;
-  unsigned zip_size{space->zip_size()};
-  if (UNIV_LIKELY(!zip_size))
-  {
-  allocate_block:
-    if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
-      goto fail;
-  }
-  else if (recv_recovery_is_on())
-  {
-    zip_size|= 1;
-    goto allocate_block;
-  }
-
   count= 0;
   for (; new_low <= new_high_1; ++new_low)
   {
     if (space->is_stopping())
       break;
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(new_low.fold());
     space->reacquire();
-    if (reinterpret_cast<buf_page_t*>(-1) ==
-        buf_read_page_low(new_low, zip_size, nullptr,
-                          chain, space, block, nullptr))
-    {
-      count++;
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(new_low.fold());
+    if (buf_pool.page_hash_contains(new_low, chain))
+      goto func_exit;
+
+    buf_block_t *block= buf_read_acquire();
+    if (!block)
+      goto func_exit;
+
+    if (!buf_read_page_low(new_low, 0, nullptr, chain, space, block))
       ut_ad(!block);
-      if ((UNIV_LIKELY(!zip_size) || (zip_size & 1)) &&
-          UNIV_UNLIKELY(!(block= buf_read_acquire())))
-        break;
+    else
+      buf_read_release(block);
+
+    count++;
+  }
+func_exit:
+  buf_read_ahead_count(count);
+  space->release();
+  return count;
+}
+
+/** Read ahead a number of pages.
+@param space    tablespace
+@param pages    pages to read ahead
+@param ibuf     whether we are inside the ibuf routine */
+void buf_read_ahead_pages(fil_space_t *space,
+                          st_::span<const uint32_t> pages) noexcept
+{
+  ut_ad(!recv_recovery_is_on());
+  /* No space->is_stopping() re-check (cf. buf_read_ahead_undo()): the caller
+  is prefetching leaves of a user index/table being scanned, which is not
+  shrunk under a live scan; each page is guarded by space->acquire() and
+  last_page_number() below, and a lost race just fails that one read. */
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
+    return;
+  page_id_t id{space->id, 0};
+  const size_t zip_size{space->zip_size()};
+  const ulint len{zip_size ? zip_size : srv_page_size};
+  ulint count= 0;
+  for (const uint32_t page : pages)
+  {
+    if (space->last_page_number() < page || !space->acquire())
+      return;
+    id.set_page_no(page);
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(id.fold());
+    buf_block_t *block=
+      zip_size ? nullptr : buf_LRU_get_free_block(have_no_mutex);
+    if (buf_page_t *bpage=
+        buf_page_init_for_read(id, zip_size, chain, block))
+    {
+      const bool exist(uintptr_t(bpage) & 1);
+      bpage= reinterpret_cast<buf_page_t*>(uintptr_t(bpage) & ~uintptr_t{1});
+      if (exist)
+      {
+        bpage->unfix();
+        buf_read_release(block);
+        space->release();
+      }
+      else if (UNIV_LIKELY(space->io(IORequest(IORequest::READ_ASYNC),
+                                os_offset_t{id.page_no()} * len, len,
+                                zip_size ? bpage->zip.data : bpage->frame,
+                                bpage).err == DB_SUCCESS))
+        /* On success the reference acquired above is handed to the
+        asynchronous read and released on completion. */
+        count++;
+      else
+      {
+        buf_pool.corrupted_evict(bpage, buf_page_t::READ_FIX);
+        space->release();
+      }
+      continue;
     }
+
+    buf_read_release(block);
+    /* We stop on the first error, or the first page that already
+    resides in the buffer pool. */
+    space->release();
+    break;
   }
 
-  space->release();
-  return buf_read_release_count(block, count);
+  buf_read_ahead_count(count);
 }
 
 /** Schedule a page for recovery.

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -379,126 +379,131 @@ static void buf_read_release(buf_block_t *block) noexcept
 }
 
 ATTRIBUTE_NOINLINE
-/** Free a buffer block if needed, and update the read-ahead count.
-@param block  block to be freed
+/** Update the read-ahead count.
 @param count  number of blocks that were read ahead
 @return count*/
-static size_t buf_read_release_count(buf_block_t *block, size_t count) noexcept
+static size_t buf_read_ahead_count(size_t count) noexcept
 {
-  if (block || count)
-  {
-    mysql_mutex_lock(&buf_pool.mutex);
-    if (block)
-      buf_LRU_block_free_non_file_page(block);
-    if (count)
-    {
-      /* Read ahead is considered one I/O operation for the purpose of
-      LRU policy decision. */
-      buf_LRU_stat_inc_io();
-      buf_pool.stat.n_ra_pages_read+= count;
-    }
-    mysql_mutex_unlock(&buf_pool.mutex);
-  }
+  if (count == 0)
+    return 0;
+  
+  mysql_mutex_lock(&buf_pool.mutex);
+  /* Read ahead is considered one I/O operation for the purpose of
+  LRU policy decision. */
+  buf_LRU_stat_inc_io();
+  buf_pool.stat.n_ra_pages_read+= count;
+  mysql_mutex_unlock(&buf_pool.mutex);
 
-  if (count)
-    if (THD *thd= current_thd)
-      if (trx_t *trx= thd_to_trx(thd))
-        if (ha_handler_stats *stats= trx->active_handler_stats)
-          stats->pages_prefetched+= count;
+  if (THD *thd= current_thd)
+    if (trx_t *trx= thd_to_trx(thd))
+      if (ha_handler_stats *stats= trx->active_handler_stats)
+        stats->pages_prefetched+= count;
   return count;
 }
 
-/** Applies a random read-ahead in buf_pool if there are at least a threshold
-value of accessed pages from the random read-ahead area. Does not read any
-page, not even the one at the position (space, offset), if the read-ahead
-mechanism is not activated. NOTE: the calling thread may own latches on
-pages: to avoid deadlocks this function must be written such that it cannot
-end up waiting for these latches!
-@param[in]	page_id		page id of a page which the current thread
-wants to access
-@return number of page read requests issued */
-TRANSACTIONAL_TARGET
-ulint buf_read_ahead_random(const page_id_t page_id) noexcept
+/** Apply a random read-ahead of pages.
+@param space    tablespace
+@param low      first page to attempt to read
+@param high     last page to attempt to read */
+void buf_read_ahead_random(fil_space_t *space, page_id_t low,
+                           page_id_t high) noexcept
 {
-  if (!srv_random_read_ahead || page_id.space() >= SRV_TMP_SPACE_ID)
-    /* Disable the read-ahead for temporary tablespace */
-    return 0;
+  const size_t zip_size{space->zip_size()};
+  size_t count{0};
 
-  if (srv_startup_is_before_trx_rollback_phase)
-    /* No read-ahead to avoid thread deadlocks */
-    return 0;
-
-  if (os_aio_pending_reads_approx() >
-      buf_pool.curr_size() / BUF_READ_AHEAD_PEND_LIMIT)
-    return 0;
-
-  fil_space_t* space= fil_space_t::get(page_id.space());
-  if (!space)
-    return 0;
-
-  const uint32_t buf_read_ahead_area= buf_pool.read_ahead_area;
-  ulint count= 5 + buf_read_ahead_area / 8;
-  const page_id_t low= page_id - (page_id.page_no() % buf_read_ahead_area);
-  page_id_t high= low + buf_read_ahead_area;
-  high.set_page_no(std::min(high.page_no(), space->last_page_number()));
-
-  /* Count how many blocks in the area have been recently accessed,
-  that is, reside near the start of the LRU list. */
-
-  for (page_id_t i= low; i < high; ++i)
-  {
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
-    transactional_shared_lock_guard<page_hash_latch> g
-      {buf_pool.page_hash.lock_get(chain)};
-    if (const buf_page_t *bpage= buf_pool.page_hash.get(i, chain))
-      if (bpage->is_accessed() && buf_page_peek_if_young(bpage) && !--count)
-        goto read_ahead;
-  }
-
-no_read_ahead:
-  space->release();
-  return 0;
-
-read_ahead:
-  if (space->is_stopping())
-    goto no_read_ahead;
-
-  /* Read all the suitable blocks within the area */
-  buf_block_t *block= nullptr;
-  unsigned zip_size{space->zip_size()};
-  if (UNIV_LIKELY(!zip_size))
-  {
-  allocate_block:
-    if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
-      goto no_read_ahead;
-  }
-  else if (recv_recovery_is_on())
-  {
-    zip_size|= 1;
-    goto allocate_block;
-  }
-
-  /* Read all the suitable blocks within the area */
   for (page_id_t i= low; i < high; ++i)
   {
     if (space->is_stopping())
       break;
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
     space->reacquire();
-    if (reinterpret_cast<buf_page_t*>(-1) ==
-        buf_read_page_low(i, zip_size, nullptr, chain, space, block, nullptr))
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
+    if (buf_pool.page_hash_contains(i, chain))
     {
-      count++;
-      ut_ad(!block);
-      if ((UNIV_LIKELY(!zip_size) || (zip_size & 1)) &&
-          UNIV_UNLIKELY(!(block= buf_read_acquire())))
-        break;
+skip:
+      space->release();
+      return;
     }
+
+    buf_block_t *block= nullptr;
+    if (UNIV_LIKELY(!zip_size))
+    {
+allocate_block:
+      if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
+        goto skip;
+    }
+    else if (recv_recovery_is_on())
+      goto allocate_block;
+
+    if (!buf_read_page_low(i, zip_size, nullptr, chain, space, block))
+      ut_ad(!block);
+    else
+      buf_read_release(block);
+
+    count++;
   }
 
-  space->release();
+  if (count)
+  {
+    DBUG_PRINT("ib_buf", ("random read-ahead %zu pages from %s: %u",
+               count, space->chain.start->name, low.page_no()));
+    buf_read_ahead_count(count);
+  }
+}
 
-  return buf_read_release_count(block, count);
+/** Read ahead a page if it is not yet in the buffer pool.
+@param space    tablespace
+@param page     page to read ahead */
+void buf_read_ahead_one(fil_space_t *space, uint32_t page) noexcept
+{
+  /* Unlike buf_read_ahead_undo(), we do not re-check space->is_stopping():
+  this is used for user index/table tablespaces, which are not shrunk under a
+  live scan (DROP/TRUNCATE are blocked by space->acquire() below). A stale
+  last_page_number() at worst yields one page read that fails and is evicted. */
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
+    return;
+
+  page_id_t id{space->id, page};
+  auto &page_hash= buf_pool.page_hash;
+  auto& chain= page_hash.cell_get(id.fold());
+  page_hash_latch &hash_lock= page_hash.lock_get(chain);
+
+  hash_lock.lock_shared();
+  buf_page_t *b= page_hash.get(id, chain);
+  hash_lock.unlock_shared();
+  if (b)
+    return;
+  if (space->last_page_number() < page || !space->acquire())
+    return;
+
+  const size_t zip_size{space->zip_size()};
+  buf_block_t *block=
+    zip_size ? nullptr : buf_LRU_get_free_block(have_no_mutex);
+
+  if (buf_page_t *bpage=
+        buf_page_init_for_read(id, zip_size, chain, block))
+  {
+    const bool exist(uintptr_t(bpage) & 1);
+    bpage= reinterpret_cast<buf_page_t*>(uintptr_t(bpage) & ~uintptr_t{1});
+    if (exist)
+    {
+      bpage->unfix();
+      goto func_exit;
+    }
+    const ulint len{zip_size ? zip_size : srv_page_size};
+    if (UNIV_LIKELY(space->io(IORequest(IORequest::READ_ASYNC),
+                              os_offset_t{page} * len, len,
+                              zip_size ? bpage->zip.data : bpage->frame,
+                              bpage).err == DB_SUCCESS))
+    {
+      buf_read_ahead_count(1);
+      return;
+    }
+    buf_pool.corrupted_evict(bpage, buf_page_t::READ_FIX);
+  }
+  else
+func_exit:
+    buf_read_release(block);
+  space->release();
 }
 
 buf_block_t *buf_read_page(const page_id_t page_id, dberr_t *err,
@@ -580,42 +585,31 @@ void buf_read_page_background(const page_id_t page_id, fil_space_t *space,
   }
 }
 
-/** Applies linear read-ahead if in the buf_pool the page is a border page of
+/** Apply linear read-ahead if an undo log page is a border page of
 a linear read-ahead area and all the pages in the area have been accessed.
-Does not read any page if the read-ahead mechanism is not activated. Note
-that the algorithm looks at the 'natural' adjacent successor and
-predecessor of the page, which on the leaf level of a B-tree are the next
-and previous page in the chain of leaves. To know these, the page specified
-in (space, offset) must already be present in the buf_pool. Thus, the
-natural way to use this function is to call it when a page in the buf_pool
-is accessed the first time, calling this function just after it has been
-bufferfixed.
-NOTE 1: as this function looks at the natural predecessor and successor
-fields on the page, what happens, if these are not initialized to any
-sensible value? No problem, before applying read-ahead we check that the
-area to read is within the span of the space, if not, read-ahead is not
-applied. An uninitialized value may result in a useless read operation, but
-only very improbably.
-NOTE 2: the calling thread may own latches on pages: to avoid deadlocks this
-function must be written such that it cannot end up waiting for these
-latches!
-@param[in]	page_id		page id; see NOTE 3 above
+Does not read any page if the read-ahead mechanism is not activated.
+@param space     undo tablespace or fil_system.space, or nullptr
+@param id        undo page identifier
 @return number of page read requests issued */
-ulint buf_read_ahead_linear(const page_id_t page_id) noexcept
+TRANSACTIONAL_TARGET
+ulint buf_read_ahead_undo(fil_space_t *space, const page_id_t page_id) noexcept
 {
-  /* check if readahead is disabled.
-  Disable the read ahead logic for temporary tablespace */
-  if (!srv_read_ahead_threshold || page_id.space() >= SRV_TMP_SPACE_ID)
+  if (!srv_read_ahead_threshold)
     return 0;
 
   if (srv_startup_is_before_trx_rollback_phase)
     /* No read-ahead to avoid thread deadlocks */
     return 0;
 
-  if (os_aio_pending_reads_approx() >
-      buf_pool.curr_size() / BUF_READ_AHEAD_PEND_LIMIT)
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
     return 0;
 
+  /* Prevent race condition with undo tablespace truncation by checking
+  if the space is being truncated (STOPPING_READS flag set) */
+  if (!space->acquire())
+    return 0;
+
+  ut_ad(!space->zip_size());
   const uint32_t buf_read_ahead_area= buf_pool.read_ahead_area;
   const page_id_t low= page_id - (page_id.page_no() % buf_read_ahead_area);
   const page_id_t high_1= low + (buf_read_ahead_area - 1);
@@ -625,35 +619,46 @@ ulint buf_read_ahead_linear(const page_id_t page_id) noexcept
   const bool descending= page_id != low;
 
   if (!descending && page_id != high_1)
-    /* This is not a border page of the area */
-    return 0;
-
-  fil_space_t *space= fil_space_t::get(page_id.space());
-  if (!space)
-    return 0;
-
-  if (high_1.page_no() > space->last_page_number())
   {
-    /* The area is not whole. */
-fail:
+    /* This is not a border page of the area */
     space->release();
     return 0;
   }
 
-  if (trx_sys_hdr_page(page_id))
-    /* If it is an ibuf bitmap page or trx sys hdr, we do no
-    read-ahead, as that could break the ibuf page access order */
-    goto fail;
+  ulint count;
+
+  /* Re-check if space is being truncated before
+  using last_page_number(). This prevents race
+  where acquire() succeeded but truncation started
+  before we check the page bounds. */
+  if (space->is_stopping())
+  {
+    space->release();
+    return 0;
+  }
+
+  if (high_1.page_no() > space->last_page_number())
+  {
+    /* The area is not whole. */
+  fail:
+    count= 0;
+    space->release();
+    return count;
+  }
 
   /* How many out of order accessed pages can we ignore
   when working out the access pattern for linear readahead */
-  ulint count= std::min<ulint>(buf_pool_t::READ_AHEAD_PAGES -
-                               srv_read_ahead_threshold,
-                               uint32_t{buf_pool.read_ahead_area});
+  count= std::min<ulint>(buf_pool_t::READ_AHEAD_PAGES -
+                         srv_read_ahead_threshold,
+                         uint32_t{buf_pool.read_ahead_area});
   page_id_t new_low= low, new_high_1= high_1;
   unsigned prev_accessed= 0;
   for (page_id_t i= low; i <= high_1; ++i)
   {
+    /* Check if space is being truncated during
+    access pattern analysis */
+    if (space->is_stopping())
+      goto fail;
     buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(i.fold());
     page_hash_latch &hash_lock= buf_pool.page_hash.lock_get(chain);
     /* It does not make sense to use transactional_lock_guard here,
@@ -738,41 +743,93 @@ failed:
   }
 
   /* If we got this far, read-ahead can be sensible: do it */
-  buf_block_t *block= nullptr;
-  unsigned zip_size{space->zip_size()};
-  if (UNIV_LIKELY(!zip_size))
-  {
-  allocate_block:
-    if (UNIV_UNLIKELY(!(block= buf_read_acquire())))
-      goto fail;
-  }
-  else if (recv_recovery_is_on())
-  {
-    zip_size|= 1;
-    goto allocate_block;
-  }
-
   count= 0;
   for (; new_low <= new_high_1; ++new_low)
   {
     if (space->is_stopping())
       break;
-    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(new_low.fold());
     space->reacquire();
-    if (reinterpret_cast<buf_page_t*>(-1) ==
-        buf_read_page_low(new_low, zip_size, nullptr,
-                          chain, space, block, nullptr))
-    {
-      count++;
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(new_low.fold());
+    if (buf_pool.page_hash_contains(new_low, chain))
+      goto func_exit;
+
+    buf_block_t *block= buf_read_acquire();
+    if (!block)
+      goto func_exit;
+
+    if (!buf_read_page_low(new_low, 0, nullptr, chain, space, block))
       ut_ad(!block);
-      if ((UNIV_LIKELY(!zip_size) || (zip_size & 1)) &&
-          UNIV_UNLIKELY(!(block= buf_read_acquire())))
-        break;
+    else
+      buf_read_release(block);
+
+    count++;
+  }
+func_exit:
+  buf_read_ahead_count(count);
+  space->release();
+  return count;
+}
+
+/** Read ahead a number of pages.
+@param space    tablespace
+@param pages    pages to read ahead
+@param ibuf     whether we are inside the ibuf routine */
+void buf_read_ahead_pages(fil_space_t *space,
+                          st_::span<const uint32_t> pages) noexcept
+{
+  ut_ad(!recv_recovery_is_on());
+  /* No space->is_stopping() re-check (cf. buf_read_ahead_undo()): the caller
+  is prefetching leaves of a user index/table being scanned, which is not
+  shrunk under a live scan; each page is guarded by space->acquire() and
+  last_page_number() below, and a lost race just fails that one read. */
+  if (os_aio_pending_reads_approx() > buf_pool.curr_size() / 2)
+    return;
+  page_id_t id{space->id, 0};
+  const size_t zip_size{space->zip_size()};
+  const ulint len{zip_size ? zip_size : srv_page_size};
+  ulint count= 0;
+  for (const uint32_t page : pages)
+  {
+    if (space->last_page_number() < page || !space->acquire())
+      return;
+    id.set_page_no(page);
+    buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(id.fold());
+    buf_block_t *block=
+      zip_size ? nullptr : buf_LRU_get_free_block(have_no_mutex);
+    if (buf_page_t *bpage=
+        buf_page_init_for_read(id, zip_size, chain, block))
+    {
+      const bool exist(uintptr_t(bpage) & 1);
+      bpage= reinterpret_cast<buf_page_t*>(uintptr_t(bpage) & ~uintptr_t{1});
+      if (exist)
+      {
+        bpage->unfix();
+        buf_read_release(block);
+        space->release();
+      }
+      else if (UNIV_LIKELY(space->io(IORequest(IORequest::READ_ASYNC),
+                                os_offset_t{id.page_no()} * len, len,
+                                zip_size ? bpage->zip.data : bpage->frame,
+                                bpage).err == DB_SUCCESS))
+        /* On success the reference acquired above is handed to the
+        asynchronous read and released on completion. */
+        count++;
+      else
+      {
+        buf_pool.corrupted_evict(bpage, buf_page_t::READ_FIX);
+        space->release();
+      }
+      continue;
     }
+
+    buf_read_release(block);
+    /* We stop on the first error, or the first page that already
+    resides in the buffer pool. */
+    space->release();
+    break;
   }
 
-  space->release();
-  return buf_read_release_count(block, count);
+  buf_read_ahead_count(count);
 }
 
 /** Schedule a page for recovery.

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -33,6 +33,7 @@ Created Jan 06, 2010 Vasil Dimov
 #include "log.h"
 #include "btr0btr.h"
 #include "btr0sea.h"
+#include "buf0rea.h"
 #include "que0que.h"
 #include "scope.h"
 #include "debug_sync.h"
@@ -1993,6 +1994,77 @@ struct n_diff_data_t {
 	ib_uint64_t	n_external_pages_sum;
 };
 
+/** Prefetch, as one asynchronous batch, the child pages of the records that
+dict_stats_analyze_index_for_n_prefix() is about to dive below.
+Must be called with the mini-transaction holding only the index SX-latch
+@param[in]	index		index being analyzed
+@param[in]	level		B-tree level the samples are picked from
+@param[in]	dive_idx	record indices to dive below
+@param[in,out]	mtr		mini-transaction */
+static
+void
+dict_stats_prefetch_sample_children(
+	dict_index_t*			index,
+	ulint				level,
+	const std::vector<ib_uint64_t>&	dive_idx,
+	mtr_t*				mtr)
+{
+	fil_space_t*	space = index->table->space;
+
+	if (!space || dive_idx.empty()) {
+		return;
+	}
+
+	const auto	sp = mtr->get_savepoint();
+	btr_pcur_t	pcur;
+
+	if (btr_pcur_open_level(&pcur, level, mtr, index) != DB_SUCCESS
+	    || !btr_pcur_move_to_next_on_page(&pcur)) {
+		mtr->rollback_to_savepoint(sp);
+		return;
+	}
+
+	std::vector<uint32_t>	pages;
+	pages.reserve(dive_idx.size());
+
+	mem_heap_t*	heap = NULL;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs_init(offsets_);
+
+	ib_uint64_t	rec_idx = 0;
+
+	for (ib_uint64_t di : dive_idx) {
+		while (rec_idx < di && btr_pcur_is_on_user_rec(&pcur)) {
+			btr_pcur_move_to_next_user_rec(&pcur, mtr);
+			rec_idx++;
+		}
+
+		/* The B-tree changed under us, or we reached the end of the
+		level: stop collecting, prefetch what we have. */
+		if (rec_idx != di || !btr_pcur_is_on_user_rec(&pcur)) {
+			break;
+		}
+
+		const rec_t*	rec = btr_pcur_get_rec(&pcur);
+		rec_offs*	offsets = rec_get_offsets(
+			rec, index, offsets_, 0, ULINT_UNDEFINED, &heap);
+
+		pages.push_back(btr_node_ptr_get_child_page_no(rec, offsets));
+	}
+
+	if (heap != NULL) {
+		mem_heap_free(heap);
+	}
+
+	mtr->rollback_to_savepoint(sp);
+
+	if (!pages.empty()) {
+		buf_read_ahead_pages(
+			space,
+			st_::span<const uint32_t>(pages.data(), pages.size()));
+	}
+}
+
 /** Estimate the number of different key values in an index when looking at
 the first n_prefix columns. For a given level in an index select
 n_diff_data->n_leaf_pages_to_analyze records from that level and dive below
@@ -2039,6 +2111,39 @@ dict_stats_analyze_index_for_n_prefix(
 	n_diff_data->n_diff_all_analyzed_pages = 0;
 	n_diff_data->n_external_pages_sum = 0;
 
+	/* Pick the record index to dive below in each of
+	n_leaf_pages_to_analyze segments (a random record from each), and
+	prefetch those pages up front so the dives below find warm pages. Both
+	the prefetch and the analysis pass use the same dive_idx, so they dive
+	below the same (randomly chosen) records. The prefetch must run here,
+	while the mtr still holds only the index SX-latch (savepoint == 1),
+	before we open our own level cursor - see
+	dict_stats_prefetch_sample_children(). */
+	const ib_uint64_t	last_idx_on_level = boundaries->at(
+		static_cast<unsigned>(n_diff_data->n_diff_on_level - 1));
+
+	std::vector<ib_uint64_t>	dive_idx;
+	dive_idx.reserve(static_cast<size_t>(
+		n_diff_data->n_leaf_pages_to_analyze));
+
+	for (i = 0; i < n_diff_data->n_leaf_pages_to_analyze; i++) {
+		const ib_uint64_t	n_diff = n_diff_data->n_diff_on_level;
+		const ib_uint64_t	n_pick
+			= n_diff_data->n_leaf_pages_to_analyze;
+		const ib_uint64_t	left = n_diff * i / n_pick;
+		const ib_uint64_t	right = n_diff * (i + 1) / n_pick - 1;
+
+		ut_a(left <= right);
+		ut_a(right <= last_idx_on_level);
+
+		dive_idx.push_back(boundaries->at(static_cast<unsigned>(
+			left + ut_rnd_interval(
+				static_cast<ulint>(right - left)))));
+	}
+
+	dict_stats_prefetch_sample_children(index, n_diff_data->level,
+					    dive_idx, mtr);
+
 	if (btr_pcur_open_level(&pcur, n_diff_data->level, mtr, index)
 	    != DB_SUCCESS
 	    || !btr_pcur_move_to_next_on_page(&pcur)) {
@@ -2060,55 +2165,12 @@ dict_stats_analyze_index_for_n_prefix(
 		return;
 	}
 
-	const ib_uint64_t	last_idx_on_level = boundaries->at(
-		static_cast<unsigned>(n_diff_data->n_diff_on_level - 1));
-
 	rec_idx = 0;
 
 	for (i = 0; i < n_diff_data->n_leaf_pages_to_analyze; i++) {
-		/* there are n_diff_on_level elements
-		in 'boundaries' and we divide those elements
-		into n_leaf_pages_to_analyze segments, for example:
-
-		let n_diff_on_level=100, n_leaf_pages_to_analyze=4, then:
-		segment i=0:  [0, 24]
-		segment i=1: [25, 49]
-		segment i=2: [50, 74]
-		segment i=3: [75, 99] or
-
-		let n_diff_on_level=1, n_leaf_pages_to_analyze=1, then:
-		segment i=0: [0, 0] or
-
-		let n_diff_on_level=2, n_leaf_pages_to_analyze=2, then:
-		segment i=0: [0, 0]
-		segment i=1: [1, 1] or
-
-		let n_diff_on_level=13, n_leaf_pages_to_analyze=7, then:
-		segment i=0:  [0,  0]
-		segment i=1:  [1,  2]
-		segment i=2:  [3,  4]
-		segment i=3:  [5,  6]
-		segment i=4:  [7,  8]
-		segment i=5:  [9, 10]
-		segment i=6: [11, 12]
-
-		then we select a random record from each segment and dive
-		below it */
-		const ib_uint64_t	n_diff = n_diff_data->n_diff_on_level;
-		const ib_uint64_t	n_pick
-			= n_diff_data->n_leaf_pages_to_analyze;
-
-		const ib_uint64_t	left = n_diff * i / n_pick;
-		const ib_uint64_t	right = n_diff * (i + 1) / n_pick - 1;
-
-		ut_a(left <= right);
-		ut_a(right <= last_idx_on_level);
-
-		const ulint	rnd = ut_rnd_interval(
-			static_cast<ulint>(right - left));
-
-		const ib_uint64_t	dive_below_idx
-			= boundaries->at(static_cast<unsigned>(left + rnd));
+		/* Dive below the record picked for this segment above (see the
+		dive_idx computation), and analyze the leaf page there. */
+		const ib_uint64_t	dive_below_idx = dive_idx[i];
 
 #if 0
 		DEBUG_PRINTF("    %s(): dive below record with index="

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -752,6 +752,20 @@ ATTRIBUTE_COLD bool fil_space_t::acquire_and_prepare() noexcept
   return is_open;
 }
 
+void fil_space_t::set_stopping_reads() noexcept
+{
+  mysql_mutex_lock(&fil_system.mutex);
+  n_pending.fetch_or(STOPPING_READS, std::memory_order_acquire);
+  mysql_mutex_unlock(&fil_system.mutex);
+}
+
+void fil_space_t::clear_stopping_reads() noexcept
+{
+  mysql_mutex_lock(&fil_system.mutex);
+  n_pending.fetch_and(~STOPPING_READS, std::memory_order_release);
+  mysql_mutex_unlock(&fil_system.mutex);
+}
+
 /** Try to extend a tablespace if it is smaller than the specified size.
 @param[in,out]	space	tablespace
 @param[in]	size	desired size in pages

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -112,6 +112,7 @@ bool is_update_query(enum enum_sql_command command);
 #include "row0ext.h"
 #include "trx0undo.h"
 #include "innodb_binlog.h"
+#include "buf0rea.h"
 
 #include "lz4.h"
 #include "lzo/lzo1x.h"
@@ -9192,6 +9193,17 @@ ha_innobase::index_read(
 		build_template(false);
 	}
 
+	/* Trigger full table scan with small size for read ahead operation. */
+	if (!key_len && !m_ra_max_pages) {
+		init_readahead_window(buf_pool_t::READ_AHEAD_PAGES);
+	}
+
+	uint32_t ra_buf[buf_pool_t::READ_AHEAD_PAGES];
+	btr_read_ahead_t read_ahead(ra_buf, std::min<uint>(
+		m_readahead_pages, buf_pool_t::READ_AHEAD_PAGES));
+	btr_read_ahead_t *read_ahead_ptr=
+		m_readahead_pages ? &read_ahead : nullptr;
+
 	if (key_len) {
 		ut_ad(key_ptr);
 		/* Convert the search key value to InnoDB format into
@@ -9224,9 +9236,12 @@ ha_innobase::index_read(
 
 	mariadb_set_stats temp(m_prebuilt->trx, handler_stats);
 	dberr_t ret =
-		row_search_mvcc(buf, mode, m_prebuilt, m_last_match_mode, 0);
+	  row_search_mvcc(buf, mode, m_prebuilt, m_last_match_mode, 0,
+			  read_ahead_ptr);
 
 	DBUG_EXECUTE_IF("ib_select_query_failure", ret = DB_ERROR;);
+
+	start_readahead(read_ahead, mode == PAGE_CUR_L || mode == PAGE_CUR_LE);
 
 	if (UNIV_LIKELY(ret == DB_SUCCESS)) {
 		table->status = 0;
@@ -9475,8 +9490,36 @@ ha_innobase::general_fetch(
 	int	error;
 
 	mariadb_set_stats temp(trx, handler_stats);
-	switch (dberr_t	ret = row_search_mvcc(buf, PAGE_CUR_UNSUPP, m_prebuilt,
-					      match_mode, direction)) {
+
+	/* Trigger read-ahead prefetch based on row count.
+	Refills halfway through the current batch to prevent
+	I/O stalls during index scans. */
+	if (m_ra_l1_page != FIL_NULL && m_ra_countdown && !--m_ra_countdown) {
+		readahead_refill();
+		m_ra_countdown= records_per_leaf() *
+			std::max<uint>(1, m_readahead_pages / 2);
+	}
+
+	/* A scan that positions through this path collects its leaf
+	pages during the first fetch's descent;
+	start_readahead() below then prefetches them and sets
+	up rolling read-ahead, as index_read() does.
+	Gated by sql_stat_start so only that first fetch collects. */
+	uint32_t ra_buf[buf_pool_t::READ_AHEAD_PAGES];
+	btr_read_ahead_t read_ahead(ra_buf, std::min<uint>(
+		m_readahead_pages, buf_pool_t::READ_AHEAD_PAGES));
+	btr_read_ahead_t *read_ahead_ptr=
+		(m_prebuilt->sql_stat_start && m_readahead_pages)
+		? &read_ahead : nullptr;
+
+	dberr_t ret = row_search_mvcc(buf, PAGE_CUR_UNSUPP, m_prebuilt,
+				      match_mode, direction, read_ahead_ptr);
+
+	if (read_ahead_ptr) {
+		start_readahead(read_ahead, direction == ROW_SEL_PREV);
+	}
+
+	switch (ret) {
 	case DB_SUCCESS:
 		error = 0;
 		table->status = 0;
@@ -9641,6 +9684,10 @@ ha_innobase::rnd_init(
 
 	if (!scan) {
 		try_semi_consistent_read(0);
+	} else if (!m_ra_max_pages) {
+		/* Full table scan: read the whole clustered index
+		in order, so enable read-ahead up to a full batch.*/
+		init_readahead_window(buf_pool_t::READ_AHEAD_PAGES);
 	}
 
 	m_start_of_scan = true;
@@ -16313,6 +16360,14 @@ ha_innobase::reset()
 	reset_template();
 
 	m_ds_mrr.dsmrr_close();
+	m_scanned_page_range = unused_page_range;
+	/* Clear all read-ahead state together */
+	m_readahead_pages = 0;
+	m_ra_max_pages = 0;
+	m_ra_l1_page = FIL_NULL;
+	m_ra_l1_child = FIL_NULL;
+	m_ra_desc = false;
+	m_ra_countdown = 0;
 
 	/* TODO: This should really be reset in reset_template() but for now
 	it's safer to do it explicitly here. */
@@ -20661,9 +20716,204 @@ static void innodb_params_adjust()
   ut_ad(MYSQL_SYSVAR_NAME(log_write_ahead_size).max_val == 4096);
 }
 
+/** Estimate the average number of records per leaf page
+from table statistics.
+@return records per leaf page, at least 1 */
+uint ha_innobase::records_per_leaf() const
+{
+  uint per_page= 0;
+  if (const uint page_size= uint(stats.block_size))
+  {
+    if (const ha_rows pages= stats.data_file_length / page_size)
+      per_page= uint(stats.records / pages);
+    if (active_index < table->s->keys)
+    {
+      const uint key_length= table->key_info[active_index].key_length;
+      if (key_length)
+      {
+        const uint max_records= page_size / key_length;
+        per_page= per_page ? std::min(per_page, max_records) : max_records;
+      }
+    }
+  }
+  return per_page ? per_page : 1;
+}
+
+/** Extract the number of leaf pages based on limit context
+@param limit estimated row to fetch
+@return leaf pages to read ahead */
+uint ha_innobase::mrr_readahead_pages(ha_rows limit) const
+{
+  const uint max_pages= buf_pool_t::READ_AHEAD_PAGES;
+
+  if (limit != HA_POS_ERROR && limit <= 2)
+    return 0;
+
+  if (limit == HA_POS_ERROR)
+    return max_pages;
+
+  /* Pages needed for the limit, plus a 20% margin for
+  sparse/deleted rows. */
+  const uint per_page= records_per_leaf();
+  ulonglong pages= (ulonglong(limit) + per_page - 1) / per_page;
+  pages+= pages / 5;
+  return uint(std::min<ulonglong>(pages ? pages : 1, max_pages));
+}
+
+/** Prefetch the next batch of leaf pages for the ongoing scan.
+Resumes from the read-ahead cursor (m_ra_l1_page / m_ra_l1_child):
+re-latches the PAGE_LEVEL=1 page under an index S-latch (To avoid
+split or reorganized), harvests the next m_readahead_pages
+child page numbers in scan order, chaining to the next level-1 sibling when
+the current one is exhausted, and issues buf_read_ahead_pages() for them.
+Aborts the read ahead when leaf reported by records_in_range()
+as the scan's last. */
+void ha_innobase::readahead_refill() noexcept
+{
+  dict_index_t *const index= m_prebuilt->index;
+  fil_space_t *const space= index->table->space;
+  if (!space || !index->is_btree())
+  {
+    m_ra_l1_page= FIL_NULL;
+    return;
+  }
+
+  const uint batch= std::min<uint>(m_readahead_pages,
+                                   buf_pool_t::READ_AHEAD_PAGES);
+  const uint32_t stop_page=
+    uint32_t(m_ra_desc ? m_scanned_page_range.first_page
+                       : m_scanned_page_range.last_page);
+  uint32_t pages[buf_pool_t::READ_AHEAD_PAGES];
+  btr_read_ahead_t ra(pages, batch);
+  uint32_t l1= m_ra_l1_page;
+  uint32_t resume_child= m_ra_l1_child;   /* FIL_NULL = start from page edge */
+  bool done= false;
+
+  mtr_t mtr{m_prebuilt->trx};
+  mtr.start();
+  mtr_s_lock_index(index, &mtr);
+
+  while (ra.n < ra.capacity && l1 != FIL_NULL && !done)
+  {
+    dberr_t err;
+    buf_block_t *block= btr_block_get(*index, l1, RW_S_LATCH, &mtr, &err);
+    if (!block || btr_page_get_level(block->page.frame) != 1)
+    {
+      done= true;
+      break;
+    }
+
+    /* Resume from the record after collecting the last child */
+    const rec_t *rec= btr_read_ahead_resume_rec(block, index, resume_child,
+                                                m_ra_desc);
+    if (!rec)
+    {
+      done= true;
+      break;
+    }
+
+    if (m_ra_desc ? page_rec_is_infimum(rec) : page_rec_is_supremum(rec))
+    {
+      /* This level-1 page has no more records in the scan direction */
+      l1= m_ra_desc ? btr_page_get_prev(block->page.frame)
+                    : btr_page_get_next(block->page.frame);
+      resume_child= FIL_NULL;
+      continue;
+    }
+
+    switch (btr_read_ahead_collect(&ra, index, rec, m_ra_desc, stop_page))
+    {
+    case BTR_RA_STOP:
+      done= true;
+      break;
+    case BTR_RA_FULL:
+      resume_child= ra.l1_child;
+      break;
+    case BTR_RA_EDGE:
+      l1= m_ra_desc ? btr_page_get_prev(block->page.frame)
+                    : btr_page_get_next(block->page.frame);
+      resume_child= FIL_NULL;
+      break;
+    }
+  }
+
+  mtr.commit();
+
+  m_ra_l1_page= done ? FIL_NULL : l1;
+  m_ra_l1_child= resume_child;
+
+  /* Increment the window for next readahead batch */
+  m_readahead_pages= std::min<uint>(m_readahead_pages * 2, m_ra_max_pages);
+
+  if (ra.n)
+    buf_read_ahead_pages(space, st_::span<const uint32_t>(pages, ra.n));
+}
+
+void ha_innobase::start_readahead(const btr_read_ahead_t &ra,
+                                  bool descending) noexcept
+{
+  m_ra_l1_page= FIL_NULL;
+  if (!ra.n)
+    return;
+
+  /* (1) Prefetch the leaves collected during the descent - one async batch. */
+  buf_read_ahead_pages(m_prebuilt->index->table->space,
+                       st_::span<const uint32_t>(ra.pages, ra.n));
+
+  /* (2) Set up the readahead parameter for next readahead batch. So
+  general_fetch() can keep prefetching as the scan advances. */
+  m_ra_desc= descending;
+  if (ra.l1_page != FIL_NULL)
+  {
+    m_ra_l1_page= ra.l1_page;
+    m_ra_l1_child= ra.l1_child;
+    m_ra_countdown= records_per_leaf() * std::max<uint>(1, ra.n / 2);
+  }
+}
+
 /****************************************************************************
  * DS-MRR implementation
  ***************************************************************************/
+
+void ha_innobase::advise_page_range(const page_range *scan_range)
+{
+  m_scanned_page_range= *scan_range;
+}
+
+/** Estimate the read-ahead page count for the upcoming range scan.
+The optimizer supplies, via advise_page_range(), the leaf-page extent
+[first_page, last_page] that the scan is expected to touch (from
+records_in_range()). We deliberately do NOT read that physical span:
+InnoDB interleaves indexes within a tablespace, so the numeric gap
+last_page - first_page is not a leaf count and the intervening pages
+may belong to other indexes. Instead the extent is used only as a
+coarse "how large is this scan" signal:
+
+  - first_page == last_page: the whole result fits on one leaf, so
+    read-ahead is pointless -> disabled.
+  - extent unknown: fall back to the LIMIT-based estimate.
+  - otherwise: a multi-leaf scan -> read ahead a full batch.
+
+The pages actually prefetched are the real leaves collected logically
+during the B-tree descent (see btr_cur_t::search_leaf()).
+@return leaf pages to read ahead (0 disables read-ahead) */
+uint ha_innobase::mrr_readahead_from_scan_range() const
+{
+  const page_range &r= m_scanned_page_range;
+
+  if (r.first_page == UNUSED_PAGE_NO || r.last_page == UNUSED_PAGE_NO)
+    /* Extent unknown: let the LIMIT heuristic decide. */
+    return mrr_readahead_pages(m_ds_mrr.get_limit());
+
+  if (r.first_page == r.last_page)
+    /* Single-leaf range: nothing to read ahead. */
+    return 0;
+
+  /* Multi-leaf range: prefetch a full batch, but never more than the
+  LIMIT-derived bound would allow. */
+  const uint by_limit= mrr_readahead_pages(m_ds_mrr.get_limit());
+  return by_limit ? by_limit : buf_pool_t::READ_AHEAD_PAGES;
+}
 
 /**
 Multi Range Read interface, DS-MRR calls */
@@ -20675,8 +20925,9 @@ ha_innobase::multi_range_read_init(
 	uint		mode,
 	HANDLER_BUFFER*	buf)
 {
-	return(m_ds_mrr.dsmrr_init(this, seq, seq_init_param,
-				 n_ranges, mode, buf));
+    init_readahead_window(mrr_readahead_from_scan_range());
+    return(m_ds_mrr.dsmrr_init(this, seq, seq_init_param,
+				n_ranges, mode, buf));
 }
 
 int
@@ -20694,11 +20945,12 @@ ha_innobase::multi_range_read_info_const(
 	uint		n_ranges,
 	uint*		bufsz,
 	uint*		flags,
+	page_range*	pr,
         ha_rows         limit,
 	Cost_estimate*	cost)
 {
 	/* See comments in ha_myisam::multi_range_read_info_const */
-	m_ds_mrr.init(this, table);
+	m_ds_mrr.init(this, table, limit);
 
 	if (m_prebuilt->select_lock_type != LOCK_NONE) {
 		*flags |= HA_MRR_USE_DEFAULT_IMPL;
@@ -20706,7 +20958,7 @@ ha_innobase::multi_range_read_info_const(
 
 	ha_rows res= m_ds_mrr.dsmrr_info_const(keyno, seq, seq_init_param,
                                                n_ranges,
-                                               bufsz, flags, limit, cost);
+                                               bufsz, flags, pr, limit, cost);
 	return res;
 }
 

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -391,8 +391,14 @@ public:
 		uint			n_ranges,
 		uint*			bufsz,
 		uint*			flags,
-                ha_rows                 limit,
+		page_range*		pr,
+		ha_rows                 limit,
 		Cost_estimate*		cost) override;
+
+	/** Remember the leaf-page extent of an upcoming range
+	scan so that multi_range_read_init() can size the
+	read-ahead. */
+	void advise_page_range(const page_range *scan_range) override;
 
 	/** Initialize multi range read and get information.
 	@see DsMrr_impl::dsmrr_info
@@ -545,6 +551,80 @@ protected:
 	/** If true, disable the Rowid Filter. It is disabled when
 	the engine is intialized for making rnd_pos() calls */
 	bool                    m_disable_rowid_filter;
+
+	/** Current range scan is estimated to touch, as advised
+	by the optimizer via advise_page_range(). */
+	page_range	m_scanned_page_range= unused_page_range;
+
+	/** Read-ahead initial batch size for the first batch */
+	static constexpr uint RA_INITIAL_BATCH_SIZE= 4;
+
+	/** Current read-ahead window.
+	Leaves to prefetch in the next batch.
+	Starts small and readahead_refill() moves it toward
+	m_ra_max_pages. */
+	uint		m_readahead_pages= 0;
+
+	/** Read-ahead maximum limit for the current scan,
+	derived from the scan's estimated extent. */
+	uint		m_ra_max_pages= 0;
+
+	/** Enable read-ahead for a scan whose full window
+	is 'max_pages' leaves. */
+	void init_readahead_window(uint max_pages)
+	{
+		m_ra_max_pages= max_pages;
+		m_readahead_pages=
+		  max_pages
+		  ? std::min<uint>(RA_INITIAL_BATCH_SIZE, max_pages)
+		  : 0;
+	}
+
+	/** Marker for read-ahead mechanism. After first positioning,
+	read ahead prefetches only RA_INITIAL_BATCH_SIZE and these
+	fields acts as a marker and makes general_fetch() keep prefetching
+	further as the scan advances */
+	/** PAGE_LEVEL=1 page to resume read ahead from */
+	uint32_t	m_ra_l1_page= 0xFFFFFFFF;
+
+	/** child page number of the last node pointer read ahead was
+	requested from m_ra_l1_page; FIL_NULL = resume from the page edge. */
+	uint32_t	m_ra_l1_child= 0xFFFFFFFF;
+
+	/** true if the scan runs in descending key order */
+	bool		m_ra_desc= false;
+	/** After m_ra_countdown rows returned, trigger next batch of
+	read ahead */
+	ha_rows		m_ra_countdown= 0;
+
+	/** Estimate the average number of records per leaf page (>= 1). */
+	uint records_per_leaf() const;
+
+	/** Prefetch the next batch of leaves for the ongoing scan,
+	resuming from the read-ahead cursor. */
+	void readahead_refill() noexcept;
+
+	/** Start read-ahead for a just-positioned scan.
+	Set the marker like m_ra_l1_page, m_ra_l1_child during inital
+	positioning. so general_fetch() can continue prefetching
+	as the scan advances.
+	@param ra          Read ahead context filled during the
+			   positioning descent
+	@param descending  whether the scan proceeds in key order */
+	void start_readahead(const btr_read_ahead_t &ra,
+                             bool descending) noexcept;
+
+	/** Estimate how many leaf pages to prefetch for a
+	positioning read.
+	@param limit  estimated rows to fetch,
+	@return leaf pages to read ahead */
+	uint mrr_readahead_pages(ha_rows limit) const;
+
+	/** Estimate the read-ahead page count from the scan's
+	advised leaf-page extent (m_scanned_page_range),
+	falling back to the LIMIT.
+	@return leaf pages to read ahead */
+	uint mrr_readahead_from_scan_range() const;
 };
 
 

--- a/storage/innobase/include/btr0cur.h
+++ b/storage/innobase/include/btr0cur.h
@@ -660,6 +660,51 @@ enum btr_cur_method {
 #endif
 };
 
+/** Return value of btr_read_ahead_collect() */
+enum btr_ra_result
+{
+  /* Already read full capacity */
+  BTR_RA_FULL,
+  /* Current level page was completed; sibling may continue it */
+  BTR_RA_EDGE,
+  /* Reached stop_page */
+  BTR_RA_STOP
+};
+
+/** Read node-pointer leaf page numbers from a single PAGE_LEVEL=1
+page into a read-ahead collector, walking from rec in scan order.
+Appends to ra->pages and updates ra->l1_child, so a later call can
+resume from where this one stopped by re-locating that child.
+@param ra          read ahead collector to append to
+@param index       index the record belongs to
+@param rec         first node pointer to harvest
+@param descending  walk backwards (prev) rather than forwards (next)
+@param stop_page   if not FIL_NULL, stop right after the child
+@retval BTR_RA_FULL when ra->n reached ra->capacity
+@retval BTR_RA_EDGE when ra->l1_page was completely scanned
+@retval BTR_RA_STOP when child reached stop_page */
+btr_ra_result btr_read_ahead_collect(btr_read_ahead_t *ra,
+                                     const dict_index_t *index,
+                                     const rec_t *rec, bool descending,
+                                     uint32_t stop_page=FIL_NULL) noexcept;
+
+/** Find the record on a PAGE_LEVEL=1 page from which read-ahead should
+resume. Node pointer following the one whose child page number
+is 'resume_child'. The page is walked only through its genuine record
+chain (from the infimum/supremum), so a concurrent reorganization
+cannot cause an invalid read; at worst the child is not found.
+@param block         PAGE_LEVEL=1 page
+@param index         index the record belongs to
+@param resume_child  child page number last read, or FIL_NULL to resume
+                     from the page edge
+@param descending    scan direction
+@return the record to resume harvesting from
+@retval nullptr if 'resume_child' is no longer present on this page */
+const rec_t *btr_read_ahead_resume_rec(const buf_block_t *block,
+                                       const dict_index_t *index,
+                                       uint32_t resume_child,
+                                       bool descending) noexcept;
+
 /** The tree cursor: the definition appears here only for the compiler
 to know struct size! */
 struct btr_cur_t {
@@ -721,18 +766,25 @@ struct btr_cur_t {
   @param index         B-tree
   @param latch_mode    which latches to acquire
   @param mtr           mini-transaction
+  @param read_ahead    optional context for logical read-ahead;
+                       if set, leaf page numbers are collected at
+                       PAGE_LEVEL=1
   @return error code */
   dberr_t open_leaf(bool first, dict_index_t *index, btr_latch_mode latch_mode,
-                    mtr_t *mtr);
+                    mtr_t *mtr, btr_read_ahead_t *read_ahead= nullptr);
 
   /** Search the leaf page record corresponding to a key.
   @param tuple      key to search for, with correct n_fields_cmp
   @param mode       search mode; PAGE_CUR_LE for unique prefix or for inserting
   @param latch_mode latch mode
   @param mtr        mini-transaction
+  @param read_ahead optional context for logical read-ahead;
+                    if set, leaf page numbers are collected at
+                    PAGE_LEVEL=1
   @return error code */
   dberr_t search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
-                      btr_latch_mode latch_mode, mtr_t *mtr);
+                      btr_latch_mode latch_mode, mtr_t *mtr,
+                      btr_read_ahead_t *read_ahead = nullptr);
 
   /** Search the leaf page record corresponding to a key, exclusively latching
   all sibling pages on the way.

--- a/storage/innobase/include/btr0pcur.h
+++ b/storage/innobase/include/btr0pcur.h
@@ -79,11 +79,13 @@ cursor.
 @param latch_mode BTR_SEARCH_LEAF, ...
 @param cursor     memory buffer for persistent cursor
 @param mtr        mini-transaction
+@param read_ahead context for read ahead operation
 @return DB_SUCCESS on success or error code otherwise. */
 inline
 dberr_t btr_pcur_open_with_no_init(const dtuple_t *tuple, page_cur_mode_t mode,
                                    btr_latch_mode latch_mode,
-                                   btr_pcur_t *cursor, mtr_t *mtr);
+                                   btr_pcur_t *cursor, mtr_t *mtr,
+                                   btr_read_ahead_t *read_ahead = nullptr);
 
 /**************************************************************//**
 Gets the up_match value for a pcur after a search.
@@ -381,7 +383,7 @@ struct btr_pcur_t
   @param mtr           mini-transaction
   @return error code */
   dberr_t open_leaf(bool first, dict_index_t *index, btr_latch_mode latch_mode,
-                    mtr_t *mtr)
+                    mtr_t *mtr, btr_read_ahead_t *read_ahead = nullptr)
 
   {
     this->latch_mode= BTR_LATCH_MODE_WITHOUT_FLAGS(latch_mode);
@@ -389,7 +391,7 @@ struct btr_pcur_t
     pos_state= BTR_PCUR_IS_POSITIONED;
     old_rec= nullptr;
 
-    return btr_cur.open_leaf(first, index, this->latch_mode, mtr);
+    return btr_cur.open_leaf(first, index, this->latch_mode, mtr, read_ahead);
   }
 };
 

--- a/storage/innobase/include/btr0pcur.inl
+++ b/storage/innobase/include/btr0pcur.inl
@@ -313,13 +313,14 @@ cursor.
 inline
 dberr_t btr_pcur_open_with_no_init(const dtuple_t *tuple, page_cur_mode_t mode,
                                    btr_latch_mode latch_mode,
-                                   btr_pcur_t *cursor, mtr_t *mtr)
+                                   btr_pcur_t *cursor, mtr_t *mtr,
+                                   btr_read_ahead_t *read_ahead)
 {
   cursor->latch_mode= BTR_LATCH_MODE_WITHOUT_INTENTION(latch_mode);
   cursor->search_mode= mode;
   cursor->pos_state= BTR_PCUR_IS_POSITIONED;
   cursor->trx_if_known= nullptr;
-  return cursor->btr_cur.search_leaf(tuple, mode, latch_mode, mtr);
+  return cursor->btr_cur.search_leaf(tuple, mode, latch_mode, mtr, read_ahead);
 }
 
 /**************************************************************//**

--- a/storage/innobase/include/btr0types.h
+++ b/storage/innobase/include/btr0types.h
@@ -105,3 +105,25 @@ enum btr_latch_mode {
 	/** Try to delete mark a spatial index record */
 	BTR_RTREE_DELETE_MARK = 256
 };
+
+/** Collector of B-tree leaf child page numbers gathered
+during a root-to-leaf descent (at PAGE_LEVEL=1), used to drive
+logical read-ahead. */
+struct btr_read_ahead_t
+{
+  /** Array receiving up to capacity child page numbers */
+  uint32_t *const pages;
+  /** capacity of pages[] */
+  const uint capacity;
+  /** number of entries filled in pages[] */
+  uint n= 0;
+  /** PAGE_LEVEL=1 page the child numbers were collected from, or
+  FIL_NULL if none. Used it with l1_child to resume the read ahead
+  operation */
+  uint32_t l1_page= 0xFFFFFFFF;
+  /** child page number of the last node pointer collected from
+  l1_page. */
+  uint32_t l1_child= 0xFFFFFFFF;
+
+  btr_read_ahead_t(uint32_t *buf, uint cap) : pages(buf), capacity(cap) {}
+};

--- a/storage/innobase/include/buf0rea.h
+++ b/storage/innobase/include/buf0rea.h
@@ -53,39 +53,32 @@ void buf_read_page_background(const page_id_t page_id, fil_space_t *space,
                               trx_t *trx) noexcept
   MY_ATTRIBUTE((nonnull(2)));
 
-/** Applies a random read-ahead in buf_pool if there are at least a threshold
-value of accessed pages from the random read-ahead area. Does not read any
-page, not even the one at the position (space, offset), if the read-ahead
-mechanism is not activated. NOTE: the calling thread may own latches on
-pages: to avoid deadlocks this function must be written such that it cannot
-end up waiting for these latches!
-@param[in]	page_id		page id of a page which the current thread
-wants to access
-@return number of page read requests issued */
-ulint buf_read_ahead_random(const page_id_t page_id) noexcept;
+/** Apply a random read-ahead of pages.
+@param space    tablespace
+@param low      first page to attempt to read
+@param high     last page to attempt to read */
+void buf_read_ahead_random(fil_space_t *space,
+                           page_id_t low, page_id_t high) noexcept;
 
-/** Applies linear read-ahead if in the buf_pool the page is a border page of
+/** Apply linear read-ahead if an undo log page is a border page of
 a linear read-ahead area and all the pages in the area have been accessed.
-Does not read any page if the read-ahead mechanism is not activated. Note
-that the algorithm looks at the 'natural' adjacent successor and
-predecessor of the page, which on the leaf level of a B-tree are the next
-and previous page in the chain of leaves. To know these, the page specified
-in (space, offset) must already be present in the buf_pool. Thus, the
-natural way to use this function is to call it when a page in the buf_pool
-is accessed the first time, calling this function just after it has been
-bufferfixed.
-NOTE 1: as this function looks at the natural predecessor and successor
-fields on the page, what happens, if these are not initialized to any
-sensible value? No problem, before applying read-ahead we check that the
-area to read is within the span of the space, if not, read-ahead is not
-applied. An uninitialized value may result in a useless read operation, but
-only very improbably.
-NOTE 2: the calling thread may own latches on pages: to avoid deadlocks this
-function must be written such that it cannot end up waiting for these
-latches!
-@param[in]	page_id		page id; see NOTE 3 above
+Does not read any page if the read-ahead mechanism is not activated.
+@param space     undo tablespace or fil_system.space, or nullptr
+@param id        undo page identifier
 @return number of page read requests issued */
-ulint buf_read_ahead_linear(const page_id_t page_id) noexcept;
+ulint buf_read_ahead_undo(fil_space_t *space, const page_id_t id) noexcept;
+
+/** Read ahead a page if it is not yet in the buffer pool.
+@param space    tablespace
+@param page     page to read ahead */
+void buf_read_ahead_one(fil_space_t *space, uint32_t page) noexcept;
+
+/** Read ahead a number of pages.
+@param space    tablespace
+@param pages    pages to read ahead
+@param ibuf     whether we are inside the ibuf routine */
+void buf_read_ahead_pages(fil_space_t *space,
+                          st_::span<const uint32_t> pages) noexcept;
 
 /** Schedule a page for recovery.
 @param space    tablespace

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -623,6 +623,12 @@ public:
     ut_ad((n & ~PENDING) == (STOPPING | CLOSING));
   }
 
+  /** Set the STOPPING_READS */
+  void set_stopping_reads() noexcept;
+
+  /** Clear the STOPPING_READS flag */
+  void clear_stopping_reads() noexcept;
+
 private:
   /** Clear the CLOSING flag */
   void clear_closing() noexcept

--- a/storage/innobase/include/row0sel.h
+++ b/storage/innobase/include/row0sel.h
@@ -144,7 +144,8 @@ row_search_mvcc(
 	page_cur_mode_t	mode,
 	row_prebuilt_t*	prebuilt,
 	ulint		match_mode,
-	ulint		direction)
+	ulint		direction,
+	btr_read_ahead_t* read_ahead = nullptr)
 	MY_ATTRIBUTE((warn_unused_result));
 
 /********************************************************************//**

--- a/storage/innobase/include/trx0undo.h
+++ b/storage/innobase/include/trx0undo.h
@@ -106,15 +106,13 @@ trx_undo_page_get_next_rec(const buf_block_t *undo_page, uint16_t rec,
                            uint32_t page_no, uint16_t offset);
 /** Get the previous record in an undo log.
 @param[in,out]  block   undo log page
+@param[in]	undo	undo log object
 @param[in]      rec     undo record offset in the page
-@param[in]      page_no undo log header page number
-@param[in]      offset  undo log header offset on page
-@param[in]      shared  latching mode: true=RW_S_LATCH, false=RW_X_LATCH
 @param[in,out]  mtr     mini-transaction
 @return undo log record, the page latched, NULL if none */
 trx_undo_rec_t*
-trx_undo_get_prev_rec(buf_block_t *&block, uint16_t rec, uint32_t page_no,
-                      uint16_t offset, bool shared, mtr_t *mtr);
+trx_undo_get_prev_rec(buf_block_t *&block, const trx_undo_t &undo,
+                      uint16_t rec, mtr_t *mtr);
 
 /** Get the first undo log record on a page.
 @param[in]	block	undo log page

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -624,6 +624,12 @@ void mtr_t::commit_shrink(fil_space_t &space, uint32_t size)
   const lsn_t start_lsn= do_write().first;
   ut_d(m_log.erase());
 
+  /* Set STOPPING_READS flag to prevent read-ahead operations
+  during truncation. This prevents race condition where
+  buf_read_ahead_undo() could request pages beyond the new
+  truncated size. */
+  space.set_stopping_reads();
+
   fil_node_t *file= UT_LIST_GET_LAST(space.chain);
   mysql_mutex_lock(&fil_system.mutex);
   ut_ad(file->is_open());
@@ -713,6 +719,7 @@ void mtr_t::commit_shrink(fil_space_t &space, uint32_t size)
 
   release();
   release_resources();
+  space.clear_stopping_reads();
 }
 
 /** Commit a mini-transaction that is deleting or renaming a file.

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -46,6 +46,7 @@ Completed by Sunny Bains and Marko Makela
 #include "row0vers.h"
 #include "handler0alter.h"
 #include "btr0bulk.h"
+#include "buf0rea.h"
 #ifdef BTR_CUR_ADAPT
 # include "btr0sea.h"
 #endif /* BTR_CUR_ADAPT */
@@ -2215,6 +2216,14 @@ end_of_index:
 				}
 
 				buf_page_make_young_if_needed(&block->page);
+
+				/* This is a sequential scan of the
+				whole clustered index, so the
+				following leaf is certain to be read
+				next. */
+				buf_read_ahead_one(
+					old_table->space,
+					btr_page_get_next(block->page.frame));
 
 				const auto s = mtr.get_savepoint();
 				mtr.rollback_to_savepoint(s - 2, s - 1);

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -4345,7 +4345,8 @@ row_search_mvcc(
 	page_cur_mode_t	mode,
 	row_prebuilt_t*	prebuilt,
 	ulint		match_mode,
-	ulint		direction)
+	ulint		direction,
+	btr_read_ahead_t* read_ahead)
 {
 	DBUG_ENTER("row_search_mvcc");
 	DBUG_ASSERT(prebuilt->index->table == prebuilt->table);
@@ -4796,7 +4797,7 @@ wait_table_again:
 		} else {
 			err = btr_pcur_open_with_no_init(search_tuple, mode,
 							 BTR_SEARCH_LEAF,
-							 pcur, &mtr);
+							 pcur, &mtr, read_ahead);
 		}
 
 		if (err != DB_SUCCESS) {
@@ -4843,7 +4844,7 @@ page_corrupted:
 		}
 	} else if (mode == PAGE_CUR_G || mode == PAGE_CUR_L) {
 		err = pcur->open_leaf(mode == PAGE_CUR_G, index,
-				      BTR_SEARCH_LEAF, &mtr);
+				      BTR_SEARCH_LEAF, &mtr, read_ahead);
 
 		if (err != DB_SUCCESS) {
 			if (err == DB_DECRYPTION_FAILED) {

--- a/storage/innobase/row/row0undo.cc
+++ b/storage/innobase/row/row0undo.cc
@@ -324,8 +324,7 @@ static buf_block_t* row_undo_rec_get(undo_node_t* node)
 
 	buf_block_t* prev_page = undo_page;
 	if (trx_undo_rec_t* prev_rec = trx_undo_get_prev_rec(
-		    prev_page, offset, undo->hdr_page_no, undo->hdr_offset,
-		    true, &mtr)) {
+		    prev_page, *undo, offset, &mtr)) {
 		if (prev_page != undo_page) {
 			trx->pages_undone++;
 		}

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -620,9 +620,7 @@ static dberr_t trx_resurrect_table_locks(trx_t *trx, const trx_undo_t &undo)
                             &updated_extern, &undo_no, &table_id);
       tables.emplace(table_id, type == TRX_UNDO_EMPTY);
       ut_ad(page_offset(undo_rec) == undo_rec_offset);
-      undo_rec= trx_undo_get_prev_rec(block, undo_rec_offset,
-                                      undo.hdr_page_no, undo.hdr_offset,
-                                      true, &mtr);
+      undo_rec= trx_undo_get_prev_rec(block, undo, undo_rec_offset, &mtr);
       if (!undo_rec)
         break;
       undo_rec_offset= uint16_t(undo_rec - block->page.frame);

--- a/storage/maria/ha_maria.cc
+++ b/storage/maria/ha_maria.cc
@@ -4259,7 +4259,8 @@ int ha_maria::multi_range_read_next(range_id_t *range_info)
 ha_rows ha_maria::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                void *seq_init_param,
                                                uint n_ranges, uint *bufsz,
-                                              uint *flags, ha_rows limit,
+                                              uint *flags,  page_range *pr,
+                                              ha_rows limit,
                                               Cost_estimate *cost)
 {
   /*
@@ -4269,7 +4270,7 @@ ha_rows ha_maria::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   */
   ds_mrr.init(this, table);
   return ds_mrr.dsmrr_info_const(keyno, seq, seq_init_param, n_ranges, bufsz,
-                                 flags, limit, cost);
+                                 flags, pr, limit, cost);
 }
 
 ha_rows ha_maria::multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/storage/maria/ha_maria.h
+++ b/storage/maria/ha_maria.h
@@ -168,7 +168,7 @@ public:
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param,
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, ha_rows limit,
+                                      uint *flags, page_range *pr, ha_rows limit,
                                       Cost_estimate *cost) override final;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz,

--- a/storage/mroonga/ha_mroonga.cpp
+++ b/storage/mroonga/ha_mroonga.cpp
@@ -12340,6 +12340,7 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+                                                        page_range *pr,
                                                         ha_rows limit,
                                                         Cost_estimate *cost)
 {
@@ -12348,8 +12349,8 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   KEY *key_info = &(table->key_info[keyno]);
   if (mrn_is_geo_key(key_info)) {
     rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                n_ranges, bufsz, flags, limit,
-                                                cost);
+                                                n_ranges, bufsz, flags, pr,
+                                                limit, cost);
     DBUG_RETURN(rows);
   }
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
@@ -12358,7 +12359,7 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
     set_pk_bitmap();
   rows = wrap_handler->multi_range_read_info_const(keyno, seq, seq_init_param,
                                                    n_ranges, bufsz, flags,
-                                                   limit, cost);
+                                                   pr, limit, cost);
   MRN_SET_BASE_SHARE_KEY(share, table->s);
   MRN_SET_BASE_TABLE_KEY(this, table);
   DBUG_RETURN(rows);
@@ -12370,6 +12371,7 @@ ha_rows ha_mroonga::storage_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+                                                        page_range *pr,
                                                         ha_rows limit,
                                                         Cost_estimate *cost)
 {
@@ -12377,14 +12379,15 @@ ha_rows ha_mroonga::storage_multi_range_read_info_const(uint keyno,
   ha_rows rows = handler::multi_range_read_info_const(keyno, seq,
                                                       seq_init_param,
                                                       n_ranges, bufsz, flags,
-                                                      limit, cost);
+                                                      pr, limit, cost);
   DBUG_RETURN(rows);
 }
 
 ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                 void *seq_init_param,
                                                 uint n_ranges, uint *bufsz,
-                                                uint *flags, ha_rows limit,
+                                                uint *flags, page_range *pr,
+                                                ha_rows limit,
                                                 Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -12393,11 +12396,11 @@ ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   {
     rows = wrapper_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, limit, cost);
+                                               flags, pr, limit, cost);
   } else {
     rows = storage_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, limit, cost);
+                                               flags, pr, limit, cost);
   }
   DBUG_RETURN(rows);
 }

--- a/storage/mroonga/ha_mroonga.hpp
+++ b/storage/mroonga/ha_mroonga.hpp
@@ -494,7 +494,8 @@ public:
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param,
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, ha_rows limit,
+                                      uint *flags, page_range *pr,
+                                      ha_rows limit,
                                       Cost_estimate *cost) mrn_override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
 #ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_KEY_PARTS
@@ -1047,6 +1048,7 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+                                              page_range *pr,
                                               ha_rows limit,
                                               Cost_estimate *cost);
   ha_rows storage_multi_range_read_info_const(uint keyno,
@@ -1055,6 +1057,7 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+                                              page_range *pr,
                                               ha_rows limit,
                                               Cost_estimate *cost);
   ha_rows wrapper_multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/storage/myisam/ha_myisam.cc
+++ b/storage/myisam/ha_myisam.cc
@@ -2649,7 +2649,8 @@ int ha_myisam::multi_range_read_next(range_id_t *range_info)
 ha_rows ha_myisam::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                void *seq_init_param, 
                                                uint n_ranges, uint *bufsz,
-                                               uint *flags, ha_rows limit,
+                                               uint *flags, page_range* pr,
+                                               ha_rows limit,
                                                Cost_estimate *cost)
 {
   /*
@@ -2659,7 +2660,7 @@ ha_rows ha_myisam::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   */
   ds_mrr.init(this, table);
   return ds_mrr.dsmrr_info_const(keyno, seq, seq_init_param, n_ranges, bufsz,
-                                 flags, limit, cost);
+                                 flags, pr, limit, cost);
 }
 
 ha_rows ha_myisam::multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/storage/myisam/ha_myisam.h
+++ b/storage/myisam/ha_myisam.h
@@ -154,7 +154,7 @@ class ha_myisam final : public handler
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param, 
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, ha_rows limit,
+                                      uint *flags, page_range *pr, ha_rows limit,
                                       Cost_estimate *cost) override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz, 

--- a/storage/spider/ha_spider.cc
+++ b/storage/spider/ha_spider.cc
@@ -2382,6 +2382,7 @@ ha_rows ha_spider::multi_range_read_info_const(
   uint n_ranges,
   uint *bufsz,
   uint *flags,
+  page_range *pr,
   ha_rows limit,
   Cost_estimate *cost
 )
@@ -2422,6 +2423,7 @@ ha_rows ha_spider::multi_range_read_info_const(
       n_ranges,
       bufsz,
       flags,
+      pr,
       limit,
       cost
     );

--- a/storage/spider/ha_spider.h
+++ b/storage/spider/ha_spider.h
@@ -297,6 +297,7 @@ public:
     uint n_ranges,
     uint *bufsz,
     uint *flags,
+    page_range *pr,
     ha_rows limit,
     Cost_estimate *cost
   ) override;

--- a/storage/videx/ha_videx.cc
+++ b/storage/videx/ha_videx.cc
@@ -120,7 +120,8 @@ public:
 
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param, uint n_ranges,
-                                      uint *bufsz, uint *flags, ha_rows limit,
+                                      uint *bufsz, uint *flags, page_range *pr,
+                                      ha_rows limit,
                                       Cost_estimate *cost) override;
 
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
@@ -737,13 +738,14 @@ int ha_videx::multi_range_read_next(range_id_t *range_info)
 ha_rows ha_videx::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                               void *seq_init_param,
                                               uint n_ranges, uint *bufsz,
-                                              uint *flags, ha_rows limit,
+                                              uint *flags, page_range *pr,
+                                              ha_rows limit,
                                               Cost_estimate *cost)
 {
   m_ds_mrr.init(this, table);
 
   return (m_ds_mrr.dsmrr_info_const(keyno, seq, seq_init_param, n_ranges,
-                                    bufsz, flags, limit, cost));
+                                    bufsz, flags, pr, limit, cost));
 }
 
 ha_rows ha_videx::multi_range_read_info(uint keyno, uint n_ranges, uint keys,


### PR DESCRIPTION
MDEV-32067 InnoDB linear read ahead had better be logical
    
    The traditional linear read-ahead, enabled by innodb_read_ahead_threshold=56,
    only works if pages are allocated on adjacent page numbers, which is not
    always the case for B-tree leaf pages.
    
    After this change, the exact nonzero values of
    innodb_read_ahead_threshold matter only for the read-ahead of
    undo log pages.
    
    Introduced Multi-Range Read (MRR) aware read-ahead that collects
    actual leaf page numbers during B-tree traversal
    
    buf_read_ahead_undo(): Renamed from buf_read_ahead_linear().
    This function will no longer be invoked on any BLOB pages
    (for which FIL_PAGE_PREV and FIL_PAGE_NEXT were not initialized
    consistently) nor on any index pages. For index leaf pages,
    we will introduce buf_read_ahead_one() and buf_read_ahead_pages().
    
    buf_read_ahead_one(): Read ahead one (sibling leaf) page.
    This logic cannot be disabled.
    
    buf_read_ahead_pages(): Read ahead B-tree index leaf pages.
    
    buf_read_ahead_random(): Split the function into two parts: one
    that determines which range of pages should be read, and another
    that actually initiates a read of the pages.
    
    btr_pcur_move_to_next_page(): Invoke buf_read_ahead_one()
    instead of buf_read_ahead_linear().
    
    btr_pcur_move_backward_from_page(): Implement a fast path of
    trying to acquire a latch on the previous page without waiting,
    and invoke buf_read_ahead_one() on the preceding page, with the
    assumption that we may be accessing that page in the near future.
    
    btr_copy_blob_prefix(): Simplify the logic. On other than
    ROW_FORMAT=COMPRESSED BLOB pages, the FIL_PAGE_NEXT field is not
    meaningfully initialized. The FIL_PAGE_PREV field is not pointing
    to anything meaningful either. buf_read_ahead_linear() expects
    these to be set meaningfully. Only the non-default setting
    innodb_random_read_ahead=ON might be meaningful here.
    
    btr_cur_t::search_leaf(): Add MRR read-ahead context to collect
    leaf page numbers at PAGE_LEVEL=1 during B-tree traversal.
    The collected page numbers represent actual leaf pages that
    will be accessed, enabling more targeted
    read-ahead than linear page number assumptions.
    
    mrr_readahead_ctx_t: New structure for passing MRR context
    through the call chain from ha_innobase -> row_search_mvcc()
    -> btr_pcur_open() -> search_leaf() and it has
    READ_AHEAD_PAGES=64 limit.
