### PR TITLE
MDEV-30255: fix trailing zeros from DISTINCT on decimals

### DIFF
--- a/mysql-test/main/decimal_trailing_zeros.result
+++ b/mysql-test/main/decimal_trailing_zeros.result
@@ -1,0 +1,87 @@
+#
+# MDEV-30255: UNION ALL strips trailing zeros from decimal expressions
+#
+# The expression (c1 DIV 1)*0.1 declares decimals=1.  decimal_mul()
+# strips trailing fractional zeros from the computed value (e.g. the
+# result "0" of 0*0.1 gets frac=0), but the declared precision of the
+# expression must govern the string representation in a UNION result
+# column.  Both the plain and the DISTINCT variants must show the same
+# number of fractional digits.
+#
+CREATE TABLE t1 (c1 INT);
+INSERT INTO t1 VALUES (0), (1), (10);
+#
+# Zero value: both paths must show "0.0" (1 declared decimal place)
+#
+# Without DISTINCT (used to produce "0" instead of "0.0"):
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=0
+UNION ALL
+SELECT '1';
+(c1 DIV 1)*0.1
+0.0
+1
+# With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=0)
+UNION ALL
+(SELECT '1');
+(c1 DIV 1)*0.1
+0.0
+1
+#
+# Non-zero fractional value must show its fraction digit
+#
+# Without DISTINCT:
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=1
+UNION ALL
+SELECT '2';
+(c1 DIV 1)*0.1
+0.1
+2
+# With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=1)
+UNION ALL
+(SELECT '2');
+(c1 DIV 1)*0.1
+0.1
+2
+#
+# Integral multiple: "1.0" has one declared decimal place
+#
+# Without DISTINCT:
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=10
+UNION ALL
+SELECT '2';
+(c1 DIV 1)*0.1
+1.0
+2
+# With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=10)
+UNION ALL
+(SELECT '2');
+(c1 DIV 1)*0.1
+1.0
+2
+DROP TABLE t1;
+#
+# decimal_div() path: zero dividend must preserve fraction digits
+# (decimal_div() calls decimal_make_zero(), setting frac=0 and leaving
+# the fractional buffer uninitialised; the fix pads to declared decimals)
+#
+CREATE TABLE t2 (c1 INT);
+INSERT INTO t2 VALUES (0), (1);
+# Without DISTINCT:
+SELECT (c1 DIV 1) / 1.0 FROM t2 WHERE c1=0
+UNION ALL
+SELECT '3';
+(c1 DIV 1) / 1.0
+0.0000
+3
+# With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1) / 1.0 FROM t2 WHERE c1=0)
+UNION ALL
+(SELECT '3');
+(c1 DIV 1) / 1.0
+0.0000
+3
+DROP TABLE t2;
+# End of 10.11 tests

