### PR TITLE
MDEV-38735 Support --hex-blob option for mysqldump --tab/--dir and mariadb-import to preserve binary data

### DIFF
--- a/client/import_util.cc
+++ b/client/import_util.cc
@@ -23,6 +23,7 @@
 */
 
 #include <string>
+#include <cstring>
 #include <vector>
 #include <pcre2posix.h>
 
@@ -58,9 +59,17 @@ std::string extract_first_create_table(const std::string &script)
 TableDDLInfo::TableDDLInfo(const std::string &create_table_stmt)
 {
   regex_t primary_key_regex, constraint_regex, index_regex, engine_regex,
-      table_name_regex;
+      table_name_regex, column_regex;
   constexpr size_t MAX_MATCHES= 10;
   regmatch_t match[10];
+
+  // Extract just the CREATE TABLE statement if the input contains other SQL
+  std::string actual_create_table = extract_first_create_table(create_table_stmt);
+  if (actual_create_table.empty())
+  {
+    // Input might already be just the CREATE TABLE statement
+    actual_create_table = create_table_stmt;
+  }
 
   regcomp(&primary_key_regex, "\\n\\s*(PRIMARY\\s+KEY\\s+(.*?)),?\\n",
           REG_EXTENDED);
@@ -73,8 +82,13 @@ TableDDLInfo::TableDDLInfo(const std::string &create_table_stmt)
   regcomp(&engine_regex, "\\bENGINE\\s*=\\s*(\\w+)", REG_EXTENDED);
   regcomp(&table_name_regex, "CREATE\\s+TABLE\\s+(`?(?:[^`]|``)+`?)\\s*\\(",
           REG_EXTENDED);
+  // Column regex: matches lines starting with column name followed by type
+  // Must be inside parentheses, not starting with constraint/key keywords
+  regcomp(&column_regex,
+          "\\n\\s*(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*)\\s+([a-zA-Z]+[a-zA-Z0-9()]*)",
+          REG_EXTENDED);
 
-  const char *stmt= create_table_stmt.c_str();
+  const char *stmt= actual_create_table.c_str();
   const char *search_start= stmt;
 
   // Extract primary key
@@ -129,11 +143,108 @@ TableDDLInfo::TableDDLInfo(const std::string &create_table_stmt)
       }
     }
   }
+
+// Extract column definitions - find the column definition block
+  const char *col_start = strchr(stmt, '(');
+  if (col_start)
+  {
+    col_start++; // Move past the opening '('
+
+    // Find the matching closing parenthesis
+    int depth = 1;
+    const char *col_end = col_start;
+    bool in_string = false;
+    char string_delim = 0;
+
+    while (*col_end && depth > 0)
+    {
+      // Handle strings
+      if (!in_string && (*col_end == '\'' || *col_end == '"' || *col_end == '`'))
+      {
+        in_string = true;
+        string_delim = *col_end;
+      }
+      else if (in_string && *col_end == string_delim)
+      {
+        // Check for escaped delimiter
+        if (*(col_end + 1) == string_delim)
+          col_end++; // Skip escaped
+        else
+          in_string = false;
+      }
+      else if (!in_string)
+      {
+        if (*col_end == '(')
+          depth++;
+        else if (*col_end == ')')
+        {
+          depth--;
+          if (depth == 0)
+            break; // Found the matching closing paren
+        }
+      }
+      col_end++;
+    }
+
+    if (depth == 0 && col_end > col_start)
+    {
+      // col_end now points to the closing ')'
+      std::string columns_block(col_start, col_end - col_start);
+
+      // Now parse column definitions from this block only
+      // Pattern matches lines that start with whitespace + a backtick-quoted identifier 
+      // that may contain escaped backticks + whitespace + type
+      regcomp(&column_regex,
+              "\\n[ \\t]*(`([^`]|``)*`|[a-zA-Z_][a-zA-Z0-9_]*)[ \\t]+([a-zA-Z]+)",
+              REG_EXTENDED);
+
+      const char *block = columns_block.c_str();
+      search_start = block;
+
+      while (regexec(&column_regex, search_start, MAX_MATCHES, match, 0) == 0)
+      {
+        std::string col_name(search_start + match[1].rm_so,
+                             match[1].rm_eo - match[1].rm_so);
+        std::string col_type(search_start + match[3].rm_so,
+                             match[3].rm_eo - match[3].rm_so);
+
+        // Remove surrounding backticks and unescape doubled backticks inside
+        if (!col_name.empty() && col_name.front() == '`' && col_name.back() == '`')
+        {
+          std::string unescaped;
+          for (size_t k= 1; k < col_name.size() - 1; k++)
+          {
+            if (col_name[k] == '`' && k + 1 < col_name.size() - 1 &&
+                col_name[k + 1] == '`')
+              k++; /* skip the second backtick of an escaped pair */
+            unescaped += col_name[k];
+          }
+          col_name= unescaped;
+        }
+
+        // Convert to uppercase for comparison
+        std::string col_name_upper = col_name;
+        for (char &c : col_name_upper) c = toupper(c);
+
+        // Skip constraint/key lines
+        if (col_name_upper != "PRIMARY" && col_name_upper != "CONSTRAINT" &&
+            col_name_upper != "KEY" && col_name_upper != "INDEX" &&
+            col_name_upper != "UNIQUE" && col_name_upper != "FULLTEXT" &&
+            col_name_upper != "SPATIAL" && col_name_upper != "VECTOR")
+        {
+          columns.push_back({col_name, col_type});
+        }
+
+        search_start += match[0].rm_eo - 1;
+      }
+    }
+  }
   regfree(&primary_key_regex);
   regfree(&constraint_regex);
   regfree(&index_regex);
   regfree(&engine_regex);
   regfree(&table_name_regex);
+  regfree(&column_regex);
 }
 
 /**

--- a/client/import_util.h
+++ b/client/import_util.h
@@ -40,6 +40,12 @@ struct KeyDefinition
   std::string name;
 };
 
+struct ColumnInfo
+{
+  std::string name;
+  std::string type;
+};
+
 /**
    Information about keys and constraints, extracted from
    CREATE TABLE statement
@@ -50,6 +56,7 @@ struct TableDDLInfo
   KeyDefinition primary_key;
   std::vector<KeyDefinition> constraints;
   std::vector<KeyDefinition> secondary_indexes;
+  std::vector<ColumnInfo> columns;
   std::string storage_engine;
   std::string table_name;
   /* Innodb is using first UNIQUE key for clustering, if no PK is set*/

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -3473,7 +3473,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       mysql_free_result(result);
     }
     my_snprintf(query_buff, sizeof(query_buff),
-                "select column_name, extra, generation_expression, data_type "
+                "select column_name, extra, generation_expression, data_type, character_set_name "
                 "from information_schema.columns where table_schema=database() "
                 "and table_name=%s order by ordinal_position",
                 quote_for_equal(table, temp_buff));
@@ -3506,6 +3506,25 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
           dynstr_append_checked(&select_field_names_for_header, ", ");
       }
       init=1;
+      my_bool is_print_as_hex= 0;
+      /*
+        Check if this is a binary/blob field that should be hex-encoded.
+        For multi_file_output (--tab/--dir), we need to wrap with HEX() in SELECT.
+        Binary fields have character_set_name = NULL or 'binary'.
+      */
+      if (opt_hex_blob && multi_file_output && row[3])
+      {
+        /* Check for blob/binary types with binary charset */
+        if (strcmp(row[3], "binary") == 0 ||
+             strcmp(row[3], "varbinary") == 0 ||
+             strcmp(row[3], "tinyblob") == 0 ||
+             strcmp(row[3], "blob") == 0 ||
+             strcmp(row[3], "mediumblob") == 0 ||
+             strcmp(row[3], "longblob") == 0)
+        {
+          is_print_as_hex= 1;
+        }
+      }
 
       last_name= quote_name(row[0], name_buff, 0);
       if (opt_dump_history && *versioned && opt_update_history &&
@@ -3520,9 +3539,16 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
         dynstr_append_checked(&select_field_names, ") as ");
         dynstr_append_checked(&select_field_names, last_name);
       }
