### PR TITLE
MDEV-37948 ALTER TABLE TRUNCATE PARTITION requires only DROP privilege

### DIFF
--- a/mysql-test/main/partition_grant.result
+++ b/mysql-test/main/partition_grant.result
@@ -49,3 +49,49 @@ drop table t1;
 drop user mysqltest_1@localhost;
 drop schema mysqltest_1;
 End of 5.1 tests
+#
+# MDEV-37948: ALTER TABLE ... TRUNCATE PARTITION should require
+# ALTER or DROP privilege
+#
+CREATE DATABASE mysqltest_2;
+USE mysqltest_2;
+CREATE TABLE t1 (a INT)
+PARTITION BY LIST (a) (
+PARTITION p1 VALUES IN (1),
+PARTITION p2 VALUES IN (2),
+PARTITION p3 VALUES IN (3)
+);
+INSERT INTO t1 VALUES (1),(2),(3);
+CREATE USER mysqltest_2@localhost;
+# Test with only DROP privilege (should succeed)
+GRANT DROP ON mysqltest_2.* TO mysqltest_2@localhost;
+connect  conn_drop,localhost,mysqltest_2,,mysqltest_2;
+SHOW GRANTS FOR CURRENT_USER;
+Grants for mysqltest_2@localhost
+GRANT USAGE ON *.* TO `mysqltest_2`@`localhost`
+GRANT DROP ON `mysqltest_2`.* TO `mysqltest_2`@`localhost`
+ALTER TABLE t1 TRUNCATE PARTITION p1;
+disconnect conn_drop;
+connection default;
+REVOKE DROP ON mysqltest_2.* FROM mysqltest_2@localhost;
+# Test with only ALTER privilege (should succeed)
+GRANT ALTER ON mysqltest_2.* TO mysqltest_2@localhost;
+connect  conn_alter,localhost,mysqltest_2,,mysqltest_2;
+SHOW GRANTS FOR CURRENT_USER;
+Grants for mysqltest_2@localhost
+GRANT USAGE ON *.* TO `mysqltest_2`@`localhost`
+GRANT ALTER ON `mysqltest_2`.* TO `mysqltest_2`@`localhost`
+ALTER TABLE t1 TRUNCATE PARTITION p2;
+disconnect conn_alter;
+connection default;
+REVOKE ALTER ON mysqltest_2.* FROM mysqltest_2@localhost;
+# Test with no privileges (should fail)
+GRANT SELECT ON mysqltest_2.* TO mysqltest_2@localhost;
+connect  conn_none,localhost,mysqltest_2,,mysqltest_2;
+ALTER TABLE t1 TRUNCATE PARTITION p3;
+ERROR 42000: ALTER command denied to user 'mysqltest_2'@'localhost' for table `mysqltest_2`.`t1`
+disconnect conn_none;
+connection default;
+DROP TABLE t1;
+DROP USER mysqltest_2@localhost;
+DROP DATABASE mysqltest_2;

--- a/mysql-test/main/partition_grant.test
+++ b/mysql-test/main/partition_grant.test
@@ -80,3 +80,55 @@ drop user mysqltest_1@localhost;
 drop schema mysqltest_1;
 
 --echo End of 5.1 tests
