### PR TITLE
MDEV-7270: Fix replicas not honoring slave_skip_errors for 1677

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_row_slave_skip_errors.result
+++ b/mysql-test/suite/rpl/r/rpl_row_slave_skip_errors.result
@@ -1,0 +1,38 @@
+include/master-slave.inc
+[connection master]
+CREATE TABLE t (name VARCHAR(25) DEFAULT NULL, age INT);
+include/sync_slave_sql_with_master.inc
+ALTER TABLE t MODIFY name VARCHAR(255);
+connection master;
+INSERT INTO t VALUE ('Omar', 22);
+include/sync_slave_sql_with_master.inc
+include/check_slave_no_error.inc
+connection slave;
+ALTER TABLE t alter name set default "slave_default";
+connection master;
+INSERT INTO t VALUE ('Khokh', 22);
+include/sync_slave_sql_with_master.inc
+include/check_slave_no_error.inc
+# The skipped conversions take the default value defined for the column.
+connection master;
+SELECT * FROM t;
+name	age
+Omar	22
+Khokh	22
+connection slave;
+SELECT * FROM t;
+name	age
+NULL	22
+slave_default	22
+connection master;
+SELECT COUNT(*) AS master_count FROM t;
+master_count
+2
+connection slave;
+SELECT COUNT(*) AS slave_count FROM t;
+slave_count
+2
+==== Clean up ====
+connection master;
+DROP TABLE t;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_row_slave_skip_errors.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_slave_skip_errors.opt
@@ -1,0 +1,2 @@
+--slave-skip-errors=1677
+

--- a/mysql-test/suite/rpl/t/rpl_row_slave_skip_errors.test
+++ b/mysql-test/suite/rpl/t/rpl_row_slave_skip_errors.test
@@ -1,0 +1,56 @@
+# ==== Purpose ====
+#
+# Check that slave-skip-errors can skip ER_SLAVE_CONVERSION_FAILED.
+#
+# ==== Implementation ====
+# On slave, set slave_skip_errors=1677, so that slave skips ER_SLAVE_CONVERSION_FAILED 
+# reported during application of row based events.
+# On master, create a table t with two columns, a VARCHAR with a length of 25 and an INT.
+# On slave, increase the VARCHAR length to 255. For any row, the slave leaves the VARCHAR
+# field as the default value, while the INT is replicated correctly.
+#
+# References
+#   MDEV-7270: cannot slave_skip_errors for 1677
+
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+# On master create table t which contains a field named 'name' with length
+# varchar(25).
+CREATE TABLE t (name VARCHAR(25) DEFAULT NULL, age INT);
+--source include/sync_slave_sql_with_master.inc
+
+# On slave alter the name field length to varchar(255).
+ALTER TABLE t MODIFY name VARCHAR(255);
+
+connection master;
+INSERT INTO t VALUE ('Omar', 22);
+--source include/sync_slave_sql_with_master.inc
+--source include/check_slave_no_error.inc
+
+connection slave;
+ALTER TABLE t alter name set default "slave_default";
+
+connection master;
+INSERT INTO t VALUE ('Khokh', 22);
+--source include/sync_slave_sql_with_master.inc
+--source include/check_slave_no_error.inc
+
+--echo # The skipped conversions take the default value defined for the column.
+connection master;
+SELECT * FROM t;
+
+connection slave;
+SELECT * FROM t;
+
+connection master;
+SELECT COUNT(*) AS master_count FROM t;
+connection slave;
+SELECT COUNT(*) AS slave_count FROM t;
+
+
+--echo ==== Clean up ====
+connection master;
+DROP TABLE t;
+--source include/rpl_end.inc
+

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -328,20 +328,6 @@ inline int idempotent_error_code(int err_code)
   return (ret);
 }
 
-/**
-  Ignore error code specified on command line.
-*/
-
-inline int ignored_error_code(int err_code)
-{
-  if (use_slave_mask && bitmap_is_set(&slave_error_mask, err_code))
-  {
-    statistic_increment(slave_skipped_errors, LOCK_status);
-    return 1;
-  }
-  return err_code == ER_SLAVE_IGNORED_TABLE;
-}
-
 /*
   This function converts an engine's error to a server error.
    

--- a/sql/rpl_utility_server.cc
+++ b/sql/rpl_utility_server.cc
@@ -18,6 +18,7 @@
 #include <my_bit.h>
 #include "rpl_utility.h"
 #include "log_event.h"
+#include "slave.h"
 
 #if defined(MYSQL_CLIENT)
 #error MYSQL_CLIENT must not be defined here
@@ -1104,6 +1105,10 @@ bool RPL_TABLE_LIST::give_compatibility_error(rpl_group_info *rgi, uint col)
   }
   case SLAVE_FIELD_WRONG_TYPE:
   {
+    if (ignored_error_code(ER_SLAVE_CONVERSION_FAILED))
+    {
+      error_level= WARNING_LEVEL;
+    }
     Field *field= table->field[m_tabledef.master_to_slave_map[col]];
     const char *db_name= table->s->db.str;
     const char *tbl_name= table->s->table_name.str;
@@ -1117,10 +1122,13 @@ bool RPL_TABLE_LIST::give_compatibility_error(rpl_group_info *rgi, uint col)
     field->sql_rpl_type(&target_type);
     DBUG_ASSERT(source_type.length() > 0);
     DBUG_ASSERT(target_type.length() > 0);
-    rgi->rli->report(ERROR_LEVEL, ER_SLAVE_CONVERSION_FAILED, rgi->gtid_info(),
-                     ER_THD(thd, ER_SLAVE_CONVERSION_FAILED),
-                     col, db_name, tbl_name,
-                     source_type.c_ptr_safe(), target_type.c_ptr_safe());
+    if (error_level == ERROR_LEVEL || table->in_use->variables.log_warnings >= 1)
+    {
+      rgi->rli->report(
+          error_level, ER_SLAVE_CONVERSION_FAILED, rgi->gtid_info(),
+          ER_THD(thd, ER_SLAVE_CONVERSION_FAILED), col, db_name, tbl_name,
+          source_type.c_ptr_safe(), target_type.c_ptr_safe());
+    }
     break;
   }
   }

--- a/sql/slave.h
+++ b/sql/slave.h
@@ -135,6 +135,20 @@ extern ulonglong slave_skipped_errors;
 extern const char *relay_log_index;
 extern const char *relay_log_basename;
 
+/**
+  Ignore error code specified on command line.
+*/
+
+inline int ignored_error_code(int err_code)
+{
+  if (use_slave_mask && bitmap_is_set(&slave_error_mask, err_code))
+  {
+    statistic_increment(slave_skipped_errors, LOCK_status);
+    return 1;
+  }
+  return err_code == ER_SLAVE_IGNORED_TABLE;
+}
+
 /*
   4 possible values for Master_info::slave_running and
   Relay_log_info::slave_running.


### PR DESCRIPTION
#### Summary
- This PR fixes replicas crashing on column type mismatch for row-based replication, not honoring the `slave_skip_errors` configuration.
- The issue comments on JIRA pointed to an upstream (mysql) test, which was helpful for tracking the bug and eventually implementing the fix.
- The replica now skips the event gracefully (in case the error is actually caught and the column is not convertible), logs a warning and does not abort. 
----
#### Fix: [MDEV-7270](https://jira.mariadb.org/browse/MDEV-7270)