+      else if (is_print_as_hex)
+      {
+	dynstr_append_checked(&select_field_names, "HEX(");
+        dynstr_append_checked(&select_field_names, last_name);
+        dynstr_append_checked(&select_field_names, ") AS ");
+        dynstr_append_checked(&select_field_names, last_name);
+      }
       else
         dynstr_append_checked(&select_field_names, last_name);
-      dynstr_append_checked(&insert_field_names, last_name);
+        dynstr_append_checked(&insert_field_names, last_name);
       if (opt_header)
         dynstr_append_checked(&select_field_names_for_header,
                               quote_for_equal(row[0], name_buff));

--- a/mysql-test/main/mariadb-import.result
+++ b/mysql-test/main/mariadb-import.result
@@ -387,3 +387,361 @@ use test;
 mariadb-import: Path 'MYSQLTEST_VARDIR/tmp/non_existing' specified by option '--dir' does not exist
 # Test too many threads, builtin limit 256
 Too many connections, max value for --parallel is 256
+#
+# Test --hex-blob option for mariadb-import
+# Round-trip tests: export with mysqldump --hex-blob, import with mariadb-import --hex-blob
+#
+USE test;
+# Test 1: Round-trip basic BLOB types with --hex-blob
+CREATE TABLE t_blob_roundtrip (
+id INT PRIMARY KEY,
+tiny_blob TINYBLOB,
+normal_blob BLOB,
+medium_blob MEDIUMBLOB,
+long_blob LONGBLOB
+);
+INSERT INTO t_blob_roundtrip VALUES
+(1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+(2, NULL, NULL, NULL, NULL),
+(3, '', '', '', ''),
+(4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D'),
+(5, X'00FF00FF', X'A5A5A5A5', X'12345678', X'FFFFFFFF');
+# Export with mysqldump --hex-blob --tab
+# Save original data for comparison
+CREATE TABLE t_blob_original LIKE t_blob_roundtrip;
+INSERT INTO t_blob_original SELECT * FROM t_blob_roundtrip;
+# Drop table and recreate from .sql file
+DROP TABLE t_blob_roundtrip;
+# Import with mariadb-import --hex-blob
+test.t_blob_roundtrip: Records: 5  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity - should return 0 rows (all data matches)
+SELECT * FROM t_blob_roundtrip WHERE id NOT IN (SELECT id FROM t_blob_original);
+id	tiny_blob	normal_blob	medium_blob	long_blob
+SELECT * FROM t_blob_original WHERE id NOT IN (SELECT id FROM t_blob_roundtrip);
+id	tiny_blob	normal_blob	medium_blob	long_blob
+SELECT o.id FROM t_blob_original o, t_blob_roundtrip r
+WHERE o.id = r.id
+AND (o.tiny_blob IS NOT NULL AND r.tiny_blob IS NOT NULL AND o.tiny_blob != r.tiny_blob);
+id
+# Show successful import
+SELECT id, HEX(tiny_blob), HEX(normal_blob) FROM t_blob_roundtrip ORDER BY id;
+id	HEX(tiny_blob)	HEX(normal_blob)
+1	74696E790064617461	6E6F726D616C00626C6F62
+2	NULL	NULL
+3		
+4	DEADBEEF	CAFEBABE
+5	00FF00FF	A5A5A5A5
+DROP TABLE t_blob_roundtrip;
+DROP TABLE t_blob_original;
+# Test 2: Round-trip BINARY and VARBINARY types
+CREATE TABLE t_binary_roundtrip (
+id INT PRIMARY KEY,
+bin_col BINARY(10),
+varbin_col VARBINARY(100)
+);
+INSERT INTO t_binary_roundtrip VALUES
+(1, X'0102030405', 'varbinary\0test'),
+(2, NULL, NULL),
+(3, X'00', ''),
+(4, X'FFFFFFFFFFFFFF', X'DEADBEEFCAFEBABE');
+# Export with mysqldump --hex-blob --tab
+CREATE TABLE t_binary_original LIKE t_binary_roundtrip;
+INSERT INTO t_binary_original SELECT * FROM t_binary_roundtrip;
+DROP TABLE t_binary_roundtrip;
+# Import with mariadb-import --hex-blob
+test.t_binary_roundtrip: Records: 4  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity
+SELECT o.id FROM t_binary_original o, t_binary_roundtrip r
+WHERE o.id = r.id
+AND ((o.bin_col IS NOT NULL AND r.bin_col IS NOT NULL AND o.bin_col != r.bin_col)
+OR (o.varbin_col IS NOT NULL AND r.varbin_col IS NOT NULL AND o.varbin_col != r.varbin_col));
+id
+# Show successful import
+SELECT id, HEX(bin_col), HEX(varbin_col) FROM t_binary_roundtrip ORDER BY id;
+id	HEX(bin_col)	HEX(varbin_col)
+1	01020304050000000000	76617262696E6172790074657374
+2	NULL	NULL
+3	00000000000000000000	
+4	FFFFFFFFFFFFFF000000	DEADBEEFCAFEBABE
+DROP TABLE t_binary_roundtrip;
+DROP TABLE t_binary_original;
+# Test 3: Round-trip mixed table (BLOB and non-BLOB columns)
+CREATE TABLE t_mixed_roundtrip (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+data BLOB,
+description TEXT,
+binary_data VARBINARY(100)
+);
+INSERT INTO t_mixed_roundtrip VALUES
+(1, 'First', X'ABCD', 'Description 1', X'1234'),
+(2, 'Second', NULL, 'Description 2', NULL),
+(3, 'Third', '', 'Description 3', ''),
+(4, 'Special\tChars', X'00FF00FF', 'Desc\nWith\nNewlines', X'CAFEBABE');
+# Export with mysqldump --hex-blob --tab
+CREATE TABLE t_mixed_original LIKE t_mixed_roundtrip;
+INSERT INTO t_mixed_original SELECT * FROM t_mixed_roundtrip;
+DROP TABLE t_mixed_roundtrip;
+# Import with mariadb-import --hex-blob
+test.t_mixed_roundtrip: Records: 4  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify all columns match
+SELECT o.id FROM t_mixed_original o, t_mixed_roundtrip r
+WHERE o.id = r.id
+AND (o.name != r.name OR o.description != r.description
+OR (o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data)
+OR (o.binary_data IS NOT NULL AND r.binary_data IS NOT NULL AND o.binary_data != r.binary_data));
+id
+# Show successful import
+SELECT id, name, HEX(data), description, HEX(binary_data) FROM t_mixed_roundtrip ORDER BY id;
+id	name	HEX(data)	description	HEX(binary_data)
+1	First	ABCD	Description 1	1234
+2	Second	NULL	Description 2	NULL
+3	Third		Description 3	
+4	Special	Chars	00FF00FF	Desc
+With
+Newlines	CAFEBABE
+DROP TABLE t_mixed_roundtrip;
+DROP TABLE t_mixed_original;
+# Test 4: Round-trip with --columns parameter (subset of columns)
+CREATE TABLE t_columns_test (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+blob1 BLOB,
+blob2 BLOB,
+text_col TEXT
+);
+INSERT INTO t_columns_test VALUES
+(1, 'Row1', X'ABCD', X'1234', 'Text1'),
+(2, 'Row2', NULL, NULL, 'Text2'),
+(3, 'Row3', X'BEEF', X'CAFE', 'Text3');
+# Export with mysqldump --hex-blob --tab
+CREATE TABLE t_columns_original LIKE t_columns_test;
+INSERT INTO t_columns_original SELECT * FROM t_columns_test;
+DROP TABLE t_columns_test;
+# Import with --hex-blob and --columns (id, blob1, blob2)
+test.t_columns_test: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify blob columns match
+SELECT o.id FROM t_columns_original o, t_columns_test r
+WHERE o.id = r.id
+AND ((o.blob1 IS NOT NULL AND r.blob1 IS NOT NULL AND o.blob1 != r.blob1)
+OR (o.blob2 IS NOT NULL AND r.blob2 IS NOT NULL AND o.blob2 != r.blob2));
+id
+# Show successful import
+SELECT id, name, HEX(blob1), HEX(blob2), text_col FROM t_columns_test ORDER BY id;
+id	name	HEX(blob1)	HEX(blob2)	text_col
+1	Row1	ABCD	1234	Text1
+2	Row2	NULL	NULL	Text2
+3	Row3	BEEF	CAFE	Text3
+DROP TABLE t_columns_test;
+DROP TABLE t_columns_original;
+# Test 5: Import WITHOUT --hex-blob (default behavior - should fail or produce wrong data)
+CREATE TABLE t_no_hex_import (
+id INT,
+data BLOB
+);
+INSERT INTO t_no_hex_import VALUES (1, X'DEADBEEF'), (2, NULL);
+CREATE TABLE t_no_hex_original LIKE t_no_hex_import;
+INSERT INTO t_no_hex_original SELECT * FROM t_no_hex_import;
+DROP TABLE t_no_hex_import;
+# Import WITHOUT --hex-blob - data will be interpreted as ASCII string, not binary
+test.t_no_hex_import: Records: 2  Deleted: 0  Skipped: 0  Warnings: 0
+# Show data mismatch - imported data is ASCII "DEADBEEF" not binary 0xDEADBEEF
+SELECT id, HEX(data) as hex_data, LENGTH(data) as data_length FROM t_no_hex_import ORDER BY id;
+id	hex_data	data_length
+1	4445414442454546	8
+2	NULL	NULL
+# Original was binary (4 bytes), imported is ASCII string (8 bytes)
+SELECT id, HEX(data) as hex_data, LENGTH(data) as data_length FROM t_no_hex_original ORDER BY id;
+id	hex_data	data_length
+1	DEADBEEF	4
+2	NULL	NULL
+DROP TABLE t_no_hex_import;
+DROP TABLE t_no_hex_original;
+# Test 6: NULL and empty blob handling
+CREATE TABLE t_null_empty (
+id INT PRIMARY KEY,
+blob_null BLOB,
+blob_empty BLOB,
+blob_data BLOB
+);
+INSERT INTO t_null_empty VALUES
+(1, NULL, '', X'ABCD'),
+(2, NULL, '', X'1234');
+CREATE TABLE t_null_empty_original LIKE t_null_empty;
+INSERT INTO t_null_empty_original SELECT * FROM t_null_empty;
+DROP TABLE t_null_empty;
+test.t_null_empty: Records: 2  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify NULL remains NULL and empty remains empty
+SELECT id, blob_null IS NULL as is_null, LENGTH(blob_empty) as empty_length, HEX(blob_data) FROM t_null_empty ORDER BY id;
+id	is_null	empty_length	HEX(blob_data)
+1	1	0	ABCD
+2	1	0	1234
+SELECT o.id FROM t_null_empty_original o, t_null_empty r
+WHERE o.id = r.id
+AND ((o.blob_null IS NULL) != (r.blob_null IS NULL)
+OR o.blob_empty != r.blob_empty
+OR o.blob_data != r.blob_data);
+id
+DROP TABLE t_null_empty;
+DROP TABLE t_null_empty_original;
+# Test 7: Table with only BLOB columns
+CREATE TABLE t_all_blobs (
+blob1 BLOB,
+blob2 TINYBLOB,
+blob3 MEDIUMBLOB
+);
+INSERT INTO t_all_blobs VALUES
+(X'ABCDEF', X'123456', X'FEDCBA'),
+(NULL, NULL, NULL),
+(X'FF', X'00', X'AA');
+CREATE TABLE t_all_blobs_original LIKE t_all_blobs;
+INSERT INTO t_all_blobs_original SELECT * FROM t_all_blobs;
+DROP TABLE t_all_blobs;
+test.t_all_blobs: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify all blob columns match
+SELECT HEX(blob1), HEX(blob2), HEX(blob3) FROM t_all_blobs ORDER BY blob1;
+HEX(blob1)	HEX(blob2)	HEX(blob3)
+NULL	NULL	NULL
+ABCDEF	123456	FEDCBA
+FF	00	AA
+SELECT o.blob1 FROM t_all_blobs_original o
+WHERE NOT EXISTS (
+SELECT * FROM t_all_blobs r
+WHERE (o.blob1 IS NULL AND r.blob1 IS NULL) OR o.blob1 = r.blob1
+);
+blob1
+DROP TABLE t_all_blobs;
+DROP TABLE t_all_blobs_original;
+# Test 8: Round-trip with --dir option
+CREATE TABLE t_dir_import (
+id INT PRIMARY KEY,
+data BLOB
+);
+INSERT INTO t_dir_import VALUES
+(1, X'DEADBEEF'),
+(2, 'test\0data'),
+(3, NULL);
+CREATE TABLE t_dir_import_original LIKE t_dir_import;
+INSERT INTO t_dir_import_original SELECT * FROM t_dir_import;
+DROP TABLE t_dir_import;
+# Import with mariadb-import --hex-blob from --dir export
+test.t_dir_import: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity
+SELECT o.id FROM t_dir_import_original o, t_dir_import r
+WHERE o.id = r.id
+AND ((o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data));
+id
+SELECT id, HEX(data) FROM t_dir_import ORDER BY id;
+id	HEX(data)
+1	DEADBEEF
+2	746573740064617461
+3	NULL
+DROP TABLE t_dir_import;
+DROP TABLE t_dir_import_original;
+# Test 9: Column names containing commas are parsed correctly with --hex-blob --columns
+CREATE TABLE t_comma_col (id INT PRIMARY KEY, `a,b` BLOB);
+INSERT INTO t_comma_col VALUES (1, X'DEADBEEF'), (2, NULL), (3, X'CAFEBABE');
+CREATE TABLE t_comma_col_orig LIKE t_comma_col;
+INSERT INTO t_comma_col_orig SELECT * FROM t_comma_col;
+DROP TABLE t_comma_col;
+# Import with --hex-blob and --columns containing a backtick-quoted name with a comma
+test.t_comma_col: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_comma_col_orig o, t_comma_col r
+WHERE o.id = r.id
+AND ((o.`a,b` IS NOT NULL AND r.`a,b` IS NOT NULL AND o.`a,b` != r.`a,b`)
+OR (o.`a,b` IS NULL) != (r.`a,b` IS NULL));
+id
+# Show imported data
+SELECT id, HEX(`a,b`) FROM t_comma_col ORDER BY id;
+id	HEX(`a,b`)
+1	DEADBEEF
+2	NULL
+3	CAFEBABE
+DROP TABLE t_comma_col;
+DROP TABLE t_comma_col_orig;
+# Test 10: Column names containing backticks are parsed correctly with --hex-blob --columns
+CREATE TABLE t_backtick_col (id INT PRIMARY KEY, `a``b` BLOB);
+INSERT INTO t_backtick_col VALUES (1, X'DEADBEEF'), (2, NULL), (3, X'CAFEBABE');
+CREATE TABLE t_backtick_col_orig LIKE t_backtick_col;
+INSERT INTO t_backtick_col_orig SELECT * FROM t_backtick_col;
+DROP TABLE t_backtick_col;
+# Import with --hex-blob and --columns containing a backtick-quoted name with a backtick
+test.t_backtick_col: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_backtick_col_orig o, t_backtick_col r
+WHERE o.id = r.id
+AND ((o.`a``b` IS NOT NULL AND r.`a``b` IS NOT NULL AND o.`a``b` != r.`a``b`)
+OR (o.`a``b` IS NULL) != (r.`a``b` IS NULL));
+id
+# Show imported data
+SELECT id, HEX(`a``b`) FROM t_backtick_col ORDER BY id;
+id	HEX(`a``b`)
+1	DEADBEEF
+2	NULL
+3	CAFEBABE
+DROP TABLE t_backtick_col;
+DROP TABLE t_backtick_col_orig;
+# Test 11: Round-trip with --hex-blob and --dir on both dump and import sides
+CREATE TABLE t_hex_dir (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+data BLOB,
+bin_data VARBINARY(100)
+);
+INSERT INTO t_hex_dir VALUES
+(1, 'First',  X'DEADBEEF', X'CAFEBABE'),
+(2, 'Second', NULL,        NULL),
+(3, 'Third',  X'00FF00FF', 'plain\0text');
+CREATE TABLE t_hex_dir_orig LIKE t_hex_dir;
+INSERT INTO t_hex_dir_orig SELECT * FROM t_hex_dir;
+DROP TABLE t_hex_dir;
+# Import with mariadb-import --hex-blob --dir
+test.t_hex_dir: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_hex_dir_orig o, t_hex_dir r
+WHERE o.id = r.id
+AND (o.name != r.name
+OR (o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data)
+OR (o.data IS NULL) != (r.data IS NULL)
+OR (o.bin_data IS NOT NULL AND r.bin_data IS NOT NULL AND o.bin_data != r.bin_data)
+OR (o.bin_data IS NULL) != (r.bin_data IS NULL));
+id
+# Show imported data
+SELECT id, name, HEX(data), HEX(bin_data) FROM t_hex_dir ORDER BY id;
+id	name	HEX(data)	HEX(bin_data)
+1	First	DEADBEEF	CAFEBABE
+2	Second	NULL	NULL
+3	Third	00FF00FF	706C61696E0074657874
+DROP TABLE t_hex_dir;
+DROP TABLE t_hex_dir_orig;
+# Test 12: Round-trip with --hex-blob and --dir where a BLOB column name contains a backtick
+CREATE TABLE t_hex_dir_backtick (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+`da``ta` BLOB
+);
+INSERT INTO t_hex_dir_backtick VALUES
+(1, 'First',  X'DEADBEEF'),
+(2, 'Second', NULL),
+(3, 'Third',  X'CAFEBABE');
+CREATE TABLE t_hex_dir_backtick_orig LIKE t_hex_dir_backtick;
+INSERT INTO t_hex_dir_backtick_orig SELECT * FROM t_hex_dir_backtick;
+DROP TABLE t_hex_dir_backtick;
+# Import with mariadb-import --hex-blob --dir
+test.t_hex_dir_backtick: Records: 3  Deleted: 0  Skipped: 0  Warnings: 0
+# Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_hex_dir_backtick_orig o, t_hex_dir_backtick r
+WHERE o.id = r.id
+AND (o.name != r.name
+OR (o.`da``ta` IS NOT NULL AND r.`da``ta` IS NOT NULL AND o.`da``ta` != r.`da``ta`)
+OR (o.`da``ta` IS NULL) != (r.`da``ta` IS NULL));
+id
+# Show imported data
+SELECT id, name, HEX(`da``ta`) FROM t_hex_dir_backtick ORDER BY id;
+id	name	HEX(`da``ta`)
+1	First	DEADBEEF
+2	Second	NULL
+3	Third	CAFEBABE
+DROP TABLE t_hex_dir_backtick;
+DROP TABLE t_hex_dir_backtick_orig;

--- a/mysql-test/main/mariadb-import.test
+++ b/mysql-test/main/mariadb-import.test
@@ -235,3 +235,449 @@ use test;
 --exec $MYSQL_IMPORT --dir $MYSQLTEST_VARDIR/tmp/dump --parallel=300 2>&1
 
 --rmdir $MYSQLTEST_VARDIR/tmp/dump
+
+--echo #
+--echo # Test --hex-blob option for mariadb-import
+--echo # Round-trip tests: export with mysqldump --hex-blob, import with mariadb-import --hex-blob
+--echo #
+
+USE test;
+
+--echo # Test 1: Round-trip basic BLOB types with --hex-blob
+CREATE TABLE t_blob_roundtrip (
+  id INT PRIMARY KEY,
+  tiny_blob TINYBLOB,
+  normal_blob BLOB,
+  medium_blob MEDIUMBLOB,
+  long_blob LONGBLOB
+);
+
+INSERT INTO t_blob_roundtrip VALUES
+  (1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+  (2, NULL, NULL, NULL, NULL),
+  (3, '', '', '', ''),
+  (4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D'),
+  (5, X'00FF00FF', X'A5A5A5A5', X'12345678', X'FFFFFFFF');
+
+--echo # Export with mysqldump --hex-blob --tab
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_blob_roundtrip
+
+--echo # Save original data for comparison
+CREATE TABLE t_blob_original LIKE t_blob_roundtrip;
+INSERT INTO t_blob_original SELECT * FROM t_blob_roundtrip;
+
+--echo # Drop table and recreate from .sql file
+DROP TABLE t_blob_roundtrip;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_blob_roundtrip.sql
+
+--echo # Import with mariadb-import --hex-blob
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/t_blob_roundtrip.txt
+
+--echo # Verify data integrity - should return 0 rows (all data matches)
+SELECT * FROM t_blob_roundtrip WHERE id NOT IN (SELECT id FROM t_blob_original);
+SELECT * FROM t_blob_original WHERE id NOT IN (SELECT id FROM t_blob_roundtrip);
+SELECT o.id FROM t_blob_original o, t_blob_roundtrip r
+WHERE o.id = r.id
+AND (o.tiny_blob IS NOT NULL AND r.tiny_blob IS NOT NULL AND o.tiny_blob != r.tiny_blob);
+
+--echo # Show successful import
+SELECT id, HEX(tiny_blob), HEX(normal_blob) FROM t_blob_roundtrip ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_blob_roundtrip.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_blob_roundtrip.txt
+DROP TABLE t_blob_roundtrip;
+DROP TABLE t_blob_original;
+
+--echo # Test 2: Round-trip BINARY and VARBINARY types
+CREATE TABLE t_binary_roundtrip (
+  id INT PRIMARY KEY,
+  bin_col BINARY(10),
+  varbin_col VARBINARY(100)
+);
+
+INSERT INTO t_binary_roundtrip VALUES
+  (1, X'0102030405', 'varbinary\0test'),
+  (2, NULL, NULL),
+  (3, X'00', ''),
+  (4, X'FFFFFFFFFFFFFF', X'DEADBEEFCAFEBABE');
+
+--echo # Export with mysqldump --hex-blob --tab
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_binary_roundtrip
+
+CREATE TABLE t_binary_original LIKE t_binary_roundtrip;
+INSERT INTO t_binary_original SELECT * FROM t_binary_roundtrip;
+
+DROP TABLE t_binary_roundtrip;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_binary_roundtrip.sql
+
+--echo # Import with mariadb-import --hex-blob
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/t_binary_roundtrip.txt
+
+--echo # Verify data integrity
+SELECT o.id FROM t_binary_original o, t_binary_roundtrip r
+WHERE o.id = r.id
+AND ((o.bin_col IS NOT NULL AND r.bin_col IS NOT NULL AND o.bin_col != r.bin_col)
+     OR (o.varbin_col IS NOT NULL AND r.varbin_col IS NOT NULL AND o.varbin_col != r.varbin_col));
+
+--echo # Show successful import
+SELECT id, HEX(bin_col), HEX(varbin_col) FROM t_binary_roundtrip ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_binary_roundtrip.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_binary_roundtrip.txt
+DROP TABLE t_binary_roundtrip;
+DROP TABLE t_binary_original;
+
+--echo # Test 3: Round-trip mixed table (BLOB and non-BLOB columns)
+CREATE TABLE t_mixed_roundtrip (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  data BLOB,
+  description TEXT,
+  binary_data VARBINARY(100)
+);
+
+INSERT INTO t_mixed_roundtrip VALUES
+  (1, 'First', X'ABCD', 'Description 1', X'1234'),
+  (2, 'Second', NULL, 'Description 2', NULL),
+  (3, 'Third', '', 'Description 3', ''),
+  (4, 'Special\tChars', X'00FF00FF', 'Desc\nWith\nNewlines', X'CAFEBABE');
+
+--echo # Export with mysqldump --hex-blob --tab
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_mixed_roundtrip
+
+CREATE TABLE t_mixed_original LIKE t_mixed_roundtrip;
+INSERT INTO t_mixed_original SELECT * FROM t_mixed_roundtrip;
+
+DROP TABLE t_mixed_roundtrip;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_mixed_roundtrip.sql
+
+--echo # Import with mariadb-import --hex-blob
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/t_mixed_roundtrip.txt
+
+--echo # Verify all columns match
+SELECT o.id FROM t_mixed_original o, t_mixed_roundtrip r
+WHERE o.id = r.id
+AND (o.name != r.name OR o.description != r.description
+     OR (o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data)
+     OR (o.binary_data IS NOT NULL AND r.binary_data IS NOT NULL AND o.binary_data != r.binary_data));
+
+--echo # Show successful import
+SELECT id, name, HEX(data), description, HEX(binary_data) FROM t_mixed_roundtrip ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_mixed_roundtrip.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_mixed_roundtrip.txt
+DROP TABLE t_mixed_roundtrip;
+DROP TABLE t_mixed_original;
+
+--echo # Test 4: Round-trip with --columns parameter (subset of columns)
+CREATE TABLE t_columns_test (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  blob1 BLOB,
+  blob2 BLOB,
+  text_col TEXT
+);
+
+INSERT INTO t_columns_test VALUES
+  (1, 'Row1', X'ABCD', X'1234', 'Text1'),
+  (2, 'Row2', NULL, NULL, 'Text2'),
+  (3, 'Row3', X'BEEF', X'CAFE', 'Text3');
+
+--echo # Export with mysqldump --hex-blob --tab
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_columns_test
+
+CREATE TABLE t_columns_original LIKE t_columns_test;
+INSERT INTO t_columns_original SELECT * FROM t_columns_test;
+
+DROP TABLE t_columns_test;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_columns_test.sql
+
+--echo # Import with --hex-blob and --columns (id, blob1, blob2)
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob --columns=id,name,blob1,blob2,text_col test $MYSQLTEST_VARDIR/tmp/t_columns_test.txt
+
+--echo # Verify blob columns match
+SELECT o.id FROM t_columns_original o, t_columns_test r
+WHERE o.id = r.id
+AND ((o.blob1 IS NOT NULL AND r.blob1 IS NOT NULL AND o.blob1 != r.blob1)
+     OR (o.blob2 IS NOT NULL AND r.blob2 IS NOT NULL AND o.blob2 != r.blob2));
+
+--echo # Show successful import
+SELECT id, name, HEX(blob1), HEX(blob2), text_col FROM t_columns_test ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_columns_test.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_columns_test.txt
+DROP TABLE t_columns_test;
+DROP TABLE t_columns_original;
+
+--echo # Test 5: Import WITHOUT --hex-blob (default behavior - should fail or produce wrong data)
+CREATE TABLE t_no_hex_import (
+  id INT,
+  data BLOB
+);
+
+INSERT INTO t_no_hex_import VALUES (1, X'DEADBEEF'), (2, NULL);
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_no_hex_import
+
+CREATE TABLE t_no_hex_original LIKE t_no_hex_import;
+INSERT INTO t_no_hex_original SELECT * FROM t_no_hex_import;
+
+DROP TABLE t_no_hex_import;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_no_hex_import.sql
+
+--echo # Import WITHOUT --hex-blob - data will be interpreted as ASCII string, not binary
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 test $MYSQLTEST_VARDIR/tmp/t_no_hex_import.txt
+
+--echo # Show data mismatch - imported data is ASCII "DEADBEEF" not binary 0xDEADBEEF
+SELECT id, HEX(data) as hex_data, LENGTH(data) as data_length FROM t_no_hex_import ORDER BY id;
+--echo # Original was binary (4 bytes), imported is ASCII string (8 bytes)
+SELECT id, HEX(data) as hex_data, LENGTH(data) as data_length FROM t_no_hex_original ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_no_hex_import.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_no_hex_import.txt
+DROP TABLE t_no_hex_import;
+DROP TABLE t_no_hex_original;
+
+--echo # Test 6: NULL and empty blob handling
+CREATE TABLE t_null_empty (
+  id INT PRIMARY KEY,
+  blob_null BLOB,
+  blob_empty BLOB,
+  blob_data BLOB
+);
+
+INSERT INTO t_null_empty VALUES
+  (1, NULL, '', X'ABCD'),
+  (2, NULL, '', X'1234');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_null_empty
+
+CREATE TABLE t_null_empty_original LIKE t_null_empty;
+INSERT INTO t_null_empty_original SELECT * FROM t_null_empty;
+
+DROP TABLE t_null_empty;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_null_empty.sql
+
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/t_null_empty.txt
+
+--echo # Verify NULL remains NULL and empty remains empty
+SELECT id, blob_null IS NULL as is_null, LENGTH(blob_empty) as empty_length, HEX(blob_data) FROM t_null_empty ORDER BY id;
+SELECT o.id FROM t_null_empty_original o, t_null_empty r
+WHERE o.id = r.id
+AND ((o.blob_null IS NULL) != (r.blob_null IS NULL)
+     OR o.blob_empty != r.blob_empty
+     OR o.blob_data != r.blob_data);
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_null_empty.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_null_empty.txt
+DROP TABLE t_null_empty;
+DROP TABLE t_null_empty_original;
+
+--echo # Test 7: Table with only BLOB columns
+CREATE TABLE t_all_blobs (
+  blob1 BLOB,
+  blob2 TINYBLOB,
+  blob3 MEDIUMBLOB
+);
+
+INSERT INTO t_all_blobs VALUES
+  (X'ABCDEF', X'123456', X'FEDCBA'),
+  (NULL, NULL, NULL),
+  (X'FF', X'00', X'AA');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_all_blobs
+
+CREATE TABLE t_all_blobs_original LIKE t_all_blobs;
+INSERT INTO t_all_blobs_original SELECT * FROM t_all_blobs;
+
+DROP TABLE t_all_blobs;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_all_blobs.sql
+
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/t_all_blobs.txt
+
+--echo # Verify all blob columns match
+SELECT HEX(blob1), HEX(blob2), HEX(blob3) FROM t_all_blobs ORDER BY blob1;
+SELECT o.blob1 FROM t_all_blobs_original o
+WHERE NOT EXISTS (
+  SELECT * FROM t_all_blobs r
+  WHERE (o.blob1 IS NULL AND r.blob1 IS NULL) OR o.blob1 = r.blob1
+);
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.txt
+DROP TABLE t_all_blobs;
+DROP TABLE t_all_blobs_original;
+
+--echo # Test 8: Round-trip with --dir option
+CREATE TABLE t_dir_import (
+  id INT PRIMARY KEY,
+  data BLOB
+);
+
+INSERT INTO t_dir_import VALUES
+  (1, X'DEADBEEF'),
+  (2, 'test\0data'),
+  (3, NULL);
+
+--mkdir $MYSQLTEST_VARDIR/tmp/dump_hex
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/dump_hex test
+
+CREATE TABLE t_dir_import_original LIKE t_dir_import;
+INSERT INTO t_dir_import_original SELECT * FROM t_dir_import;
+
+DROP TABLE t_dir_import;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/dump_hex/test/t_dir_import.sql
+
+--echo # Import with mariadb-import --hex-blob from --dir export
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob test $MYSQLTEST_VARDIR/tmp/dump_hex/test/t_dir_import.txt
+
+--echo # Verify data integrity
+SELECT o.id FROM t_dir_import_original o, t_dir_import r
+WHERE o.id = r.id
+AND ((o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data));
+
+SELECT id, HEX(data) FROM t_dir_import ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/dump_hex/test/t_dir_import.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/dump_hex/test/t_dir_import.txt
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex/test
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex
+DROP TABLE t_dir_import;
+DROP TABLE t_dir_import_original;
+
+--echo # Test 9: Column names containing commas are parsed correctly with --hex-blob --columns
+CREATE TABLE t_comma_col (id INT PRIMARY KEY, `a,b` BLOB);
+INSERT INTO t_comma_col VALUES (1, X'DEADBEEF'), (2, NULL), (3, X'CAFEBABE');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_comma_col
+
+CREATE TABLE t_comma_col_orig LIKE t_comma_col;
+INSERT INTO t_comma_col_orig SELECT * FROM t_comma_col;
+
+DROP TABLE t_comma_col;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_comma_col.sql
+
+--echo # Import with --hex-blob and --columns containing a backtick-quoted name with a comma
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob "--columns=id,\`a,b\`" test $MYSQLTEST_VARDIR/tmp/t_comma_col.txt
+
+--echo # Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_comma_col_orig o, t_comma_col r
+WHERE o.id = r.id
+AND ((o.`a,b` IS NOT NULL AND r.`a,b` IS NOT NULL AND o.`a,b` != r.`a,b`)
+     OR (o.`a,b` IS NULL) != (r.`a,b` IS NULL));
+
+--echo # Show imported data
+SELECT id, HEX(`a,b`) FROM t_comma_col ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_comma_col.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_comma_col.txt
+DROP TABLE t_comma_col;
+DROP TABLE t_comma_col_orig;
+
+--echo # Test 10: Column names containing backticks are parsed correctly with --hex-blob --columns
+CREATE TABLE t_backtick_col (id INT PRIMARY KEY, `a``b` BLOB);
+INSERT INTO t_backtick_col VALUES (1, X'DEADBEEF'), (2, NULL), (3, X'CAFEBABE');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_backtick_col
+
+CREATE TABLE t_backtick_col_orig LIKE t_backtick_col;
+INSERT INTO t_backtick_col_orig SELECT * FROM t_backtick_col;
+
+DROP TABLE t_backtick_col;
+--exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/t_backtick_col.sql
+
+--echo # Import with --hex-blob and --columns containing a backtick-quoted name with a backtick
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob "--columns=id,\`a\`\`b\`" test $MYSQLTEST_VARDIR/tmp/t_backtick_col.txt
+
+--echo # Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_backtick_col_orig o, t_backtick_col r
+WHERE o.id = r.id
+AND ((o.`a``b` IS NOT NULL AND r.`a``b` IS NOT NULL AND o.`a``b` != r.`a``b`)
+     OR (o.`a``b` IS NULL) != (r.`a``b` IS NULL));
+
+--echo # Show imported data
+SELECT id, HEX(`a``b`) FROM t_backtick_col ORDER BY id;
+
+--remove_file $MYSQLTEST_VARDIR/tmp/t_backtick_col.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_backtick_col.txt
+DROP TABLE t_backtick_col;
+DROP TABLE t_backtick_col_orig;
+
+--echo # Test 11: Round-trip with --hex-blob and --dir on both dump and import sides
+CREATE TABLE t_hex_dir (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  data BLOB,
+  bin_data VARBINARY(100)
+);
+
+INSERT INTO t_hex_dir VALUES
+  (1, 'First',  X'DEADBEEF', X'CAFEBABE'),
+  (2, 'Second', NULL,        NULL),
+  (3, 'Third',  X'00FF00FF', 'plain\0text');
+
+--mkdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/dump_hex_dir test
+
+CREATE TABLE t_hex_dir_orig LIKE t_hex_dir;
+INSERT INTO t_hex_dir_orig SELECT * FROM t_hex_dir;
+
+DROP TABLE t_hex_dir;
+
+--echo # Import with mariadb-import --hex-blob --dir
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/dump_hex_dir
+
+--echo # Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_hex_dir_orig o, t_hex_dir r
+WHERE o.id = r.id
+AND (o.name != r.name
+     OR (o.data IS NOT NULL AND r.data IS NOT NULL AND o.data != r.data)
+     OR (o.data IS NULL) != (r.data IS NULL)
+     OR (o.bin_data IS NOT NULL AND r.bin_data IS NOT NULL AND o.bin_data != r.bin_data)
+     OR (o.bin_data IS NULL) != (r.bin_data IS NULL));
+
+--echo # Show imported data
+SELECT id, name, HEX(data), HEX(bin_data) FROM t_hex_dir ORDER BY id;
+
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir/test
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir
+DROP TABLE t_hex_dir;
+DROP TABLE t_hex_dir_orig;
+
+--echo # Test 12: Round-trip with --hex-blob and --dir where a BLOB column name contains a backtick
+CREATE TABLE t_hex_dir_backtick (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  `da``ta` BLOB
+);
+
+INSERT INTO t_hex_dir_backtick VALUES
+  (1, 'First',  X'DEADBEEF'),
+  (2, 'Second', NULL),
+  (3, 'Third',  X'CAFEBABE');
+
+--mkdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir_bt
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/dump_hex_dir_bt test
+
+CREATE TABLE t_hex_dir_backtick_orig LIKE t_hex_dir_backtick;
+INSERT INTO t_hex_dir_backtick_orig SELECT * FROM t_hex_dir_backtick;
+
+DROP TABLE t_hex_dir_backtick;
+
+--echo # Import with mariadb-import --hex-blob --dir
+--exec $MYSQL_IMPORT --default-character-set=utf8mb4 --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/dump_hex_dir_bt
+
+--echo # Verify data integrity - should return 0 rows (all data matches)
+SELECT o.id FROM t_hex_dir_backtick_orig o, t_hex_dir_backtick r
+WHERE o.id = r.id
+AND (o.name != r.name
+     OR (o.`da``ta` IS NOT NULL AND r.`da``ta` IS NOT NULL AND o.`da``ta` != r.`da``ta`)
+     OR (o.`da``ta` IS NULL) != (r.`da``ta` IS NULL));
+
+--echo # Show imported data
+SELECT id, name, HEX(`da``ta`) FROM t_hex_dir_backtick ORDER BY id;
+
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir_bt/test
+--rmdir $MYSQLTEST_VARDIR/tmp/dump_hex_dir_bt
+DROP TABLE t_hex_dir_backtick;
+DROP TABLE t_hex_dir_backtick_orig;

--- a/mysql-test/main/mysqldump-hexblob.result
+++ b/mysql-test/main/mysqldump-hexblob.result
@@ -1,0 +1,411 @@
+#
+# Test --hex-blob with --tab (--dir)
+# Verify that BLOB and BINARY columns are hex-encoded in tab-separated output
+#
+USE test;
+# Test 1: Basic BLOB types with hex-blob
+CREATE TABLE t_hex_blob (
+id INT PRIMARY KEY,
+tiny_blob TINYBLOB,
+normal_blob BLOB,
+medium_blob MEDIUMBLOB,
+long_blob LONGBLOB
+);
+INSERT INTO t_hex_blob VALUES
+(1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+(2, NULL, NULL, NULL, NULL),
+(3, '', '', '', ''),
+(4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D');
+# Check SQL file
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_hex_blob`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_hex_blob` (
+  `id` int(11) NOT NULL,
+  `tiny_blob` tinyblob DEFAULT NULL,
+  `normal_blob` blob DEFAULT NULL,
+  `medium_blob` mediumblob DEFAULT NULL,
+  `long_blob` longblob DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - blob data should be hex-encoded
+1	74696E790064617461	6E6F726D616C00626C6F62	6D656469756D00626C6F62	6C6F6E6700626C6F62
+2	\N	\N	\N	\N
+3				
+4	DEADBEEF	CAFEBABE	FEEDFACE	BAADF00D
+DROP TABLE t_hex_blob;
+# Test 2: BINARY and VARBINARY types with hex-blob
+CREATE TABLE t_hex_binary (
+id INT PRIMARY KEY,
+bin_col BINARY(10),
+varbin_col VARBINARY(100)
+);
+INSERT INTO t_hex_binary VALUES
+(1, X'0102030405', 'varbinary\0test'),
+(2, NULL, NULL),
+(3, X'00', ''),
+(4, X'FFFFFFFFFFFFFF', X'DEADBEEFCAFEBABE');
+# Check SQL file
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_hex_binary`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_hex_binary` (
+  `id` int(11) NOT NULL,
+  `bin_col` binary(10) DEFAULT NULL,
+  `varbin_col` varbinary(100) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - binary data should be hex-encoded
+1	01020304050000000000	76617262696E6172790074657374
+2	\N	\N
+3	00000000000000000000	
+4	FFFFFFFFFFFFFF000000	DEADBEEFCAFEBABE
+DROP TABLE t_hex_binary;
+# Test 3: Mixed table with BLOB and non-BLOB columns
+CREATE TABLE t_hex_mixed (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+data BLOB,
+description TEXT,
+binary_data VARBINARY(100)
+);
+INSERT INTO t_hex_mixed VALUES
+(1, 'First', X'ABCD', 'Description 1', X'1234'),
+(2, 'Second', NULL, 'Description 2', NULL),
+(3, 'Third', '', 'Description 3', ''),
+(4, 'Special\tChars', X'00FF00FF', 'Desc\nWith\nNewlines', X'CAFEBABE');
+# Check SQL file - should have HEX() wrapper for BLOB/BINARY columns
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_hex_mixed`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_hex_mixed` (
+  `id` int(11) NOT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `data` blob DEFAULT NULL,
+  `description` text DEFAULT NULL,
+  `binary_data` varbinary(100) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - only BLOB/BINARY columns should be hex-encoded
+1	First	ABCD	Description 1	1234
+2	Second	\N	Description 2	\N
+3	Third		Description 3	
+4	Special\	Chars	00FF00FF	Desc\
+With\
+Newlines	CAFEBABE
+DROP TABLE t_hex_mixed;
+# Test 4: Verify --tab without --hex-blob (default behavior)
+CREATE TABLE t_no_hex (
+id INT,
+blob_col BLOB
+);
+INSERT INTO t_no_hex VALUES (1, 'test\0data'), (2, NULL);
+# Check SQL file - should NOT have HEX() wrapper
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_no_hex`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_no_hex` (
+  `id` int(11) DEFAULT NULL,
+  `blob_col` blob DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - blob data NOT hex-encoded (binary content)
+1	test\0data
+2	\N
+DROP TABLE t_no_hex;
+# Test 5: Table with only BLOB columns
+CREATE TABLE t_all_blobs (
+blob1 BLOB,
+blob2 TINYBLOB,
+blob3 MEDIUMBLOB
+);
+INSERT INTO t_all_blobs VALUES
+(X'ABCDEF', X'123456', X'FEDCBA'),
+(NULL, NULL, NULL);
+# Check SQL file
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_all_blobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_all_blobs` (
+  `blob1` blob DEFAULT NULL,
+  `blob2` tinyblob DEFAULT NULL,
+  `blob3` mediumblob DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file
+ABCDEF	123456	FEDCBA
+\N	\N	\N
+DROP TABLE t_all_blobs;
+# Test 6: Empty table with BLOB columns
+CREATE TABLE t_empty_blobs (
+id INT,
+data BLOB
+);
+# Check SQL file
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_empty_blobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_empty_blobs` (
+  `id` int(11) DEFAULT NULL,
+  `data` blob DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - should be empty
+DROP TABLE t_empty_blobs;
+#
+# Test --hex-blob with --dir option
+# --dir creates subdirectories for each database
+#
+# Test 7: Basic BLOB types with --hex-blob and --dir
+CREATE TABLE t_dir_hex_blob (
+id INT PRIMARY KEY,
+tiny_blob TINYBLOB,
+normal_blob BLOB,
+medium_blob MEDIUMBLOB,
+long_blob LONGBLOB
+);
+INSERT INTO t_dir_hex_blob VALUES
+(1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+(2, NULL, NULL, NULL, NULL),
+(3, '', '', '', ''),
+(4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D');
+# Check SQL file in test subdirectory
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_dir_hex_blob`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_dir_hex_blob` (
+  `id` int(11) NOT NULL,
+  `tiny_blob` tinyblob DEFAULT NULL,
+  `normal_blob` blob DEFAULT NULL,
+  `medium_blob` mediumblob DEFAULT NULL,
+  `long_blob` longblob DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - blob data should be hex-encoded
+1	74696E790064617461	6E6F726D616C00626C6F62	6D656469756D00626C6F62	6C6F6E6700626C6F62
+2	\N	\N	\N	\N
+3				
+4	DEADBEEF	CAFEBABE	FEEDFACE	BAADF00D
+DROP TABLE t_dir_hex_blob;
+# Test 8: Mixed table with --dir and --hex-blob
+CREATE TABLE t_dir_mixed (
+id INT PRIMARY KEY,
+name VARCHAR(50),
+data BLOB,
+binary_data VARBINARY(50)
+);
+INSERT INTO t_dir_mixed VALUES
+(1, 'First', X'ABCD', X'1234'),
+(2, 'Second', NULL, NULL),
+(3, 'Third', '', '');
+# Check SQL file
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_dir_mixed`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_dir_mixed` (
+  `id` int(11) NOT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `data` blob DEFAULT NULL,
+  `binary_data` varbinary(50) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - only BLOB/BINARY columns should be hex-encoded
+1	First	ABCD	1234
+2	Second	\N	\N
+3	Third		
+DROP TABLE t_dir_mixed;
+# Test 9: Verify --dir without --hex-blob (default behavior)
+CREATE TABLE t_dir_no_hex (
+id INT,
+blob_col BLOB
+);
+INSERT INTO t_dir_no_hex VALUES (1, 'test\0data'), (2, NULL);
+# Check SQL file - should NOT have HEX() wrapper
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+DROP TABLE IF EXISTS `t_dir_no_hex`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `t_dir_no_hex` (
+  `id` int(11) DEFAULT NULL,
+  `blob_col` blob DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+# Check data file - blob data NOT hex-encoded
+1	test\0data
+2	\N
+DROP TABLE t_dir_no_hex;

--- a/mysql-test/main/mysqldump-hexblob.test
+++ b/mysql-test/main/mysqldump-hexblob.test
@@ -1,0 +1,213 @@
+# Test --hex-blob with --tab (--dir)
+# Verify that BLOB and BINARY columns are hex-encoded in tab-separated output
+
+--source include/not_embedded.inc
+
+--echo #
+--echo # Test --hex-blob with --tab (--dir)
+--echo # Verify that BLOB and BINARY columns are hex-encoded in tab-separated output
+--echo #
+
+USE test;
+
+--echo # Test 1: Basic BLOB types with hex-blob
+CREATE TABLE t_hex_blob (
+  id INT PRIMARY KEY,
+  tiny_blob TINYBLOB,
+  normal_blob BLOB,
+  medium_blob MEDIUMBLOB,
+  long_blob LONGBLOB
+);
+
+INSERT INTO t_hex_blob VALUES
+  (1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+  (2, NULL, NULL, NULL, NULL),
+  (3, '', '', '', ''),
+  (4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_hex_blob
+--echo # Check SQL file
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_blob.sql
+--echo # Check data file - blob data should be hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_blob.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_blob.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_blob.txt
+
+DROP TABLE t_hex_blob;
+
+--echo # Test 2: BINARY and VARBINARY types with hex-blob
+CREATE TABLE t_hex_binary (
+  id INT PRIMARY KEY,
+  bin_col BINARY(10),
+  varbin_col VARBINARY(100)
+);
+
+INSERT INTO t_hex_binary VALUES
+  (1, X'0102030405', 'varbinary\0test'),
+  (2, NULL, NULL),
+  (3, X'00', ''),
+  (4, X'FFFFFFFFFFFFFF', X'DEADBEEFCAFEBABE');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_hex_binary
+--echo # Check SQL file
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_binary.sql
+--echo # Check data file - binary data should be hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_binary.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_binary.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_binary.txt
+
+DROP TABLE t_hex_binary;
+
+--echo # Test 3: Mixed table with BLOB and non-BLOB columns
+CREATE TABLE t_hex_mixed (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  data BLOB,
+  description TEXT,
+  binary_data VARBINARY(100)
+);
+
+INSERT INTO t_hex_mixed VALUES
+  (1, 'First', X'ABCD', 'Description 1', X'1234'),
+  (2, 'Second', NULL, 'Description 2', NULL),
+  (3, 'Third', '', 'Description 3', ''),
+  (4, 'Special\tChars', X'00FF00FF', 'Desc\nWith\nNewlines', X'CAFEBABE');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_hex_mixed
+--echo # Check SQL file - should have HEX() wrapper for BLOB/BINARY columns
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_mixed.sql
+--echo # Check data file - only BLOB/BINARY columns should be hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/t_hex_mixed.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_mixed.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_hex_mixed.txt
+
+DROP TABLE t_hex_mixed;
+
+--echo # Test 4: Verify --tab without --hex-blob (default behavior)
+CREATE TABLE t_no_hex (
+  id INT,
+  blob_col BLOB
+);
+
+INSERT INTO t_no_hex VALUES (1, 'test\0data'), (2, NULL);
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --tab=$MYSQLTEST_VARDIR/tmp/ test t_no_hex
+--echo # Check SQL file - should NOT have HEX() wrapper
+--cat_file $MYSQLTEST_VARDIR/tmp/t_no_hex.sql
+--echo # Check data file - blob data NOT hex-encoded (binary content)
+--cat_file $MYSQLTEST_VARDIR/tmp/t_no_hex.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_no_hex.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_no_hex.txt
+
+DROP TABLE t_no_hex;
+
+--echo # Test 5: Table with only BLOB columns
+CREATE TABLE t_all_blobs (
+  blob1 BLOB,
+  blob2 TINYBLOB,
+  blob3 MEDIUMBLOB
+);
+
+INSERT INTO t_all_blobs VALUES
+  (X'ABCDEF', X'123456', X'FEDCBA'),
+  (NULL, NULL, NULL);
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_all_blobs
+--echo # Check SQL file
+--cat_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.sql
+--echo # Check data file
+--cat_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_all_blobs.txt
+
+DROP TABLE t_all_blobs;
+
+--echo # Test 6: Empty table with BLOB columns
+CREATE TABLE t_empty_blobs (
+  id INT,
+  data BLOB
+);
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --tab=$MYSQLTEST_VARDIR/tmp/ test t_empty_blobs
+--echo # Check SQL file
+--cat_file $MYSQLTEST_VARDIR/tmp/t_empty_blobs.sql
+--echo # Check data file - should be empty
+--cat_file $MYSQLTEST_VARDIR/tmp/t_empty_blobs.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/t_empty_blobs.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/t_empty_blobs.txt
+
+DROP TABLE t_empty_blobs;
+
+--echo #
+--echo # Test --hex-blob with --dir option
+--echo # --dir creates subdirectories for each database
+--echo #
+
+--echo # Test 7: Basic BLOB types with --hex-blob and --dir
+CREATE TABLE t_dir_hex_blob (
+  id INT PRIMARY KEY,
+  tiny_blob TINYBLOB,
+  normal_blob BLOB,
+  medium_blob MEDIUMBLOB,
+  long_blob LONGBLOB
+);
+
+INSERT INTO t_dir_hex_blob VALUES
+  (1, 'tiny\0data', 'normal\0blob', 'medium\0blob', 'long\0blob'),
+  (2, NULL, NULL, NULL, NULL),
+  (3, '', '', '', ''),
+  (4, X'DEADBEEF', X'CAFEBABE', X'FEEDFACE', X'BAADF00D');
+
+--mkdir $MYSQLTEST_VARDIR/tmp/backup_dir
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/backup_dir test
+--echo # Check SQL file in test subdirectory
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_hex_blob.sql
+--echo # Check data file - blob data should be hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_hex_blob.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_hex_blob.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_hex_blob.txt
+
+DROP TABLE t_dir_hex_blob;
+
+--echo # Test 8: Mixed table with --dir and --hex-blob
+CREATE TABLE t_dir_mixed (
+  id INT PRIMARY KEY,
+  name VARCHAR(50),
+  data BLOB,
+  binary_data VARBINARY(50)
+);
+
+INSERT INTO t_dir_mixed VALUES
+  (1, 'First', X'ABCD', X'1234'),
+  (2, 'Second', NULL, NULL),
+  (3, 'Third', '', '');
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --hex-blob --dir=$MYSQLTEST_VARDIR/tmp/backup_dir test
+--echo # Check SQL file
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_mixed.sql
+--echo # Check data file - only BLOB/BINARY columns should be hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_mixed.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_mixed.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_mixed.txt
+
+DROP TABLE t_dir_mixed;
+
+--echo # Test 9: Verify --dir without --hex-blob (default behavior)
+CREATE TABLE t_dir_no_hex (
+  id INT,
+  blob_col BLOB
+);
+
+INSERT INTO t_dir_no_hex VALUES (1, 'test\0data'), (2, NULL);
+
+--exec $MYSQL_DUMP --default-character-set=utf8mb4 --skip-comments --dir=$MYSQLTEST_VARDIR/tmp/backup_dir test
+--echo # Check SQL file - should NOT have HEX() wrapper
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_no_hex.sql
+--echo # Check data file - blob data NOT hex-encoded
+--cat_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_no_hex.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_no_hex.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/backup_dir/test/t_dir_no_hex.txt
+--rmdir $MYSQLTEST_VARDIR/tmp/backup_dir/test
+--rmdir $MYSQLTEST_VARDIR/tmp/backup_dir
+
+DROP TABLE t_dir_no_hex;


### PR DESCRIPTION
Extend the existing --hex-blob option to work with --tab/--dir mode for both mysqldump and mariadb-import:

1. mysqldump --hex-blob --tab/--dir:
   - Automatically detect BLOB and BINARY columns
   - Wrap them with HEX() in the SELECT statement
   - Export binary data as hexadecimal strings in .txt files

2. mariadb-import --hex-blob:
   - Automatically detect BLOB and BINARY columns from table structure
   - Apply UNHEX() transformation during LOAD DATA
   - Convert hex strings back to binary data

Together, these changes enable a complete round-trip export/import workflow for tables containing binary data.