+
+--echo #
+--echo # MDEV-37948: ALTER TABLE ... TRUNCATE PARTITION should require
+--echo # ALTER or DROP privilege
+--echo #
+
+CREATE DATABASE mysqltest_2;
+USE mysqltest_2;
+
+CREATE TABLE t1 (a INT)
+  PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (2),
+    PARTITION p3 VALUES IN (3)
+  );
+INSERT INTO t1 VALUES (1),(2),(3);
+
+CREATE USER mysqltest_2@localhost;
+
+--echo # Test with only DROP privilege (should succeed)
+GRANT DROP ON mysqltest_2.* TO mysqltest_2@localhost;
+
+connect (conn_drop,localhost,mysqltest_2,,mysqltest_2);
+SHOW GRANTS FOR CURRENT_USER;
+ALTER TABLE t1 TRUNCATE PARTITION p1;
+disconnect conn_drop;
+
+connection default;
+REVOKE DROP ON mysqltest_2.* FROM mysqltest_2@localhost;
+
+--echo # Test with only ALTER privilege (should succeed)
+GRANT ALTER ON mysqltest_2.* TO mysqltest_2@localhost;
+
+connect (conn_alter,localhost,mysqltest_2,,mysqltest_2);
+SHOW GRANTS FOR CURRENT_USER;
+ALTER TABLE t1 TRUNCATE PARTITION p2;
+disconnect conn_alter;
+
+connection default;
+REVOKE ALTER ON mysqltest_2.* FROM mysqltest_2@localhost;
+
+--echo # Test with no privileges (should fail)
+GRANT SELECT ON mysqltest_2.* TO mysqltest_2@localhost;
+connect (conn_none,localhost,mysqltest_2,,mysqltest_2);
+--error ER_TABLEACCESS_DENIED_ERROR
+ALTER TABLE t1 TRUNCATE PARTITION p3;
+disconnect conn_none;
+
+connection default;
+DROP TABLE t1;
+DROP USER mysqltest_2@localhost;
+DROP DATABASE mysqltest_2;

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -873,7 +873,8 @@ bool Sql_cmd_alter_table_truncate_partition::execute(THD *thd)
     write the statement to the binary log if necessary.
   */
 
-  if (check_one_table_access(thd, DROP_ACL, first_table))
+  if (check_single_table_access(thd, DROP_ACL, first_table, true) &&
+      check_single_table_access(thd, ALTER_ACL, first_table, false))
     DBUG_RETURN(TRUE);
 
 #ifdef WITH_WSREP


### PR DESCRIPTION
## Description

`ALTER TABLE ... TRUNCATE PARTITION` only checks for DROP privilege, which is inconsistent with the expectation that `ALTER TABLE` statements should require `ALTER` privilege. This creates a privilege gap since users with only `DROP` can truncate partitions without `ALTER` rights.
    
Add `ALTER` privilege check to `TRUNCATE PARTITION`, allowing either `DROP` or `ALTER` privilege for backwards compatibility. This matches the intended behavior while preserving existing functionality.

## Release Notes

N/A

## How can this PR be tested?

Execute the `main.partition_grant` test in mysql-test-run. This commit adds a test in `partition_grant.test`.

### Before the fix

A user with only `ALTER` privilege cannot truncate partitions (only DROP works):
```
main.partition_grant                     [ fail ]
        Test ended at 2026-02-25 19:04:08

CURRENT_TEST: main.partition_grant
mysqltest: At line 118: query 'ALTER TABLE t1 TRUNCATE PARTITION p2' failed: ER_TABLEACCESS_DENIED_ERROR (1142): DROP command denied to user 'mysqltest_2'@'localhost' for table `mysqltest_2`.`t1`

The result from queries just before the failure was:
< snip >
CREATE USER mysqltest_2@localhost;
# Test with only DROP privilege (should succeed)
GRANT DROP ON mysqltest_2.* TO mysqltest_2@localhost;
connect  conn_drop,localhost,mysqltest_2,,mysqltest_2;
SHOW GRANTS FOR CURRENT_USER;
Grants for mysqltest_2@localhost
GRANT USAGE ON *.* TO `mysqltest_2`@`localhost`
GRANT DROP ON `mysqltest_2`.* TO `mysqltest_2`@`localhost`
ALTER TABLE t1 TRUNCATE PARTITION p1;
disconnect conn_drop;
connection default;
REVOKE DROP ON mysqltest_2.* FROM mysqltest_2@localhost;
# Test with only ALTER privilege (should succeed)
GRANT ALTER ON mysqltest_2.* TO mysqltest_2@localhost;
connect  conn_alter,localhost,mysqltest_2,,mysqltest_2;
SHOW GRANTS FOR CURRENT_USER;
Grants for mysqltest_2@localhost
GRANT USAGE ON *.* TO `mysqltest_2`@`localhost`
GRANT ALTER ON `mysqltest_2`.* TO `mysqltest_2`@`localhost`
ALTER TABLE t1 TRUNCATE PARTITION p2;
```

### After the fix

A user needs either `ALTER` or `DROP` privilege to truncate partitions. Users with neither privilege are denied:
```
main.partition_grant                     [ pass ]    108
```
## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix, and the PR is based against the branch 10.6._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.