### PR TITLE
MDEV-38787 wsrep_slave_fk_checks=OFF results in inconsistency

### DIFF
--- a/mysql-test/suite/sys_vars/r/sysvars_wsrep.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_wsrep.result
@@ -578,7 +578,7 @@ GLOBAL_VALUE_ORIGIN	COMPILE-TIME
 DEFAULT_VALUE	ON
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Should slave thread do foreign key constraint checks
+VARIABLE_COMMENT	Should slave thread do foreign key constraint checks (deprecated, has no effect)
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/mysql-test/suite/sys_vars/r/wsrep_slave_fk_checks_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_slave_fk_checks_basic.result
@@ -12,24 +12,34 @@ SELECT @@global.wsrep_slave_fk_checks;
 SELECT @@session.wsrep_slave_fk_checks;
 ERROR HY000: Variable 'wsrep_slave_FK_checks' is a GLOBAL variable
 SET @@global.wsrep_slave_fk_checks=OFF;
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 SELECT @@global.wsrep_slave_fk_checks;
 @@global.wsrep_slave_fk_checks
 0
 SET @@global.wsrep_slave_fk_checks=ON;
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 SELECT @@global.wsrep_slave_fk_checks;
 @@global.wsrep_slave_fk_checks
 1
 
 # valid values
 SET @@global.wsrep_slave_fk_checks='OFF';
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 SELECT @@global.wsrep_slave_fk_checks;
 @@global.wsrep_slave_fk_checks
 0
 SET @@global.wsrep_slave_fk_checks=ON;
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 SELECT @@global.wsrep_slave_fk_checks;
 @@global.wsrep_slave_fk_checks
 1
 SET @@global.wsrep_slave_fk_checks=default;
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 SELECT @@global.wsrep_slave_fk_checks;
 @@global.wsrep_slave_fk_checks
 1
@@ -42,4 +52,6 @@ ERROR 42000: Variable 'wsrep_slave_FK_checks' can't be set to the value of 'junk
 
 # restore the initial value
 SET @@global.wsrep_slave_fk_checks = @wsrep_slave_fk_checks_global_saved;
+Warnings:
+Warning	1287	'@@wsrep_slave_FK_checks' is deprecated and will be removed in a future release
 # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6195,9 +6195,10 @@ static Sys_var_mybool Sys_wsrep_load_data_splitting(
 
 static Sys_var_mybool Sys_wsrep_slave_FK_checks(
        "wsrep_slave_FK_checks", "Should slave thread do "
-       "foreign key constraint checks",
+       "foreign key constraint checks (deprecated, has no effect)",
        GLOBAL_VAR(wsrep_slave_FK_checks), 
-       CMD_LINE(OPT_ARG), DEFAULT(TRUE));
+       CMD_LINE(OPT_ARG), DEFAULT(TRUE), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(0), ON_UPDATE(0), DEPRECATED("")); // since 10.6.26
 
 static Sys_var_mybool Sys_wsrep_slave_UK_checks(
        "wsrep_slave_UK_checks", "Should slave thread do "

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -114,10 +114,7 @@ static void wsrep_setup_uk_and_fk_checks(THD* thd)
   else
     thd->variables.option_bits&= ~OPTION_RELAXED_UNIQUE_CHECKS;
 
-  if (wsrep_slave_FK_checks == FALSE)
-    thd->variables.option_bits|= OPTION_NO_FOREIGN_KEY_CHECKS;
-  else
-    thd->variables.option_bits&= ~OPTION_NO_FOREIGN_KEY_CHECKS;
+  thd->variables.option_bits&= ~OPTION_NO_FOREIGN_KEY_CHECKS;
 }
 
 static int apply_events(THD*                       thd,


### PR DESCRIPTION
Since ATM wsrep does not replicate any cascaded changes (because they are not binlogged in the upstream code) we have to rely on foreign checks on replicas to reproduce the cascade. Thus setting wsrep_slave_fk_checks=OFF will result in inconsistency in any setup where there are cascading relations. Mark this option as deprecated and make it a NOOP.