### PR TITLE
MDEV-38757 Fix EXCHANGE PARTITION with generated columns containing and/or

### DIFF
--- a/mysql-test/suite/parts/r/partition_exchange_generated_columns.result
+++ b/mysql-test/suite/parts/r/partition_exchange_generated_columns.result
@@ -1,0 +1,103 @@
+#
+# Test EXCHANGE PARTITION with generated columns containing AND/OR conditions
+# This verifies that Item_cond::eq() correctly performs set-based comparison
+# for commutative AND/OR operations, allowing partition exchange to succeed
+# even when condition order differs between original and re-parsed expressions.
+# verifies MDEV-38757
+#
+DROP TABLE IF EXISTS t1, t1_working;
+# Test 1: Generated column with OR condition
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+vcol1 TINYINT(1) GENERATED ALWAYS AS (col1 > 80 OR col1 < 20) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB,
+PARTITION p2 VALUES IN (2) ENGINE = InnoDB);
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+INSERT INTO t1_working (userId, col1) VALUES (1, 10), (1, 50), (1, 90);
+# This should succeed: EXCHANGE PARTITION with OR condition
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, vcol1 FROM t1 ORDER BY id;
+id	userId	col1	vcol1
+1	1	10	1
+2	1	50	0
+3	1	90	1
+DROP TABLE t1_working;
+DROP TABLE t1;
+# Test 2: Generated column with AND condition
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+col2 INT NOT NULL,
+vcol2 TINYINT(1) GENERATED ALWAYS AS (col1 > 10 AND col2 < 100) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+INSERT INTO t1_working (userId, col1, col2) VALUES (1, 20, 50), (1, 5, 200);
+# This should succeed: EXCHANGE PARTITION with AND condition
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, col2, vcol2 FROM t1 ORDER BY id;
+id	userId	col1	col2	vcol2
+1	1	20	50	1
+2	1	5	200	0
+DROP TABLE t1_working;
+DROP TABLE t1;
+# Test 3: Multiple generated columns with different AND/OR combinations
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+col2 INT NOT NULL,
+vcol1 TINYINT(1) GENERATED ALWAYS AS (col1 > 80 OR col1 < 20) STORED,
+vcol2 TINYINT(1) GENERATED ALWAYS AS (col1 > 10 AND col2 < 100) STORED,
+vcol3 TINYINT(1) GENERATED ALWAYS AS (col2 > 50 OR col2 < 10) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB,
+PARTITION p2 VALUES IN (2) ENGINE = InnoDB);
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+INSERT INTO t1_working (userId, col1, col2) VALUES (1, 15, 75), (1, 90, 5), (1, 50, 200);
+# This should succeed: EXCHANGE PARTITION with multiple AND/OR conditions
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, col2, vcol1, vcol2, vcol3 FROM t1 ORDER BY id;
+id	userId	col1	col2	vcol1	vcol2	vcol3
+1	1	15	75	1	1	1
+2	1	90	5	1	1	1
+3	1	50	200	0	0	1
+DROP TABLE t1_working;
+DROP TABLE t1;
+# Test 4: Nested AND/OR conditions
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+col2 INT NOT NULL,
+col3 INT NOT NULL,
+vcol4 TINYINT(1) GENERATED ALWAYS AS ((col1 > 10 AND col2 < 100) OR col3 > 50) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+INSERT INTO t1_working (userId, col1, col2, col3) VALUES (1, 20, 50, 30), (1, 5, 200, 60);
+# This should succeed: EXCHANGE PARTITION with nested AND/OR conditions
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
+id	userId	col1	col2	col3	vcol4
+1	1	20	50	30	1
+2	1	5	200	60	1
+DROP TABLE t1_working;
+DROP TABLE t1;
+# End of test

--- a/mysql-test/suite/parts/r/partition_exchange_generated_columns.result
+++ b/mysql-test/suite/parts/r/partition_exchange_generated_columns.result
@@ -1,8 +1,7 @@
 #
 # Test EXCHANGE PARTITION with generated columns containing AND/OR conditions
