### PR TITLE
MDEV-34228: Support underscores in numeric literals (SQL:2023 T662)

### DIFF
--- a/mysql-test/main/numeric_underscores.result
+++ b/mysql-test/main/numeric_underscores.result
@@ -1,0 +1,78 @@
+#
+# MDEV-34228: Underscores in numeric literals
+#
+# Standard integers
+SELECT 1_000;
+1000
+1000
+SELECT 1_234_567;
+1234567
+1234567
+SELECT +1_000, -1_000;
+1000	-1_000
+1000	-1000
+# Consecutive underscores -> Identifier
+CREATE TABLE t1 (1__000 INT);
+INSERT INTO t1 VALUES (5);
+SELECT 1__000 AS val FROM t1;
+val
+5
+DROP TABLE t1;
+# Hexadecimal
+SELECT 0x_FF;
+0x_FF
+ÿ
+SELECT 0x_FFFF_FFFF;
+0x_FFFF_FFFF
+ÿÿÿÿ
+SELECT 0x1_F;
+0x1_F
+
+# Binary
+SELECT 0b_1010;
+0b_1010
+
+
+SELECT 0b_1111_0000;
+0b_1111_0000
+ð
+SELECT 0b1_0;
+0b1_0
+
+# Decimal
+SELECT 1_000.001;
+1000.001
+1000.001
+SELECT 1000.000_5;
+1000.0005
+1000.0005
+SELECT 1_000.000_001;
+1000.000001
+1000.000001
+# Floating point
+SELECT 1_2.3_4e1_0;
+12.34e10
+123400000000
+SELECT 1.2e+1_0;
+1.2e+10
+12000000000
+SELECT 1.2e-1_0;
+1.2e-10
+0.00000000012
+# Digit start, contains letter -> Identifier
+CREATE TABLE t1 (1a INT);
+INSERT INTO t1 VALUES (3);
+SELECT 1a FROM t1;
+1a
+3
+DROP TABLE t1;
+# This should fail because 1_000 is now a number, not an identifier
+CREATE TABLE t1 (1_000 INT);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1_000 INT)' at line 1
+# Mixed tests
+SELECT 1_000 + 0x_FF;
+1_000 + 0x_FF
+1255
+SELECT 1_2.3_4e1 + 1_0;
+1_2.3_4e1 + 1_0
+133.4

--- a/mysql-test/main/numeric_underscores.result
+++ b/mysql-test/main/numeric_underscores.result
@@ -114,3 +114,149 @@ SELECT 1_0.0_1e1_0;
 SELECT 0x1_F, 0b1_0;
 0x1_F	0b1_0
 	
