### PR TITLE
MDEV-38924: Add pre-freeze and post-thaw scripts

### DIFF
--- a/scripts/mariadb-post-thaw.sh
+++ b/scripts/mariadb-post-thaw.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 ARZ Haan AG
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+#
+# MariaDB Post-Thaw Script for MariaDB 11.5+ (InnoDB only)
+#
+# Use this script together with the mariadb-pre-freeze.sh script for external
+# volume-based backup tools like Veeam.
+#
+# Purpose:
+# - End the BACKUP STAGE and release locks after a Veeam snapshot.
+# - Clean up the runtime directory created by the pre-freeze script.
+#
+# Usage:
+# - Optionally override SCRIPT_TIMEOUT_SEC (the script can run slightly longer).
+# - Optionally override DEBUG_LOGS_ENABLED=true for verbose logging.
+#
+# Requirements:
+# - A running mariadb client session started by the pre-freeze script.
+# - The runtime directory with FIFO files and state file must exist.
+# - systemd-cat is optional; without it logs go to stdout/stderr only.
+#
+# Notes:
+# - If FREEZE_AND_THAW_TIMEOUT_SEC (from pre-freeze) has expired, the mariadb
+#   client may already be terminated. In this case, BACKUP STAGE END will fail,
+#   but the script will still clean up the runtime directory.
+#
+# Flow and Process Safety:
+# - This script is called AFTER the snapshot is taken
+# - It communicates with the persistent mariadb session started by pre-freeze
+# - It must release all BACKUP STAGE locks before returning
+# - If the persistent session is dead (timeout), it still cleans up the runtime dir
+# - Exit code 0 = success (BACKUP STAGE END completed)
+# - Exit code 1 = warnings/errors (e.g., client already dead, but cleanup OK)
+#
+# Return Codes:
+#   0 = Everything OK, BACKUP STAGE END sent successfully
+#   1 = Errors detected (state file mismatch, client dead, FIFOs missing, etc.)
+#       In this case, runtime dir is still cleaned up, but backup consistency is unclear.
+#       Administrator should verify database state: SHOW VARIABLES LIKE 'innodb_backup_stage';
+#
+# Required State File Content:
+# - pre-freeze must have written "BLOCK_COMMIT" to the state file
+# - post-thaw verifies this state and warns if it differs
+# - If state is unknown, return code will be 1
+#
+# Process Cleanup Order (Important):
+# 1. Send BACKUP STAGE END (if client still alive)
+# 2. Kill mariadb client (releases backup stage locks)
+# 3. Kill FIFO holder (closes FIFOs, allows mariadb to fully exit)
+# 4. Remove lock file (signals any remaining processes)
+# 5. Remove entire runtime directory
+#
+# Troubleshooting:
+#
+# 1. "RUN_DIR does not exist":
+#    - pre-freeze never ran or crashed before creating run dir
+#    - Check if database is actually locked: SHOW PROCESSLIST;
+#    - Manually check BACKUP STAGE state: SHOW VARIABLES LIKE 'innodb_backup_stage';
+#    - Manually release if stuck: BACKUP STAGE END;
+#    - You may need to investigate why pre-freeze failed
+#
+# 2. "Unexpected state: START/FLUSH/BLOCK_DDL":
+#    - pre-freeze crashed after starting stages but before reaching BLOCK_COMMIT
+#    - Return code will be 1, but cleanup still proceeds
+#    - This is a sign of serious problems; investigate pre-freeze logs
+#    - Database may be in inconsistent state; verify backup integrity after restore
+#
+# 3. "mariadb client already stopped (may have timed out)":
+#    - Snapshot took > FREEZE_AND_THAW_TIMEOUT_SEC
+#    - Mariadb was force-killed by the timeout wrapper
+#    - BACKUP STAGE locks may still be held (check with SHOW PROCESSLIST)
+#    - Cleanup still proceeds; runtime dir removed
+#    - Administrator should verify database state manually
+#    - Next backup attempt can proceed (pre-freeze will clean stale lock)
+#
+# 4. "BACKUP STAGE END failed":
+#    - mariadb connection lost or broken
+#    - SQL command did not return the expected marker
+#    - Return code will be 1
+#    - Cleanup still proceeds, but database may remain locked
+#    - Check logs: journalctl -t mariadb-stage-backup
+#
+# 5. "Timeout waiting for SQL response":
+#    - post-thaw itself timed out (SCRIPT_TIMEOUT_SEC exceeded)
+#    - FIFOs may be broken or mariadb hung
+#    - Increase timeout: env SCRIPT_TIMEOUT_SEC=300 ./mariadb-post-thaw.sh
+#    - Or force kill: kill -9 <mariadb_pid>, rm -rf ~/.mariadb-stage-backup-run-dir
+#
+# 6. "mariadb pid validation failed (likely PID reuse)":
+#    - The PID file contains a dead or wrong process
+#    - Script will skip killing (safety measure)
+#    - Runtime dir is still cleaned up
+#    - Check for zombie mariadb processes: ps aux | grep -i mariadb
+#
+# Best Practices:
+# - Always check logs after every backup: journalctl -t mariadb-stage-backup -n 50
+# - Monitor FREEZE_AND_THAW_TIMEOUT_SEC; set it > expected snapshot time + 5 min
+# - Test the full backup pipeline regularly (pre-freeze + snapshot + post-thaw)
+# - Document your snapshot tool's expected duration and behavior
+# - Verify restore procedure (point-in-time recovery) in a test environment
+# - Keep detailed backups logs and correlate them with database logs
+# - Alert on non-zero exit codes from either script
+#
+
+set -euo pipefail
+readonly DEBUG_LOGS_ENABLED="${DEBUG_LOGS_ENABLED:-false}"
+readonly SCRIPT_TIMEOUT_SEC="${SCRIPT_TIMEOUT_SEC:-180}"  # 3 minutes default
+
+# Safety check: HOME must be set and absolute
+if [[ -z "${HOME:-}" ]] || [[ ! "${HOME}" =~ ^/ ]]; then
+    echo "[ERROR] HOME is not set or not absolute. Cannot proceed." >&2
+    exit 1
+fi
+
+readonly LOG_PREFIX="[post-thaw]"
+readonly SQL_MARKER="---MARKER---"
+
+# same as in mariadb-pre-freeze.sh!
+readonly LOG_TAG="mariadb-stage-backup"
+readonly RUN_DIR="${HOME}/.mariadb-stage-backup-run-dir"
+readonly MARIADB_PID_FILE="${RUN_DIR}/mariadb.pid"
+readonly FIFO_IN="${RUN_DIR}/mariadb.in.fifo"
+readonly FIFO_OUT="${RUN_DIR}/mariadb.out.fifo"
+readonly STATE_FILE="${RUN_DIR}/mariadb-stage-backup.state"
+
+# remember start time of this script.
+SCRIPT_START_EPOCH="$(date +%s)"
+readonly SCRIPT_START_EPOCH
+
+HAS_SYSTEMD_CAT="false"
+if command -v systemd-cat &>/dev/null; then
+    HAS_SYSTEMD_CAT="true"
+fi
+readonly HAS_SYSTEMD_CAT
+
+# --- Logs to journald via systemd-cat and to stdout and stderr according to log level. ---
+# Usage: log <prio 0..7> <message...>
+function log() {
+    local prio="${1:-6}"   # default: info (6)
+    shift || true
+
+    # best effort failsafe for wrong prio level
+    if [[ ! "$prio" =~ ^[0-7]$ ]]; then
+        prio=6
+    fi
+
+    local line="${LOG_PREFIX} $*"
+
+    # journald (if available)
+    if [[ "${HAS_SYSTEMD_CAT}" == "true" ]]; then
+        printf '%s\n' "$line" | systemd-cat -t "${LOG_TAG}" -p "${prio}"
+    fi
+
+    # stdout/stderr according to severity
+    if (( prio <= 3 )); then
+        printf '%s\n' "$line" >&2
+    else
+        printf '%s\n' "$line"
+    fi
+}
+function log_debug() {
+    if [[ "${DEBUG_LOGS_ENABLED}" == "true" ]]; then
+        log 7 "[DEBUG] $*"
+    fi
+}
+function log_info() { log 6 "[INFO] $*"; }
+function log_warn() { log 4 "[WARN] $*"; }
+function log_error() { log 3 "[ERROR] $*"; }
+
+# helper function: remaining time in seconds until script timeout
+# A minimum of 1 sec will be returned so that timed reads do not exit immediately.
+function remaining_seconds() {
+    local now elapsed remaining
+    now="$(date +%s)"
+    elapsed=$(( now - SCRIPT_START_EPOCH ))
+    remaining=$(( SCRIPT_TIMEOUT_SEC - elapsed ))
+
+    # Minimum 1 second so reads do not time out immediately.
+    if (( remaining < 1 )); then
+        remaining=1
+    fi
+    echo "${remaining}"
+}
+
+function timeout_reached() {
+    local now
+    now="$(date +%s)"
+    (( now - SCRIPT_START_EPOCH >= SCRIPT_TIMEOUT_SEC ))
+}
+
+# helper function: validate PID against reuse
+# PID file format: PID:CMDLINE:START_TIME
+# Returns 0 if PID is valid and matches, 1 otherwise
+function validate_pid() {
+    local pid_file="$1"
+    local expected_cmdline_pattern="$2"  # regex pattern to match in cmdline
+
+    if [[ ! -f "${pid_file}" ]]; then
+        return 1
+    fi
+
+    local pid_info
+    pid_info="$(cat "${pid_file}" 2>/dev/null || true)"
+    if [[ -z "${pid_info}" ]]; then
+        return 1
+    fi
+
+    local pid cmdline start_time
+    local original_ifs="${IFS}"
+    IFS=':' read -r pid cmdline start_time <<< "${pid_info}"
+    IFS="${original_ifs}"
+
+    # Check if PID is still running
+    if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+        return 1
+    fi
+
+    # Check cmdline matches (protect against PID reuse)
+    if [[ -n "${expected_cmdline_pattern}" ]]; then
+        local current_cmdline
+        current_cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || true)"
+        if [[ ! "${current_cmdline}" =~ ${expected_cmdline_pattern} ]]; then
+            log_warn "PID ${pid} cmdline mismatch. Expected pattern: ${expected_cmdline_pattern}, got: ${current_cmdline}"
+            return 1
+        fi
+    fi
+
+    # Check start time matches (additional protection against PID reuse)
+    if [[ -n "${start_time}" ]] && [[ -f "/proc/${pid}/stat" ]]; then
+        local current_start_time
+        current_start_time="$(awk '{print $22}' /proc/"${pid}"/stat 2>/dev/null || true)"
+        if [[ -n "${current_start_time}" ]] && [[ "${current_start_time}" != "${start_time}" ]]; then
+            log_warn "PID ${pid} start time mismatch. Expected: ${start_time}, got: ${current_start_time}"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# helper function: extract PID from PID file (first field)
+function get_pid_from_file() {
+    local pid_file="$1"
+    if [[ ! -f "${pid_file}" ]]; then
+        return 1
+    fi
+    local pid_info
+    pid_info="$(cat "${pid_file}" 2>/dev/null || true)"
+    echo "${pid_info}" | cut -d: -f1
+}
+
+# helper function: stop and kill a process by pid file with PID reuse protection
+function stop_and_kill_by_pid_file() {
+    local pid_file="$1"
+    local label="${2:-process}"
+    local expected_cmdline_pattern="${3:-}"  # optional cmdline pattern for validation
+
+    if [[ ! -f "${pid_file}" ]]; then
+        log_debug "Pid file not found (${pid_file}). Cannot stop or kill ${label}."
+        return 0
+    fi
+
+    local pid
+    pid="$(get_pid_from_file "${pid_file}" || true)"
+
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+        # Validate against PID reuse if pattern provided
+        if [[ -n "${expected_cmdline_pattern}" ]] && ! validate_pid "${pid_file}" "${expected_cmdline_pattern}"; then
+            log_warn "PID validation failed for ${label} (${pid}) - likely PID reuse, skipping kill"
+            rm -f "${pid_file}"
+            return 0
+        fi
+
+        log_debug "Stopping ${label} (${pid})..."
+        kill "${pid}" 2>/dev/null || true
+        local i
+        # shellcheck disable=SC2034
+        for i in $(seq 1 3); do
+            kill -0 "${pid}" 2>/dev/null || break
+            sleep 1
+        done
+        if kill -0 "${pid}" 2>/dev/null; then
+            log_warn "Force-killing ${label} (${pid})"
+            kill -9 "${pid}" 2>/dev/null || true
+        fi
+        log_info "Stopped ${label} (${pid})."
+    fi
+    rm -f "${pid_file}"
+}
+
+# --- check directory ---
+# Without data from the run directory this script cannot work.
+if [[ ! -d "${RUN_DIR}" ]]; then
+    log_error "RUN_DIR (${RUN_DIR}) does not exist. The database may be locked! The mariadb process may still be running. The backup may be inconsistent."
+    exit 1
+fi
+
+# Trying to free the locks in a clean way, with a best effort failover.
+# If the clean way does not work, the return code will not be 0.
+return_code=0
+
+# --- check state file ---
+current_state="$(cat "${STATE_FILE}" 2>/dev/null || echo "UNKNOWN")"
+log_info "Current backup state: ${current_state}"
+if [[ "${current_state}" != "BLOCK_COMMIT" ]]; then
+    log_warn "Unexpected state: ${current_state}. Backup may be inconsistent."
+    return_code=1
+else
+    log_debug "state file check passed with: ${current_state}"
+fi
+
+# --- Load mariadb pid (actually the timeout wrapper PID from pre-freeze) ---
+MARIADB_PID=""
+if [[ -f "${MARIADB_PID_FILE}" ]]; then
+    MARIADB_PID="$(get_pid_from_file "${MARIADB_PID_FILE}" || true)"
+    if [[ -z "${MARIADB_PID}" ]]; then
+        log_error "No mariadb pid found in ${MARIADB_PID_FILE}."
+        return_code=1
+    elif ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
+        log_error "mariadb pid validation failed (likely PID reuse) in ${MARIADB_PID_FILE}."
+        return_code=1
+        MARIADB_PID=""  # Reset to avoid killing wrong process
+    else
+        log_debug "Loaded and validated mariadb pid (timeout wrapper): ${MARIADB_PID}"
+    fi
+else
+    log_error "Missing mariadb pid file: ${MARIADB_PID_FILE}."
+    return_code=1
+fi
+readonly MARIADB_PID
+
+if [[ -n "${MARIADB_PID}" ]] && kill -0 "${MARIADB_PID}" 2>/dev/null; then
+    # --- send SQL "BACKUP STAGE END" if FIFOs exist ---
+    if [[ -p "${FIFO_IN}" && -p "${FIFO_OUT}" ]]; then
+        # --- Create persistent file descriptors for this script ---
+        # FD 3 = Writing to FIFO_IN (additionally to the holder)
+        # FD 4 = Reading from FIFO_OUT (additionally to the holder)
+        exec 3> "${FIFO_IN}"
+        exec 4< "${FIFO_OUT}"
+        log_debug "Created persistent FD for FIFO_IN and FIFO_OUT"
+
+        function send_sql() {
+            local sql="$1"
+
+            if ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
+                log_error "mariadb client is not running anymore (${MARIADB_PID})."
+                return 1
+            fi
+
+            # Validate PID hasn't been reused before sending SQL
+            if ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
+                log_error "mariadb client PID validation failed (likely PID reuse)."
+                return 1
+            fi
+
+            # send SQL + Marker via FD 3
+            log_debug "mariadb> ${sql}\\nSELECT \"${SQL_MARKER}\" AS marker;\\n"
+            printf '%s\nSELECT "%s" AS marker;\n' "${sql}" "${SQL_MARKER}" >&3
+
+            # read response until marker appears (or timeout)
+            local line
+            local response=""
+            local found_marker=0
+            local read_timeout
+            local has_error=0
+
+            # Read response from FD 4 until marker is found or timeout
+            while true; do
+                read_timeout="$(remaining_seconds)"
+
+                if ! read -r -t "${read_timeout}" line <&4; then
+                    if timeout_reached; then
+                        log_error "Timeout waiting for SQL response: ${sql}"
+                        return 1
+                    fi
+                    # EOF or timeout
+                    break
+                fi
+
+                log_debug "mariadb> ${line}"
+
+                # Check for SQL errors (ERROR keyword from MariaDB)
+                if [[ "$line" =~ ^ERROR ]]; then
+                    log_debug "SQL Error in response: ${line}"
+                    has_error=1
+                fi
+
+                # Check for marker to indicate command completion
+                if [[ "$line" == "${SQL_MARKER}" ]]; then
+                    found_marker=1
+                    break
+                fi
+
+                response+="${line}"$'\n'
+            done
+
+            # Validate successful completion: marker found AND no SQL error
+            if (( found_marker == 1 )); then
+                if (( has_error == 1 )); then
+                    log_error "SQL command failed (error detected in response): ${sql}, response ${response}"
+                    return 1
+                fi
+                log_info "SQL command succeeded: ${sql}"
+                return 0
+            elif timeout_reached; then
+                log_error "Timeout waiting for SQL response marker: ${sql}"
+                return 1
+            else
+                log_error "SQL command did not complete properly: ${sql}, response ${response}"
+                return 1
+            fi
+        }
+
+        # --- send BACKUP STAGE END ---
+        log_info "Sending BACKUP STAGE END to persistent session..."
+        if send_sql "BACKUP STAGE END;"; then
+            echo "END" > "${STATE_FILE}"
+            log_info "BACKUP STAGE END completed successfully"
+        else
+            log_error "BACKUP STAGE END failed"
+            return_code=1
+        fi
+
+        # --- Close FDs, but FIFO_HOLDER background process still keeps the FIFOs open. ---
+        exec 3>&-
+        exec 4<&-
+    else
+        log_warn "Missing FIFO files: ${FIFO_IN} and/or ${FIFO_OUT}."
+        return_code=1
+    fi
+
+    # --- Stop mariadb process (via timeout wrapper), that will also free the "backup stage" locks. ---
+    # Killing the timeout wrapper will propagate the signal to the mariadb client.
+    if kill -0 "${MARIADB_PID}" 2>/dev/null; then
+        stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client_via_timeout_wrapper" "timeout.*mariadb"
+    else
+        log_info "mariadb client already stopped (may have timed out after ${FREEZE_AND_THAW_TIMEOUT_SEC}s)."
+        rm -f "${MARIADB_PID_FILE}"
+    fi
+fi
+
+# --- Final cleanup: remove entire run dir ---
+# Also deletes the lock file which signals the fifo_holder background process from pre-freeze script to stop.
+rm -rf "${RUN_DIR}" 2>/dev/null || true
+log_info "Runtime directory (${RUN_DIR}) cleaned up."
+
+log_info "Post-thaw cleanup completed"
+exit ${return_code}

