### PR TITLE
MDEV-38864: Use `mmap` for MEMORY engine allocations

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -173,6 +173,8 @@ extern void *my_multi_malloc(PSI_memory_key key, myf MyFlags, ...);
 extern void *my_multi_malloc_large(PSI_memory_key key, myf MyFlags, ...);
 extern void *my_realloc(PSI_memory_key key, void *ptr, size_t size, myf MyFlags);
 extern void my_free(void *ptr);
+extern void *my_vmalloc(PSI_memory_key key, size_t size, myf MyFlags);
+extern void my_vmrelease(void *ptr);
 extern void *my_memdup(PSI_memory_key key, const void *from,size_t length,myf MyFlags);
 extern char *my_strdup(PSI_memory_key key, const char *from,myf MyFlags);
 extern char *my_strndup(PSI_memory_key key, const char *from, size_t length, myf MyFlags);

--- a/include/my_virtual_mem.h
+++ b/include/my_virtual_mem.h
@@ -30,8 +30,7 @@ char *my_virtual_mem_reserve(size_t *size);
 char *my_virtual_mem_commit(char *ptr, size_t size);
 void my_virtual_mem_decommit(char *ptr, size_t size);
 void my_virtual_mem_release(char *ptr, size_t size);
-
+char *my_virtual_mem_alloc(size_t size);
 #ifdef __cplusplus
 }
 #endif
-

--- a/mysys/my_malloc.c
+++ b/mysys/my_malloc.c
@@ -15,9 +15,13 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
 
+#include "my_virtual_mem.h"
 #include "mysys_priv.h"
 #include "mysys_err.h"
 #include <m_string.h>