+#
+# MDEV-34228: Underscores in CAST and string-to-number conversions
+#
+# =========================================
+# CAST to UNSIGNED — reuse literal patterns
+# =========================================
+SELECT CAST('1_000' AS UNSIGNED);
+CAST('1_000' AS UNSIGNED)
+1000
+SELECT CAST('1_234_567' AS UNSIGNED);
+CAST('1_234_567' AS UNSIGNED)
+1234567
+SELECT CAST('+1_000' AS UNSIGNED);
+CAST('+1_000' AS UNSIGNED)
+1000
+# CAST to SIGNED
+SELECT CAST('-1_000' AS SIGNED);
+CAST('-1_000' AS SIGNED)
+-1000
+SELECT CAST('1_000' AS SIGNED);
+CAST('1_000' AS SIGNED)
+1000
+SELECT CAST('+1_234_567' AS SIGNED);
+CAST('+1_234_567' AS SIGNED)
+1234567
+# CAST to DECIMAL — from the decimal/float literals above
+SELECT CAST('1_000.001' AS DECIMAL(10,3));
+CAST('1_000.001' AS DECIMAL(10,3))
+1000.001
+SELECT CAST('1000.000_5' AS DECIMAL(10,4));
+CAST('1000.000_5' AS DECIMAL(10,4))
+1000.0005
+SELECT CAST('1_000.000_001' AS DECIMAL(13,6));
+CAST('1_000.000_001' AS DECIMAL(13,6))
+1000.000001
+# CAST to DOUBLE — from the float literals above
+SELECT CAST('1_2.3_4e1_0' AS DOUBLE);
+CAST('1_2.3_4e1_0' AS DOUBLE)
+123400000000
+SELECT CAST('1.2e+1_0' AS DOUBLE);
+CAST('1.2e+1_0' AS DOUBLE)
+12000000000
+SELECT CAST('1.2e-1_0' AS DOUBLE);
+CAST('1.2e-1_0' AS DOUBLE)
+0.00000000012
+# =================================
+# Invalid underscores in CAST input
+# =================================
+# Consecutive underscores — should truncate after first digit group
+SELECT CAST('1__234' AS UNSIGNED);
+CAST('1__234' AS UNSIGNED)
+1
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '1__234'
+SELECT CAST('1__234' AS SIGNED);
+CAST('1__234' AS SIGNED)
+1
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '1__234'
+SELECT CAST('1__234' AS DECIMAL(10,0));
+CAST('1__234' AS DECIMAL(10,0))
+1
+Warnings:
+Warning	1292	Truncated incorrect DECIMAL value: '1__234'
+SELECT CAST('1__234' AS DOUBLE);
+CAST('1__234' AS DOUBLE)
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '1__234'
+# Trailing underscore — should truncate
+SELECT CAST('1000_' AS UNSIGNED);
+CAST('1000_' AS UNSIGNED)
+1000
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '1000_'
+# Leading underscore — should be 0 with warning
+SELECT CAST('_1000' AS UNSIGNED);
+CAST('_1000' AS UNSIGNED)
+0
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '_1000'
+# Underscore adjacent to decimal point
+SELECT CAST('1_.0' AS DECIMAL(10,1));
+CAST('1_.0' AS DECIMAL(10,1))
+1.0
+Warnings:
+Warning	1292	Truncated incorrect DECIMAL value: '1_.0'
+SELECT CAST('1._0' AS DECIMAL(10,1));
+CAST('1._0' AS DECIMAL(10,1))
+1.0
+Warnings:
+Warning	1292	Truncated incorrect DECIMAL value: '1._0'
+# Underscore adjacent to exponent marker
+SELECT CAST('1.0_e10' AS DOUBLE);
+CAST('1.0_e10' AS DOUBLE)
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '1.0_e10'
+SELECT CAST('1.0e_10' AS DOUBLE);
+CAST('1.0e_10' AS DOUBLE)
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '1.0e_10'
+# ============================
+# Implicit string-to-number
+# ============================
+SELECT '1_000' + 0;
+'1_000' + 0
+1000
+SELECT '1_234_567' + 0;
+'1_234_567' + 0
+1234567
+SELECT '-1_000' + 0;
+'-1_000' + 0
+-1000
+SELECT '1_000.50' + 0.0;
+'1_000.50' + 0.0
+1000.5
+SELECT '1_2.3_4e1_0' + 0e0;
+'1_2.3_4e1_0' + 0e0
+123400000000
+# Invalid underscore in implicit conversion
+SELECT '1__234' + 0;
+'1__234' + 0
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '1__234'
+SELECT '1000_' + 0;
+'1000_' + 0
+1000
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '1000_'
+SELECT '_1000' + 0;
+'_1000' + 0
+0
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '_1000'
+# ============================
+# Hex/Binary strings via CAST
+# ============================
+# Note: CAST('0xFF' as UNSIGNED) itself returns 0, hence CAST('0x_FF' AS UNSIGNED) also doesn't work yet.
+SELECT CAST('0x_FF' AS UNSIGNED);
+CAST('0x_FF' AS UNSIGNED)
+0
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '0x_FF'

--- a/mysql-test/main/numeric_underscores.result
+++ b/mysql-test/main/numeric_underscores.result
@@ -28,6 +28,9 @@ SELECT 0x_FFFF_FFFF;
 SELECT 0x1_F;
 0x1_F
 
+SELECT 0xABCD_EF01;
+0xABCD_EF01
+«Íï
 # Binary
 SELECT 0b_1010;
 0b_1010
@@ -39,6 +42,9 @@ SELECT 0b_1111_0000;
 SELECT 0b1_0;
 0b1_0
 
+SELECT 0b1111_0000;
+0b1111_0000
+ð
 # Decimal
 SELECT 1_000.001;
 1000.001