-# This verifies that Item_cond::eq() correctly performs set-based comparison
-# for commutative AND/OR operations, allowing partition exchange to succeed
-# even when condition order differs between original and re-parsed expressions.
+# This verifies set comparison of generated column conditions during
+# partition exchange.
 # verifies MDEV-38757
 #
 DROP TABLE IF EXISTS t1, t1_working;
@@ -93,6 +92,38 @@ CREATE TABLE t1_working LIKE t1;
 ALTER TABLE t1_working REMOVE PARTITIONING;
 INSERT INTO t1_working (userId, col1, col2, col3) VALUES (1, 20, 50, 30), (1, 5, 200, 60);
 # This should succeed: EXCHANGE PARTITION with nested AND/OR conditions
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
+id	userId	col1	col2	col3	vcol4
+1	1	20	50	30	1
+2	1	5	200	60	1
+DROP TABLE t1_working;
+DROP TABLE t1;
+# Test 5: Reordered condition with a duplicate term
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+col2 INT NOT NULL,
+col3 INT NOT NULL,
+vcol4 TINYINT(1) GENERATED ALWAYS AS
+(col1 > 10 AND col2 < 100 OR col3 > 50) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+CREATE TABLE t1_working (
+id INT NOT NULL AUTO_INCREMENT,
+userId INT NOT NULL,
+col1 INT NOT NULL,
+col2 INT NOT NULL,
+col3 INT NOT NULL,
+vcol4 TINYINT(1) GENERATED ALWAYS AS
+(col3 > 50 OR col1 > 10 AND col2 < 100 OR col3 > 50) STORED,
+PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+INSERT INTO t1_working (userId, col1, col2, col3)
+VALUES (1, 20, 50, 30), (1, 5, 200, 60);
 ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
 SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
 id	userId	col1	col2	col3	vcol4

--- a/mysql-test/suite/parts/t/partition_exchange_generated_columns.test
+++ b/mysql-test/suite/parts/t/partition_exchange_generated_columns.test
@@ -1,0 +1,117 @@
+--source include/have_innodb.inc
+--source include/have_partition.inc
+
+--echo #
+--echo # Test EXCHANGE PARTITION with generated columns containing AND/OR conditions
+--echo # This verifies that Item_cond::eq() correctly performs set-based comparison
+--echo # for commutative AND/OR operations, allowing partition exchange to succeed
+--echo # even when condition order differs between original and re-parsed expressions.
+--echo # verifies MDEV-38757
+--echo #
+
+--disable_warnings
+DROP TABLE IF EXISTS t1, t1_working;
+--enable_warnings
+
+--echo # Test 1: Generated column with OR condition
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  vcol1 TINYINT(1) GENERATED ALWAYS AS (col1 > 80 OR col1 < 20) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB,
+ PARTITION p2 VALUES IN (2) ENGINE = InnoDB);
+
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+
+INSERT INTO t1_working (userId, col1) VALUES (1, 10), (1, 50), (1, 90);
+
+--echo # This should succeed: EXCHANGE PARTITION with OR condition
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+
+SELECT id, userId, col1, vcol1 FROM t1 ORDER BY id;
+DROP TABLE t1_working;
+DROP TABLE t1;
+
+--echo # Test 2: Generated column with AND condition
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  vcol2 TINYINT(1) GENERATED ALWAYS AS (col1 > 10 AND col2 < 100) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+
+INSERT INTO t1_working (userId, col1, col2) VALUES (1, 20, 50), (1, 5, 200);
+
+--echo # This should succeed: EXCHANGE PARTITION with AND condition
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+
+SELECT id, userId, col1, col2, vcol2 FROM t1 ORDER BY id;
+DROP TABLE t1_working;
+DROP TABLE t1;
+
+--echo # Test 3: Multiple generated columns with different AND/OR combinations
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  vcol1 TINYINT(1) GENERATED ALWAYS AS (col1 > 80 OR col1 < 20) STORED,
+  vcol2 TINYINT(1) GENERATED ALWAYS AS (col1 > 10 AND col2 < 100) STORED,
+  vcol3 TINYINT(1) GENERATED ALWAYS AS (col2 > 50 OR col2 < 10) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB,
+ PARTITION p2 VALUES IN (2) ENGINE = InnoDB);
+
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+
+INSERT INTO t1_working (userId, col1, col2) VALUES (1, 15, 75), (1, 90, 5), (1, 50, 200);
+
+--echo # This should succeed: EXCHANGE PARTITION with multiple AND/OR conditions
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+
+SELECT id, userId, col1, col2, vcol1, vcol2, vcol3 FROM t1 ORDER BY id;
+DROP TABLE t1_working;
+DROP TABLE t1;
+
+--echo # Test 4: Nested AND/OR conditions
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  col3 INT NOT NULL,
+  vcol4 TINYINT(1) GENERATED ALWAYS AS ((col1 > 10 AND col2 < 100) OR col3 > 50) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+
+CREATE TABLE t1_working LIKE t1;
+ALTER TABLE t1_working REMOVE PARTITIONING;
+
+INSERT INTO t1_working (userId, col1, col2, col3) VALUES (1, 20, 50, 30), (1, 5, 200, 60);
+
+--echo # This should succeed: EXCHANGE PARTITION with nested AND/OR conditions
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+
+SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
+DROP TABLE t1_working;
+
+DROP TABLE t1;
+
+--echo # End of test

