### PR TITLE
MDEV-38747:  ASAN errors in Optimizer_hint_parser::Identifier::to_ide…

### DIFF
--- a/mysql-test/main/sp.result
+++ b/mysql-test/main/sp.result
@@ -8867,3 +8867,12 @@ SPECIFIC_NAME
 upper
 DROP FUNCTION upper;
 # End of 11.8 tests
+#
+# MDEV-38747:  ASAN errors in Optimizer_hint_parser::Identifier::to_ident_cli
+#
+CREATE TABLE t (a INT);
+INSERT INTO t VALUES (1),(2);
+CREATE TEMPORARY TABLE tmp (b INT);
+CREATE TRIGGER tr AFTER DELETE ON t FOR EACH ROW CREATE OR REPLACE TEMPORARY TABLE tmp AS SELECT /*+ QB_NAME(xxxx) */ 1;
+DELETE FROM t;
+DROP TABLE t;

--- a/mysql-test/main/sp.test
+++ b/mysql-test/main/sp.test
@@ -9618,3 +9618,14 @@ SELECT SPECIFIC_NAME FROM INFORMATION_SCHEMA.PARAMETERS WHERE SPECIFIC_SCHEMA='t
 DROP FUNCTION upper;
 
 --echo # End of 11.8 tests
+
+--echo #
+--echo # MDEV-38747:  ASAN errors in Optimizer_hint_parser::Identifier::to_ident_cli
+--echo #
+CREATE TABLE t (a INT);
+INSERT INTO t VALUES (1),(2);
+CREATE TEMPORARY TABLE tmp (b INT);
+# Can be SELECT ... old.a, or SELECT ... * FROM sometable, etc.
+CREATE TRIGGER tr AFTER DELETE ON t FOR EACH ROW CREATE OR REPLACE TEMPORARY TABLE tmp AS SELECT /*+ QB_NAME(xxxx) */ 1;
+DELETE FROM t;
+DROP TABLE t;

--- a/sql/sp_instr.h
+++ b/sql/sp_instr.h
@@ -504,6 +504,15 @@ protected:
 
 private:
   /**
+    Buffer responsible for keeping the query text over the lifetime of
+    *this.  If reparsing is required, then this string is cleared and
+    replaced with the new text on reparse.  Allows for deferred hint
+    resolution when query hints are specified as part of the trigger
+    definition.
+   */
+  String sql_query_cache;
+
+  /**
     List of Item_trigger_field objects created on parsing of a SQL statement
     corresponding to this SP-instruction.
   */


### PR DESCRIPTION
…nt_cli

Summary:
A trigger specifying a hint where the hint has a query block name will cause
an ASAN failure because hint resolution occurs after query parsing, not
during query parsing.  The trigger execution logic uses a stack-local
string to hold the query and hint text during parsing.  During trigger
execution, query parsing and query execution happen in different function
contexts, so the query string used during parsing goes out of scope, freeing
its memory.  But as hint resolution occurs after parsing is complete (and
hints merely point into the query string, they don't copy from it), the hints
refer into a deallocated query string upon hint resolution.

Details:
Prior to the commit introducing this bug, hint resolution was done via a call
to `LEX::resolve_optimizer_hints_in_last_select` when parsing the
`query_specification:` grammar rule.  This meant that any string containing
the query (and hints) was in scope for the entire lifetime of query parsing
and hint resolution.

In the patch introducing this bug, `resolve_optimizer_hints_in_last_select`
was replaced with `handle_parsed_optimizer_hints_in_last_select`, changing
the parsing such that it merely cached hints for resolution during query
execution.  Later, after parsing ends and upon query execution,
`mysql_execute_command` calls `LEX::resolve_optimizer_hints` to resolve hints.
When executing a typical SQL command trigger, `sp_lex_instr::parse_expr`
reparses the query associated with the trigger and does so using a stack-local
String variable to hold the query text.  `sp_lex_instr::parse_expr` returns after
query parsing completes but before hint resolution begins.  Since
the string holding the query was stack-local in `sp_lex_instr::parse_expr` and
destroyed when the method returned, the query string (and hints with it) were
deallocated, leading to the ASAN failure on hint resolution.  When executing
the trigger, `sp_instr_stmt::exec_core` calls `mysql_execute_command` which
calls `LEX::resolve_optimizer_hints` to complete hint resolution but the query
string that the hints depends on no longer exists at this point.

As noted, the stack-local `query_string` variable in `sp_lex_inst::parse_expr`
goes out-of-scope and is freed when the `sp_lex_instr::parse_expr` returns.  In
contrast, in the general case, when a `COM_QUERY` is processed during
`dispatch_command`, the query string lives on the `THD` for the lifetime of
the query independent of some particular function's scope.

For triggers, the necessary lifetime of that query string needs to be as long
as `sp_lex_keeper::validate_lex_and_exec_core` which covers both the query
string parsing via `sp_lex_instr::parse_expr` and the procedure's execution
during `reset_lex_and_exec_core`.  Consequently, this patch lifts the
`query_string` buffer up out of `parse_expr` and onto the `sp_lex_instr` itself
which guarantees that its lifetime is as long as the instruction, which also
guarantees the query string's lifetime extends across parsing and execution,
including hint resolution.  This also covers any cases where the trigger is
successfully executed consecutive times but not reparsed between those
executions.

QB_NAME is not the only affected hint kind; hints with some query block
identifier text for the query block, like
```
NO_MERGE(`@select#1`)
```
will also cause the crash while `NO_MERGE()` will not.