@@ -76,3 +82,35 @@ SELECT 1_000 + 0x_FF;
 SELECT 1_2.3_4e1 + 1_0;
 1_2.3_4e1 + 1_0
 133.4
+#
+# Boundary cases and negative tests
+#
+# Underscore adjacent to decimal point (should NOT be a single number)
+SELECT (1._0);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '_0)' at line 1
+SELECT (1_.0);
+ERROR 42S02: Unknown table '1_' in SELECT
+# Hex and Binary prefixes (leading underscore is valid per T662)
+SELECT 0x_FF, 0b_1010;
+0x_FF	0b_1010
+ÿ	
+
+# 1_e10 -> should be an identifier, so (1_e10) fails if no such column
+SELECT (1_e10);
+ERROR 42S22: Unknown column '1_e10' in 'SELECT'
+# 1.0_e10 -> (1.0_e10) should fail as syntax error if split
+SELECT (1.0_e10);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '_e10)' at line 1
+# 1e_10 -> identifier or error
+SELECT (1e_10);
+ERROR 42S22: Unknown column '1e_10' in 'SELECT'
+# Start with underscore
+SELECT _1.0;
+Got one of the listed errors
+# Valid cases for comparison
+SELECT 1_0.0_1e1_0;
+10.01e10
+100100000000
+SELECT 0x1_F, 0b1_0;
+0x1_F	0b1_0
+	

--- a/mysql-test/main/numeric_underscores.test
+++ b/mysql-test/main/numeric_underscores.test
@@ -83,3 +83,73 @@ SELECT _1.0;
 --echo # Valid cases for comparison
 SELECT 1_0.0_1e1_0;
 SELECT 0x1_F, 0b1_0;
+
+--echo #
+--echo # MDEV-34228: Underscores in CAST and string-to-number conversions
+--echo #
+
+--echo # =========================================
+--echo # CAST to UNSIGNED — reuse literal patterns
+--echo # =========================================
+SELECT CAST('1_000' AS UNSIGNED);
+SELECT CAST('1_234_567' AS UNSIGNED);
+SELECT CAST('+1_000' AS UNSIGNED);
+
+--echo # CAST to SIGNED
+SELECT CAST('-1_000' AS SIGNED);
+SELECT CAST('1_000' AS SIGNED);
+SELECT CAST('+1_234_567' AS SIGNED);
+
+--echo # CAST to DECIMAL — from the decimal/float literals above
+SELECT CAST('1_000.001' AS DECIMAL(10,3));
+SELECT CAST('1000.000_5' AS DECIMAL(10,4));
+SELECT CAST('1_000.000_001' AS DECIMAL(13,6));
+
+--echo # CAST to DOUBLE — from the float literals above
+SELECT CAST('1_2.3_4e1_0' AS DOUBLE);
+SELECT CAST('1.2e+1_0' AS DOUBLE);
+SELECT CAST('1.2e-1_0' AS DOUBLE);
+
+--echo # =================================
+--echo # Invalid underscores in CAST input
+--echo # =================================
+
+--echo # Consecutive underscores — should truncate after first digit group
+SELECT CAST('1__234' AS UNSIGNED);
+SELECT CAST('1__234' AS SIGNED);
+SELECT CAST('1__234' AS DECIMAL(10,0));
+SELECT CAST('1__234' AS DOUBLE);
+
+--echo # Trailing underscore — should truncate
+SELECT CAST('1000_' AS UNSIGNED);
+
+--echo # Leading underscore — should be 0 with warning
+SELECT CAST('_1000' AS UNSIGNED);
+
+--echo # Underscore adjacent to decimal point
+SELECT CAST('1_.0' AS DECIMAL(10,1));
+SELECT CAST('1._0' AS DECIMAL(10,1));
+
+--echo # Underscore adjacent to exponent marker
+SELECT CAST('1.0_e10' AS DOUBLE);
+SELECT CAST('1.0e_10' AS DOUBLE);
+
+--echo # ============================
+--echo # Implicit string-to-number
+--echo # ============================
+SELECT '1_000' + 0;
+SELECT '1_234_567' + 0;
+SELECT '-1_000' + 0;
+SELECT '1_000.50' + 0.0;
+SELECT '1_2.3_4e1_0' + 0e0;
+
+--echo # Invalid underscore in implicit conversion
+SELECT '1__234' + 0;
+SELECT '1000_' + 0;
+SELECT '_1000' + 0;
+
+--echo # ============================
+--echo # Hex/Binary strings via CAST
+--echo # ============================
+--echo # Note: CAST('0xFF' as UNSIGNED) itself returns 0, hence CAST('0x_FF' AS UNSIGNED) also doesn't work yet.
+SELECT CAST('0x_FF' AS UNSIGNED);