--- a/mysql-test/suite/parts/t/partition_exchange_generated_columns.test
+++ b/mysql-test/suite/parts/t/partition_exchange_generated_columns.test
@@ -3,9 +3,8 @@
 
 --echo #
 --echo # Test EXCHANGE PARTITION with generated columns containing AND/OR conditions
---echo # This verifies that Item_cond::eq() correctly performs set-based comparison
---echo # for commutative AND/OR operations, allowing partition exchange to succeed
---echo # even when condition order differs between original and re-parsed expressions.
+--echo # This verifies set comparison of generated column conditions during
+--echo # partition exchange.
 --echo # verifies MDEV-38757
 --echo #
 
@@ -112,6 +111,40 @@ ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
 SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
 DROP TABLE t1_working;
 
+DROP TABLE t1;
+
+--echo # Test 5: Reordered condition with a duplicate term
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  col3 INT NOT NULL,
+  vcol4 TINYINT(1) GENERATED ALWAYS AS
+    (col1 > 10 AND col2 < 100 OR col3 > 50) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY LIST (userId)
+(PARTITION p1 VALUES IN (1) ENGINE = InnoDB);
+
+CREATE TABLE t1_working (
+  id INT NOT NULL AUTO_INCREMENT,
+  userId INT NOT NULL,
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  col3 INT NOT NULL,
+  vcol4 TINYINT(1) GENERATED ALWAYS AS
+    (col3 > 50 OR col1 > 10 AND col2 < 100 OR col3 > 50) STORED,
+  PRIMARY KEY (id, userId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO t1_working (userId, col1, col2, col3)
+VALUES (1, 20, 50, 30), (1, 5, 200, 60);
+
+ALTER TABLE t1 EXCHANGE PARTITION p1 WITH TABLE t1_working;
+SELECT id, userId, col1, col2, col3, vcol4 FROM t1 ORDER BY id;
+
+DROP TABLE t1_working;
 DROP TABLE t1;
 
 --echo # End of test

--- a/sql/field.h
+++ b/sql/field.h
@@ -659,7 +659,8 @@ public:
   bool cleanup_session_expr();
   bool fix_and_check_expr(THD *thd, TABLE *table);
   bool check_access(THD *thd);
-  inline bool is_equal(const Virtual_column_info* vcol, bool cmp_names) const;
+  inline bool is_equal(const Virtual_column_info* vcol, bool cmp_names,
+                       bool unordered_conditions= false) const;
   inline void print(String*);
 };
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -1269,8 +1269,11 @@ public:
   {
     bool binary_cmp;        /**< Make binary comparison */
     bool omit_table_names;  /**< Skip table and db names comparison */
-    Eq_config(bool binary_cmp, bool omit_table_names= false)
-      : binary_cmp(binary_cmp), omit_table_names(omit_table_names) {}
+    bool unordered_conditions; /**< Ignore AND/OR operand order and duplicates */
+    Eq_config(bool binary_cmp, bool omit_table_names= false,
+              bool unordered_conditions= false)
+      : binary_cmp(binary_cmp), omit_table_names(omit_table_names),
+        unordered_conditions(unordered_conditions) {}
   };
   virtual bool eq(const Item *, const Eq_config &config) const;
   enum_field_types field_type() const
@@ -8385,11 +8388,13 @@ bool fix_escape_item(THD *thd, Item *escape_item, String *tmp_str,
                      int *escape);
 
 inline bool Virtual_column_info::is_equal(const Virtual_column_info* vcol,
-                                          bool omit_table_names) const
+                                          bool omit_table_names,
+                                          bool unordered_conditions) const
 {
   return type_handler()  == vcol->type_handler()
       && stored_in_db == vcol->is_stored()
-      && expr->eq(vcol->expr, {true, omit_table_names});
+      && expr->eq(vcol->expr,
+                  {true, omit_table_names, unordered_conditions});
 }
 
 inline void Virtual_column_info::print(String* str)

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -5597,37 +5597,36 @@ bool Item_cond::excl_dep_on_grouping_fields(st_select_lex *sel)
 
 /**
   Compare two Item_cond expressions for equality.
-  
-  For AND/OR conditions, the order of arguments doesn't matter (commutative),
-  so we need to do a set-based comparison rather than order-based.
-  
+
+  Distinct AND/OR items are normally not considered equal, preserving their
+  execution order. Some metadata comparisons can explicitly request a set
+  comparison because table definitions may be serialized with their
+  arguments reordered.
+
   @param item   The other Item to compare with
   @param config Comparison configuration
-  
+
   @return true if expressions are equivalent, false otherwise
 */
 bool Item_cond::eq(const Item *item, const Eq_config &config) const
 {
-  /* Assume we don't have rtti */
   if (this == item)
     return true;
-  
-  /* Ensure we are comparing two condition items */
-  if (item->type() != COND_ITEM)
+
+  if (item->type() != COND_ITEM || (used_tables() & RAND_TABLE_BIT))
     return false;
-  
+
   const Item_cond *item_cond= (const Item_cond *) item;
-  
-  /* Must be same type (AND vs OR) */
   if (functype() != item_cond->functype())
     return false;
-  
-  /* Must have same number of arguments */
-  if (list.elements != item_cond->list.elements)
+
+  if (!config.unordered_conditions)
     return false;
-  
-  /* For AND/OR conditions, order doesn't matter - do set-based comparison */
-  /* Check if every argument in this list has an equivalent in the other list */
+
+  /*
+    Treat the argument lists as sets. Checking both directions deliberately
+    ignores duplicate terms: A OR B and A OR B OR A are equivalent here.
+  */
   List_iterator_fast<Item> li1(const_cast<List<Item>&>(list));
   Item *arg1;
   while ((arg1= li1++))
@@ -5646,9 +5645,7 @@ bool Item_cond::eq(const Item *item, const Eq_config &config) const
     if (!found_match)
       return false;
   }
