### PR TITLE
MDEV-38853 Guard VALIDITY_ASSERT in Json_writer for NDEBUG builds

### DIFF
--- a/sql/my_json_writer.h
+++ b/sql/my_json_writer.h
@@ -32,7 +32,11 @@
 #else
 #include "sql_class.h"  // For class THD
 #include "log.h" // for sql_print_error
+#ifndef NDEBUG
 #define VALIDITY_ASSERT(x) DBUG_ASSERT(x)
+#else
+#define VALIDITY_ASSERT(x) do { } while (0)
+#endif
 #endif
 
 #include <type_traits>


### PR DESCRIPTION
This fixes a release/NDEBUG build failure caused by unguarded VALIDITY_ASSERT usage
in Json_writer::add_unquoted_str() and Json_writer::add_str().

The VALIDITY_ASSERT blocks are now compiled only for debug builds or when
JSON_WRITER_UNIT_TEST is enabled, matching the availability of the referenced symbols.

JIRA: MDEV-38853