### PR TITLE
MDEV-36676 Add debug function to print MEM_ROOT name

### DIFF
--- a/storage/perfschema/pfs_instr_class.cc
+++ b/storage/perfschema/pfs_instr_class.cc
@@ -1591,6 +1591,30 @@ PFS_memory_class *sanitize_memory_class(PFS_memory_class *unsafe)
   SANITIZE_ARRAY_BODY(PFS_memory_class, memory_class_array, memory_class_max, unsafe);
 }
 
+
+#ifndef DBUG_OFF
+/*
+  Return the name of a MEM_ROOT for use from a debugger.
+  @param root the MEM_ROOT to identify (may be NULL)
+  @return the instrument name, or "<NULL>"
+*/
+extern "C"
+const char *dbug_print_memroot_name(MEM_ROOT *root)
+{
+  if (!root)
+    return "<NULL>";
+
+  if (root->psi_key != PSI_NOT_INSTRUMENTED)
+  {
+    PFS_memory_class *klass= find_memory_class(root->psi_key);
+    if (klass != NULL && klass->m_name[0])
+      return klass->m_name;
+  }
+
+  return "";
+}
+#endif
+
 PFS_instr_class *find_table_class(uint index)
 {
   if (index == 1)

--- a/storage/perfschema/pfs_instr_class.h
+++ b/storage/perfschema/pfs_instr_class.h
@@ -625,6 +625,9 @@ PFS_socket_class *find_socket_class(PSI_socket_key key);
 PFS_socket_class *sanitize_socket_class(PFS_socket_class *unsafe);
 PFS_memory_class *find_memory_class(PSI_memory_key key);
 PFS_memory_class *sanitize_memory_class(PFS_memory_class *unsafe);
+#ifndef DBUG_OFF
+extern "C" const char *dbug_print_memroot_name(struct st_mem_root *root);
+#endif
 PFS_instr_class *find_idle_class(uint index);
 PFS_instr_class *sanitize_idle_class(PFS_instr_class *unsafe);
 PFS_instr_class *find_metadata_class(uint index);

--- a/storage/perfschema/unittest/CMakeLists.txt
+++ b/storage/perfschema/unittest/CMakeLists.txt
@@ -36,5 +36,5 @@ ADD_DEPENDENCIES(pfs_server_stubs GenError)
 
 MY_ADD_TESTS(pfs_instr_class pfs_instr_class-oom pfs_instr pfs_instr-oom
              pfs_account-oom pfs_host-oom pfs_user-oom pfs_noop pfs
-             pfs_misc
+             pfs_misc pfs_memroot_name
   EXT "cc" LINK_LIBRARIES perfschema mysys pfs_server_stubs)

--- a/storage/perfschema/unittest/pfs_memroot_name-t.cc
+++ b/storage/perfschema/unittest/pfs_memroot_name-t.cc
@@ -1,0 +1,86 @@
+/* Copyright (c) 2025, MariaDB Corporation.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
+
+#include <my_global.h>
+#include <my_thread.h>
+#include <pfs_instr.h>
+#include <pfs_stat.h>
+#include <pfs_global.h>
+#include <pfs_instr_class.h>
+#include <pfs_buffer_container.h>
+#include <tap.h>
+
+#include "stub_global_status_var.h"
+
+#ifndef DBUG_OFF
+
+void do_all_tests()
+{
+  MEM_ROOT root;
+  PFS_memory_key key;
+  const char *name;
+  int rc;
+
+  rc= init_memory_class(5);
+  ok(rc == 0, "init_memory_class");
+
+  key= register_memory_class("test_memroot", 12, 0);
+  ok(key > 0, "test_memroot registered (key=%u)", key);
+
+  /* NULL input */
+  name= dbug_print_memroot_name(NULL);
+  ok(strcmp(name, "<NULL>") == 0, "NULL returns '<NULL>'");
+
+  /* Registered key returns name */
+  init_alloc_root(key, &root, 1024, 0, MYF(0));
+  name= dbug_print_memroot_name(&root);
+  ok(strcmp(name, "test_memroot") == 0,
+     "registered key returns 'test_memroot' (got '%s')", name);
+  free_root(&root, MYF(0));
+
+  /* PSI_NOT_INSTRUMENTED returns empty string */
+  init_alloc_root(PSI_NOT_INSTRUMENTED, &root, 1024, 0, MYF(0));
+  name= dbug_print_memroot_name(&root);
+  ok(strcmp(name, "") == 0, "PSI_NOT_INSTRUMENTED returns ''");
+  free_root(&root, MYF(0));
+
+  /* Invalid key returns empty string */
+  init_alloc_root(9999, &root, 1024, 0, MYF(0));
+  name= dbug_print_memroot_name(&root);
+  ok(strcmp(name, "") == 0, "invalid key 9999 returns ''");
+  free_root(&root, MYF(0));
+
+  cleanup_memory_class();
+}
+
+int main(int, char **)
+{
+  plan(6);
+  MY_INIT("pfs_memroot_name-t");
+  do_all_tests();
+  my_end(0);
+  return (exit_status());
+}
+
+#else /* DBUG_OFF */
+
+int main(int, char **)
+{
+  plan(1);
+  ok(1, "dbug_print_memroot_name is a no-op in release builds");
+  return (exit_status());
+}
+
+#endif /* DBUG_OFF */


### PR DESCRIPTION
## Description

MEM_ROOTs used to have names stored inside the structure. Now these names are stored in Performance Schema, making it difficult to retrieve them during debugging.

Add dbug_print_memroot_name() function that retrieves and prints the name of a MEM_ROOT from Performance Schema. The function uses DBUG_PRINT to output the MEM_ROOT name, address, and PSI key. The function is debug-only (wrapped in #ifndef DBUG_OFF) with zero production overhead.

## How can this PR be tested?

A TAP unit test `pfs_memroot_name-t.cc` has been added under `storage/perfschema/unittest/`. It verifies that `dbug_print_memroot_name()` correctly handles NULL pointers, registered PSI keys, PSI_NOT_INSTRUMENTED, and invalid keys.

Unit test:
```
cd build
cmake ../mariadb-server -G Ninja -DCMAKE_BUILD_TYPE=Debug
ninja pfs_memroot_name-t
./storage/perfschema/unittest/pfs_memroot_name-t
```
Expected output:
```
1..9
ok 1 - init_memory_class
ok 2 - test_memroot registered (key=1)
ok 3 - test_memroot_second registered (key=2)
ok 4 - NULL MEM_ROOT returns '<NULL>'
ok 5 - registered key returns 'test_memroot' (got 'test_memroot')
ok 6 - PSI_NOT_INSTRUMENTED returns empty string
ok 7 - invalid key 9999 returns empty string
ok 8 - second key returns 'test_memroot_second' (got 'test_memroot_second')
ok 9 - Allocation on MEM_ROOT with second key succeeds
```
End-to-end test from GDB on a running debug server:
```
(gdb) p dbug_print_memroot_name(thd->mem_root)
$1 = "memory/sql/thd::main_mem_root"
```
## Basing the PR against the correct MariaDB version

✅ _This is a new feature and the PR is based against the latest MariaDB development branch_

## PR quality check

✅ I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
✅ For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.