### PR TITLE
MDEV-34210 Improve auto-inc upgrade check message

### DIFF
--- a/mysql-test/suite/innodb/r/autoinc_import.result
+++ b/mysql-test/suite/innodb/r/autoinc_import.result
@@ -68,13 +68,13 @@ test.t1	check	status	OK
 test.t1b	check	status	OK
 test.t1t	check	status	OK
 test.t1z	check	status	OK
-test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7	check	status	OK
-test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7b	check	status	OK
-test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1	check	status	OK
-test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1b	check	status	OK
 CHECK TABLE t1, t1b, t1t, t1z, t5_7, t5_7b, t10_1, t10_1b FOR UPGRADE;
 Table	Op	Msg_type	Msg_text
@@ -82,13 +82,13 @@ test.t1	check	status	OK
 test.t1b	check	status	OK
 test.t1t	check	status	OK
 test.t1z	check	status	OK
-test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7	check	status	OK
-test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7b	check	status	OK
-test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1	check	status	OK
-test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1b	check	status	OK
 # restart: --innodb-read-only --read-only
 CHECK TABLE t1, t1b, t1t, t1z, t5_7, t5_7b, t10_1, t10_1b;
@@ -97,13 +97,13 @@ test.t1	check	status	OK
 test.t1b	check	status	OK
 test.t1t	check	status	OK
 test.t1z	check	status	OK
-test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7	check	status	OK
-test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7b	check	status	OK
-test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1	check	status	OK
-test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1b	check	status	OK
 CHECK TABLE t1, t1b, t1t, t1z, t5_7, t5_7b, t10_1, t10_1b FOR UPGRADE;
 Table	Op	Msg_type	Msg_text
@@ -111,13 +111,13 @@ test.t1	check	status	OK
 test.t1b	check	status	OK
 test.t1t	check	status	OK
 test.t1z	check	status	OK
-test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7	check	status	OK
-test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t5_7b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t5_7b	check	status	OK
-test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1	check	status	OK
-test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed
+test.t10_1b	check	note	Auto_increment will be checked on each open until CHECK TABLE FOR UPGRADE is executed when the server is not in a read-only state
 test.t10_1b	check	status	OK
 # restart: --innodb-read-only
 CHECK TABLE t1, t1b, t1t, t1z, t5_7, t5_7b, t10_1, t10_1b;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15268,7 +15268,7 @@ ha_innobase::check(
 	ulint		n_rows_in_table	= ULINT_UNDEFINED;
 	bool		is_ok		= true;
 	dberr_t		ret;
-        uint handler_flags= check_opt->handler_flags;
+	uint handler_flags= check_opt->handler_flags;
 
 	DBUG_ENTER("ha_innobase::check");
 	DBUG_ASSERT(thd == ha_thd());
@@ -15277,7 +15277,7 @@ ha_innobase::check(
 	ut_a(m_prebuilt->trx == thd_to_trx(thd));
 	ut_ad(m_prebuilt->trx->mysql_thd == thd);
 
-	if (handler_flags || check_for_upgrade(check_opt)) {
+	if (handler_flags) {
 		/* The file was already checked and fixed as part of open */
 		print_check_msg(thd, table->s->db.str, table->s->table_name.str,
 				"check", "note",
@@ -15286,9 +15286,10 @@ ha_innobase::check(
 				? "Auto_increment will be"
 				" checked on each open until"
 				" CHECK TABLE FOR UPGRADE is executed"
+				" when the server is not in a read-only state"
 				: "Auto_increment checked and"
 				" .frm file version updated", 1);
-		if (handler_flags && (check_opt->sql_flags & TT_FOR_UPGRADE)) {
+		if (check_opt->sql_flags & TT_FOR_UPGRADE) {
 			/*
 			  No other issues found (as handler_flags was only
 			  set if there as not other problems with the table
@@ -15502,7 +15503,7 @@ func_exit:
 }
 
 /**
-Check if we there is a problem with the InnoDB table.
+Check if there is a problem with the InnoDB table.
 @param check_opt     check options
 @retval HA_ADMIN_OK           if Table is ok
 @retval HA_ADMIN_NEEDS_ALTER  User should run ALTER TABLE FOR UPGRADE
@@ -15523,6 +15524,7 @@ int ha_innobase::check_for_upgrade(HA_CHECK_OPT *check_opt)
     if (m_prebuilt->table->get_index(*autoinc_col))
     {
       check_opt->handler_flags= 1;
+      // Prevent ha_check() from updating frm version if InnoDB (but not the server) is in a read-only state
       return (high_level_read_only && !opt_readonly)
         ? HA_ADMIN_FAILED : HA_ADMIN_NEEDS_CHECK;
     }

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -2527,7 +2527,7 @@ public:
   /** @return number of unique columns in FTS_DOC_ID index */
   unsigned fts_n_uniq() const { return versioned() ? 2 : 1; }
 
-  /** @return the index for that starts with a specific column */
+  /** @return the index that starts with a specific column */
   dict_index_t *get_index(const dict_col_t &col) const;
 
   /** @return whether the statistics are initialized */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Improvements to clarity for auto increment checks during `CHECK TABLE FOR UPGRADE` operations. The message now makes it clear that a `CHECK TABLE FOR UPGRADE` must be run while the engine is not in a read-only state for the auto increment check on each open notification to be cleared.

## Release Notes
N/A

## How can this PR be tested?

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

Existing `innodb.autoinc_import` MTR had been updated according to the new notification message.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.