--- a/scripts/mariadb-post-thaw.sh
+++ b/scripts/mariadb-post-thaw.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2026 ARZ Haan AG
+# Author: Gerd Aschbrenner
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,40 +33,50 @@
 #
 # MariaDB Post-Thaw Script for MariaDB 11.5+ (InnoDB only)
 #
-# Use this script together with the mariadb-pre-freeze.sh script for external
-# volume-based backup tools like Veeam.
+# Use this script together with the mariadb-pre-freeze.sh script. Read the
+# documentation there first!
 #
 # Purpose:
-# - End the BACKUP STAGE and release locks after a Veeam snapshot.
+# - End the BACKUP STAGE and release locks right after a file system snapshot.
 # - Clean up the runtime directory created by the pre-freeze script.
 #
+# If the script is not called, or if it fails, the database write locks will
+# be released after the timeout configured in the pre-freeze script, if
+# they still exist.
+# As soon as this script is called, the backup is consistent:
+#  - if the pre-freeze script completed successfully
+#  - and the filesystem snapshot was taken successfully
+#
 # Usage:
-# - Optionally override SCRIPT_TIMEOUT_SEC (the script can run slightly longer).
+# - Optionally override POST_THAW_FLOW_TIMEOUT_SEC (the script can run
+#   slightly longer).
 # - Optionally override DEBUG_LOGS_ENABLED=true for verbose logging.
 #
 # Requirements:
-# - A running mariadb client session started by the pre-freeze script.
+# - A running MariaDB client session started by the pre-freeze script.
 # - The runtime directory with FIFO files and state file must exist.
 # - systemd-cat is optional; without it logs go to stdout/stderr only.
 #
 # Notes:
-# - If FREEZE_AND_THAW_TIMEOUT_SEC (from pre-freeze) has expired, the mariadb
+# - If FREEZE_AND_THAW_TIMEOUT_SEC from pre-freeze has expired, the MariaDB
 #   client may already be terminated. In this case, BACKUP STAGE END will fail,
 #   but the script will still clean up the runtime directory.
 #
 # Flow and Process Safety:
 # - This script is called AFTER the snapshot is taken
-# - It communicates with the persistent mariadb session started by pre-freeze
+# - It communicates with the persistent MariaDB client session started by
+#   pre-freeze.
 # - It must release all BACKUP STAGE locks before returning
-# - If the persistent session is dead (timeout), it still cleans up the runtime dir
+# - If the persistent session is dead (timeout), it still cleans up the runtime
+#   dir
 # - Exit code 0 = success (BACKUP STAGE END completed)
 # - Exit code 1 = warnings/errors (e.g., client already dead, but cleanup OK)
 #
 # Return Codes:
 #   0 = Everything OK, BACKUP STAGE END sent successfully
 #   1 = Errors detected (state file mismatch, client dead, FIFOs missing, etc.)
-#       In this case, runtime dir is still cleaned up, but backup consistency is unclear.
-#       Administrator should verify database state: SHOW VARIABLES LIKE 'innodb_backup_stage';
+#       In this case, runtime dir is still cleaned up, but backup consistency
+#       is unclear.
 #
 # Required State File Content:
 # - pre-freeze must have written "BLOCK_COMMIT" to the state file
@@ -74,68 +85,48 @@
 #
 # Process Cleanup Order (Important):
 # 1. Send BACKUP STAGE END (if client still alive)
-# 2. Kill mariadb client (releases backup stage locks)
-# 3. Kill FIFO holder (closes FIFOs, allows mariadb to fully exit)
-# 4. Remove lock file (signals any remaining processes)
-# 5. Remove entire runtime directory
+# 2. Kill MariaDB client (releases backup stage locks)
+# 3. Remove entire runtime directory
+#    - This also removes any FIFO/lock artifacts (signals any remaining background processes)
 #
 # Troubleshooting:
+#
+# Check logs: journalctl -t mariadb-stage-backup
 #
 # 1. "RUN_DIR does not exist":
 #    - pre-freeze never ran or crashed before creating run dir
 #    - Check if database is actually locked: SHOW PROCESSLIST;
-#    - Manually check BACKUP STAGE state: SHOW VARIABLES LIKE 'innodb_backup_stage';
-#    - Manually release if stuck: BACKUP STAGE END;
-#    - You may need to investigate why pre-freeze failed
+#      Search for "backup stage" commands and kill them, if no backup job is
+#      running.
 #
 # 2. "Unexpected state: START/FLUSH/BLOCK_DDL":