--- a/mysql-test/main/numeric_underscores.test
+++ b/mysql-test/main/numeric_underscores.test
@@ -1,0 +1,50 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-34228: Underscores in numeric literals
+--echo #
+
+--echo # Standard integers
+SELECT 1_000;
+SELECT 1_234_567;
+SELECT +1_000, -1_000;
+
+--echo # Consecutive underscores -> Identifier
+CREATE TABLE t1 (1__000 INT);
+INSERT INTO t1 VALUES (5);
+SELECT 1__000 AS val FROM t1;
+DROP TABLE t1;
+
+--echo # Hexadecimal
+SELECT 0x_FF;
+SELECT 0x_FFFF_FFFF;
+SELECT 0x1_F;
+
+--echo # Binary
+SELECT 0b_1010;
+SELECT 0b_1111_0000;
+SELECT 0b1_0;
+
+--echo # Decimal
+SELECT 1_000.001;
+SELECT 1000.000_5;
+SELECT 1_000.000_001;
+
+--echo # Floating point
+SELECT 1_2.3_4e1_0;
+SELECT 1.2e+1_0;
+SELECT 1.2e-1_0;
+
+--echo # Digit start, contains letter -> Identifier
+CREATE TABLE t1 (1a INT);
+INSERT INTO t1 VALUES (3);
+SELECT 1a FROM t1;
+DROP TABLE t1;
+
+--echo # This should fail because 1_000 is now a number, not an identifier
+--error ER_PARSE_ERROR
+CREATE TABLE t1 (1_000 INT);
+
+--echo # Mixed tests
+SELECT 1_000 + 0x_FF;
+SELECT 1_2.3_4e1 + 1_0;

--- a/mysql-test/main/numeric_underscores.test
+++ b/mysql-test/main/numeric_underscores.test
@@ -19,11 +19,13 @@ DROP TABLE t1;
 SELECT 0x_FF;
 SELECT 0x_FFFF_FFFF;
 SELECT 0x1_F;
+SELECT 0xABCD_EF01;
 
 --echo # Binary
 SELECT 0b_1010;
 SELECT 0b_1111_0000;
 SELECT 0b1_0;
+SELECT 0b1111_0000;
 
 --echo # Decimal
 SELECT 1_000.001;
@@ -48,3 +50,36 @@ CREATE TABLE t1 (1_000 INT);
 --echo # Mixed tests
 SELECT 1_000 + 0x_FF;
 SELECT 1_2.3_4e1 + 1_0;
+
+--echo #
+--echo # Boundary cases and negative tests
+--echo #
+
+--echo # Underscore adjacent to decimal point (should NOT be a single number)
+--error ER_PARSE_ERROR
+SELECT (1._0);
+--error ER_UNKNOWN_TABLE
+SELECT (1_.0);
+
+--echo # Hex and Binary prefixes (leading underscore is valid per T662)
+SELECT 0x_FF, 0b_1010;
+
+--echo # 1_e10 -> should be an identifier, so (1_e10) fails if no such column
+--error ER_BAD_FIELD_ERROR
+SELECT (1_e10);
+
+--echo # 1.0_e10 -> (1.0_e10) should fail as syntax error if split
+--error ER_PARSE_ERROR
+SELECT (1.0_e10);
+
+--echo # 1e_10 -> identifier or error
+--error ER_BAD_FIELD_ERROR
+SELECT (1e_10);
+
+--echo # Start with underscore
+--error ER_BAD_FIELD_ERROR,ER_UNKNOWN_TABLE
+SELECT _1.0;
+
+--echo # Valid cases for comparison
+SELECT 1_0.0_1e1_0;
+SELECT 0x1_F, 0b1_0;

