### PR TITLE
MDEV-37608: Increase default binlog_row_event_max_size to 64k

### DIFF
--- a/mysql-test/main/alter_table_online_debug.opt
+++ b/mysql-test/main/alter_table_online_debug.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -1778,7 +1778,7 @@ binlog-large-commit-threshold 134217728
 binlog-legacy-event-pos FALSE
 binlog-optimize-thread-scheduling TRUE
 binlog-row-event-fragment-threshold 1073741824
-binlog-row-event-max-size 8192
+binlog-row-event-max-size 65536
 binlog-row-image FULL
 binlog-row-metadata NO_LOG
 binlog-space-limit 0

--- a/mysql-test/main/tmp_space_usage-master.opt
+++ b/mysql-test/main/tmp_space_usage-master.opt
@@ -1,4 +1,1 @@
---log-bin
---binlog-format=row
---max_tmp_session_space_usage=512K
---max_tmp_total_space_usage=768K
+--log-bin --binlog-format=row --max_tmp_session_space_usage=512K --max_tmp_total_space_usage=768K --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/binlog/include/binlog_cache_stat.opt
+++ b/mysql-test/suite/binlog/include/binlog_cache_stat.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/binlog/t/binlog_bug23533.opt
+++ b/mysql-test/suite/binlog/t/binlog_bug23533.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/binlog_encryption/rpl_packet.cnf
+++ b/mysql-test/suite/binlog_encryption/rpl_packet.cnf
@@ -3,8 +3,10 @@
 [mysqld.1]
 max_allowed_packet=1024
 net_buffer_length=1024
+binlog_row_event_max_size=8192
 
 [mysqld.2]
 max_allowed_packet=1024
 net_buffer_length=1024
 slave_max_allowed_packet=1024
+binlog_row_event_max_size=8192

--- a/mysql-test/suite/binlog_in_engine/rpl_dual_cache-master.opt
+++ b/mysql-test/suite/binlog_in_engine/rpl_dual_cache-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/binlog_in_engine/rpl_oob.opt
+++ b/mysql-test/suite/binlog_in_engine/rpl_oob.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/encryption/t/tempfiles.opt
+++ b/mysql-test/suite/encryption/t/tempfiles.opt
@@ -1,1 +1,1 @@
---encrypt-tmp-files
+--encrypt-tmp-files --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/galera/t/galera_binlog_cache_size.opt
+++ b/mysql-test/suite/galera/t/galera_binlog_cache_size.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/perfschema/t/io_cache-master.opt
+++ b/mysql-test/suite/perfschema/t/io_cache-master.opt
@@ -1,3 +1,1 @@
---binlog_cache_size=4096
---binlog_stmt_cache_size=4096
---log-bin=master-bin
+--binlog_cache_size=4096 --binlog_stmt_cache_size=4096 --log-bin=master-bin --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/max_binlog_total_size-master.opt
+++ b/mysql-test/suite/rpl/t/max_binlog_total_size-master.opt
@@ -1,5 +1,1 @@
---log-bin=binary
---max-binlog-total-size=1500
---max-binlog-size=4096
---binlog-format=row
---slave_connections_needed_for_purge=1
+--log-bin=binary --max-binlog-total-size=1500 --max-binlog-size=4096 --binlog-format=row --slave_connections_needed_for_purge=1 --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_binlog_cache_disk_full_row-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_binlog_cache_disk_full_row-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_checksum_cache.opt
+++ b/mysql-test/suite/rpl/t/rpl_checksum_cache.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_create_select_row-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_create_select_row-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_fragment_row_event_main.cnf
+++ b/mysql-test/suite/rpl/t/rpl_fragment_row_event_main.cnf
@@ -1,5 +1,8 @@
 !include ../my.cnf
 
+[mysqld]
+binlog-row-event-max-size=8192
+
 [mysqld.1]
 gtid_domain_id=0
 server_id=1

