### PR TITLE
MDEV-38842 Server fails to drop .ibd file when vector table creation fails

### DIFF
--- a/mysql-test/suite/atomic/vector_innodb.result
+++ b/mysql-test/suite/atomic/vector_innodb.result
@@ -1816,3 +1816,20 @@ count(*)
 2
 master-bin.000002	#	Query	#	#	use `test`; ALTER TABLE t1 DROP INDEX a
 ALTER DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci;
+#
+#  MDEV-38842 Server fails to drop .ibd file when vector table creation fails
+#
+CREATE DATABASE test_1;
+CREATE TABLE test_1.t (a INT,b VECTOR (5) NOT NULL,
+VECTOR INDEX (b)) ENGINE=INNODB;
+DROP TABLE test_1.t;
+call mtr.add_suppression("InnoDB: (Operating system )?[Ee]rror number");
+call mtr.add_suppression("InnoDB: Error number 17 means 'File exists'");
+call mtr.add_suppression("InnoDB: The file '.*t1#i#00\\.ibd' already exists though the corresponding table did not exist in the InnoDB data dictionary.");
+CREATE TABLE test_1.t1(a INT, b VECTOR(5) NOT NULL,
+VECTOR INDEX(b))ENGINE=InnoDB;
+ERROR HY000: Can't create table `test_1`.`t1` (errno: 184 "Tablespace already exists")
+# Print the files exist in test_1 directory
+db.opt
+t1#i#00.ibd
+DROP DATABASE test_1;

--- a/mysql-test/suite/atomic/vector_innodb.test
+++ b/mysql-test/suite/atomic/vector_innodb.test
@@ -1,3 +1,24 @@
 let $skip_vector=1;
 let $extra_fields=, v vector(5) not null default x'e360d63ebe554f3fcdbc523f4522193f5236083d', vector index(v);
 --source alter_table_innodb.test
+
+--echo #
+--echo #  MDEV-38842 Server fails to drop .ibd file when vector table creation fails
+--echo #
+let $MYSQLD_DATADIR= `select @@datadir`;
+CREATE DATABASE test_1;
+CREATE TABLE test_1.t (a INT,b VECTOR (5) NOT NULL,
+                       VECTOR INDEX (b)) ENGINE=INNODB;
+--copy_file $MYSQLD_DATADIR/test_1/t#i#00.ibd $MYSQLD_DATADIR/test_1/t1#i#00.ibd
+DROP TABLE test_1.t;
+call mtr.add_suppression("InnoDB: (Operating system )?[Ee]rror number");
+call mtr.add_suppression("InnoDB: Error number 17 means 'File exists'");
+call mtr.add_suppression("InnoDB: The file '.*t1#i#00\\.ibd' already exists though the corresponding table did not exist in the InnoDB data dictionary.");
+
+--error ER_CANT_CREATE_TABLE
+CREATE TABLE test_1.t1(a INT, b VECTOR(5) NOT NULL,
+                       VECTOR INDEX(b))ENGINE=InnoDB;
+--echo # Print the files exist in test_1 directory
+--list_files $MYSQLD_DATADIR/test_1
+--remove_file $MYSQLD_DATADIR/test_1/t1#i#00.ibd
+DROP DATABASE test_1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6485,10 +6485,9 @@ static int ha_create_table_from_share(THD *thd, TABLE_SHARE *share,
   @param frm            an frm image or NULL (meaning, read it from the file)
   @param skip_frm_file  do not write the frm image to the .frm file
 
-  @retval
-   0  ok
-  @retval
-   1  error
+  @retval 0  ok
+  @retval 1  error. Any table (and high level index tables) that were
+             created are dropped before returning.
 */
 int ha_create_table(THD *thd, const char *path, const char *db,
                     const char *table_name, HA_CREATE_INFO *create_info,
@@ -6580,10 +6579,18 @@ int ha_create_table(THD *thd, const char *path, const char *db,
       uint unused;
       if ((error= ha_create_table_from_share(thd, &index_share, &index_cinfo,
                                              &unused)))
+      {
+        ha_delete_table(thd, create_info->db_type, file_name,
+                        &share.db, &share.table_name, 0);
         break;
+      }
     }
     thd->lex->sql_command= old_sql_command;
     free_table_share(&index_share);
+
+    if (error)
+      ha_delete_table(thd, create_info->db_type, path,
+                      &share.db, &share.table_name, 0);
   }
 
 err:


### PR DESCRIPTION
MDEV-38842 Server fails to drop .ibd file when vector table creation fails
Problem:
========
When creating tables with vector indexes, if the secondary table
creation fails after the main table is successfully created,
the server was not properly cleaning up the main table's .ibd file.
Stale file exists because create_table_impl() always called
ddl_log_complete() on any error, which disables DDL log entries
instead of executing them for cleanup. The main table would be
left behind even though the overall CREATE TABLE operation failed.

Solution:
=========
ha_create_table(): Make it responsible for cleaning up
everything it created when it returns an error.
On failure of the high level index creation, drop the main
table and shadow table.