-#    - pre-freeze crashed after starting stages but before reaching BLOCK_COMMIT
-#    - Return code will be 1, but cleanup still proceeds
-#    - This is a sign of serious problems; investigate pre-freeze logs
-#    - Database may be in inconsistent state; verify backup integrity after restore
+#    - pre-freeze crashed after starting stages but before reaching
+#      BLOCK_COMMIT
+#    - Return code will be 1, but cleanup still proceeds. This should not
+#      cause locks to remain, but backup consistency is not guaranteed.
+#    - Usually, backup tools treat script failures as failed backups; verify
+#      this behavior in your backup tool.
 #
-# 3. "mariadb client already stopped (may have timed out)":
-#    - Snapshot took > FREEZE_AND_THAW_TIMEOUT_SEC
-#    - Mariadb was force-killed by the timeout wrapper
+# 3. "MariaDB client already stopped (may have timed out, or network issue)":
+#    - Snapshot took longer than FREEZE_AND_THAW_TIMEOUT_SEC configured in the
+#      pre-freeze script.
+#    - MariaDB client was force-killed by the timeout wrapper
 #    - BACKUP STAGE locks may still be held (check with SHOW PROCESSLIST)
 #    - Cleanup still proceeds; runtime dir removed
-#    - Administrator should verify database state manually
 #    - Next backup attempt can proceed (pre-freeze will clean stale lock)
 #
-# 4. "BACKUP STAGE END failed":
-#    - mariadb connection lost or broken
-#    - SQL command did not return the expected marker
-#    - Return code will be 1
-#    - Cleanup still proceeds, but database may remain locked
-#    - Check logs: journalctl -t mariadb-stage-backup
-#
-# 5. "Timeout waiting for SQL response":
-#    - post-thaw itself timed out (SCRIPT_TIMEOUT_SEC exceeded)
-#    - FIFOs may be broken or mariadb hung
-#    - Increase timeout: env SCRIPT_TIMEOUT_SEC=300 ./mariadb-post-thaw.sh
-#    - Or force kill: kill -9 <mariadb_pid>, rm -rf ~/.mariadb-stage-backup-run-dir
-#
-# 6. "mariadb pid validation failed (likely PID reuse)":
+# 4. "MariaDB client PID validation failed (likely PID reuse)":
 #    - The PID file contains a dead or wrong process
 #    - Script will skip killing (safety measure)
 #    - Runtime dir is still cleaned up
-#    - Check for zombie mariadb processes: ps aux | grep -i mariadb
-#
-# Best Practices:
-# - Always check logs after every backup: journalctl -t mariadb-stage-backup -n 50
-# - Monitor FREEZE_AND_THAW_TIMEOUT_SEC; set it > expected snapshot time + 5 min
-# - Test the full backup pipeline regularly (pre-freeze + snapshot + post-thaw)
-# - Document your snapshot tool's expected duration and behavior
-# - Verify restore procedure (point-in-time recovery) in a test environment
-# - Keep detailed backups logs and correlate them with database logs
-# - Alert on non-zero exit codes from either script
+#    - Check for zombie MariaDB client processes: ps aux | grep -i mariadb
 #
 
 set -euo pipefail
 readonly DEBUG_LOGS_ENABLED="${DEBUG_LOGS_ENABLED:-false}"
-readonly SCRIPT_TIMEOUT_SEC="${SCRIPT_TIMEOUT_SEC:-180}"  # 3 minutes default
+readonly POST_THAW_FLOW_TIMEOUT_SEC="${POST_THAW_FLOW_TIMEOUT_SEC:-180}"  # 3 minutes default
 
-# Safety check: HOME must be set and absolute
+# Safety check: HOME must be set and absolute.
 if [[ -z "${HOME:-}" ]] || [[ ! "${HOME}" =~ ^/ ]]; then
     echo "[ERROR] HOME is not set or not absolute. Cannot proceed." >&2
     exit 1
@@ -144,7 +135,7 @@ fi
 readonly LOG_PREFIX="[post-thaw]"
 readonly SQL_MARKER="---MARKER---"
 
-# same as in mariadb-pre-freeze.sh!
+# Same as in mariadb-pre-freeze.sh!
 readonly LOG_TAG="mariadb-stage-backup"
 readonly RUN_DIR="${HOME}/.mariadb-stage-backup-run-dir"
 readonly MARIADB_PID_FILE="${RUN_DIR}/mariadb.pid"
@@ -152,7 +143,7 @@ readonly FIFO_IN="${RUN_DIR}/mariadb.in.fifo"
 readonly FIFO_OUT="${RUN_DIR}/mariadb.out.fifo"
 readonly STATE_FILE="${RUN_DIR}/mariadb-stage-backup.state"
 
-# remember start time of this script.
+# Remember the start time of this script.
 SCRIPT_START_EPOCH="$(date +%s)"
 readonly SCRIPT_START_EPOCH
 