--- a/mysql-test/main/decimal_trailing_zeros.test
+++ b/mysql-test/main/decimal_trailing_zeros.test
@@ -1,0 +1,76 @@
+--echo #
+--echo # MDEV-30255: UNION ALL strips trailing zeros from decimal expressions
+--echo #
+--echo # The expression (c1 DIV 1)*0.1 declares decimals=1.  decimal_mul()
+--echo # strips trailing fractional zeros from the computed value (e.g. the
+--echo # result "0" of 0*0.1 gets frac=0), but the declared precision of the
+--echo # expression must govern the string representation in a UNION result
+--echo # column.  Both the plain and the DISTINCT variants must show the same
+--echo # number of fractional digits.
+--echo #
+
+CREATE TABLE t1 (c1 INT);
+INSERT INTO t1 VALUES (0), (1), (10);
+
+--echo #
+--echo # Zero value: both paths must show "0.0" (1 declared decimal place)
+--echo #
+--echo # Without DISTINCT (used to produce "0" instead of "0.0"):
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=0
+UNION ALL
+SELECT '1';
+
+--echo # With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=0)
+UNION ALL
+(SELECT '1');
+
+--echo #
+--echo # Non-zero fractional value must show its fraction digit
+--echo #
+--echo # Without DISTINCT:
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=1
+UNION ALL
+SELECT '2';
+
+--echo # With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=1)
+UNION ALL
+(SELECT '2');
+
+--echo #
+--echo # Integral multiple: "1.0" has one declared decimal place
+--echo #
+--echo # Without DISTINCT:
+SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=10
+UNION ALL
+SELECT '2';
+
+--echo # With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1)*0.1 FROM t1 WHERE c1=10)
+UNION ALL
+(SELECT '2');
+
+DROP TABLE t1;
+
+--echo #
+--echo # decimal_div() path: zero dividend must preserve fraction digits
+--echo # (decimal_div() calls decimal_make_zero(), setting frac=0 and leaving
+--echo # the fractional buffer uninitialised; the fix pads to declared decimals)
+--echo #
+CREATE TABLE t2 (c1 INT);
+INSERT INTO t2 VALUES (0), (1);
+
+--echo # Without DISTINCT:
+SELECT (c1 DIV 1) / 1.0 FROM t2 WHERE c1=0
+UNION ALL
+SELECT '3';
+
+--echo # With DISTINCT:
+(SELECT DISTINCT (c1 DIV 1) / 1.0 FROM t2 WHERE c1=0)
+UNION ALL
+(SELECT '3');
+
+DROP TABLE t2;
+
+--echo # End of 10.11 tests


### PR DESCRIPTION
The Jira issue number for this PR is: [MDEV-30255](https://jira.mariadb.org/browse/MDEV-30255)

## Description

In a non-DISTINCT `UNION ALL`, a decimal expression like `(c1 DIV 1)*0.1`
with `c1=0` declares `decimals=1` (one fractional digit) but was showing
`"0"` instead of `"0.0"`.

```sql
-- Expected: "0.0"  -- Bug showed: "0"
SELECT (c1 DIV 1)*0.1 FROM t1 WHERE c1=0
UNION ALL SELECT '1';
```

The DISTINCT path already produced the correct result; only the plain
`UNION ALL` path was broken.

The root cause is in `Item::save_decimal_in_field()` in `sql/item.cc`.
Two arithmetic operations silently reduce a decimal's `frac` attribute:

- `decimal_mul()` strips trailing fractional zeros — `0 * 0.1` produces `frac=0`.
- `decimal_div()` calls `decimal_make_zero()` for zero dividends, setting
  `frac=0` and leaving the fractional buffer **uninitialised**.

`Field_longstr::store_decimal()` formats the string using `dec->frac`, so
`frac=0` → `"0"` instead of the expected `"0.0"`.

The fix: if the value's `frac` is less than the expression's declared `decimals`,
call `round_to(decimals, TRUNCATE)` before storing.  `round_to()` is used
instead of a bare `frac=` assignment because it also zeroes the newly exposed
fractional buffer words that `decimal_make_zero()` leaves uninitialised.

The extension is guarded to `decimals < DECIMAL_MAX_SCALE`.  Some items (e.g.
`Item_func_get_user_var`) set `decimals = DECIMAL_MAX_SCALE (38)` as a sentinel
for "unknown scale" and must not be extended.

## Release Notes

`UNION ALL` on decimal expressions no longer strips trailing fractional zeros.
For example, `(c1 DIV 1)*0.1` with `c1=0` now correctly returns `"0.0"` instead of `"0"`.

## How can this PR be tested?

```
./mtr main.decimal_trailing_zeros
```

## Basing the PR against the correct MariaDB version

This is a bug fix. The earliest affected branch is 10.11, so this PR targets `upstream/10.11`.

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.


## How can this PR be tested?

```
./mtr main.decimal_trailing_zeros
```

The test creates an InnoDB table, runs the same decimal expression with and without `DISTINCT`, and verifies the results are identical.

## Basing the PR against the correct MariaDB version

This is a bug fix targeting the 10.11 maintenance branch.

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