--- a/mysql-test/main/sp_notembedded.result
+++ b/mysql-test/main/sp_notembedded.result
@@ -38,22 +38,22 @@ ERROR 70100: Query execution was interrupted
 drop procedure bug6807|
 create user 'mysqltest_1'@'localhost';
 grant all privileges on test.* to 'mysqltest_1'@'localhost';
-create procedure 15298_1 () sql security definer show grants for current_user;
-create procedure 15298_2 () sql security definer show grants;
+create procedure 15298__1 () sql security definer show grants for current_user;
+create procedure 15298__2 () sql security definer show grants;
 connect  con1,localhost,mysqltest_1,,test;
-call 15298_1();
+call 15298__1();
 Grants for root@localhost
 GRANT ALL PRIVILEGES ON *.* TO `root`@`localhost` WITH GRANT OPTION
 GRANT PROXY ON ''@'%' TO 'root'@'localhost' WITH GRANT OPTION
-call 15298_2();
+call 15298__2();
 Grants for root@localhost
 GRANT ALL PRIVILEGES ON *.* TO `root`@`localhost` WITH GRANT OPTION
 GRANT PROXY ON ''@'%' TO 'root'@'localhost' WITH GRANT OPTION
 connection default;
 disconnect con1;
 drop user mysqltest_1@localhost;
-drop procedure 15298_1;
-drop procedure 15298_2;
+drop procedure 15298__1;
+drop procedure 15298__2;
 create table t1 (value varchar(15));
 create procedure p1() update t1 set value='updated' where value='old';
 call p1();

--- a/mysql-test/main/sp_notembedded.test
+++ b/mysql-test/main/sp_notembedded.test
@@ -68,18 +68,18 @@ delimiter ;|
 #
 create user 'mysqltest_1'@'localhost';
 grant all privileges on test.* to 'mysqltest_1'@'localhost';
-create procedure `15298_1` () sql security definer show grants for current_user;
-create procedure `15298_2` () sql security definer show grants;
+create procedure 15298__1 () sql security definer show grants for current_user;
+create procedure 15298__2 () sql security definer show grants;
 
 connect (con1,localhost,mysqltest_1,,test);
-call `15298_1`();
-call `15298_2`();
+call 15298__1();
+call 15298__2();
 
 connection default;
 disconnect con1;
 drop user mysqltest_1@localhost;
-drop procedure `15298_1`;
-drop procedure `15298_2`;
+drop procedure 15298__1;
+drop procedure 15298__2;
 
 #
 # Bug#29936 Stored Procedure DML ignores low_priority_updates setting

--- a/mysql-test/main/sp_notembedded.test
+++ b/mysql-test/main/sp_notembedded.test
@@ -68,18 +68,18 @@ delimiter ;|
 #
 create user 'mysqltest_1'@'localhost';
 grant all privileges on test.* to 'mysqltest_1'@'localhost';
-create procedure 15298_1 () sql security definer show grants for current_user;
-create procedure 15298_2 () sql security definer show grants;
+create procedure `15298_1` () sql security definer show grants for current_user;
+create procedure `15298_2` () sql security definer show grants;
 
 connect (con1,localhost,mysqltest_1,,test);
-call 15298_1();
-call 15298_2();
+call `15298_1`();
+call `15298_2`();
 
 connection default;
 disconnect con1;
 drop user mysqltest_1@localhost;