--- a/mysql-test/suite/rpl/t/rpl_loaddata_map-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_loaddata_map-master.opt
@@ -1,1 +1,1 @@
---read_buffer_size=12K --max_allowed_packet=8K --net-buffer-length=8K
+--read_buffer_size=12K --max_allowed_packet=8K --net-buffer-length=8K --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_loaddata_map-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_loaddata_map-slave.opt
@@ -1,1 +1,1 @@
---max_allowed_packet=8K --net-buffer-length=8K
+--max_allowed_packet=8K --net-buffer-length=8K --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_mdev-11092.opt
+++ b/mysql-test/suite/rpl/t/rpl_mdev-11092.opt
@@ -1,1 +1,1 @@
---binlog_checksum=1 --binlog-annotate-row-events=1
+--binlog_checksum=1 --binlog-annotate-row-events=1 --loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_mixed_binlog_max_cache_size-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_mixed_binlog_max_cache_size-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_row_binlog_max_cache_size-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_binlog_max_cache_size-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_row_binlog_tmp_file_flush_enospc-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_binlog_tmp_file_flush_enospc-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/rpl/t/rpl_stm_binlog_max_cache_size-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_binlog_max_cache_size-master.opt
@@ -1,0 +1,1 @@
+--loose-binlog-row-event-max-size=8192

--- a/mysql-test/suite/sys_vars/r/binlog_row_event_max_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/binlog_row_event_max_size_basic.result
@@ -1,0 +1,16 @@
+# Verify Read-Only Status (SET should fail)
+SET @@global.binlog_row_event_max_size= 4096;
+ERROR HY000: Variable 'binlog_row_event_max_size' is a read only variable
+# Restarting with --binlog-row-event-max-size=100
+# restart: --binlog-row-event-max-size=100
+# Should be clipped to 256 (the minimum)
+SELECT @@global.binlog_row_event_max_size;
+@@global.binlog_row_event_max_size
+256
+# Restarting with --binlog-row-event-max-size=4300000000
+# restart: --binlog-row-event-max-size=4300000000
+# Should be clipped to 4294967040 (the maximum)
+SELECT @@global.binlog_row_event_max_size;
+@@global.binlog_row_event_max_size
+4294967040
+# End of sys_vars.binlog_row_event_max_size_basic