-  
-  /* Also check the reverse - every argument in other list has equivalent in this list */
-  /* (This handles cases where there might be duplicates) */
+
   List_iterator_fast<Item> li2(const_cast<List<Item>&>(item_cond->list));
   Item *arg2;
   while ((arg2= li2++))
@@ -5667,7 +5664,7 @@ bool Item_cond::eq(const Item *item, const Eq_config &config) const
     if (!found_match)
       return false;
   }
-  
+
   return true;
 }
 

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -3341,6 +3341,7 @@ public:
   Item *deep_copy(THD *thd) const override;
   bool excl_dep_on_table(table_map tab_map) override;
   bool excl_dep_on_grouping_fields(st_select_lex *sel) override;
+  bool eq(const Item *item, const Eq_config &config) const override;
 
 private:
   void merge_sub_condition(List_iterator<Item>& li);

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -248,7 +248,7 @@ bool compare_table_with_partition(THD *thd, TABLE *table, TABLE *part_table,
     the same, so any table using data/index_file_name will fail.
   */
   if (mysql_compare_tables(table, &part_alter_info, &part_create_info,
-                           &metadata_equal))
+                           &metadata_equal, true))
   {
     my_error(ER_TABLES_DIFFERENT_METADATA, MYF(0));
     DBUG_RETURN(TRUE);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7531,13 +7531,17 @@ static void update_altered_table(const Alter_inplace_info &ha_alter_info,
                              second table.
   @param[in]  create_info    Create options for the second table.
   @param[out] metadata_equal Result of comparison.
+  @param[in]  compare_vcol_expr_as_sets
+                             Ignore AND/OR order and duplicate terms in
+                             generated column expressions.
 
   @retval true   error
   @retval false  success
 */
 
 bool mysql_compare_tables(TABLE *table, Alter_info *alter_info,
-                          HA_CREATE_INFO *create_info, bool *metadata_equal)
+                          HA_CREATE_INFO *create_info, bool *metadata_equal,
+                          bool compare_vcol_expr_as_sets)
 {
   DBUG_ENTER("mysql_compare_tables");
 
@@ -7606,7 +7610,8 @@ bool mysql_compare_tables(TABLE *table, Alter_info *alter_info,
     {
       if (!tmp_new_field->field->vcol_info)
         DBUG_RETURN(false);
-      if (!field->vcol_info->is_equal(tmp_new_field->field->vcol_info, true))
+      if (!field->vcol_info->is_equal(tmp_new_field->field->vcol_info,
+                                      true, compare_vcol_expr_as_sets))
         DBUG_RETURN(false);
     }
 

--- a/sql/sql_table.h
+++ b/sql/sql_table.h
@@ -165,7 +165,8 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
 bool mysql_compare_tables(TABLE *table,
                           Alter_info *alter_info,
                           HA_CREATE_INFO *create_info,
-                          bool *metadata_equal);
+                          bool *metadata_equal,
+                          bool compare_vcol_expr_as_sets);
 bool mysql_recreate_table(THD *thd, TABLE_LIST *table_list,
                           class Recreate_info *recreate_info, bool table_copy);
 bool mysql_rename_table(handlerton *base, const LEX_CSTRING *old_db,


### PR DESCRIPTION
EXCHANGE PARTITION fails with ERROR 1736 (Tables have different definitions) when tables contain generated columns with AND/OR conditions, even when the expressions are logically equivalent. This occurs because when expressions are re-parsed (e.g., via CREATE TABLE ... LIKE), the order of arguments in AND/OR conditions may change, but the comparison was order-sensitive.

The Item_cond::eq() method was implemented to perform set-based comparison for commutative AND/OR operations. The set-based comparison algorithm ensures that two Item_cond expressions are considered equal if they contain the same set of equivalent arguments, regardless of order.

Added comprehensive test case covering:
- Generated columns with OR conditions
- Generated columns with AND conditions
- Multiple generated columns with different AND/OR combinations
- Nested AND/OR conditions

The fix allows EXCHANGE PARTITION to succeed when expressions are logically equivalent but have different argument ordering, which is correct behavior since AND/OR operations are commutative.