+
+#define VM_ALLOC_THRESHOLD 262144
+#define VM_ALLOC_FLAG 4
 
 struct my_memory_header
 {
@@ -255,3 +259,106 @@ char *my_strndup(PSI_memory_key key, const char *from, size_t length, myf my_fla
   DBUG_RETURN(ptr);
 }
 
+/*
+  Allocate a block of memory by memory mapping.
+
+  @param  key    Key to register instrumented memory
+  @param  size   The size of the memory block in bytes.
+  @param  flags  Failure action modifiers (bitmasks).
+
+  @return A pointer to the allocated memory block, or NULL on failure.
+
+  @note   Allocated memory block is zero-filled except for cases when my_vmalloc
+          falls back my_malloc. This implementation does not guarantee page
+          alignment.
+ */
+void *my_vmalloc(PSI_memory_key key, size_t size, myf my_flags)
+{
+  my_memory_header *mh;
+  void *ptr;
+  int flag;
+  DBUG_ENTER("my_vmalloc");
+  DBUG_PRINT("my",("size: %zu flags: %lu", size, my_flags));
+
+  compile_time_assert(sizeof(my_memory_header) <= HEADER_SIZE);
+
+  if (size < VM_ALLOC_THRESHOLD)
+    DBUG_RETURN(my_malloc(key, size, my_flags));
+
+  if (!(my_flags & (MY_WME | MY_FAE)))
+    my_flags|= my_global_flags;
+
+  if (!size)
+    size= 1;
+
+  size= ALIGN_SIZE(size);
+  if (size > SIZE_T_MAX - HEADER_SIZE - 1024L*1024L*16L)
+    DBUG_RETURN(0);
+
+  if (DBUG_IF("simulate_out_of_memory"))
+    mh= NULL;
+  else
+    mh= (my_memory_header*) my_virtual_mem_alloc(size + HEADER_SIZE);
+
+  if (mh == NULL)
+  {
+#ifdef _WIN32
+    my_errno= GetLastError();
+#else
+    my_errno= errno;
+#endif
+    DBUG_PRINT("warning",
+               ("Couldn't allocate %zu bytes with my_virtual_mem_alloc, "
+                "failed with error: %d, falling back to my_malloc.",
+                (size + HEADER_SIZE), my_errno));
+
+    /* If virtual memory allocation fails, fallback to my_malloc */
+    DBUG_RETURN(my_malloc(key, size, my_flags));
+  }
+  else
+  {
+    flag= MY_TEST(my_flags & MY_THREAD_SPECIFIC);
+    mh->m_size= size | flag;
+    mh->m_key= PSI_CALL_memory_alloc(key, size, &mh->m_owner);
+    mh->m_size |= (2 | VM_ALLOC_FLAG);
+
+    update_malloc_size(size + HEADER_SIZE, flag);
+    ptr= HEADER_TO_USER(mh);
+  }
+
+  DBUG_PRINT("exit",("ptr: %p", ptr));
+  DBUG_RETURN(ptr);
+}
+
+/*
+  Release a block of memory.
+
+  @param  ptr  Pointer to memory allocated by my_vmalloc.
+ */
+void my_vmrelease(void *ptr)
+{
+  my_memory_header *mh;
+  size_t size;
+  my_bool flags;
+  DBUG_ENTER("my_vmrelease");
+
+  if (ptr == NULL)
+    DBUG_VOID_RETURN;
+
+  mh= USER_TO_HEADER(ptr);
+  if (!(mh->m_size & VM_ALLOC_FLAG))
+  {
+    my_free(ptr);
+    DBUG_VOID_RETURN;
+  }
+
+  size= mh->m_size & ~(VM_ALLOC_FLAG | 3);
+  flags= mh->m_size & 3;
+  PSI_CALL_memory_free(mh->m_key, size, mh->m_owner);
+
+  if (flags & 2)
+    update_malloc_size(-(longlong) size - HEADER_SIZE, flags & 1);
+
+  my_virtual_mem_release((char *) mh, size + HEADER_SIZE);
+  DBUG_VOID_RETURN;
+}

--- a/mysys/my_virtual_mem.c
+++ b/mysys/my_virtual_mem.c
@@ -21,6 +21,18 @@
 # include <sys/shm.h>
 #endif
 
+#if defined(HAVE_MMAP) && !defined(_WIN32)
+/* Solaris for example has only MAP_ANON, FreeBSD has MAP_ANONYMOUS and
+MAP_ANON but MAP_ANONYMOUS is marked "for compatibility" */
+#if defined(MAP_ANONYMOUS)
+#define OS_MAP_ANON     MAP_ANONYMOUS
+#elif defined(MAP_ANON)
+#define OS_MAP_ANON     MAP_ANON
+#else
+#error unsupported mmap - no MAP_ANON{YMOUS}
+#endif
+#endif /* HAVE_MMAP && !_WIN32 */
+
 /*
   Functionality for handling virtual memory
 
@@ -103,7 +115,7 @@ char *my_virtual_mem_commit(char *ptr, size_t size)
 # else
     void *p= 0;
     const int flags=
-      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED;
+      MAP_PRIVATE | OS_MAP_ANON | MAP_FIXED;
     p= mmap(ptr, size, PROT_READ | PROT_WRITE, flags, -1, 0);
     if (p == MAP_FAILED)
     {
@@ -162,10 +174,24 @@ void my_virtual_mem_decommit(char *ptr, size_t size)
   update_malloc_size(-(longlong) size, 0);
 }
 
+
+char *my_virtual_mem_alloc(size_t size)
+{
+#ifdef _WIN32
+  return VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
+  char *ptr= mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | OS_MAP_ANON,
+                  -1, 0);
+  if (ptr == MAP_FAILED)
+    return NULL;
+  return ptr;
+#endif
+}
+
+
 void my_virtual_mem_release(char *ptr, size_t size)
 {
 #ifdef _WIN32
-  DBUG_ASSERT(my_use_large_pages || !is_memory_committed(ptr, size));
   if (!VirtualFree(ptr, 0, MEM_RELEASE))
   {
     my_error(EE_BADMEMORYRELEASE, MYF(ME_ERROR_LOG_ONLY), ptr, size,

--- a/storage/heap/hp_block.c
+++ b/storage/heap/hp_block.c
@@ -80,10 +80,9 @@ int hp_get_new_block(HP_SHARE *info, HP_BLOCK *block, size_t *alloc_length)
                   (ulonglong)block->records_in_block * block->recbuffer);
   /* Alloc in blocks of powers of 2 */
   *alloc_length= MY_MAX(*alloc_length, block->alloc_size);
-  if (!(root=(HP_PTRS*) my_malloc(hp_key_memory_HP_PTRS, *alloc_length,
-                                  MYF(MY_WME |
-                                      (info->internal ?
-                                       MY_THREAD_SPECIFIC : 0)))))
+  if (!(root=(HP_PTRS*) my_vmalloc(hp_key_memory_HP_PTRS, *alloc_length,
+                                    MYF(MY_WME | (info->internal ?
+                                        MY_THREAD_SPECIFIC : 0)))))
     return 1;
 
   if (i == 0)
@@ -150,7 +149,7 @@ uchar *hp_free_level(HP_BLOCK *block, uint level, HP_PTRS *pos, uchar *last_pos)
   }
   if ((uchar*) pos != last_pos)
   {
-    my_free(pos);
+    my_vmrelease(pos);
     return last_pos;
   }
   return next_ptr;			/* next memory position */


### PR DESCRIPTION
_Fixes [MDEV-38864](https://jira.mariadb.org/browse/MDEV-38864)_

MEMORY engine's data and indexes blocks are allocated using `my_malloc`. This created internal fragmentation within the system allocator, causing gradual memory growth and leading to OOM server crash, as observed in [MDEV-30889](https://jira.mariadb.org/browse/MDEV-30889)

This patch introduces memory mapping for MEMORY engine's allocations.
- Implements `my_vmalloc` and `my_vmrelease` functions.
- These functions wrap `my_virtual_mem_alloc` & `my_virtual_mem_release` to provide error handling, interface with Performance Schema(PSI) and global memory accounting.