-drop procedure 15298_1;
-drop procedure 15298_2;
+drop procedure `15298_1`;
+drop procedure `15298_2`;
 
 #
 # Bug#29936 Stored Procedure DML ignores low_priority_updates setting

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1576,7 +1576,7 @@ LEX_CSTRING Lex_input_stream::get_numeric_token(uint skip, uint length)
 
 
 LEX_CSTRING Lex_input_stream::strip_underscores(const char *str,
-                                                size_t length)
+                                                uint length)
 {
   LEX_CSTRING res;
   char *to;
@@ -1594,7 +1594,7 @@ LEX_CSTRING Lex_input_stream::strip_underscores(const char *str,
     return res;
   }
   res.str= to;
-  for (size_t i= 0; i < length; i++)
+  for (uint i= 0; i < length; i++)
   {
     if (str[i] != '_')
       *to++= str[i];

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1562,6 +1562,52 @@ LEX_CSTRING Lex_input_stream::get_token(uint skip, uint length)
   return tmp;
 }
 
+/* Wrapper for get_token that handles underscores in numeric literals */
+LEX_CSTRING Lex_input_stream::get_numeric_token(uint skip, uint length)
+{
+  const char *str= m_tok_start + skip;
+  for (uint i= 0; i < length; i++)
+  {
+    if (str[i] == '_')
+      return strip_underscores(str, length);
+  }
+  return get_token(skip, length);
+}
+
+
+LEX_CSTRING Lex_input_stream::strip_underscores(const char *str,
+                                                size_t length)
+{
+  LEX_CSTRING res;
+  char *to;
+  yyUnget();
+
+  /* 
+    Allocate memory for the new string with length size (at least 1 
+    underscore will be removed. We can iterate over str to count
+    exact size of the new string, but that may be slower.
+  */
+  if (!(to= m_thd->alloc<char>(length)))
+  {
+    res.str= 0;
+    res.length= 0;
+    return res;
+  }
+  res.str= to;
+  for (size_t i= 0; i < length; i++)
+  {
+    if (str[i] != '_')
+      *to++= str[i];
+  }
+  *to= 0;
+  res.length= to - res.str;
+
+  m_cpp_text_start= m_cpp_tok_start + (str - m_tok_start);
+  m_cpp_text_end= m_cpp_text_start + length;
+
+  return res;
+}
+
 
 static size_t
 my_unescape(CHARSET_INFO *cs, char *to, const char *str, const char *end,
@@ -2201,11 +2247,31 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
         c= yyGet();
         if (c == 'x')
         {
-          while (my_isxdigit(cs, (c = yyGet()))) ;
+          c= yyPeek();
+          if (c == '_')
+          {
+            yySkip();
+            if (my_isxdigit(cs, yyPeek()))
+            {
+              while (my_isxdigit(cs, (c= yyGet())) ||
+                     (c == '_' && my_isxdigit(cs, yyPeek()))) ;
+            }
+            else
+            {
+              yyUnget(); // Unget _
+              state= MY_LEX_IDENT_START;
+              break;
+            }
+          }
+          else
+          {
+            while (my_isxdigit(cs, (c= yyGet())) ||
+                   (c == '_' && my_isxdigit(cs, yyPeek()))) ;
+          }
           if ((yyLength() >= 3) && !ident_map[c])
           {
             /* skip '0x' */
-            yylval->lex_str= get_token(2, yyLength() - 2);
+            yylval->lex_str= get_numeric_token(2, yyLength() - 2);
             return (HEX_NUM);
           }
           yyUnget();
@@ -2214,12 +2280,31 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
         }
         else if (c == 'b')
         {
-          while ((c= yyGet()) == '0' || c == '1')
-            ;
+          c= yyPeek();
+          if (c == '_')
+          {
+            yySkip();
+            if ((c= yyPeek()) == '0' || c == '1')
+            {
+              while ((c= yyGet()) == '0' || c == '1' ||
+                     (c == '_' && ((c= yyPeek()) == '0' || c == '1'))) ;
+            }
+            else
+            {
+              yyUnget(); // Unget _
+              state= MY_LEX_IDENT_START;
+              break;
+            }
+          }
+          else
+          {
+            while ((c= yyGet()) == '0' || c == '1' ||
+                   (c == '_' && ((c= yyPeek()) == '0' || c == '1'))) ;
+          }
           if ((yyLength() >= 3) && !ident_map[c])
           {
             /* Skip '0b' */
-            yylval->lex_str= get_token(2, yyLength() - 2);
+            yylval->lex_str= get_numeric_token(2, yyLength() - 2);
             return (BIN_NUM);
           }
           yyUnget();
@@ -2229,7 +2314,8 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
         yyUnget();
       }
 
-      while (my_isdigit(cs, (c= yyGet()))) ;
+      while (my_isdigit(cs, (c= yyGet())) ||
+             (c == '_' && my_isdigit(cs, yyPeek()))) ;
       if (!ident_map[c])
       {                                        // Can't be identifier
         state=MY_LEX_INT_OR_REAL;
@@ -2244,8 +2330,9 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
           if (my_isdigit(cs, yyPeek()))         // Number must have digit after sign
           {
             yySkip();
-            while (my_isdigit(cs, yyGet())) ;
-            yylval->lex_str= get_token(0, yyLength());
+            while (my_isdigit(cs, (c= yyGet())) ||
+                   (c == '_' && my_isdigit(cs, yyPeek()))) ;
+            yylval->lex_str= get_numeric_token(0, yyLength());
             return(FLOAT_NUM);
           }
         }
@@ -2284,12 +2371,13 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
           - the number is either not followed by a dot at all, or
           - the number is followed by a double dot as in: FOR i IN 1..10
         */
-        yylval->lex_str= get_token(0, yyLength());
+        yylval->lex_str= get_numeric_token(0, yyLength());
         return int_token(yylval->lex_str.str, (uint) yylval->lex_str.length);
       }
       // fall through
     case MY_LEX_REAL:                           // Incomplete real number
-      while (my_isdigit(cs, c= yyGet())) ;
+      while (my_isdigit(cs, (c= yyGet())) ||
+             (c == '_' && my_isdigit(cs, yyPeek()))) ;
 
       if (c == 'e' || c == 'E')
       {
@@ -2298,11 +2386,12 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
           c= yyGet();                           // Skip sign
         if (!my_isdigit(cs, c))
 	  return ABORT_SYM; // No digit after sign
-        while (my_isdigit(cs, yyGet())) ;
-        yylval->lex_str= get_token(0, yyLength());
+        while (my_isdigit(cs, (c= yyGet())) ||
+               (c == '_' && my_isdigit(cs, yyPeek()))) ;
+        yylval->lex_str= get_numeric_token(0, yyLength());
         return(FLOAT_NUM);
       }
-      yylval->lex_str= get_token(0, yyLength());
+      yylval->lex_str= get_numeric_token(0, yyLength());
       return(DECIMAL_NUM);
 
     case MY_LEX_HEX_NUMBER:             // Found x'hexstring'

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1566,11 +1566,8 @@ LEX_CSTRING Lex_input_stream::get_token(uint skip, uint length)
 LEX_CSTRING Lex_input_stream::get_numeric_token(uint skip, uint length)
 {
   const char *str= m_tok_start + skip;
-  for (uint i= 0; i < length; i++)
-  {
-    if (str[i] == '_')
-      return strip_underscores(str, length);
-  }
+  if (memchr(str, '_', length))
+    return strip_underscores(str, length);
   return get_token(skip, length);
 }
 

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -2247,26 +2247,17 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
         c= yyGet();
         if (c == 'x')
         {
-          c= yyPeek();
-          if (c == '_')
-          {
-            yySkip();
-            if (my_isxdigit(cs, yyPeek()))
-            {
-              while (my_isxdigit(cs, (c= yyGet())) ||
-                     (c == '_' && my_isxdigit(cs, yyPeek()))) ;
-            }
-            else
-            {
-              yyUnget(); // Unget _
-              state= MY_LEX_IDENT_START;
-              break;
-            }
-          }
-          else
+          if (my_isxdigit(cs, (c= yyGet())) ||
+              (c == '_' && my_isxdigit(cs, yyPeek())))
           {
             while (my_isxdigit(cs, (c= yyGet())) ||
                    (c == '_' && my_isxdigit(cs, yyPeek()))) ;
+          }
+          else
+          {
+            yyUnget(); // Unget character
+            state= MY_LEX_IDENT_START;
+            break;
           }
           if ((yyLength() >= 3) && !ident_map[c])
           {
@@ -2280,26 +2271,17 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
         }
         else if (c == 'b')
         {
-          c= yyPeek();
-          if (c == '_')
-          {
-            yySkip();
-            if ((c= yyPeek()) == '0' || c == '1')
-            {
-              while ((c= yyGet()) == '0' || c == '1' ||
-                     (c == '_' && ((c= yyPeek()) == '0' || c == '1'))) ;
-            }
-            else
-            {
-              yyUnget(); // Unget _
-              state= MY_LEX_IDENT_START;
-              break;
-            }
-          }
-          else
+          if ((c= yyGet()) == '0' || c == '1' ||
+              (c == '_' && ((c= yyPeek()) == '0' || c == '1')))
           {
             while ((c= yyGet()) == '0' || c == '1' ||
                    (c == '_' && ((c= yyPeek()) == '0' || c == '1'))) ;
+          }
+          else
+          {
+            yyUnget();
+            state= MY_LEX_IDENT_START;
+            break;
           }
           if ((yyLength() >= 3) && !ident_map[c])
           {
@@ -2376,8 +2358,11 @@ int Lex_input_stream::lex_one_token(YYSTYPE *yylval, THD *thd)
       }
       // fall through
     case MY_LEX_REAL:                           // Incomplete real number
-      while (my_isdigit(cs, (c= yyGet())) ||
-             (c == '_' && my_isdigit(cs, yyPeek()))) ;
+      if (my_isdigit(cs, (c= yyGet())))
+      {
+        while (my_isdigit(cs, (c= yyGet())) ||
+               (c == '_' && my_isdigit(cs, yyPeek()))) ;
+      }
 
       if (c == 'e' || c == 'E')
       {

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -2792,7 +2792,7 @@ private:
   int find_keyword_qualified_special_func(Lex_ident_cli_st *str, uint len) const;
   LEX_CSTRING get_token(uint skip, uint length);
   LEX_CSTRING get_numeric_token(uint skip, uint length);
-  LEX_CSTRING strip_underscores(const char *str, size_t length);
+  LEX_CSTRING strip_underscores(const char *str, uint length);
   int scan_ident_start(THD *thd, Lex_ident_cli_st *str);
   int scan_ident_middle(THD *thd, Lex_ident_cli_st *str,
                         CHARSET_INFO **cs, my_lex_states *);

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -2791,6 +2791,8 @@ private:
   int find_keyword(Lex_ident_cli_st *str, uint len, bool function) const;
   int find_keyword_qualified_special_func(Lex_ident_cli_st *str, uint len) const;
   LEX_CSTRING get_token(uint skip, uint length);
+  LEX_CSTRING get_numeric_token(uint skip, uint length);
+  LEX_CSTRING strip_underscores(const char *str, size_t length);
   int scan_ident_start(THD *thd, Lex_ident_cli_st *str);
   int scan_ident_middle(THD *thd, Lex_ident_cli_st *str,
                         CHARSET_INFO **cs, my_lex_states *);


### PR DESCRIPTION
The main contributions of this PR are:

- Added function get_numeric_token(), which is a wrapper around get_token() and it checks if there's an underscore in the current token.
- Added helper function strip_underscores(), which just erases underscores from the current token.
- Updated sql_lex.cc states (MY_LEX_NUMBER_IDENT, MY_LEX_INT_OR_REAL, MY_LEX_REAL) to permit single underscores between digits in decimal, hexadecimal, and binary literals.
- New Test Suite: Added mysql-test/main/numeric_underscores.test covering all possible cases.

New validation rules:
- Only a single underscore is allowed between digits.
- Consecutive underscores are prohibited (e.g., 1__000 is an error).
- An underscore cannot appear at the end of a numeric literal.
- An underscore cannot appear adjacent to a decimal point . or exponent marker e/E (e.g., 1_.0 and 1_e10 are invalid).
- Underscore is allowed immediately after the base prefix (e.g., 0x_FF, 0b_10).
- Regarding CAST, the same syntax should accepted.

### UPDATE
The official T662 feature is behind a paywall. However, my main source of using these rules was how Postgresql does it. Peter Eisentraut, who introduced this in SQL standard was also behind the Postgresql adaptation. [SQL:2023 T662](https://peter.eisentraut.org/blog/2023/09/20/grouping-digits-in-sql)

All the 5 validation rules are taken from: [PGDocs 4.1.2.6](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS-NUMERIC)
Rule for CAST - Taken from [SQL:2023 T662](https://peter.eisentraut.org/blog/2023/09/20/grouping-digits-in-sql)
Relevant statement from the blog - The SQL standard also requires that the same syntax be accepted in casts from character strings to numeric types.