### PR TITLE
MDEV-35821 vector index sizes are not in information_schema.TABLES nor SHOW TABLE STATUS

### DIFF
--- a/mysql-test/main/vector.result
+++ b/mysql-test/main/vector.result
@@ -892,3 +892,20 @@ t	CREATE TABLE `t` (
   VECTOR KEY `v` (`v`) `distance`=cosine
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 drop table t;
+#
+# MDEV-35821 - vector index sizes are not in INDEX_LENGTH
+#
+create table t1 (id int primary key, v vector(1) not null, vector index (v));
+insert into t1 values (1, vec_fromtext('[1]'));
+select index_length > 0 as has_index_length
+from information_schema.tables
+where table_schema = database() and table_name = 't1';
+has_index_length
+1
+flush tables;
+select index_length > 0 as has_index_length
+from information_schema.tables
+where table_schema = database() and table_name = 't1';
+has_index_length
+1
+drop table t1;

--- a/mysql-test/main/vector.test
+++ b/mysql-test/main/vector.test
@@ -441,3 +441,21 @@ insert into t values (0x31313131); # Optional, fails either way
 alter table t drop index v, add vector(v) distance=cosine;
 show create table t;
 drop table t;
+
+--echo #
+--echo # MDEV-35821 - vector index sizes are not in INDEX_LENGTH
+--echo #
+create table t1 (id int primary key, v vector(1) not null, vector index (v));
+insert into t1 values (1, vec_fromtext('[1]'));
+
+select index_length > 0 as has_index_length
+from information_schema.tables
+where table_schema = database() and table_name = 't1';
+
+flush tables;
+
+select index_length > 0 as has_index_length
+from information_schema.tables
+where table_schema = database() and table_name = 't1';
+
+drop table t1;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -6072,6 +6072,17 @@ static int get_schema_tables_record(THD *thd, TABLE_LIST *tables,
         goto err;
       }
 
+      if (show_table->s->hlindexes())
+      {
+          // make sure hlindex is opened
+          if (show_table->hlindex || !show_table->hlindex_open(show_table->s->keys))
+          {
+              handler *hi= show_table->hlindex->file;
+              if (!hi->info(HA_STATUS_VARIABLE))
+                  file->stats.index_file_length+= hi->stats.data_file_length;
+          }
+      }
+
       enum row_type row_type = file->get_row_type();
       switch (row_type) {
       case ROW_TYPE_NOT_USED:


### PR DESCRIPTION
InnoDB stores the HNSW graph for a VECTOR INDEX in a separate tablespace file (tst/vec_test#i#01.ibd) This tablespace was not accounted for when computing stats.index_file_length in ha_innobase::info_low(), causing INDEX_LENGTH to always report 0 for tables with a vector index.

Fix: after computing index_file_length from regular secondary indexes, look up the hlindex tablespace via dict_table_open_on_name() using the normalized path + HLINDEX_TEMPLATE suffix, and add its size to stats.index_file_length.