### PR TITLE
Draft: MDEV-38045: Implement implicit query block names for optimizer hints

### DIFF
--- a/mysql-test/main/opt_hints.result
+++ b/mysql-test/main/opt_hints.result
@@ -439,6 +439,18 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t2	ref	f1	f1	8	test.t3.f1,test.t3.f2	2	50.00	Using where; FirstMatch(t3)
 Warnings:
 Note	1003	update /*+ BKA(`t2`@`select#2`) NO_BNL(`t1`@`select#2`) NO_RANGE_OPTIMIZATION(`t3`@`select#1` `PRIMARY`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f2` = `test`.`t3`.`f2` and `test`.`t3`.`f1` > 30 and `test`.`t3`.`f1` < 33 and `test`.`t3`.`f2` between `test`.`t3`.`f1` and `test`.`t1`.`f2` and `test`.`t3`.`f2` + 1 >= `test`.`t3`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
+# Same as above but addressing tables with QB name
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t3 PRIMARY) BKA(t2@QB1) NO_BNL(t1@QB1)*/ t3
+SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
+(SELECT /*+ QB_NAME(QB1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
+t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	range	PRIMARY,f2_idx,f3_idx	f2_idx	4	NULL	2	100.00	Using index condition; Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	3	3.33	Using where
+1	PRIMARY	t2	ref	f1	f1	8	test.t3.f1,test.t3.f2	2	50.00	Using where; FirstMatch(t3)
+Warnings:
+Note	1003	update /*+ BKA(`t2`@`QB1`) NO_BNL(`t1`@`QB1`) NO_RANGE_OPTIMIZATION(`t3`@`select#1` `PRIMARY`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f1` = `test`.`t3`.`f1` and `test`.`t2`.`f2` = `test`.`t3`.`f2` and `test`.`t3`.`f1` > 30 and `test`.`t3`.`f1` < 33 and `test`.`t3`.`f2` between `test`.`t3`.`f1` and `test`.`t1`.`f2` and `test`.`t3`.`f2` + 1 >= `test`.`t3`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
 # Turn off range access for all keys.
 EXPLAIN EXTENDED UPDATE /*+ NO_RANGE_OPTIMIZATION(t3) */ t3
 SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
@@ -450,6 +462,31 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t3	eq_ref	PRIMARY,f2_idx,f3_idx	PRIMARY	4	test.t2.f1	1	100.00	Using where; End temporary
 Warnings:
 Note	1003	update /*+ NO_RANGE_OPTIMIZATION(`t3`@`select#1`) */ `test`.`t3` semi join (`test`.`t1` join `test`.`t2`) set `test`.`t3`.`f3` = 'mnbv' where `test`.`t1`.`f1` = `test`.`t2`.`f1` and `test`.`t3`.`f1` = `test`.`t2`.`f1` and `test`.`t3`.`f2` = `test`.`t2`.`f2` and `test`.`t2`.`f1` > 30 and `test`.`t2`.`f1` < 33 and `test`.`t2`.`f2` between `test`.`t2`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t2`.`f1` + 1 and `test`.`t3`.`f3` = `test`.`t2`.`f3`
+# Multi-table UPDATE with a derived table
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt)*/ t3,
+(SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	ALL	PRIMARY,f2_idx	NULL	NULL	NULL	56	100.00	
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t3.f1	8	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
+2	DERIVED	t2	index	f1	f1	8	NULL	28	100.00	Using where; Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ update /*+ NO_RANGE_OPTIMIZATION(`t2`@`dt`) */ `test`.`t3` join (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`f1` AS `f1`,`test`.`t1`.`f2` AS `f2` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`f1` > `test`.`t2`.`f1`) `dt` set `test`.`t3`.`f3` = 'mnbv' where `dt`.`f1` = `test`.`t3`.`f1`
+# Multi-table UPDATE with a derived table and both table-level and
+# query block-level hints
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt) NO_BNL(@dt)*/ t3,
+(SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	ALL	PRIMARY,f2_idx	NULL	NULL	NULL	56	100.00	
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t3.f1	8	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
+2	DERIVED	t2	index	f1	f1	8	NULL	28	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ update /*+ NO_BNL(@`dt`) NO_RANGE_OPTIMIZATION(`t2`@`dt`) */ `test`.`t3` join (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`f1` AS `f1`,`test`.`t1`.`f2` AS `f2` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`f1` > `test`.`t2`.`f1`) `dt` set `test`.`t3`.`f3` = 'mnbv' where `dt`.`f1` = `test`.`t3`.`f1`
 EXPLAIN EXTENDED DELETE FROM t3
 WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
 (SELECT /*+ QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
@@ -500,7 +537,7 @@ Warnings:
 Note	1003	(insert into `test`.`t3`(f1,f2,f3) select /*+ NO_ICP(`t5`@`select#1`) */ `test`.`t4`.`x` AS `x`,`test`.`t5`.`y` AS `y`,'filler' AS `filler` from `test`.`t4` join `test`.`t4` `t5` where `test`.`t4`.`y` = 8 and `test`.`t5`.`x` between 7 and <cache>(8 + 0))
 # Turn off ICP for a particular table and a key
 EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
-(SELECT /*+ QB_NAME(qb1) NO_ICP(t5@QB1 x_idx)*/ t4.x, t5.y, 'filler' FROM t4, t4 t5
+(SELECT /*+ NO_ICP(t5@QB1 x_idx) QB_NAME(qb1) */ t4.x, t5.y, 'filler' FROM t4, t4 t5
 WHERE t4.y = 8 AND t5.x BETWEEN 7 AND t4.y+0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t4	ref	y_idx	y_idx	5	const	1	100.00	
@@ -550,15 +587,14 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 Warnings:
 Warning	4219	Hint QB_NAME(`qb1`) is ignored as conflicting/duplicated
 Note	1003	select /*+ QB_NAME(`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t2`
-# Should issue warning
-EXPLAIN EXTENDED SELECT /*+ BKA(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
+# QB_NAME may appear after the hint, but the hint is still resolved
+EXPLAIN EXTENDED SELECT /*+ NO_BNL(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
-1	SIMPLE	t2	ALL	f1	NULL	NULL	NULL	28	25.00	Using where; Using join buffer (flat, BNL join)
+1	SIMPLE	t2	ALL	f1	NULL	NULL	NULL	28	25.00	Using where
 Warnings:
-Warning	4220	Query block name `qb1` is not found for BKA hint
-Note	1003	select /*+ QB_NAME(`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`f1` = `test`.`t1`.`f1` and `test`.`t2`.`f2` between `test`.`t1`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t1`.`f1` + 1
+Note	1003	select /*+ QB_NAME(`qb1`) NO_BNL(@`qb1`) */ `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f3` AS `f3` from `test`.`t1` join `test`.`t2` where `test`.`t2`.`f1` = `test`.`t1`.`f1` and `test`.`t2`.`f2` between `test`.`t1`.`f1` and `test`.`t1`.`f2` and `test`.`t2`.`f2` + 1 >= `test`.`t1`.`f1` + 1
 # Should not crash
 PREPARE stmt1 FROM "SELECT /*+ BKA(t2) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1";

--- a/mysql-test/main/opt_hints.test
+++ b/mysql-test/main/opt_hints.test
@@ -248,11 +248,31 @@ SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
   (SELECT /*+ BKA(t2) NO_BNL(t1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
     t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
 
+--echo # Same as above but addressing tables with QB name
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t3 PRIMARY) BKA(t2@QB1) NO_BNL(t1@QB1)*/ t3
+  SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
+  (SELECT /*+ QB_NAME(QB1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
+    t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+
 --echo # Turn off range access for all keys.
 EXPLAIN EXTENDED UPDATE /*+ NO_RANGE_OPTIMIZATION(t3) */ t3
 SET f3 = 'mnbv' WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
   (SELECT t2.f1, t2.f2, t2.f3 FROM t1,t2 WHERE t1.f1=t2.f1 AND
     t2.f2 BETWEEN t1.f1 AND t1.f2 AND t2.f2 + 1 >= t1.f1 + 1);
+
+--echo # Multi-table UPDATE with a derived table
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt)*/ t3,
+  (SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
+
+--echo # Multi-table UPDATE with a derived table and both table-level and
+--echo # query block-level hints
+EXPLAIN EXTENDED
+UPDATE /*+ NO_RANGE_OPTIMIZATION(t2@dt) NO_BNL(@dt)*/ t3,
+  (SELECT /*+ qb_name(dt)*/ t1.* FROM t1, t2 WHERE t1.f1 > t2.f1) AS dt
+SET t3.f3 = 'mnbv' WHERE t3.f1 = dt.f1;
 
 EXPLAIN EXTENDED DELETE FROM t3
 WHERE f1 > 30 AND f1 < 33 AND (t3.f1, t3.f2, t3.f3) IN
@@ -282,7 +302,7 @@ EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
 
 --echo # Turn off ICP for a particular table and a key
 EXPLAIN EXTENDED INSERT INTO t3(f1, f2, f3)
-  (SELECT /*+ QB_NAME(qb1) NO_ICP(t5@QB1 x_idx)*/ t4.x, t5.y, 'filler' FROM t4, t4 t5
+  (SELECT /*+ NO_ICP(t5@QB1 x_idx) QB_NAME(qb1) */ t4.x, t5.y, 'filler' FROM t4, t4 t5
    WHERE t4.y = 8 AND t5.x BETWEEN 7 AND t4.y+0);
 
 --echo # Make sure ICP is expected to be used when there are no hints
@@ -308,8 +328,8 @@ EXPLAIN EXTENDED REPLACE INTO t3(f1, f2, f3)
 
 --echo # Should issue warning
 EXPLAIN EXTENDED SELECT /*+ QB_NAME(qb1) QB_NAME(qb1 ) */ * FROM t2;
---echo # Should issue warning
-EXPLAIN EXTENDED SELECT /*+ BKA(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
+--echo # QB_NAME may appear after the hint, but the hint is still resolved
+EXPLAIN EXTENDED SELECT /*+ NO_BNL(@qb1) QB_NAME(qb1) */ t2.f1, t2.f2, t2.f3 FROM t1,t2
 WHERE t1.f1=t2.f1 AND t2.f2 BETWEEN t1.f1 and t1.f2 and t2.f2 + 1 >= t1.f1 + 1;
 
 --echo # Should not crash

--- a/mysql-test/main/opt_hints_impl_qb_name.inc
+++ b/mysql-test/main/opt_hints_impl_qb_name.inc
@@ -1,0 +1,241 @@
+--source include/have_sequence.inc
+--enable_prepare_warnings
+
+create table t1 (a int, b int, c char(20), key idx_a(a), key idx_ab(a, b));
+
+insert into t1 select seq, seq, 'filler' from seq_1_to_100;
+
+create table t2 as select * from t1;
+
+analyze table t1,t2 persistent for all;
+
+--echo # Table-level hint
+explain extended select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # More than one reference to a single QB
+explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # QB-level hint
+explain extended select /*+ no_bnl(@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # Index-level hints
+--echo # Without the hint 'range' index access would be chosen
+explain extended select /*+ no_index(t1@`T`)*/ * from
+  (select * from t1 where a < 3) t;
+
+--echo # Without the hint 'range' index access would be chosen
+explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+  (select * from t1 where a > 100 and a < 120) as t1;
+
+--echo # Regular and derived tables share same name but the hint is applied correctly
+explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1;
+
+explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+
+explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+  (select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+
+--echo # Nested derived tables
+explain extended select /*+ no_bnl(t1@dt2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+explain extended select /*+ no_index(t1@DT2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+--echo # Explicit QB name overrides the implicit one
+explain extended select /*+ no_index(t1@dt2)*/ * from
+  (select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+
+--echo # Both hints are applied
+explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+  (select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+
+--disable_ps_protocol
+# PS protocol is disabled because the warning is genererated only during
+# PREPARE step of a statement. When the QB name cannot be resolved the hint
+# is discarded, so it is not present during EXECUTE step. The same applies
+# not only to implicit but also to explicit QB names.
+
+--echo # Nested derived tables with ambiguous names, hint is ignored
+explain extended select /*+ no_index(t1@t1)*/* from
+  (select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+
+--echo # The hint cannot be applied to a derived table with UNION
+explain extended select /*+ no_index(t2@t1)*/* from
+  (select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+
+explain extended select /*+ no_index(t1@t1)*/* from
+  (select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+
+--echo # Test INSERT..SELECT
+explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+--echo # Test MERGE and NO_MERGE hints
+explain extended select /*+ merge(@dt)*/ * from
+  (select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+
+explain extended select /*+ no_merge(@dt)*/ * from
+  (select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+
+--echo # Multiple levels of nested derived tables, all hints are applied
+explain extended
+select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+  select /*+ no_merge(du) */ * from (
+      select /*+ no_merge(dt) */ * from (
+        select t1.* from t1, t2 where t1.a > t2.a
+    ) dt
+  ) du
+) dv;
+
+--enable_ps_protocol
+
+--echo # ======================================
+--echo # Test CTEs
+--echo # By default BNL and index access to t1 are used.
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(t1@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+
+
+--disable_ps_protocol
+# See the comment above for why PS protocol is disabled
+
+--echo # Ambiguity: multiple occurencies of `cte`, the hint is ignored
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte where cnt > 10
+union
+select * from cte where cnt < 100;
+
+--echo # However, if CTE occurencies have different aliases, the hint can be applied
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte1)*/ * from cte as cte1 where cnt > 10
+union
+select * from cte where cnt < 100;
+
+--enable_ps_protocol
+
+--echo # ======================================
+--echo # Test views
+create view v1 as select * from t1 where a < 100;
+
+--echo # Default execution plan
+explain extended select *
+  from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+
+explain extended
+  select /*+ index(t1@v1 idx_ab) no_index(t1@`v2`)*/ *
+  from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+
+--echo # Nested views
+create view v2 as select * from v1 where a < 300;
+
+--echo # Default execution plan
+explain extended select * from v2;
+
+--echo # Addressing an object inside a nested view
+explain extended select /*+ index(t1@`v1` idx_ab)*/ * from v2;
+
+create view v3 as select * from t1 union select * from t2;
+
+--disable_ps_protocol
+# See the comment above for why PS protocol is disabled
+
+--echo # Unable to apply the hint to a view with UNION
+explain extended select /*+ no_index(t1@v3) */ * from v3;
+
+--echo # Ambiguity: view `v1` appears two times - should warn and ignore hint
+explain extended select /*+ index(t2@v1) */ * from v1,
+   (select a from v1 where b > 5) dt;
+
+--enable_ps_protocol
+
+--echo # Implicit QB names are not supported inside views
+create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+  (select t1.* from t1, t2 where t1.a > t2.a) as dt;
+
+show create view v4;
+
+--echo # However, a derived table inside a view can be addressed from outer query
+create view v5 as select dt.a from
+    t1, (select t1.* from t1, t2 where t1.a > t2.a) as dt where t1.a=dt.a;
+
+--echo # Addressing a single table
+explain extended select /*+ no_bnl(t2@dt) */* from v5;
+--echo # Addressing the whole derived table
+explain extended select /*+ no_bnl(@dt) */* from v5;
+
+--echo # Derived tables inside views can be addressed by their aliases
+explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+
+drop view v1, v2, v3, v4, v5;
+
+--echo # ======================================
+--echo # Not supported for DML, check presence of warnings
+
+--disable_ps_protocol
+explain extended
+update /*+ no_range_optimization(t1@dt)*/ t2,
+   (select a from t1 where a > 10) dt
+set b=1 where t2.a = dt.a;
+
+explain extended
+delete /*+ no_index(t1@dt)*/ from t2
+where t2.a in
+   (select * from (select a from t1 where a > 10) dt where dt.a > 20);
+
+--echo # ======================================
+--echo # Objects in triggers and stored functions must not be visible for hints
+create table t3 (a int, b int);
+
+--echo # Trigger with derived table inside
+delimiter |;
+create trigger tr1 before insert on t3
+for each row
+begin
+  set new.b = (select max(a) from
+    (select a from t1 where a < new.a) dt);
+end|
+delimiter ;|
+
+--echo # Warning expected
+explain extended select /*+ no_index(t1@dt) */ max(a) from t3 where a<2;
+
+--echo # Stored function with derived table inside
+create function get_max(p_a int) returns int
+return (select max(a) from
+    (select a from t1 where a < p_a) dt);
+
+--echo # Warning expected
+explain extended select /*+ no_index(t1@dt) */ a, get_max(a) from t1;
+
+--enable_ps_protocol
+drop function get_max;
+drop table t1, t2, t3;

--- a/mysql-test/main/opt_hints_impl_qb_name.result
+++ b/mysql-test/main/opt_hints_impl_qb_name.result
@@ -1,0 +1,850 @@
+set optimizer_switch = 'derived_merge=on';
+create table t1 (a int, b int, c char(20), key idx_a(a), key idx_ab(a, b));
+insert into t1 select seq, seq, 'filler' from seq_1_to_100;
+create table t2 as select * from t1;
+analyze table t1,t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	Table is already up to date
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+# Table-level hint
+explain extended select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# More than one reference to a single QB
+explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) NO_INDEX(`t1`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# QB-level hint
+explain extended select /*+ no_bnl(@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# Index-level hints
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_index(t1@`T`)*/ * from
+(select * from t1 where a < 3) t;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`T`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+(select * from t1 where a > 100 and a < 120) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	1.00	Using where
+Warnings:
+Note	1003	select /*+ NO_RANGE_OPTIMIZATION(`t1`@`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` > 100 and `test`.`t1`.`a` < 120
+# Regular and derived tables share same name but the hint is applied correctly
+explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3
+explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`t2` `idx_a`) INDEX(`t1`@`t1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
+explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition; Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ NO_INDEX(`t1`@`t1` `idx_a`,`idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 and `test`.`t1`.`a` < 3
+# Nested derived tables
+explain extended select /*+ no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+explain extended select /*+ no_index(t1@DT2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`DT2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`DT2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Explicit QB name overrides the implicit one
+explain extended select /*+ no_index(t1@dt2)*/ * from
+(select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Both hints are applied
+explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1`) NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `dt2`
+# Nested derived tables with ambiguous names, hint is ignored
+explain extended select /*+ no_index(t1@t1)*/* from
+(select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Warning	4256	Query block name `t1` is ambiguous for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5) `t1`
+# The hint cannot be applied to a derived table with UNION
+explain extended select /*+ no_index(t2@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+explain extended select /*+ no_index(t1@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+# Test INSERT..SELECT
+explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	Using temporary
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	insert into `test`.`t2` select /*+ NO_BNL(`t2`@`dt`) */ sql_buffer_result `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+# Test MERGE and NO_MERGE hints
+explain extended select /*+ merge(@dt)*/ * from
+(select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ MERGE(@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+explain extended select /*+ no_merge(@dt)*/ * from
+(select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_MERGE(@`dt`) */ `dt1`.`a` AS `a`,`dt1`.`b` AS `b`,`dt1`.`c` AS `c` from (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt1`
+# Multiple levels of nested derived tables, all hints are applied
+explain extended
+select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+select /*+ no_merge(du) */ * from (
+select /*+ no_merge(dt) */ * from (
+select t1.* from t1, t2 where t1.a > t2.a
+) dt
+) du
+) dv;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+4	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+4	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_MERGE(`dt`@`select#3`) NO_MERGE(`du`@`select#2`) NO_MERGE(`dv`@`select#1`) NO_BNL(`t2`@`dt`) */ `dv`.`a` AS `a`,`dv`.`b` AS `b`,`dv`.`c` AS `c` from (/* select#2 */ select `du`.`a` AS `a`,`du`.`b` AS `b`,`du`.`c` AS `c` from (/* select#3 */ select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#4 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`) `du`) `dv`
+# ======================================
+# Test CTEs
+# By default BNL and index access to t1 are used.
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) NO_INDEX(`t1`@`dt1`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	300	100.00	
+2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5)/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1` `idx_a`) NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+# Ambiguity: multiple occurencies of `cte`, the hint is ignored
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4256	Query block name `cte` is ambiguous for NO_BNL hint
+Note	1003	with cte as (/* select#2 */ select count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# However, if CTE occurencies have different aliases, the hint can be applied
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte1)*/ * from cte as cte1 where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using where; Using index
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte1`) */ count(0) AS `cnt` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` < 5 having `cnt` > 10)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte1`) */ `cte1`.`cnt` AS `cnt` from `cte` `cte1` where `cte1`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# ======================================
+# Test views
+create view v1 as select * from t1 where a < 100;
+# Default execution plan
+explain extended select *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+explain extended
+select /*+ index(t1@v1 idx_ab) no_index(t1@`v2`)*/ *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	99.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) NO_INDEX(`t1`@`v2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+# Nested views
+create view v2 as select * from v1 where a < 300;
+# Default execution plan
+explain extended select * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+# Addressing an object inside a nested view
+explain extended select /*+ index(t1@`v1` idx_ab)*/ * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	99	100.00	Using index condition
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+create view v3 as select * from t1 union select * from t2;
+# Unable to apply the hint to a view with UNION
+explain extended select /*+ no_index(t1@v3) */ * from v3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `v3` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `v3`.`a` AS `a`,`v3`.`b` AS `b`,`v3`.`c` AS `c` from `test`.`v3`
+# Ambiguity: view `v1` appears two times - should warn and ignore hint
+explain extended select /*+ index(t2@v1) */ * from v1,
+(select a from v1 where b > 5) dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_ab	5	NULL	99	90.20	Using where; Using index
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Warning	4256	Query block name `v1` is ambiguous for INDEX hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`b` > 5 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+# Implicit QB names are not supported inside views
+create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+Warnings:
+Warning	4242	Implicit query block names are ignored for hints specified within VIEWs
+show create view v4;
+View	Create View	character_set_client	collation_connection
+v4	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v4` AS select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (`t1` join `t2`) where `t1`.`a` > `t2`.`a`) `dt`	latin1	latin1_swedish_ci
+# However, a derived table inside a view can be addressed from outer query
+create view v5 as select dt.a from
+t1, (select t1.* from t1, t2 where t1.a > t2.a) as dt where t1.a=dt.a;
+# Addressing a single table
+explain extended select /*+ no_bnl(t2@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
+# Addressing the whole derived table
+explain extended select /*+ no_bnl(@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	Using index
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(@`dt`) */ `test`.`t1`.`a` AS `a` from `test`.`t1` join `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` > `test`.`t2`.`a`
+# Derived tables inside views can be addressed by their aliases
+explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	select /*+ NO_BNL(`t2`@`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`
+drop view v1, v2, v3, v4, v5;
+# ======================================
+# Not supported for DML, check presence of warnings
+explain extended
+update /*+ no_range_optimization(t1@dt)*/ t2,
+(select a from t1 where a > 10) dt
+set b=1 where t2.a = dt.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t2.a	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	92	100.00	Using where; Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_RANGE_OPTIMIZATION hint
+Note	1003	/* select#1 */ update `test`.`t2` join (/* select#2 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` > 10) `dt` set `test`.`t2`.`b` = 1 where `dt`.`a` = `test`.`t2`.`a`
+explain extended
+delete /*+ no_index(t1@dt)*/ from t2
+where t2.a in
+(select * from (select a from t1 where a > 10) dt where dt.a > 20);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	90.00	Using where
+1	PRIMARY	t1	ref	idx_a,idx_ab	idx_a	5	test.t2.a	1	100.00	Using index; FirstMatch(t2)
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	delete  from `test`.`t2` using (`test`.`t1`) where `test`.`t1`.`a` = `test`.`t2`.`a` and `test`.`t2`.`a` > 20 and `test`.`t2`.`a` > 10
+# ======================================
+# Objects in triggers and stored functions must not be visible for hints
+create table t3 (a int, b int);
+# Trigger with derived table inside
+create trigger tr1 before insert on t3
+for each row
+begin
+set new.b = (select max(a) from
+(select a from t1 where a < new.a) dt);
+end|
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ max(a) from t3 where a<2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select max(NULL) AS `max(a)` from `test`.`t3` where 0
+# Stored function with derived table inside
+create function get_max(p_a int) returns int
+return (select max(a) from
+(select a from t1 where a < p_a) dt);
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ a, get_max(a) from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`get_max`(`test`.`t1`.`a`) AS `get_max(a)` from `test`.`t1`
+drop function get_max;
+drop table t1, t2, t3;
+set optimizer_switch = 'derived_merge=off';
+create table t1 (a int, b int, c char(20), key idx_a(a), key idx_ab(a, b));
+insert into t1 select seq, seq, 'filler' from seq_1_to_100;
+create table t2 as select * from t1;
+analyze table t1,t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	Table is already up to date
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+# Table-level hint
+explain extended select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+# More than one reference to a single QB
+explain extended select /*+ no_bnl(t2@dt) no_index(t1@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) NO_INDEX(`t1`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+# QB-level hint
+explain extended select /*+ no_bnl(@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+# Index-level hints
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_index(t1@`T`)*/ * from
+(select * from t1 where a < 3) t;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`T`) */ `t`.`a` AS `a`,`t`.`b` AS `b`,`t`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`T`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t`
+# Without the hint 'range' index access would be chosen
+explain extended select /*+ no_range_optimization(t1@t1)*/ *  from
+(select * from t1 where a > 100 and a < 120) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	1.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_RANGE_OPTIMIZATION(`t1`@`t1`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` > 100 and `test`.`t1`.`a` < 120) `t1`
+# Regular and derived tables share same name but the hint is applied correctly
+explain extended select /*+ index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select /*+ INDEX(`t1`@`t1` `idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1`
+explain extended select /*+ no_index(t1@t2 idx_a) index(t1@t1 idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	3	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition
+2	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`t2` `idx_a`) INDEX(`t1`@`t1` `idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c`,`t2`.`a` AS `a`,`t2`.`b` AS `b`,`t2`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1` join (/* select#3 */ select /*+ QB_NAME(`t2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t2`
+explain extended select /*+ no_index(t1@t1 idx_a, idx_ab)*/ * from
+(select * from t1 where a < 3) as t1, (select * from t1 where a < 5) as t2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	2.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`t1` `idx_a`,`idx_ab`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c`,`t2`.`a` AS `a`,`t2`.`b` AS `b`,`t2`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`t1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3) `t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t2`
+# Nested derived tables
+explain extended select /*+ no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+explain extended select /*+ no_index(t1@DT2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`DT2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`DT2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+# Explicit QB name overrides the implicit one
+explain extended select /*+ no_index(t1@dt2)*/ * from
+(select count(*) from t1, (select /*+ qb_name(dt2)*/ * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+# Both hints are applied
+explain extended select /*+ no_index(t1@dt1) no_bnl(t1@dt2)*/ * from
+(select count(*) from t1, (select * from t1 where a < 5) dt1) as dt2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1`) NO_BNL(`t1`@`dt2`) */ `dt2`.`count(*)` AS `count(*)` from (/* select#2 */ select /*+ QB_NAME(`dt2`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`) `dt2`
+# Nested derived tables with ambiguous names, hint is ignored
+explain extended select /*+ no_index(t1@t1)*/* from
+(select count(*) from t1, (select * from t1 where a < 5) t1) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Warning	4256	Query block name `t1` is ambiguous for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`count(*)` AS `count(*)` from (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `t1`) `t1`
+# The hint cannot be applied to a derived table with UNION
+explain extended select /*+ no_index(t2@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+explain extended select /*+ no_index(t1@t1)*/* from
+(select * from t1 where a < 3 union select * from t2 where a < 9) as t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	8.00	Using where
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `t1` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (/* select#2 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 3 union /* select#3 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`c` AS `c` from `test`.`t2` where `test`.`t2`.`a` < 9) `t1`
+# Test INSERT..SELECT
+explain extended insert into t2 select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	insert into `test`.`t2` /* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+# Test MERGE and NO_MERGE hints
+explain extended select /*+ merge(@dt)*/ * from
+(select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+2	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ MERGE(@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+explain extended select /*+ no_merge(@dt)*/ * from
+(select * from (select t1.* from t1, t2 where t1.a > t2.a) as dt1) as dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_MERGE(@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#2 */ select /*+ QB_NAME(`dt`) */ `dt1`.`a` AS `a`,`dt1`.`b` AS `b`,`dt1`.`c` AS `c` from (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt1`) `dt`
+# Multiple levels of nested derived tables, all hints are applied
+explain extended
+select /*+ no_merge(dv) no_bnl(t2@dt) */ * from (
+select /*+ no_merge(du) */ * from (
+select /*+ no_merge(dt) */ * from (
+select t1.* from t1, t2 where t1.a > t2.a
+) dt
+) du
+) dv;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+4	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+4	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_MERGE(`dt`@`select#3`) NO_MERGE(`du`@`select#2`) NO_MERGE(`dv`@`select#1`) NO_BNL(`t2`@`dt`) */ `dv`.`a` AS `a`,`dv`.`b` AS `b`,`dv`.`c` AS `c` from (/* select#2 */ select `du`.`a` AS `a`,`du`.`b` AS `b`,`du`.`c` AS `c` from (/* select#3 */ select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#4 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`) `du`) `dv`
+# ======================================
+# Test CTEs
+# By default BNL and index access to t1 are used.
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	with cte as (/* select#2 */ select count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_BNL(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte) no_index(t1@dt1)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	400	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	4.00	Using where
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte`) NO_INDEX(`t1`@`dt1`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+explain extended
+with cte as (select count(*) from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@dt1 idx_a) no_bnl(@cte)*/ * from cte;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	300	100.00	
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	3	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+3	DERIVED	t1	range	idx_ab	idx_ab	5	NULL	3	100.00	Using index condition
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte`) */ count(0) AS `count(*)` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt1`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1`)/* select#1 */ select /*+ NO_INDEX(`t1`@`dt1` `idx_a`) NO_BNL(@`cte`) */ `cte`.`count(*)` AS `count(*)` from `cte`
+# Ambiguity: multiple occurencies of `cte`, the hint is ignored
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_bnl(@cte)*/ * from cte where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+6	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4256	Query block name `cte` is ambiguous for NO_BNL hint
+Note	1003	with cte as (/* select#2 */ select count(0) AS `cnt` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1` having `cnt` > 10)/* select#1 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# However, if CTE occurencies have different aliases, the hint can be applied
+explain extended
+with cte as (select count(*) as cnt from t1, (select * from t1 where a < 5) dt1)
+select /*+ no_index(t1@cte1)*/ * from cte as cte1 where cnt > 10
+union
+select * from cte where cnt < 100;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	Using join buffer (flat, BNL join)
+3	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+4	UNION	<derived5>	ALL	NULL	NULL	NULL	NULL	200	100.00	Using where
+5	DERIVED	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	DERIVED	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index; Using join buffer (flat, BNL join)
+6	DERIVED	t1	range	idx_a,idx_ab	idx_a	5	NULL	2	100.00	Using index condition
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Note	1003	with cte as (/* select#2 */ select /*+ QB_NAME(`cte1`) */ count(0) AS `cnt` from `test`.`t1` join (/* select#3 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 5) `dt1` having `cnt` > 10)/* select#1 */ select /*+ NO_INDEX(`t1`@`cte1`) */ `cte1`.`cnt` AS `cnt` from `cte` `cte1` where `cte1`.`cnt` > 10 union /* select#4 */ select `cte`.`cnt` AS `cnt` from `cte` where `cte`.`cnt` < 100
+# ======================================
+# Test views
+create view v1 as select * from t1 where a < 100;
+# Default execution plan
+explain extended select *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_a,idx_ab	idx_a	5	NULL	1	100.00	Using index condition
+1	SIMPLE	t1	ref	idx_a,idx_ab	idx_a	5	test.t1.a	1	100.00	
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+explain extended
+select /*+ index(t1@v1 idx_ab) no_index(t1@`v2`)*/ *
+from v1, v1 as v2 where v1.a = v2.a and v1.a < 3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	2	100.00	Using index condition
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	99.00	Using where; Using join buffer (flat, BNL join)
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) NO_INDEX(`t1`@`v2`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t1` where `test`.`t1`.`a` = `test`.`t1`.`a` and `test`.`t1`.`a` < 3 and `test`.`t1`.`a` < 100 and `test`.`t1`.`a` < 100
+# Nested views
+create view v2 as select * from v1 where a < 300;
+# Default execution plan
+explain extended select * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+# Addressing an object inside a nested view
+explain extended select /*+ index(t1@`v1` idx_ab)*/ * from v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	range	idx_ab	idx_ab	5	NULL	99	100.00	Using index condition
+Warnings:
+Note	1003	select /*+ INDEX(`t1`@`v1` `idx_ab`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`a` < 300 and `test`.`t1`.`a` < 100
+create view v3 as select * from t1 union select * from t2;
+# Unable to apply the hint to a view with UNION
+explain extended select /*+ no_index(t1@v3) */ * from v3;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	200	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	100	100.00	
+3	UNION	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	
+NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+Warnings:
+Warning	4257	Implicit query block name `v3` is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for NO_INDEX hint
+Note	1003	/* select#1 */ select `v3`.`a` AS `a`,`v3`.`b` AS `b`,`v3`.`c` AS `c` from `test`.`v3`
+# Ambiguity: view `v1` appears two times - should warn and ignore hint
+explain extended select /*+ index(t2@v1) */ * from v1,
+(select a from v1 where b > 5) dt;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	94.00	Using where
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	99	100.00	Using join buffer (flat, BNL join)
+2	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	99	90.20	Using where; Using index
+Warnings:
+Warning	4256	Query block name `v1` is ambiguous for INDEX hint
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c`,`dt`.`a` AS `a` from `test`.`t1` join (/* select#2 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`b` > 5 and `test`.`t1`.`a` < 100) `dt` where `test`.`t1`.`a` < 100
+# Implicit QB names are not supported inside views
+create view v4 as select /*+ no_bnl(t2@dt)*/ * from
+(select t1.* from t1, t2 where t1.a > t2.a) as dt;
+Warnings:
+Warning	4242	Implicit query block names are ignored for hints specified within VIEWs
+show create view v4;
+View	Create View	character_set_client	collation_connection
+v4	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v4` AS select `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (select `t1`.`a` AS `a`,`t1`.`b` AS `b`,`t1`.`c` AS `c` from (`t1` join `t2`) where `t1`.`a` > `t2`.`a`) `dt`	latin1	latin1_swedish_ci
+# However, a derived table inside a view can be addressed from outer query
+create view v5 as select dt.a from
+t1, (select t1.* from t1, t2 where t1.a > t2.a) as dt where t1.a=dt.a;
+# Addressing a single table
+explain extended select /*+ no_bnl(t2@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	PRIMARY	<derived3>	ref	key0	key0	5	test.t1.a	100	100.00	
+3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt` where `dt`.`a` = `test`.`t1`.`a`
+# Addressing the whole derived table
+explain extended select /*+ no_bnl(@dt) */* from v5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t1	index	idx_a,idx_ab	idx_a	5	NULL	100	100.00	Using where; Using index
+1	PRIMARY	<derived3>	ref	key0	key0	5	test.t1.a	100	100.00	
+3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(@`dt`) */ `dt`.`a` AS `a` from `test`.`t1` join (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt` where `dt`.`a` = `test`.`t1`.`a`
+# Derived tables inside views can be addressed by their aliases
+explain extended select /*+ no_bnl(t2@dt) */ * from v4;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10000	100.00	
+3	DERIVED	t1	ALL	idx_a,idx_ab	NULL	NULL	NULL	100	100.00	
+3	DERIVED	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select /*+ NO_BNL(`t2`@`dt`) */ `dt`.`a` AS `a`,`dt`.`b` AS `b`,`dt`.`c` AS `c` from (/* select#3 */ select /*+ QB_NAME(`dt`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` join `test`.`t2` where `test`.`t1`.`a` > `test`.`t2`.`a`) `dt`
+drop view v1, v2, v3, v4, v5;
+# ======================================
+# Not supported for DML, check presence of warnings
+explain extended
+update /*+ no_range_optimization(t1@dt)*/ t2,
+(select a from t1 where a > 10) dt
+set b=1 where t2.a = dt.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	100.00	Using where
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t2.a	9	100.00	
+2	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	92	100.00	Using where; Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_RANGE_OPTIMIZATION hint
+Note	1003	/* select#1 */ update `test`.`t2` join (/* select#2 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` > 10) `dt` set `test`.`t2`.`b` = 1 where `dt`.`a` = `test`.`t2`.`a`
+explain extended
+delete /*+ no_index(t1@dt)*/ from t2
+where t2.a in
+(select * from (select a from t1 where a > 10) dt where dt.a > 20);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	100	80.00	Using where
+1	PRIMARY	<derived3>	eq_ref	distinct_key	distinct_key	5	test.t2.a	1	100.00	
+3	DERIVED	t1	range	idx_a,idx_ab	idx_ab	5	NULL	84	100.00	Using where; Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	/* select#1 */ delete  from `test`.`t2` using (/* select#3 */ select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` > 10 and `test`.`t1`.`a` > 20) `dt` where `dt`.`a` = `test`.`t2`.`a` and `test`.`t2`.`a` > 20
+# ======================================
+# Objects in triggers and stored functions must not be visible for hints
+create table t3 (a int, b int);
+# Trigger with derived table inside
+create trigger tr1 before insert on t3
+for each row
+begin
+set new.b = (select max(a) from
+(select a from t1 where a < new.a) dt);
+end|
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ max(a) from t3 where a<2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select max(NULL) AS `max(a)` from `test`.`t3` where 0
+# Stored function with derived table inside
+create function get_max(p_a int) returns int
+return (select max(a) from
+(select a from t1 where a < p_a) dt);
+# Warning expected
+explain extended select /*+ no_index(t1@dt) */ a, get_max(a) from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	index	NULL	idx_a	5	NULL	100	100.00	Using index
+Warnings:
+Warning	4220	Query block name `dt` is not found for NO_INDEX hint
+Note	1003	select `test`.`t1`.`a` AS `a`,`get_max`(`test`.`t1`.`a`) AS `get_max(a)` from `test`.`t1`
+drop function get_max;
+drop table t1, t2, t3;
+set optimizer_switch = default;

--- a/mysql-test/main/opt_hints_impl_qb_name.test
+++ b/mysql-test/main/opt_hints_impl_qb_name.test
@@ -1,0 +1,9 @@
+set optimizer_switch = 'derived_merge=on';
+
+--source opt_hints_impl_qb_name.inc
+
+set optimizer_switch = 'derived_merge=off';
+
+--source opt_hints_impl_qb_name.inc
+
+set optimizer_switch = default;

--- a/sql/opt_hints.h
+++ b/sql/opt_hints.h
@@ -113,6 +113,7 @@
 
 #include <functional>
 #include "my_config.h"
+#include "opt_hints_structs.h"
 #include "sql_alloc.h"
 #include "sql_list.h"
 #include "mem_root_array.h"

--- a/sql/opt_hints_parser.cc
+++ b/sql/opt_hints_parser.cc
@@ -53,11 +53,13 @@ void append_table_name(THD *thd, String *str, const LEX_CSTRING &table_name,
 
 static const Lex_ident_sys null_ident_sys;
 
+
 Parse_context::Parse_context(THD *thd, st_select_lex *select)
 : thd(thd),
   mem_root(thd->mem_root),
   select(select)
 {}
+
 
 Parse_context::Parse_context(Parse_context *pc, st_select_lex *select)
 : thd(pc->thd),
@@ -1283,6 +1285,20 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
   if (!get_qb_hints(pc))
     return true;
 
+  /*
+    QB_NAME hints are resolved first so following hints can be attached to
+    the pre-configured query blocks
+  */
+  for (Hint_list::iterator li= this->begin(); li != this->end(); ++li)
+  {
+    Parser::Hint &hint= *li;
+    if (const Qb_name_hint &qb_hint= hint)
+    {
+      if (qb_hint.resolve(pc))
+        return true;
+    }
+  }
+
   for (Hint_list::iterator li= this->begin(); li != this->end(); ++li)
   {
     Parser::Hint &hint= *li;
@@ -1294,11 +1310,6 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
     else if (const Index_level_hint &index_hint= hint)
     {
       if (index_hint.resolve(pc))
-        return true;
-    }
-    else if (const Qb_name_hint &qb_hint= hint)
-    {
-      if (qb_hint.resolve(pc))
         return true;
     }
     else if (const Max_execution_time_hint &max_hint= hint)
@@ -1320,6 +1331,11 @@ bool Parser::Hint_list::resolve(Parse_context *pc) const
     {
       if (join_order_hint.resolve(pc))
         return true;
+    }
+    else if (const Qb_name_hint &qb_hint __attribute__((unused)) = hint)
+    {
+      // QB_NAME hints have been resolved earlier
+      continue;
     }
     else {
       DBUG_ASSERT(0);

--- a/sql/opt_hints_parser.h
+++ b/sql/opt_hints_parser.h
@@ -19,6 +19,7 @@
 */
 
 #include "lex_ident_sys.h"
+#include "opt_hints_structs.h"
 #include "simple_tokenizer.h"
 #include "sql_list.h"
 #include "sql_string.h"
@@ -29,45 +30,13 @@ class st_select_lex;
 class Opt_hints_qb;
 
 /**
-  Hint types, MAX_HINT_ENUM should be always last.
-  This enum should be synchronized with opt_hint_info
-  array(see opt_hints.cc).
-*/
-enum opt_hints_enum
-{
-  BKA_HINT_ENUM= 0,
-  BNL_HINT_ENUM,
-  ICP_HINT_ENUM,
-  MRR_HINT_ENUM,
-  NO_RANGE_HINT_ENUM,
-  QB_NAME_HINT_ENUM,
-  MAX_EXEC_TIME_HINT_ENUM,
-  SEMIJOIN_HINT_ENUM,
-  SUBQUERY_HINT_ENUM,
-  JOIN_PREFIX_HINT_ENUM,
-  JOIN_SUFFIX_HINT_ENUM,
-  JOIN_ORDER_HINT_ENUM,
-  JOIN_FIXED_ORDER_HINT_ENUM,
-  DERIVED_CONDITION_PUSHDOWN_HINT_ENUM,
-  MERGE_HINT_ENUM,
-  SPLIT_MATERIALIZED_HINT_ENUM,
-  INDEX_HINT_ENUM,
-  JOIN_INDEX_HINT_ENUM,
-  GROUP_INDEX_HINT_ENUM,
-  ORDER_INDEX_HINT_ENUM,
-  ROWID_FILTER_HINT_ENUM,
-  INDEX_MERGE_HINT_ENUM,
-  MAX_HINT_ENUM // This one must be the last in the list
-};
-
-
-/**
   Environment data for the name resolution phase
 */
-struct Parse_context {
-  THD * const thd;              ///< Current thread handler
-  MEM_ROOT *mem_root;           ///< Current MEM_ROOT
-  st_select_lex * select;       ///< Current SELECT_LEX object
+struct Parse_context
+{
+  THD * const thd;
+  MEM_ROOT *mem_root;
+  st_select_lex *select;
 
   Parse_context(THD *thd, st_select_lex *select);
   Parse_context(Parse_context *pc, st_select_lex *select);

--- a/sql/opt_hints_structs.h
+++ b/sql/opt_hints_structs.h
@@ -1,0 +1,53 @@
+#ifndef OPT_HINTS_STRUCTS_H
+#define OPT_HINTS_STRUCTS_H
+/*
+   Copyright (c) 2026, MariaDB
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA
+*/
+
+/**
+  Hint types, MAX_HINT_ENUM should be always last.
+  This enum should be synchronized with opt_hint_info
+  array(see opt_hints.cc).
+*/
+enum opt_hints_enum
+{
+  BKA_HINT_ENUM= 0,
+  BNL_HINT_ENUM,
+  ICP_HINT_ENUM,
+  MRR_HINT_ENUM,
+  NO_RANGE_HINT_ENUM,
+  QB_NAME_HINT_ENUM,
+  MAX_EXEC_TIME_HINT_ENUM,
+  SEMIJOIN_HINT_ENUM,
+  SUBQUERY_HINT_ENUM,
+  JOIN_PREFIX_HINT_ENUM,
+  JOIN_SUFFIX_HINT_ENUM,
+  JOIN_ORDER_HINT_ENUM,
+  JOIN_FIXED_ORDER_HINT_ENUM,
+  DERIVED_CONDITION_PUSHDOWN_HINT_ENUM,
+  MERGE_HINT_ENUM,
+  SPLIT_MATERIALIZED_HINT_ENUM,
+  INDEX_HINT_ENUM,
+  JOIN_INDEX_HINT_ENUM,
+  GROUP_INDEX_HINT_ENUM,
+  ORDER_INDEX_HINT_ENUM,
+  ROWID_FILTER_HINT_ENUM,
+  INDEX_MERGE_HINT_ENUM,
+  MAX_HINT_ENUM // This one must be the last in the list
+};
+
+#endif /* OPT_HINTS_STRUCTS_H */

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12388,3 +12388,7 @@ ER_SLAVE_INCOMPATIBLE_TABLE_DEF
         eng "Table structure for binlog event is not compatible with the table definition on this slave: %s"
 ER_UNSUPPORTED_DATA_TYPE_ATTRIBUTE
         eng "Data type '%-.64s' doesn't support %s attribute."
+ER_WARN_AMBIGUOUS_QB_NAME
+	eng "Query block name %s is ambiguous for %s hint"
+ER_WARN_IMPLICIT_QB_NAME_FOR_UNION
+	eng "Implicit query block name %s is not supported for derived tables and views with UNION/EXCEPT/INTERSECT and is ignored for %s hint"

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5816,6 +5816,8 @@ bool open_normal_and_derived_tables(THD *thd, TABLE_LIST *tables, uint flags,
   if ((dt_phases & DT_INIT) && mysql_handle_derived(thd->lex, DT_INIT))
     goto end;
 
+  thd->lex->resolve_optimizer_hints();
+
   // Process all phases remaining after DT_INIT
   if (mysql_handle_derived(thd->lex, dt_phases & ~DT_INIT))
     goto end;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5809,8 +5809,15 @@ bool open_normal_and_derived_tables(THD *thd, TABLE_LIST *tables, uint flags,
   uint counter;
   MDL_savepoint mdl_savepoint= thd->mdl_context.mdl_savepoint();
   DBUG_ENTER("open_normal_and_derived_tables");
-  if (open_tables(thd, &tables, &counter, flags, &prelocking_strategy) ||
-      mysql_handle_derived(thd->lex, dt_phases))
+  if (open_tables(thd, &tables, &counter, flags, &prelocking_strategy))
+    goto end;
+
+  // Process initialization phase if it is requested in dt_phases
+  if ((dt_phases & DT_INIT) && mysql_handle_derived(thd->lex, DT_INIT))
+    goto end;
+
+  // Process all phases remaining after DT_INIT
+  if (mysql_handle_derived(thd->lex, dt_phases & ~DT_INIT))
     goto end;
 
   DBUG_RETURN(0);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3539,7 +3539,6 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
   */
   lex->first_lists_tables_same();
   lex->fix_first_select_number();
-  lex->resolve_optimizer_hints();
   /* should be assigned after making first tables same */
   all_tables= lex->query_tables;
   /* set context for commands which do not use setup_tables */
@@ -4674,6 +4673,7 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
       select_lex->table_list.first= second_table;
       select_lex->context.table_list=
         select_lex->context.first_name_resolution_table= second_table;
+      lex->resolve_optimizer_hints();
       res= mysql_insert_select_prepare(thd, result);
       Write_record write;
       if (!res &&
@@ -6129,6 +6129,7 @@ static bool execute_sqlcom_select(THD *thd, TABLE_LIST *all_tables)
 
   if (!(res= open_and_lock_tables(thd, all_tables, TRUE, 0)))
   {
+    lex->resolve_optimizer_hints();
     if (lex->describe)
     {
       /*

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -1564,6 +1564,7 @@ static int mysql_test_select(Prepared_statement *stmt,
                                      DT_INIT | DT_PREPARE))
     goto error;
 
+  lex->resolve_optimizer_hints();
   thd->lex->used_tables= 0;                        // Updated by setup_fields
 
   /*
@@ -2304,7 +2305,6 @@ static bool check_prepared_statement(Prepared_statement *stmt)
 
   lex->first_lists_tables_same();
   lex->fix_first_select_number();
-  lex->resolve_optimizer_hints();
   tables= lex->query_tables;
 
   /* set context for commands which do not use setup_tables */

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -34748,7 +34748,7 @@ bool Sql_cmd_dml::prepare(THD *thd)
   MYSQL_DML_START(thd);
 
   lex->context_analysis_only|= CONTEXT_ANALYSIS_ONLY_DERIVED;
-
+  lex->resolve_optimizer_hints();
   if (open_tables_for_query(thd, lex->query_tables, &table_count, 0,
                             get_dml_prelocking_strategy()))
   {

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1375,6 +1375,7 @@ mysqld_show_create(THD *thd, TABLE_LIST *table_list)
   if (mysqld_show_create_get_fields(thd, table_list, &field_list, &buffer))
     goto exit;
 
+  thd->lex->resolve_optimizer_hints();
   if (protocol->send_result_set_metadata(&field_list,
                                          Protocol::SEND_NUM_ROWS |
                                          Protocol::SEND_EOF))

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -559,6 +559,7 @@ bool mysql_create_view(THD *thd, TABLE_LIST *views,
 
   /* prepare select to resolve all fields */
   lex->context_analysis_only|= CONTEXT_ANALYSIS_ONLY_VIEW;
+  lex->resolve_optimizer_hints();
   if (unit->prepare(unit->derived, 0, 0))
   {
     /*


### PR DESCRIPTION
This patch implements support for implicit query block (QB) names in
optimizer hints, allowing hints to reference query blocks and tables
within derived tables, views and CTEs without requiring explicit
QB_NAME hints.

Examples.
```
-- Addressing a table inside a derived table using implicit QB name
select /*+ no_index(t1@dt) */ *
  from (select * from t1 where a > 10) as DT;
-- this is an equivalent to:
select /*+ no_index(t1@dt) */ * from
  (select /*+ qb_name(dt)*/ * from t1 where a > 10) as DT;
-- Addressing a query block corresponding to the derived table
select /*+ no_bnl(@dt) */ *
  from (select * from t1, t2 where t.1.a > t2.a) as DT;

-- View
create view v1 as select * from t1 where a > 10 and b > 100;
-- referencing a table inside a view by implicit QB name:
select /*+ index_merge(t1@v1 idx_a, idx_b) */ *
  from v1, t2 where v1.a = t2.a;
-- equivalent to:
create view v1 as select /*+ qb_name(qb_v1) */ *
  from t1 where a > 10 and b > 100;
select /*+ index_merge(t1@qb_v1 idx_a, idx_b) */ *
  from v1, t2 where v1.a = t2.a;

-- CTE
with aless100 as (select a from t1 where b <100)
  select /*+ index(t1@aless100) */ * from aless100;
-- equivalent to:
with aless100 as (select /*+ qb_name(aless100) */ a from t1 where b <100)
  select /*+ index(t1@aless100) */ * from aless100;
```

Limitations:
  - Only SELECT statements support implicit QB names. DML operations
    (UPDATE, DELETE, INSERT) only support explicit QB names