@@ -168,7 +159,7 @@ function log() {
     local prio="${1:-6}"   # default: info (6)
     shift || true
 
-    # best effort failsafe for wrong prio level
+    # best-effort fallback for wrong prio level
     if [[ ! "$prio" =~ ^[0-7]$ ]]; then
         prio=6
     fi
@@ -196,13 +187,13 @@ function log_info() { log 6 "[INFO] $*"; }
 function log_warn() { log 4 "[WARN] $*"; }
 function log_error() { log 3 "[ERROR] $*"; }
 
-# helper function: remaining time in seconds until script timeout
+# helper function: remaining time in seconds until POST_THAW_FLOW_TIMEOUT_SEC timeout
 # A minimum of 1 sec will be returned so that timed reads do not exit immediately.
 function remaining_seconds() {
     local now elapsed remaining
     now="$(date +%s)"
     elapsed=$(( now - SCRIPT_START_EPOCH ))
-    remaining=$(( SCRIPT_TIMEOUT_SEC - elapsed ))
+    remaining=$(( POST_THAW_FLOW_TIMEOUT_SEC - elapsed ))
 
     # Minimum 1 second so reads do not time out immediately.
     if (( remaining < 1 )); then
@@ -214,7 +205,7 @@ function remaining_seconds() {
 function timeout_reached() {
     local now
     now="$(date +%s)"
-    (( now - SCRIPT_START_EPOCH >= SCRIPT_TIMEOUT_SEC ))
+    (( now - SCRIPT_START_EPOCH >= POST_THAW_FLOW_TIMEOUT_SEC ))
 }
 
 # helper function: validate PID against reuse
@@ -247,7 +238,7 @@ function validate_pid() {
     # Check cmdline matches (protect against PID reuse)
     if [[ -n "${expected_cmdline_pattern}" ]]; then
         local current_cmdline
-        current_cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || true)"
+        current_cmdline="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
         if [[ ! "${current_cmdline}" =~ ${expected_cmdline_pattern} ]]; then
             log_warn "PID ${pid} cmdline mismatch. Expected pattern: ${expected_cmdline_pattern}, got: ${current_cmdline}"
             return 1
@@ -278,14 +269,14 @@ function get_pid_from_file() {
     echo "${pid_info}" | cut -d: -f1
 }
 
-# helper function: stop and kill a process by pid file with PID reuse protection
+# helper function: stop and kill a process by PID file with PID reuse protection
 function stop_and_kill_by_pid_file() {
     local pid_file="$1"
     local label="${2:-process}"
     local expected_cmdline_pattern="${3:-}"  # optional cmdline pattern for validation
 
     if [[ ! -f "${pid_file}" ]]; then
-        log_debug "Pid file not found (${pid_file}). Cannot stop or kill ${label}."
+        log_debug "PID file not found (${pid_file}). Cannot stop or kill ${label}."
         return 0
     fi
 
@@ -320,11 +311,11 @@ function stop_and_kill_by_pid_file() {
 # --- check directory ---
 # Without data from the run directory this script cannot work.
 if [[ ! -d "${RUN_DIR}" ]]; then
-    log_error "RUN_DIR (${RUN_DIR}) does not exist. The database may be locked! The mariadb process may still be running. The backup may be inconsistent."
+    log_error "RUN_DIR (${RUN_DIR}) does not exist. The database may be locked! The MariaDB client process may still be running. The backup may be inconsistent."
     exit 1
 fi
 
-# Trying to free the locks in a clean way, with a best effort failover.
+# Trying to free the locks in a clean way, with a best effort fallback.
 # If the clean way does not work, the return code will not be 0.
 return_code=0
 
@@ -335,25 +326,25 @@ if [[ "${current_state}" != "BLOCK_COMMIT" ]]; then
     log_warn "Unexpected state: ${current_state}. Backup may be inconsistent."
     return_code=1
 else
-    log_debug "state file check passed with: ${current_state}"
+    log_debug "State file check passed with: ${current_state}"
 fi
 
-# --- Load mariadb pid (actually the timeout wrapper PID from pre-freeze) ---
+# --- Load MariaDB client PID (actually the timeout wrapper PID from pre-freeze) ---
 MARIADB_PID=""
 if [[ -f "${MARIADB_PID_FILE}" ]]; then
     MARIADB_PID="$(get_pid_from_file "${MARIADB_PID_FILE}" || true)"
     if [[ -z "${MARIADB_PID}" ]]; then
-        log_error "No mariadb pid found in ${MARIADB_PID_FILE}."
+        log_error "No MariaDB client PID found in ${MARIADB_PID_FILE}."
         return_code=1
     elif ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
-        log_error "mariadb pid validation failed (likely PID reuse) in ${MARIADB_PID_FILE}."
+        log_error "MariaDB client PID validation failed (likely PID reuse) in ${MARIADB_PID_FILE}."
         return_code=1
         MARIADB_PID=""  # Reset to avoid killing wrong process
     else
-        log_debug "Loaded and validated mariadb pid (timeout wrapper): ${MARIADB_PID}"
+        log_debug "Loaded and validated MariaDB client PID (timeout wrapper): ${MARIADB_PID}"
     fi
 else
-    log_error "Missing mariadb pid file: ${MARIADB_PID_FILE}."
+    log_error "Missing MariaDB client PID file: ${MARIADB_PID_FILE}."
     return_code=1
 fi
 readonly MARIADB_PID
@@ -361,7 +352,7 @@ readonly MARIADB_PID
 if [[ -n "${MARIADB_PID}" ]] && kill -0 "${MARIADB_PID}" 2>/dev/null; then
     # --- send SQL "BACKUP STAGE END" if FIFOs exist ---
     if [[ -p "${FIFO_IN}" && -p "${FIFO_OUT}" ]]; then
-        # --- Create persistent file descriptors for this script ---
+        # --- Create persistent file descriptors for this script. ---
         # FD 3 = Writing to FIFO_IN (additionally to the holder)
         # FD 4 = Reading from FIFO_OUT (additionally to the holder)
         exec 3> "${FIFO_IN}"
@@ -372,21 +363,21 @@ if [[ -n "${MARIADB_PID}" ]] && kill -0 "${MARIADB_PID}" 2>/dev/null; then
             local sql="$1"
 
             if ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
-                log_error "mariadb client is not running anymore (${MARIADB_PID})."
+                log_error "MariaDB client is not running anymore (${MARIADB_PID})."
                 return 1
             fi
 
             # Validate PID hasn't been reused before sending SQL
             if ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
-                log_error "mariadb client PID validation failed (likely PID reuse)."
+                log_error "MariaDB client PID validation failed (likely PID reuse)."
                 return 1
             fi
 
-            # send SQL + Marker via FD 3
+            # Send SQL and Marker via FD 3
             log_debug "mariadb> ${sql}\\nSELECT \"${SQL_MARKER}\" AS marker;\\n"
             printf '%s\nSELECT "%s" AS marker;\n' "${sql}" "${SQL_MARKER}" >&3
 
-            # read response until marker appears (or timeout)
+            # Read response until marker appears (or timeout)
             local line
             local response=""
             local found_marker=0
@@ -408,7 +399,7 @@ if [[ -n "${MARIADB_PID}" ]] && kill -0 "${MARIADB_PID}" 2>/dev/null; then
 
                 log_debug "mariadb> ${line}"
 
-                # Check for SQL errors (ERROR keyword from MariaDB)
+                # Check for SQL errors (ERROR keyword from MariaDB client output)
                 if [[ "$line" =~ ^ERROR ]]; then
                     log_debug "SQL Error in response: ${line}"
                     has_error=1
@@ -458,12 +449,12 @@ if [[ -n "${MARIADB_PID}" ]] && kill -0 "${MARIADB_PID}" 2>/dev/null; then
         return_code=1
     fi
 
-    # --- Stop mariadb process (via timeout wrapper), that will also free the "backup stage" locks. ---
-    # Killing the timeout wrapper will propagate the signal to the mariadb client.
+    # --- Stop MariaDB client process (via timeout wrapper), that will also free the "backup stage" locks. ---
+    # Killing the timeout wrapper will propagate the signal to the MariaDB client.
     if kill -0 "${MARIADB_PID}" 2>/dev/null; then
         stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client_via_timeout_wrapper" "timeout.*mariadb"
     else
-        log_info "mariadb client already stopped (may have timed out after ${FREEZE_AND_THAW_TIMEOUT_SEC}s)."
+        log_info "MariaDB client already stopped (may have timed out)."
         rm -f "${MARIADB_PID_FILE}"
     fi
 fi

--- a/scripts/mariadb-pre-freeze.sh
+++ b/scripts/mariadb-pre-freeze.sh
@@ -1,0 +1,658 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 ARZ Haan AG
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+#
+# MariaDB Pre-Freeze Script for MariaDB 11.5+ (InnoDB only)
+#
+# Use this script together with the mariadb-post-thaw.sh script for external
+# volume-based backup tools like Veeam.
+#
+# Purpose:
+# - Initiate MariaDB BACKUP STAGE steps to get a consistent filesystem snapshot
+#   without shutting down the server or taking read locks.
+# - Writes are blocked only for the shortest possible time, but applications
+#   can still see SQL timeouts during the lock window.
+# - A timeout of 10 minutes (can be overridden) is enforced; if the snapshot
+#   is not taken in time, the database files may be inconsistent, and this
+#   script will fail.
+#
+# References:
+# - https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage
+# - https://helpcenter.veeam.com/docs/vbr/userguide/pre_post_scripts.html
+#
+# Usage:
+# - Optionally override FREEZE_AND_THAW_TIMEOUT_SEC (the mariadb client + FIFO holder can run longer across freeze/thaw).
+# - Optionally override SCRIPT_TIMEOUT_SEC (the script can run slightly longer).
+# - Optionally set DEBUG_LOGS_ENABLED=true for verbose logging.
+#
+# Timeout implementation:
+# - SCRIPT_TIMEOUT_SEC limits this script's own runtime (reads, SQL responses, overall flow).
+# - FREEZE_AND_THAW_TIMEOUT_SEC limits how long the mariadb client + FIFO holder stay alive
+#   across pre-freeze, snapshot, and post-thaw.
+# - The mariadb client is run under timeout; the FIFO holder also enforces the same limit.
+# - When the limit is hit, the client is terminated and the run dir may be left behind.
+#
+# Requirements:
+# - mariadb, mkfifo, stdbuf, and timeout must be installed and in PATH.
+# - systemd-cat is optional; without it logs go to stdout/stderr only.
+# - See setup section for required files and config.
+#
+# Setup:
+# - Create a Linux user "veeam" and add its public SSH key to authorized_keys.
+# - Copy this script and mariadb-post-thaw.sh into the user's home and make them executable:
+#   chmod 700 /home/veeam/mariadb-*.sh
+#
+# Create a DB user:
+#   CREATE USER 'veeam'@'localhost' IDENTIFIED BY 'secure-password';
+#   GRANT RELOAD, PROCESS ON *.* TO 'veeam'@'localhost';
+#   FLUSH PRIVILEGES;
+#
+# Create ~/.my.cnf in the veeam user home directory:
+#   [client]
+#   user=veeam
+#   password=secure-password
+#
+# Test the script and check logs with:
+#   journalctl -t mariadb-stage-backup
+#
+# Timeout Behavior and Parameters:
+# - SCRIPT_TIMEOUT_SEC (default 600s / 10 min): limits this script's runtime.
+#   Includes all preflight checks, SQL commands, and syncs. Mainly for safety.
+# - FREEZE_AND_THAW_TIMEOUT_SEC (default 1200s / 20 min): limits the lifetime of the
+#   persistent mariadb session and FIFO holder across pre-freeze, snapshot, and post-thaw.
+#   This is the critical timeout for snapshot tools. If snapshot takes > 20 min, the
+#   database will be forcibly unlocked (BACKUP STAGE END will fail).
+#   Recommendation: snapshot should complete in 10-15 minutes; set this to 2x expected time.
+#
+# How It Works (Advanced):
+# 1. pre-freeze:
+#    a. Creates runtime directory with FIFOs and lock file
+#    b. Starts a persistent mariadb session under timeout wrapper (as background process)
+#    c. Starts FIFO holder process (keeps FIFOs open, survives pre-freeze)
+#    d. Executes BACKUP STAGE START/FLUSH/BLOCK_DDL/BLOCK_COMMIT via FIFO
+#    e. Closes its own FDs (but FIFOs stay open via FIFO holder)
+#    f. Returns with database in consistent state, ready for snapshot
+# 2. Snapshot tool takes filesystem snapshot (should complete in minutes)
+# 3. post-thaw:
+#    a. Reads state file to verify database state
+#    b. Executes BACKUP STAGE END via the still-running mariadb session
+#    c. Kills mariadb session and FIFO holder
+#    d. Removes runtime directory
+#
+# FIFO Communication Protocol:
+# - FIFOs are created in pre-freeze and survive it (held open by FIFO holder)
+# - Both scripts write to FIFO_IN and read from FIFO_OUT
+# - Each SQL command is followed by a marker "---MARKER---"
+# - Scripts wait for marker in response before considering command complete
+# - This allows one persistent connection to handle pre-freeze + post-thaw
+#
+# Troubleshooting:
+#
+# 1. Script hangs or times out:
+#    - Check DATABASE connectivity: mariadb
+#    - Check DB logs: tail -f /var/log/mariadb/mariadb.log
+#    - Look for BACKUP STAGE errors in journalctl
+#    - Example: journalctl -t mariadb-stage-backup -n 100 | grep -i error
+#
+# 2. "Cannot connect to mariadb":
+#    - Verify ~/.my.cnf exists and is readable (chmod 600)
+#    - Test credentials: mariadb -e "SELECT 1;"
+#    - Ensure veeam user has RELOAD + PROCESS grants
+#    - Check MariaDB socket/port in my.cnf [client] section
+#
+# 3. "Another backup process is running":
+#    - Check if old pre-freeze is still running: ps aux | grep mariadb-pre-freeze
+#    - If yes, wait or kill it: kill -9 <pid>
+#    - If snapshot tool crashed: manually run post-thaw to clean up (or wait until timeout)
+#    - Check lock file: ls -la ~/.mariadb-stage-backup-run-dir/
+#
+# 4. "Timeout waiting for SQL response" or "Timeout after 20 min":
+#    - Snapshot took too long or was never taken
+#    - Check if snapshot tool has errors
+#    - Increase FREEZE_AND_THAW_TIMEOUT_SEC: env FREEZE_AND_THAW_TIMEOUT_SEC=2400 ./mariadb-pre-freeze.sh
+#    - Run post-thaw to release locks: ./mariadb-post-thaw.sh
+#    - Database may have stale BACKUP STAGE state; check with: SHOW PROCESSLIST;
+#
+# 5. "Stale lock found, cleaning runtime dir":
+#    - Indicates a crashed pre-freeze from a previous run
+#    - Script auto-cleans and proceeds (safe)
+#    - Check logs for why it crashed: journalctl -t mariadb-stage-backup --since "2 hours ago"
+#
+# 6. Database locked, snapshot failed, unclear state:
+#    - Check current BACKUP STAGE state: SHOW VARIABLES LIKE 'innodb_backup_stage';
+#    - Manually release if needed: BACKUP STAGE END;
+#    - Check post-thaw cleanup worked: ls -la ~/.mariadb-stage-backup-run-dir/ (should be empty)
+#
+# Safety and Consistency:
+# - The scripts use PID validation (cmdline + start_time) to prevent killing wrong processes
+# - nohup + timeout wrapper ensures mariadb survives script termination
+# - FIFO holder survives pre-freeze; post-thaw is responsible for cleanup
+# - If post-thaw fails, manual cleanup may be needed: kill mariadb session + rm -rf run dir
+# - Always check logs and database state before retrying:
+#   journalctl -t mariadb-stage-backup
+#   SHOW PROCESSLIST;
+#
+
+set -euo pipefail
+readonly DEBUG_LOGS_ENABLED="${DEBUG_LOGS_ENABLED:-false}"
+readonly SCRIPT_TIMEOUT_SEC="${SCRIPT_TIMEOUT_SEC:-600}"  # 10 minutes default
+readonly FREEZE_AND_THAW_TIMEOUT_SEC="${FREEZE_AND_THAW_TIMEOUT_SEC:-1200}"  # 20 minutes default
+
+# Safety check: HOME must be set and absolute
+if [[ -z "${HOME:-}" ]] || [[ ! "${HOME}" =~ ^/ ]]; then
+    echo "[ERROR] HOME is not set or not absolute. Cannot proceed." >&2
+    exit 1
+fi
+
+readonly LOG_PREFIX="[pre-freeze]"
+readonly SQL_MARKER="---MARKER---"
+readonly DEFAULTS_FILE="${HOME}/.my.cnf"
+
+# same as in mariadb-post-thaw.sh!
+readonly LOG_TAG="mariadb-stage-backup"
+readonly RUN_DIR="${HOME}/.mariadb-stage-backup-run-dir"
+readonly MARIADB_PID_FILE="${RUN_DIR}/mariadb.pid"
+readonly FIFO_IN="${RUN_DIR}/mariadb.in.fifo"
+readonly FIFO_OUT="${RUN_DIR}/mariadb.out.fifo"
+readonly STATE_FILE="${RUN_DIR}/mariadb-stage-backup.state"
+
+readonly LOCK_FILE="${RUN_DIR}/mariadb-stage-backup.lock"
+readonly FIFO_HOLDER_PID_FILE="${RUN_DIR}/fifo_holder.pid"
+
+# remember start time of this script.
+SCRIPT_START_EPOCH="$(date +%s)"
+readonly SCRIPT_START_EPOCH
+
+HAS_SYSTEMD_CAT="false"
+if command -v systemd-cat &>/dev/null; then
+    HAS_SYSTEMD_CAT="true"
+fi
+readonly HAS_SYSTEMD_CAT
+
+
+# --- Logs to journald via systemd-cat and conditionally to stdout/stderr based on log level. ---
+# Usage: log <prio 0..7> <message...>
+# Priority levels: 0=emergency, 1=alert, 2=critical, 3=error, 4=warning, 5=notice, 6=info, 7=debug
+function log() {
+    local prio="${1:-6}"   # default: info (6)
+    shift || true
+
+    # best effort failsafe for wrong prio level
+    if [[ ! "$prio" =~ ^[0-7]$ ]]; then
+        prio=6
+    fi
+
+    local line="${LOG_PREFIX} $*"
+
+    # journald (if available)
+    if [[ "${HAS_SYSTEMD_CAT}" == "true" ]]; then
+        printf '%s\n' "$line" | systemd-cat -t "${LOG_TAG}" -p "${prio}"
+    fi
+
+    # stdout/stderr according to severity
+    if (( prio <= 3 )); then
+        printf '%s\n' "$line" >&2
+    else
+        printf '%s\n' "$line"
+    fi
+}
+function log_debug() {
+    if [[ "${DEBUG_LOGS_ENABLED}" == "true" ]]; then
+        log 7 "[DEBUG] $*"
+    fi
+}
+function log_info() { log 6 "[INFO] $*"; }
+function log_warn() { log 4 "[WARN] $*"; }
+function log_error() { log 3 "[ERROR] $*"; }
+
+# --- Special logger for background jobs. They should not log to stderr/stdout. ----
+# Asynchronous logging to stdout/stderr is annoying and can break automations.
+function log_system_cat_only() {
+    local prio="${1:-6}"   # default: info (6)
+    shift || true
+
+    # best effort failsafe for wrong prio level
+    if [[ ! "$prio" =~ ^[0-7]$ ]]; then
+        prio=6
+    fi
+
+    local line="${LOG_PREFIX} $*"
+
+    # journald (if available)
+    if [[ "${HAS_SYSTEMD_CAT}" == "true" ]]; then
+        printf '%s\n' "$line" | systemd-cat -t "${LOG_TAG}" -p "${prio}"
+    fi
+}
+
+# helper function: remaining time in seconds until script timeout
+# A minimum of 1 sec will be returned, so that timed reads are still possible.
+function remaining_seconds() {
+    local now elapsed remaining
+    now="$(date +%s)"
+    elapsed=$(( now - SCRIPT_START_EPOCH ))
+    remaining=$(( SCRIPT_TIMEOUT_SEC - elapsed ))
+
+    # Minimum 1 second so reads do not time out immediately.
+    if (( remaining < 1 )); then
+        remaining=1
+    fi
+    echo "${remaining}"
+}
+
+function timeout_reached() {
+    local now
+    now="$(date +%s)"
+    (( now - SCRIPT_START_EPOCH >= SCRIPT_TIMEOUT_SEC ))
+}
+
+# --- Preflight checks ---
+if [[ ! -f "${DEFAULTS_FILE}" ]]; then
+    log_error "mariadb defaults file not found: ${DEFAULTS_FILE}"
+    exit 1
+fi
+if ! command -v mariadb &>/dev/null; then
+    log_error "mariadb client not found in PATH."
+    exit 1
+fi
+if ! command -v mkfifo &>/dev/null; then
+    log_error "mkfifo not found in PATH."
+    exit 1
+fi
+if ! command -v stdbuf &>/dev/null; then
+    log_error "stdbuf not found in PATH."
+    exit 1
+fi
+if ! command -v timeout &>/dev/null; then
+    log_error "timeout not found in PATH."
+    exit 1
+fi
+
+# --- Test mariadb connectivity ---
+if ! mariadb --defaults-file="${DEFAULTS_FILE}" -e "SELECT 1;" &>/dev/null; then
+    log_error "Cannot connect to mariadb – check credentials in ${DEFAULTS_FILE}"
+    exit 1
+fi
+
+# --- No usage of unsupported database engines? ---
+# BACKUP STAGE only works with InnoDB. Warn if other engines are found.
+# This includes MyISAM, Memory, CSV, Archive, etc.
+log_info "Checking for unsupported database engines..."
+
+# Get all non-InnoDB tables (excluding temporary tables and system tables)
+unsupported_tables=$(mariadb --defaults-file="${DEFAULTS_FILE}" --skip-column-names -e "
+    SELECT CONCAT(table_schema, '.', table_name, ' (', engine, ')')
+    FROM information_schema.tables
+    WHERE table_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+    AND engine IS NOT NULL
+    AND upper(engine) != 'INNODB'
+    AND table_type = 'BASE TABLE'
+    ORDER BY table_schema, table_name;
+" 2>/dev/null)
+
+if [[ -n "${unsupported_tables}" ]]; then
+    log_error "BACKUP STAGE requires InnoDB. Found tables with unsupported engines:"
+    while IFS= read -r table; do
+        log_error "  - ${table}"
+    done <<< "${unsupported_tables}"
+    log_error "Please migrate these tables to InnoDB before proceeding."
+    log_error "Example: ALTER TABLE schema.table ENGINE=InnoDB;"
+    exit 1
+fi
+
+log_info "Database engine check passed - all tables use InnoDB"
+
+# helper function: validate PID against reuse
+# PID file format: PID:CMDLINE:START_TIME
+# Returns 0 if PID is valid and matches, 1 otherwise
+function validate_pid() {
+    local pid_file="$1"
+    local expected_cmdline_pattern="$2"  # regex pattern to match in cmdline
+
+    if [[ ! -f "${pid_file}" ]]; then
+        return 1
+    fi
+
+    local pid_info
+    pid_info="$(cat "${pid_file}" 2>/dev/null || true)"
+    if [[ -z "${pid_info}" ]]; then
+        return 1
+    fi
+
+    local pid cmdline start_time
+    local original_ifs="${IFS}"
+    IFS=':' read -r pid cmdline start_time <<< "${pid_info}"
+    IFS="${original_ifs}"
+
+    # Check if PID is still running
+    if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+        return 1
+    fi
+
+    # Check cmdline matches (protect against PID reuse)
+    if [[ -n "${expected_cmdline_pattern}" ]]; then
+        local current_cmdline
+        current_cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || true)"
+        if [[ ! "${current_cmdline}" =~ ${expected_cmdline_pattern} ]]; then
+            log_warn "PID ${pid} cmdline mismatch. Expected pattern: ${expected_cmdline_pattern}, got: ${current_cmdline}"
+            return 1
+        fi
+    fi
+
+    # Check start time matches (additional protection against PID reuse)
+    if [[ -n "${start_time}" ]] && [[ -f "/proc/${pid}/stat" ]]; then
+        local current_start_time
+        current_start_time="$(awk '{print $22}' /proc/"${pid}"/stat 2>/dev/null || true)"
+        if [[ -n "${current_start_time}" ]] && [[ "${current_start_time}" != "${start_time}" ]]; then
+            log_warn "PID ${pid} start time mismatch. Expected: ${start_time}, got: ${current_start_time}"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# helper function: save PID with metadata to protect against PID reuse
+function save_pid_with_metadata() {
+    local pid="$1"
+    local pid_file="$2"
+
+    if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+        log_error "Cannot save invalid PID: ${pid}"
+        return 1
+    fi
+
+    local cmdline start_time
+    cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || echo "unknown")"
+    start_time="$(awk '{print $22}' /proc/"${pid}"/stat 2>/dev/null || echo "0")"
+
+    printf '%s:%s:%s\n' "${pid}" "${cmdline}" "${start_time}" > "${pid_file}"
+}
+
+# helper function: extract PID from PID file (first field)
+function get_pid_from_file() {
+    local pid_file="$1"
+    if [[ ! -f "${pid_file}" ]]; then
+        return 1
+    fi
+    local pid_info
+    pid_info="$(cat "${pid_file}" 2>/dev/null || true)"
+    echo "${pid_info}" | cut -d: -f1
+}
+
+# helper function: stop and kill a process by pid file with PID reuse protection
+function stop_and_kill_by_pid_file() {
+    local pid_file="$1"
+    local label="${2:-process}"
+    local expected_cmdline_pattern="${3:-}"  # optional cmdline pattern for validation
+
+    if [[ ! -f "${pid_file}" ]]; then
+        log_debug "Pid file not found (${pid_file}). Cannot stop or kill ${label}."
+        return 0
+    fi
+
+    local pid
+    pid="$(get_pid_from_file "${pid_file}" || true)"
+
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+        # Validate against PID reuse if pattern provided
+        if [[ -n "${expected_cmdline_pattern}" ]] && ! validate_pid "${pid_file}" "${expected_cmdline_pattern}"; then
+            log_warn "PID validation failed for ${label} (${pid}) - likely PID reuse, skipping kill"
+            rm -f "${pid_file}"
+            return 0
+        fi
+
+        log_debug "Stopping ${label} (${pid})..."
+        kill "${pid}" 2>/dev/null || true
+        local i
+        # shellcheck disable=SC2034
+        for i in $(seq 1 3); do
+            kill -0 "${pid}" 2>/dev/null || break
+            sleep 1
+        done
+        if kill -0 "${pid}" 2>/dev/null; then
+            log_warn "Force-killing ${label} (${pid})"
+            kill -9 "${pid}" 2>/dev/null || true
+        fi
+        log_info "Stopped ${label} (${pid})."
+    fi
+    rm -f "${pid_file}"
+}
+
+# --- Create cleanup trap ---
+# shellcheck disable=SC2317
+function cleanup_on_abort_or_error() {
+    # All actions are best effort.
+    log_error "Pre-freeze failed – attempting cleanup"
+
+    # Close file descriptors
+    exec 3>&- 2>/dev/null || true
+    exec 4<&- 2>/dev/null || true
+
+    # Close FIFO_HOLDER background process; that should stop mariadb also.
+    stop_and_kill_by_pid_file "${FIFO_HOLDER_PID_FILE}" "fifo_holder" "bash"
+
+    # Failsafe stop of mariadb; that should release the locks.
+    stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client" "timeout.*mariadb"
+
+    rm -rf "${RUN_DIR}" || true
+    exit 1
+}
+trap cleanup_on_abort_or_error ERR INT TERM
+
+
+# --- Prepare runtime dir and lock file ---
+if [[ -f "${LOCK_FILE}" ]]; then
+    # Check if another pre-freeze instance is running using PID validation
+    if validate_pid "${LOCK_FILE}" "mariadb-pre-freeze"; then
+        old_pid="$(get_pid_from_file "${LOCK_FILE}" || true)"
+        log_error "Aborting because another backup process is running (${old_pid})"
+        exit 1
+    fi
+    log_warn "Stale lock found, cleaning runtime dir"
+    stop_and_kill_by_pid_file "${FIFO_HOLDER_PID_FILE}" "fifo_holder" "bash"
+    stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client" "timeout.*mariadb"
+    rm -rf "${RUN_DIR:?}/"*
+fi
+mkdir -p "${RUN_DIR}"
+chmod 700 "${RUN_DIR}"
+save_pid_with_metadata "$$" "${LOCK_FILE}"
+log_debug "Created lock file with PID metadata: ${LOCK_FILE}"
+
+# --- Create FIFOs for remote control of the mariadb background job ---
+rm -f "${FIFO_IN}" "${FIFO_OUT}"
+(
+    umask 077
+    mkfifo "${FIFO_IN}"
+    mkfifo "${FIFO_OUT}"
+)
+log_debug "Created FIFO_IN: ${FIFO_IN}"
+log_debug "Created FIFO_OUT: ${FIFO_OUT}"
+
+
+# --- Start mariadb as background process ---
+# nohup ::= keep running if this script exits; output goes to FIFO/redirects below.
+# stdbuf -oL ::= line-buffered output; required for FIFO line-by-line processing.
+# timeout ::= hard limit to avoid an orphaned client after pre-freeze.
+# --skip-reconnect ::= reconnects will lose session and locks.
+# Note: We store the PID of the timeout wrapper. Signals will be forwarded to mariadb.
+# When killing this PID, timeout will propagate the signal to the mariadb client.
+log_info "Starting persistent mariadb session with FIFO_IN ${FIFO_IN} and FIFO_OUT ${FIFO_OUT}..."
+nohup stdbuf -oL \
+    timeout --preserve-status --signal=KILL "${FREEZE_AND_THAW_TIMEOUT_SEC}" \
+    mariadb --defaults-file="${DEFAULTS_FILE}" --skip-reconnect --skip-column-names --silent \
+    < "${FIFO_IN}" > "${FIFO_OUT}" 2>&1 &
+
+readonly MARIADB_PID=$!
+save_pid_with_metadata "${MARIADB_PID}" "${MARIADB_PID_FILE}"
+sleep 1    # Failsafe: some time for the mariadb process to start and connect to the FIFOs.
+if [[ -z "${MARIADB_PID}" ]] || ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
+    log_error "Failed to start mariadb session (no valid pid)."
+    exit 1
+fi
+log_info "Started persistent mariadb session with pid ${MARIADB_PID} (timeout wrapper)."
+
+
+# --- Create background process to keep the FIFO open ---
+# This process survives after pre-freeze; post-thaw relies on the FIFOs staying open.
+# The lock file removal by post-thaw is the normal stop signal.
+# No logging to stdout or stderr in background jobs. This can break automations.
+(
+    exec 3> "${FIFO_IN}"
+    exec 4< "${FIFO_OUT}"
+
+    # Apply timeout
+    declare -i start_ts
+    start_ts=$(date +%s)
+
+    # Wait for a timeout or the post-thaw script to end us to avoid an orphaned process after pre-freeze.
+    while [[ -f "${LOCK_FILE}" ]]; do
+        declare -i current_ts
+        current_ts=$(date +%s)
+        if (( current_ts - start_ts >= FREEZE_AND_THAW_TIMEOUT_SEC )); then
+            log_system_cat_only 3 "[ERROR] Timeout after ${FREEZE_AND_THAW_TIMEOUT_SEC}s waiting for lock file ${LOCK_FILE}."
+            exit 124
+        fi
+        sleep 1
+    done
+
+    log_system_cat_only 6 "[INFO] FIFO_HOLDER stopped by deleted lock file ${LOCK_FILE}."
+) &
+readonly FIFO_HOLDER_PID=$!
+save_pid_with_metadata "${FIFO_HOLDER_PID}" "${FIFO_HOLDER_PID_FILE}"
+log_debug "Created background process fifo_holder with pid ${FIFO_HOLDER_PID}"
+
+# --- Create persistent file descriptors for this script ---
+# FD 3 = Writing to FIFO_IN (additionally to the holder)
+# FD 4 = Reading from FIFO_OUT (additionally to the holder)
+exec 3> "${FIFO_IN}"
+exec 4< "${FIFO_OUT}"
+
+log_debug "Created persistent FD for FIFO_IN and FIFO_OUT"
+
+function send_sql() {
+    local sql="$1"
+
+    if ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
+        log_error "mariadb client is not running anymore (${MARIADB_PID})."
+        return 1
+    fi
+
+    # Validate PID hasn't been reused before sending SQL
+    if ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
+        log_error "mariadb client PID validation failed (likely PID reuse)."
+        return 1
+    fi
+
+    # send SQL + Marker via FD 3
+    log_debug "mariadb> ${sql}\\nSELECT \"${SQL_MARKER}\" AS marker;\\n"
+    printf '%s\nSELECT "%s" AS marker;\n' "${sql}" "${SQL_MARKER}" >&3
+
+    # read response until marker appears (or timeout)
+    local line
+    local response=""
+    local found_marker=0
+    local read_timeout
+
+    # Read response from FD 4 until marker is found or timeout
+    while true; do
+        read_timeout="$(remaining_seconds)"
+
+        if ! read -r -t "${read_timeout}" line <&4; then
+            if timeout_reached; then
+                log_error "Timeout waiting for SQL response: ${sql}"
+                return 1
+            fi
+            # EOF or timeout
+            break
+        fi
+
+        log_debug "mariadb> ${line}"
+
+        # Check for SQL errors (ERROR keyword from MariaDB)
+        if [[ "$line" =~ ^ERROR ]]; then
+            log_error "SQL Error in response: ${line}"
+            return 1
+        fi
+
+        # Check for marker to indicate command completion
+        if [[ "$line" == "${SQL_MARKER}" ]]; then
+            found_marker=1
+            break
+        fi
+
+        response+="${line}"$'\n'
+    done
+
+    # Validate successful completion: marker found AND no SQL error
+    if (( found_marker == 1 )); then
+        log_info "SQL command succeeded: ${sql}"
+        return 0
+    elif timeout_reached; then
+        log_error "Timeout waiting for SQL response marker: ${sql}"
+        return 1
+    else
+        log_error "SQL command did not complete properly: ${sql}, response ${response}"
+        return 1
+    fi
+}
+
+log_info "Starting mariadb backup stages..."
+
+# Validate STATE_FILE is writable before proceeding
+if ! touch "${STATE_FILE}" 2>/dev/null; then
+    log_error "STATE_FILE (${STATE_FILE}) is not writable. Check permissions."
+    exit 1
+fi
+
+send_sql "BACKUP STAGE START;"
+echo "START" > "${STATE_FILE}"
+log_debug "STATE_FILE set to START"
+
+send_sql "BACKUP STAGE FLUSH;"
+echo "FLUSH" > "${STATE_FILE}"
+log_debug "STATE_FILE set to FLUSH"
+
+send_sql "BACKUP STAGE BLOCK_DDL;"
+echo "BLOCK_DDL" > "${STATE_FILE}"
+
+send_sql "BACKUP STAGE BLOCK_COMMIT;"
+echo "BLOCK_COMMIT" > "${STATE_FILE}"
+
+# --- Close FDs, but FIFO_HOLDER background process still keeps the FIFOs open. ---
+exec 3>&-
+exec 4<&-
+
+log_info "BACKUP STAGE BLOCK_COMMIT sent - database should now be in consistent state."
+
+sync
+log_info "Filesystem write caches synchronized. Filesystem should now be in consistent state also."
+
+exit 0

--- a/scripts/mariadb-pre-freeze.sh
+++ b/scripts/mariadb-pre-freeze.sh
@@ -479,10 +479,38 @@ function save_pid_with_metadata() {
     fi
 
     local cmdline start_time
-    cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || echo "unknown")"
+    cmdline="$(tr '\0' ' ' < /proc/"${pid}"/cmdline 2>/dev/null || echo "unknown")"
     start_time="$(awk '{print $22}' /proc/"${pid}"/stat 2>/dev/null || echo "0")"
 
     printf '%s:%s:%s\n' "${pid}" "${cmdline}" "${start_time}" > "${pid_file}"
+}
+
+# helper function: atomically create PID file with metadata
+# Uses ln(2) semantics: only one process can link to the final path.
+function create_pid_file_atomically() {
+    local pid="$1"
+    local pid_file="$2"
+
+    if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+        log_error "Cannot save invalid PID atomically: ${pid}"
+        return 1
+    fi
+
+    local cmdline start_time
+    cmdline="$(tr '\0' ' ' < /proc/"${pid}"/cmdline 2>/dev/null || echo "unknown")"
+    start_time="$(awk '{print $22}' /proc/"${pid}"/stat 2>/dev/null || echo "0")"
+
+    local tmp_pid_file
+    tmp_pid_file="${pid_file}.$$.${pid}.${RANDOM}.tmp"
+    printf '%s:%s:%s\n' "${pid}" "${cmdline}" "${start_time}" > "${tmp_pid_file}"
+
+    if ln "${tmp_pid_file}" "${pid_file}" 2>/dev/null; then
+        rm -f "${tmp_pid_file}"
+        return 0
+    fi
+
+    rm -f "${tmp_pid_file}"
+    return 1
 }
 
 # helper function: extract PID from PID file (first field)
@@ -558,22 +586,34 @@ trap cleanup_on_abort_or_error ERR INT TERM
 
 
 # --- Prepare runtime dir and lock file ---
-if [[ -f "${LOCK_FILE}" ]]; then
-    # Check if another pre-freeze instance is running using PID validation
+mkdir -p "${RUN_DIR}"
+chmod 700 "${RUN_DIR}"
+
+# Acquire pre-freeze lock atomically to prevent concurrent runs.
+if ! create_pid_file_atomically "$$" "${LOCK_FILE}"; then
+    # Check if another pre-freeze instance is running using PID validation.
     if validate_pid "${LOCK_FILE}" "mariadb-pre-freeze"; then
         old_pid="$(get_pid_from_file "${LOCK_FILE}" || true)"
         log_error "Aborting because another backup process is running (${old_pid})"
         exit 1
     fi
+
     log_warn "Stale lock found, cleaning runtime dir"
     stop_and_kill_by_pid_file "${FIFO_HOLDER_PID_FILE}" "fifo_holder" "bash"
     stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client" "timeout.*mariadb"
     rm -rf "${RUN_DIR:?}/"*
+
+    if ! create_pid_file_atomically "$$" "${LOCK_FILE}"; then
+        if validate_pid "${LOCK_FILE}" "mariadb-pre-freeze"; then
+            old_pid="$(get_pid_from_file "${LOCK_FILE}" || true)"
+            log_error "Aborting because another backup process is running (${old_pid})"
+        else
+            log_error "Failed to acquire lock file atomically: ${LOCK_FILE}"
+        fi
+        exit 1
+    fi
 fi
-mkdir -p "${RUN_DIR}"
-chmod 700 "${RUN_DIR}"
-save_pid_with_metadata "$$" "${LOCK_FILE}"
-log_debug "Created lock file with PID metadata: ${LOCK_FILE}"
+log_debug "Acquired lock file atomically with PID metadata: ${LOCK_FILE}"
 
 # --- Create FIFOs for remote control of the mariadb background job ---
 rm -f "${FIFO_IN}" "${FIFO_OUT}"

--- a/scripts/mariadb-pre-freeze.sh
+++ b/scripts/mariadb-pre-freeze.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2026 ARZ Haan AG
+# Author: Gerd Aschbrenner
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +34,39 @@
 # MariaDB Pre-Freeze Script for MariaDB 11.5+ (InnoDB only)
 #
 # Use this script together with the mariadb-post-thaw.sh script for external
-# volume-based backup tools like Veeam.
+# filesystem-based backup tools like Veeam, Commvault, etc. that do not have
+# native MariaDB integration. These scripts use the MariaDB BACKUP STAGE
+# feature instead of FTWRL (FLUSH TABLES WITH READ LOCK). This allows for
+# minimal downtime and better performance during the backup window, as
+# applications can still read from the database with only a short write
+# lock during the BACKUP STAGE commands.
+#
+# This backup strategy can only work if your applications do not execute
+# long-running transactions or DDL during or shortly before the backup window,
+# as those will block the "backup stage" commands too long and the scripts
+# will fail with a timeout. If you have such workloads, consider using a
+# different backup approach (e.g. mariadb-backup or logical dumps).
+# Taking the filesystem snapshot should also be fast enough to complete
+# within the timeout, ideally in seconds rather than minutes. A simple cp or
+# scp would be too slow for large datasets; use a proper snapshot tool or
+# filesystem that can complete within the timeout.
+#
+# The benefits of this backup strategy are:
+# - Minimal downtime: only short write locks during BACKUP STAGE commands and
+#   the filesystem snapshot operations.
+# - Tools like Veeam or Commvault can restore a VM snapshot directly without
+#   needing to restore a logical dump or mariadb-backup files.
+# - No extra disk space or I/O needed for a backup copy (unlike mariadb-backup
+#   or logical dumps).
+#
+# The downsides and risks of this backup strategy are:
+# - Backups may fail due to timeouts (long-running transactions or DDL during
+#   the backup window, or long-running filesystem snapshots)
+# - The write locks during BACKUP STAGE commands and filesystem snapshots can
+#   cause SQL timeouts in applications.
+#   If BACKUP STAGE commands and filesystem snapshots only need a few seconds,
+#   then an application might hang a short time, but if it takes minutes,
+#   then applications might start to fail with SQL timeouts.
 #
 # Purpose:
 # - Initiate MariaDB BACKUP STAGE steps to get a consistent filesystem snapshot
@@ -43,31 +76,48 @@
 # - A timeout of 10 minutes (can be overridden) is enforced; if the snapshot
 #   is not taken in time, the database files may be inconsistent, and this
 #   script will fail.
+# - Backup tools should fail if the scripts fail, so that you do not end up
+#   with inconsistent snapshots.
+# - Backup tools should execute the post-thaw script after the snapshot is
+#   taken to release the locks and clean up.
 #
 # References:
 # - https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage
-# - https://helpcenter.veeam.com/docs/vbr/userguide/pre_post_scripts.html
+# - Veeam:
+#   - https://helpcenter.veeam.com/docs/vbr/userguide/pre_post_scripts.html
+#   - https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_scripts_vm.html
+# - Commvault: https://documentation.commvault.com/v11/commcell-console/pre_freeze_and_post_thaw_processing_using_vmware_tools.html
 #
 # Usage:
-# - Optionally override FREEZE_AND_THAW_TIMEOUT_SEC (the mariadb client + FIFO holder can run longer across freeze/thaw).
-# - Optionally override SCRIPT_TIMEOUT_SEC (the script can run slightly longer).
+# - Optionally override FREEZE_AND_THAW_TIMEOUT_SEC (the MariaDB client + FIFO
+#   holder can run longer across freeze/thaw).
+# - Optionally override PRE_FREEZE_FLOW_TIMEOUT_SEC (the script can run
+#   slightly longer).
 # - Optionally set DEBUG_LOGS_ENABLED=true for verbose logging.
 #
 # Timeout implementation:
-# - SCRIPT_TIMEOUT_SEC limits this script's own runtime (reads, SQL responses, overall flow).
-# - FREEZE_AND_THAW_TIMEOUT_SEC limits how long the mariadb client + FIFO holder stay alive
-#   across pre-freeze, snapshot, and post-thaw.
-# - The mariadb client is run under timeout; the FIFO holder also enforces the same limit.
-# - When the limit is hit, the client is terminated and the run dir may be left behind.
+# - PRE_FREEZE_FLOW_TIMEOUT_SEC limits this script's own runtime (reads, SQL
+#   responses, overall flow). It is not an overall hard limit, but it covers
+#   all operations that are locking the database.
+# - FREEZE_AND_THAW_TIMEOUT_SEC limits how long the MariaDB client + FIFO
+#   holder stay alive across pre-freeze, snapshot, and post-thaw.
+# - The MariaDB client is run under timeout; the FIFO holder also enforces
+#   the same limit.
+# - When the limit is hit, the client is terminated and the run dir may be
+#   left behind.
 #
 # Requirements:
-# - mariadb, mkfifo, stdbuf, and timeout must be installed and in PATH.
+# - mariadb (client), mkfifo, stdbuf, and timeout must be installed and in PATH.
+#   This script checks for them.
 # - systemd-cat is optional; without it logs go to stdout/stderr only.
 # - See setup section for required files and config.
 #
-# Setup:
+# Setup (with "veeam" as an example backup user):
 # - Create a Linux user "veeam" and add its public SSH key to authorized_keys.
-# - Copy this script and mariadb-post-thaw.sh into the user's home and make them executable:
+#   - Use the private SSH key for running the scripts via Veeam or other tools
+#     over an SSH connection.
+# - Copy this script and mariadb-post-thaw.sh into the user's home and make
+#   them executable:
 #   chmod 700 /home/veeam/mariadb-*.sh
 #
 # Create a DB user:
@@ -83,28 +133,53 @@
 # Test the script and check logs with:
 #   journalctl -t mariadb-stage-backup
 #
+# If you do not want to create a dedicated user, or need multiple credentials
+# in the .my.cnf file, then use the defaults-group-suffix option of the
+# mariadb client. For example add this to the .my.cnf:
+#   [client-veeam]
+#   user=veeam
+#   password=secure-password
+#
+# Then you can specify the group suffix via the MYSQL_GROUP_SUFFIX environment
+# variable when calling the script, and it will use the credentials from that
+# group. For example:
+#   env MYSQL_GROUP_SUFFIX=-veeam ./mariadb-pre-freeze.sh
+#
 # Timeout Behavior and Parameters:
-# - SCRIPT_TIMEOUT_SEC (default 600s / 10 min): limits this script's runtime.
-#   Includes all preflight checks, SQL commands, and syncs. Mainly for safety.
-# - FREEZE_AND_THAW_TIMEOUT_SEC (default 1200s / 20 min): limits the lifetime of the
-#   persistent mariadb session and FIFO holder across pre-freeze, snapshot, and post-thaw.
-#   This is the critical timeout for snapshot tools. If snapshot takes > 20 min, the
-#   database will be forcibly unlocked (BACKUP STAGE END will fail).
-#   Recommendation: snapshot should complete in 10-15 minutes; set this to 2x expected time.
+# - PRE_FREEZE_FLOW_TIMEOUT_SEC (default 600s / 10 min): limits this script's
+#   runtime.
+#   Includes all preflight checks, SQL commands, and syncs until the
+#   filesystem snapshot can be taken.
+# - FREEZE_AND_THAW_TIMEOUT_SEC (default 1200s / 20 min): limits the lifetime
+#   of the persistent MariaDB client session and FIFO holder across pre-freeze,
+#   filesystem snapshot, and post-thaw.
+#   If the "backup stage" commands or the filesystem snapshot takes too long,
+#   the database will be forcibly unlocked. Applications will be able to
+#   access the database again, but the filesystem snapshot can be inconsistent
+#   and should be discarded. Backup tools should detect the script failure
+#   and fail the backup job, so that you do not end up with inconsistent
+#   snapshots.
+# - FREEZE_AND_THAW_TIMEOUT_SEC should be PRE_FREEZE_FLOW_TIMEOUT_SEC + filesystem
+#   snapshot time + post-thaw script time + some buffer.
 #
 # How It Works (Advanced):
 # 1. pre-freeze:
 #    a. Creates runtime directory with FIFOs and lock file
-#    b. Starts a persistent mariadb session under timeout wrapper (as background process)
+#    b. Starts a persistent MariaDB client session under timeout wrapper
+#       (as background process)
 #    c. Starts FIFO holder process (keeps FIFOs open, survives pre-freeze)
 #    d. Executes BACKUP STAGE START/FLUSH/BLOCK_DDL/BLOCK_COMMIT via FIFO
 #    e. Closes its own FDs (but FIFOs stay open via FIFO holder)
-#    f. Returns with database in consistent state, ready for snapshot
-# 2. Snapshot tool takes filesystem snapshot (should complete in minutes)
+#    f. Calls sync to flush filesystem caches; this is the point where the
+#       database and filesystem are in a consistent state and the snapshot
+#       should be taken immediately after this command completes.
+#    g. Returns with database in consistent state, ready for filesystem
+#       snapshot
+# 2. Snapshot tool takes filesystem snapshot (should complete in seconds)
 # 3. post-thaw:
 #    a. Reads state file to verify database state
-#    b. Executes BACKUP STAGE END via the still-running mariadb session
-#    c. Kills mariadb session and FIFO holder
+#    b. Executes BACKUP STAGE END via the still-running MariaDB client session
+#    c. Kills MariaDB client session and FIFO holder
 #    d. Removes runtime directory
 #
 # FIFO Communication Protocol:
@@ -117,39 +192,46 @@
 # Troubleshooting:
 #
 # 1. Script hangs or times out:
-#    - Check DATABASE connectivity: mariadb
+#    - Check database connectivity: mariadb
 #    - Check DB logs: tail -f /var/log/mariadb/mariadb.log
 #    - Look for BACKUP STAGE errors in journalctl
 #    - Example: journalctl -t mariadb-stage-backup -n 100 | grep -i error
 #
-# 2. "Cannot connect to mariadb":
+# 2. "Cannot connect to MariaDB":
 #    - Verify ~/.my.cnf exists and is readable (chmod 600)
 #    - Test credentials: mariadb -e "SELECT 1;"
 #    - Ensure veeam user has RELOAD + PROCESS grants
 #    - Check MariaDB socket/port in my.cnf [client] section
 #
 # 3. "Another backup process is running":
-#    - Check if old pre-freeze is still running: ps aux | grep mariadb-pre-freeze
+#    - Check if old pre-freeze is still running:
+#      ps aux | grep mariadb-pre-freeze
 #    - If yes, wait or kill it: kill -9 <pid>
-#    - If snapshot tool crashed: manually run post-thaw to clean up (or wait until timeout)
+#    - If snapshot tool crashed: manually run post-thaw to clean up (or wait
+#      until timeout)
 #    - Check lock file: ls -la ~/.mariadb-stage-backup-run-dir/
 #
-# 4. "Timeout waiting for SQL response" or "Timeout after 20 min":
+# 4. "Timeout waiting for SQL response" or "Timeout after 10 min":
 #    - Snapshot took too long or was never taken
 #    - Check if snapshot tool has errors
-#    - Increase FREEZE_AND_THAW_TIMEOUT_SEC: env FREEZE_AND_THAW_TIMEOUT_SEC=2400 ./mariadb-pre-freeze.sh
+#    - Increase FREEZE_AND_THAW_TIMEOUT_SEC:
+#      env FREEZE_AND_THAW_TIMEOUT_SEC=2400 ./mariadb-pre-freeze.sh
 #    - Run post-thaw to release locks: ./mariadb-post-thaw.sh
-#    - Database may have stale BACKUP STAGE state; check with: SHOW PROCESSLIST;
+#    - Database may have stale BACKUP STAGE state; check with:
+#      mariadb -e "SHOW PROCESSLIST";
 #
 # 5. "Stale lock found, cleaning runtime dir":
 #    - Indicates a crashed pre-freeze from a previous run
 #    - Script auto-cleans and proceeds (safe)
-#    - Check logs for why it crashed: journalctl -t mariadb-stage-backup --since "2 hours ago"
+#    - Check logs for why it crashed:
+#      journalctl -t mariadb-stage-backup --since "2 hours ago"
 #
 # 6. Database locked, snapshot failed, unclear state:
-#    - Check current BACKUP STAGE state: SHOW VARIABLES LIKE 'innodb_backup_stage';
-#    - Manually release if needed: BACKUP STAGE END;
-#    - Check post-thaw cleanup worked: ls -la ~/.mariadb-stage-backup-run-dir/ (should be empty)
+#    - Find sql connection with "backup stage" in the command:
+#      mariadb -e "SHOW PROCESSLIST;" | grep -i "backup stage"
+#    - Kill the connection too free the locks: kill <PID>
+#    - Check logs for details and errors
+#
 #
 # Safety and Consistency:
 # - The scripts use PID validation (cmdline + start_time) to prevent killing wrong processes
@@ -160,13 +242,20 @@
 #   journalctl -t mariadb-stage-backup
 #   SHOW PROCESSLIST;
 #
+# Best Practices:
+# - Have a restore strategy. Test restores regularly (ideally automated) to
+#   ensure your backups are valid and that you know the restore process.
+# - Set up alerting for failed or missing backups. Test it from time to time.
+# - Keep FREEZE_AND_THAW_TIMEOUT_SEC small, but add extra time for high-load
+#   scenarios.
+#
 
 set -euo pipefail
 readonly DEBUG_LOGS_ENABLED="${DEBUG_LOGS_ENABLED:-false}"
-readonly SCRIPT_TIMEOUT_SEC="${SCRIPT_TIMEOUT_SEC:-600}"  # 10 minutes default
+readonly PRE_FREEZE_FLOW_TIMEOUT_SEC="${PRE_FREEZE_FLOW_TIMEOUT_SEC:-600}"  # 10 minutes default
 readonly FREEZE_AND_THAW_TIMEOUT_SEC="${FREEZE_AND_THAW_TIMEOUT_SEC:-1200}"  # 20 minutes default
 
-# Safety check: HOME must be set and absolute
+# Safety check: HOME must be set and absolute.
 if [[ -z "${HOME:-}" ]] || [[ ! "${HOME}" =~ ^/ ]]; then
     echo "[ERROR] HOME is not set or not absolute. Cannot proceed." >&2
     exit 1
@@ -176,7 +265,7 @@ readonly LOG_PREFIX="[pre-freeze]"
 readonly SQL_MARKER="---MARKER---"
 readonly DEFAULTS_FILE="${HOME}/.my.cnf"
 
-# same as in mariadb-post-thaw.sh!
+# Same as in mariadb-post-thaw.sh!
 readonly LOG_TAG="mariadb-stage-backup"
 readonly RUN_DIR="${HOME}/.mariadb-stage-backup-run-dir"
 readonly MARIADB_PID_FILE="${RUN_DIR}/mariadb.pid"
@@ -187,7 +276,7 @@ readonly STATE_FILE="${RUN_DIR}/mariadb-stage-backup.state"
 readonly LOCK_FILE="${RUN_DIR}/mariadb-stage-backup.lock"
 readonly FIFO_HOLDER_PID_FILE="${RUN_DIR}/fifo_holder.pid"
 
-# remember start time of this script.
+# Remember the start time of this script.
 SCRIPT_START_EPOCH="$(date +%s)"
 readonly SCRIPT_START_EPOCH
 
@@ -205,7 +294,7 @@ function log() {
     local prio="${1:-6}"   # default: info (6)
     shift || true
 
-    # best effort failsafe for wrong prio level
+    # best-effort fallback for wrong prio level
     if [[ ! "$prio" =~ ^[0-7]$ ]]; then
         prio=6
     fi
@@ -239,7 +328,7 @@ function log_system_cat_only() {
     local prio="${1:-6}"   # default: info (6)
     shift || true
 
-    # best effort failsafe for wrong prio level
+    # best-effort fallback for wrong prio level
     if [[ ! "$prio" =~ ^[0-7]$ ]]; then
         prio=6
     fi
@@ -252,13 +341,13 @@ function log_system_cat_only() {
     fi
 }
 
-# helper function: remaining time in seconds until script timeout
+# helper function: remaining time in seconds until PRE_FREEZE_FLOW_TIMEOUT_SEC timeout
 # A minimum of 1 sec will be returned, so that timed reads are still possible.
 function remaining_seconds() {
     local now elapsed remaining
     now="$(date +%s)"
     elapsed=$(( now - SCRIPT_START_EPOCH ))
-    remaining=$(( SCRIPT_TIMEOUT_SEC - elapsed ))
+    remaining=$(( PRE_FREEZE_FLOW_TIMEOUT_SEC - elapsed ))
 
     # Minimum 1 second so reads do not time out immediately.
     if (( remaining < 1 )); then
@@ -270,16 +359,16 @@ function remaining_seconds() {
 function timeout_reached() {
     local now
     now="$(date +%s)"
-    (( now - SCRIPT_START_EPOCH >= SCRIPT_TIMEOUT_SEC ))
+    (( now - SCRIPT_START_EPOCH >= PRE_FREEZE_FLOW_TIMEOUT_SEC ))
 }
 
 # --- Preflight checks ---
 if [[ ! -f "${DEFAULTS_FILE}" ]]; then
-    log_error "mariadb defaults file not found: ${DEFAULTS_FILE}"
+    log_error "MariaDB defaults file not found: ${DEFAULTS_FILE}"
     exit 1
 fi
 if ! command -v mariadb &>/dev/null; then
-    log_error "mariadb client not found in PATH."
+    log_error "MariaDB client 'mariadb' not found in PATH."
     exit 1
 fi
 if ! command -v mkfifo &>/dev/null; then
@@ -295,13 +384,13 @@ if ! command -v timeout &>/dev/null; then
     exit 1
 fi
 
-# --- Test mariadb connectivity ---
+# --- Test MariaDB connectivity ---
 if ! mariadb --defaults-file="${DEFAULTS_FILE}" -e "SELECT 1;" &>/dev/null; then
-    log_error "Cannot connect to mariadb – check credentials in ${DEFAULTS_FILE}"
+    log_error "Cannot connect to MariaDB - check credentials in ${DEFAULTS_FILE}"
     exit 1
 fi
 
-# --- No usage of unsupported database engines? ---
+# --- Check for unsupported database engines ---
 # BACKUP STAGE only works with InnoDB. Warn if other engines are found.
 # This includes MyISAM, Memory, CSV, Archive, etc.
 log_info "Checking for unsupported database engines..."
@@ -359,7 +448,7 @@ function validate_pid() {
     # Check cmdline matches (protect against PID reuse)
     if [[ -n "${expected_cmdline_pattern}" ]]; then
         local current_cmdline
-        current_cmdline="$(cat /proc/"${pid}"/cmdline 2>/dev/null | tr '\0' ' ' || true)"
+        current_cmdline="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
         if [[ ! "${current_cmdline}" =~ ${expected_cmdline_pattern} ]]; then
             log_warn "PID ${pid} cmdline mismatch. Expected pattern: ${expected_cmdline_pattern}, got: ${current_cmdline}"
             return 1
@@ -407,14 +496,14 @@ function get_pid_from_file() {
     echo "${pid_info}" | cut -d: -f1
 }
 
-# helper function: stop and kill a process by pid file with PID reuse protection
+# helper function: stop and kill a process by PID file with PID reuse protection
 function stop_and_kill_by_pid_file() {
     local pid_file="$1"
     local label="${2:-process}"
     local expected_cmdline_pattern="${3:-}"  # optional cmdline pattern for validation
 
     if [[ ! -f "${pid_file}" ]]; then
-        log_debug "Pid file not found (${pid_file}). Cannot stop or kill ${label}."
+        log_debug "PID file not found (${pid_file}). Cannot stop or kill ${label}."
         return 0
     fi
 
@@ -456,10 +545,10 @@ function cleanup_on_abort_or_error() {
     exec 3>&- 2>/dev/null || true
     exec 4<&- 2>/dev/null || true
 
-    # Close FIFO_HOLDER background process; that should stop mariadb also.
+    # Close FIFO_HOLDER background process; that should stop the MariaDB client also.
     stop_and_kill_by_pid_file "${FIFO_HOLDER_PID_FILE}" "fifo_holder" "bash"
 
-    # Failsafe stop of mariadb; that should release the locks.
+    # Failsafe stop of MariaDB client; that should release the locks.
     stop_and_kill_by_pid_file "${MARIADB_PID_FILE}" "mariadb_client" "timeout.*mariadb"
 
     rm -rf "${RUN_DIR}" || true
@@ -497,14 +586,14 @@ log_debug "Created FIFO_IN: ${FIFO_IN}"
 log_debug "Created FIFO_OUT: ${FIFO_OUT}"
 
 
-# --- Start mariadb as background process ---
+# --- Start mariadb client as background process ---
 # nohup ::= keep running if this script exits; output goes to FIFO/redirects below.
 # stdbuf -oL ::= line-buffered output; required for FIFO line-by-line processing.
 # timeout ::= hard limit to avoid an orphaned client after pre-freeze.
 # --skip-reconnect ::= reconnects will lose session and locks.
-# Note: We store the PID of the timeout wrapper. Signals will be forwarded to mariadb.
+# Note: We store the PID of the timeout wrapper. Signals will be forwarded to mariadb client.
 # When killing this PID, timeout will propagate the signal to the mariadb client.
-log_info "Starting persistent mariadb session with FIFO_IN ${FIFO_IN} and FIFO_OUT ${FIFO_OUT}..."
+log_info "Starting persistent MariaDB client session with FIFO_IN ${FIFO_IN} and FIFO_OUT ${FIFO_OUT}..."
 nohup stdbuf -oL \
     timeout --preserve-status --signal=KILL "${FREEZE_AND_THAW_TIMEOUT_SEC}" \
     mariadb --defaults-file="${DEFAULTS_FILE}" --skip-reconnect --skip-column-names --silent \
@@ -514,16 +603,16 @@ readonly MARIADB_PID=$!
 save_pid_with_metadata "${MARIADB_PID}" "${MARIADB_PID_FILE}"
 sleep 1    # Failsafe: some time for the mariadb process to start and connect to the FIFOs.
 if [[ -z "${MARIADB_PID}" ]] || ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
-    log_error "Failed to start mariadb session (no valid pid)."
+    log_error "Failed to start MariaDB client session (no valid PID)."
     exit 1
 fi
-log_info "Started persistent mariadb session with pid ${MARIADB_PID} (timeout wrapper)."
+log_info "Started persistent MariaDB client session with PID ${MARIADB_PID} (timeout wrapper)."
 
 
 # --- Create background process to keep the FIFO open ---
 # This process survives after pre-freeze; post-thaw relies on the FIFOs staying open.
 # The lock file removal by post-thaw is the normal stop signal.
-# No logging to stdout or stderr in background jobs. This can break automations.
+# No logging to stdout or stderr in background jobs. This can break automation.
 (
     exec 3> "${FIFO_IN}"
     exec 4< "${FIFO_OUT}"
@@ -537,7 +626,7 @@ log_info "Started persistent mariadb session with pid ${MARIADB_PID} (timeout wr
         declare -i current_ts
         current_ts=$(date +%s)
         if (( current_ts - start_ts >= FREEZE_AND_THAW_TIMEOUT_SEC )); then
-            log_system_cat_only 3 "[ERROR] Timeout after ${FREEZE_AND_THAW_TIMEOUT_SEC}s waiting for lock file ${LOCK_FILE}."
+            log_system_cat_only 3 "[ERROR] Timeout after ${FREEZE_AND_THAW_TIMEOUT_SEC}s waiting for the post-thaw script to release the lock file ${LOCK_FILE}."
             exit 124
         fi
         sleep 1
@@ -561,21 +650,21 @@ function send_sql() {
     local sql="$1"
 
     if ! kill -0 "${MARIADB_PID}" 2>/dev/null; then
-        log_error "mariadb client is not running anymore (${MARIADB_PID})."
+        log_error "MariaDB client is not running anymore (${MARIADB_PID})."
         return 1
     fi
 
     # Validate PID hasn't been reused before sending SQL
     if ! validate_pid "${MARIADB_PID_FILE}" "timeout.*mariadb"; then
-        log_error "mariadb client PID validation failed (likely PID reuse)."
+        log_error "MariaDB client PID validation failed (likely PID reuse)."
         return 1
     fi
 
-    # send SQL + Marker via FD 3
+    # Send SQL and marker via FD 3
     log_debug "mariadb> ${sql}\\nSELECT \"${SQL_MARKER}\" AS marker;\\n"
     printf '%s\nSELECT "%s" AS marker;\n' "${sql}" "${SQL_MARKER}" >&3
 
-    # read response until marker appears (or timeout)
+    # Read response until marker appears (or timeout)
     local line
     local response=""
     local found_marker=0
@@ -624,7 +713,7 @@ function send_sql() {
     fi
 }
 
-log_info "Starting mariadb backup stages..."
+log_info "Starting MariaDB backup stages..."
 
 # Validate STATE_FILE is writable before proceeding
 if ! touch "${STATE_FILE}" 2>/dev/null; then
@@ -653,6 +742,6 @@ exec 4<&-
 log_info "BACKUP STAGE BLOCK_COMMIT sent - database should now be in consistent state."
 
 sync
-log_info "Filesystem write caches synchronized. Filesystem should now be in consistent state also."
+log_info "Called 'sync'. File system write caches have been synchronized. The file system should now also be in a consistent state."
 
 exit 0


### PR DESCRIPTION
For external volume-based backup tools like Veeam. 
Initiate MariaDB BACKUP STAGE steps to get a consistent filesystem snapshot without shutting down the server or taking read locks. Writes are blocked only for the shortest possible time.

https://jira.mariadb.org/browse/MDEV-38924