--- a/mysql-test/suite/sys_vars/t/binlog_row_event_max_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/binlog_row_event_max_size_basic.test
@@ -1,0 +1,31 @@
+--source include/have_binlog_format_row.inc
+
+# Verify it is READ-ONLY at runtime
+--echo # Verify Read-Only Status (SET should fail)
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.binlog_row_event_max_size= 4096;
+
+
+# Suppress warnings for testing boundary clipping (Min 256, Max 4.3G)
+--disable_query_log
+call mtr.add_suppression("option 'binlog_row_event_max_size': unsigned value 100 adjusted to 256");
+call mtr.add_suppression("option 'binlog_row_event_max_size': unsigned value 4300000000 adjusted to .*");
+--enable_query_log
+
+# Verify MINIMUM clipping (Set to 100, should clip to 256)
+--echo # Restarting with --binlog-row-event-max-size=100
+--let $restart_parameters=--binlog-row-event-max-size=100
+--source include/restart_mysqld.inc
+
+--echo # Should be clipped to 256 (the minimum)
+SELECT @@global.binlog_row_event_max_size;
+
+# Verify MAXIMUM clipping (Set to huge value, should clip to max)
+--echo # Restarting with --binlog-row-event-max-size=4300000000
+--let $restart_parameters=--binlog-row-event-max-size=4300000000
+--source include/restart_mysqld.inc
+
+--echo # Should be clipped to 4294967040 (the maximum)
+SELECT @@global.binlog_row_event_max_size;
+
+--echo # End of sys_vars.binlog_row_event_max_size_basic

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6082,7 +6082,7 @@ static Sys_var_ulong Sys_opt_binlog_rows_event_max_size(
       "grouped into events smaller than this size if possible. "
       "The value has to be a multiple of 256",
       READ_ONLY GLOBAL_VAR(opt_binlog_rows_event_max_size), CMD_LINE(REQUIRED_ARG),
-      VALID_RANGE(256, UINT_MAX32 - (UINT_MAX32 % 256)), DEFAULT(8192),
+      VALID_RANGE(256, UINT_MAX32 - (UINT_MAX32 % 256)), DEFAULT(65536),
       BLOCK_SIZE(256));
 
 static Sys_var_uint Sys_opt_binlog_partial_rows_event_max_size(


### PR DESCRIPTION
**Summary:**
This PR updates the default value of `binlog_row_event_max_size` from 8,192 bytes (8k) to 65,536 bytes (64k).

**Technical Rationale:**
The legacy 8k default causes extreme fragmentation in the binary log when handling modern workloads with large row payloads. By increasing this limit to 64k, the engine can aggregate more rows into fewer `Write_rows` events.

My benchmarks show that for a transaction involving 1,000 rows (5KB each), the 64k default reduces the number of binary log events from **1,000 to 77**—a **92.3% reduction in header and metadata overhead**. While 128k offers slightly better aggregation (39 events), 64k represents the optimal balance for memory allocation and network MTU efficiency.

---

### **Benchmark Results**

Test Case: 1,000 rows inserted in a single transaction (5KB payload per row).

| Buffer Size (Default) | Write_rows Events | Duration | Efficiency Gain |
| --- | --- | --- | --- |
| 8192 (Legacy) | 1,000 | 0.297s | - |
| 32768 | 167 | 0.294s | ~83.3% Fewer Headers |
| **65536 (Proposed)** | **77** | **0.287s** | **~92.3% Fewer Headers** |
| 131072 | 39 | 0.284s | ~96.1% Fewer Headers |

---

### **Test Environment**

* **CPU:** AMD Ryzen 5 PRO 4650G (6 Cores / 12 Threads)
* **RAM:** 16GB (15Gi Available)
* **Storage:** Kingston SNVS500G NVMe SSD (ROTA: 0)
* **OS:** Linux Mint 22.1 (Kernel 6.8.0-54-generic)

---

### **Verification**

* **Functional:** Passed `mtr binlog.binlog_row_binlog`.
* **Reproducibility:** The results can be reproduced using the attached multi-row insert script.

<details>
<summary>Click to view Benchmark Script</summary>

```bash
#!/bin/bash

# Configuration
SIZES=(8192 32768 65536 131072)
SOCKET="/tmp/mariadb_bench.sock"
DATADIR="$(pwd)/sql/data"
BINLOG_DIR="$DATADIR"

# Prepare the Payload (1000 rows, 5KB each ~ 5MB total)
echo "Preparing the heavy multi-row payload..."
VALUES_PART=$(for i in {1..999}; do echo -n "(REPEAT('M', 5000)), "; done)
VALUES_PART+="(REPEAT('M', 5000))"
SQL_QUERY="CREATE DATABASE IF NOT EXISTS bench; USE bench; DROP TABLE IF EXISTS t1; CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT, d LONGTEXT) ENGINE=InnoDB; INSERT INTO t1 (d) VALUES $VALUES_PART;"

pkill -9 mariadbd
rm -rf "$DATADIR" && mkdir -p "$DATADIR"

echo -e "\n| Size | Events | Duration |"
echo "| :--- | :--- | :--- |"

for VAL in "${SIZES[@]}"; do
    # Start server with specific size
    ./sql/mariadbd --datadir="$DATADIR" --console --skip-grant-tables \
    --binlog-format=ROW --log-bin=mysql-bin --port=3307 \
    --socket="$SOCKET" --binlog_row_event_max_size=$VAL > server.log 2>&1 &
    
    until ./client/mariadb --socket="$SOCKET" -e "SELECT 1" > /dev/null 2>&1; do
        sleep 1
    done

    # Run workload and capture time
    # We use 'bash -c' to ensure 'time' captures only the client execution
    TIME_RESULT=$( { time ./client/mariadb --socket="$SOCKET" -e "$SQL_QUERY" ; } 2>&1 )
    DURATION=$(echo "$TIME_RESULT" | grep "real" | awk '{print $2}')

    # Count Write_rows events
    LOG=$(./client/mariadb --socket="$SOCKET" -e "SHOW MASTER LOGS;" -sN | tail -1 | awk '{print $1}')
    COUNT=$(./client/mariadb-binlog "$BINLOG_DIR/$LOG" | grep "Write_rows" | wc -l)

    # Output result
    echo "| $VAL | $COUNT | $DURATION |"

    # Shutdown for next run
    pkill -9 mariadbd
    sleep 2
done

```

</details>