### PR TITLE
MDEV-38754 s3.clone run in high concurrency environments

### DIFF
--- a/mysql-test/suite/s3/clone.result
+++ b/mysql-test/suite/s3/clone.result
@@ -1,9 +1,7 @@
+DROP TABLE IF EXISTS t1;
 #
 # SELECT using ror_merged scan fails with s3 tables
 #
-DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'test.t1'
 CREATE TABLE t1 (a INT, b INT, KEY(a), KEY(b)) ENGINE=Aria;
 INSERT INTO t1 VALUES (0,0),(0,10),(3,10);
 ALTER TABLE t1 ENGINE=S3;

--- a/mysql-test/suite/s3/clone.result
+++ b/mysql-test/suite/s3/clone.result
@@ -1,12 +1,10 @@
 #
 # SELECT using ror_merged scan fails with s3 tables
 #
-DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'test.t1'
 CREATE TABLE t1 (a INT, b INT, KEY(a), KEY(b)) ENGINE=Aria;
 INSERT INTO t1 VALUES (0,0),(0,10),(3,10);
 ALTER TABLE t1 ENGINE=S3;
 SELECT * FROM t1 WHERE a = 99 OR b = 2;
 a	b
 DROP TABLE t1;
+End of 10.11 tests

--- a/mysql-test/suite/s3/clone.test
+++ b/mysql-test/suite/s3/clone.test
@@ -2,13 +2,22 @@
 --source include/have_sequence.inc
 --source include/have_innodb.inc
 
+#
+# Create unique database for running the tests
+#
+--source create_database.inc
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
 --echo #
 --echo # SELECT using ror_merged scan fails with s3 tables
 --echo #
 
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT, b INT, KEY(a), KEY(b)) ENGINE=Aria;
 INSERT INTO t1 VALUES (0,0),(0,10),(3,10);
 ALTER TABLE t1 ENGINE=S3;
 SELECT * FROM t1 WHERE a = 99 OR b = 2;
 DROP TABLE t1;
+
+--source drop_database.inc

--- a/mysql-test/suite/s3/clone.test
+++ b/mysql-test/suite/s3/clone.test
@@ -2,13 +2,21 @@
 --source include/have_sequence.inc
 --source include/have_innodb.inc
 
+#
+# Create unique database for running the tests
+#
+--source create_database.inc
+
 --echo #
 --echo # SELECT using ror_merged scan fails with s3 tables
 --echo #
 
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT, b INT, KEY(a), KEY(b)) ENGINE=Aria;
 INSERT INTO t1 VALUES (0,0),(0,10),(3,10);
 ALTER TABLE t1 ENGINE=S3;
 SELECT * FROM t1 WHERE a = 99 OR b = 2;
 DROP TABLE t1;
+
+--source drop_database.inc
+
+--echo End of 10.11 tests


### PR DESCRIPTION
s3.clone needs to source create_database.inc so that it can run in a high-concurrency environment 
where multiple MTR invocations are happening at the same time, 
while only a single S3 bucket (the S3 DB) is shared among all instances.