### PR TITLE
MDEV-38922 Fix cosmetic "stage done" output for REPAIR TABLE

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3622,7 +3622,6 @@ static int com_go(String *buffer, char *)
   timer= microsecond_interval_timer();
   executing_query= 1;
   error= mysql_real_query_for_lazy(buffer->ptr(),buffer->length());
-  report_progress_end();
 
 #ifdef HAVE_READLINE
   if (status.add_to_history) 
@@ -3660,6 +3659,7 @@ static int com_go(String *buffer, char *)
         goto end;
     }
 
+    report_progress_end();
     if (verbose >= 3 || !opt_silent)
       end_timer(timer, time_buff);
     else
@@ -3967,6 +3967,16 @@ print_as_hex(FILE *output_file, const char *str, size_t len, size_t total_bytes_
     tee_putc((int)' ', output_file);
 }
 
+static inline MYSQL_ROW fetch_row(MYSQL_RES *result)
+{
+  MYSQL_ROW row = mysql_fetch_row(result);
+#ifndef EMBEDDED_LIBRARY
+  if (last_progress_report_length) {
+    report_progress_end();
+  }
+#endif
+  return row;
+}
 
 static void
 print_table_data(MYSQL_RES *result)
@@ -4023,7 +4033,7 @@ print_table_data(MYSQL_RES *result)
     tee_puts((char*) separator.ptr(), PAGER);
   }
 
-  while ((cur= mysql_fetch_row(result)))
+  while ((cur = fetch_row(result)))
   {
     if (interrupted_query)
       break;
@@ -4195,7 +4205,7 @@ static void print_table_data_html(MYSQL_RES *result)
     }
     (void) tee_fputs("</TR>", PAGER);
   }
-  while ((cur = mysql_fetch_row(result)))
+  while ((cur = fetch_row(result)))
   {
     if (interrupted_query)
       break;
@@ -4231,7 +4241,7 @@ print_table_data_xml(MYSQL_RES *result)
             PAGER);
 
   fields = mysql_fetch_fields(result);
-  while ((cur = mysql_fetch_row(result)))
+  while ((cur = fetch_row(result)))
   {
     if (interrupted_query)
       break;
@@ -4275,7 +4285,7 @@ print_table_data_vertically(MYSQL_RES *result)
   }
 
   mysql_field_seek(result,0);
-  for (uint row_count=1; (cur= mysql_fetch_row(result)); row_count++)
+  for (uint row_count=1; (cur = fetch_row(result)); row_count++)
   {
     if (interrupted_query)
       break;
@@ -4476,7 +4486,7 @@ print_tab_data(MYSQL_RES *result)
     }
     (void) tee_fputs("\n", PAGER);
   }
-  while ((cur = mysql_fetch_row(result)))
+  while ((cur = fetch_row(result)))
   {
     lengths=mysql_fetch_lengths(result);
     field= mysql_fetch_fields(result);

--- a/mysql-test/main/mysql-interactive.result
+++ b/mysql-test/main/mysql-interactive.result
@@ -62,3 +62,66 @@ Query OK, 0 rows affected
 MariaDB [(none)]> exit
 Bye
 # End of 10.11 tests
+#
+# MDEV-38922 CLI incorrectly adds "stage done" on REPAIR TABLE output
+#
+CREATE TABLE t (c INT) ENGINE=InnoDB;
+REPAIR TABLE t;
+DROP TABLE t;
+exit
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is X
+Server version: Y
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [test]> CREATE TABLE t (c INT) ENGINE=InnoDB;
+Query OK, 0 rows affected
+
+MariaDB [test]> REPAIR TABLE t;
+Stage: X of Y 'Z' P% of stage done+--------+--------+----------+----------+
+| Table  | Op     | Msg_type | Msg_text |
++--------+--------+----------+----------+
+| test.t | repair | status   | OK       |
++--------+--------+----------+----------+
+1 row in set
+
+MariaDB [test]> DROP TABLE t;
+Query OK, 0 rows affected
+
+MariaDB [test]> exit
+Bye
+#
+# repair table output in unbuffered (--quick) mode
+#
+CREATE TABLE t (c INT) ENGINE=InnoDB;
+INSERT INTO t SELECT * FROM seq_1_to_10;
+REPAIR TABLE t;
+DROP TABLE t;
+exit
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is X
+Server version: Y
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [test]> CREATE TABLE t (c INT) ENGINE=InnoDB;
+Query OK, 0 rows affected
+
+MariaDB [test]> INSERT INTO t SELECT * FROM seq_1_to_10;
+MariaDB [test]> REPAIR TABLE t;
++--------+--------+----------+----------+
+| Table  | Op     | Msg_type | Msg_text |
++--------+--------+----------+----------+
+Stage: X of Y 'Z' P% of stage done| test.t | repair | status   | OK       |
++--------+--------+----------+----------+
+1 row in set
+
+MariaDB [test]> DROP TABLE t;
+Query OK, 0 rows affected
+
+MariaDB [test]> exit
+Bye
+# End of 11.8 tests

--- a/mysql-test/main/mysql-interactive.test
+++ b/mysql-test/main/mysql-interactive.test
@@ -1,10 +1,11 @@
+# this would need an instrumented ncurses library
+source include/not_msan.inc;
+source include/not_embedded.inc;
+source include/not_windows.inc;
+source include/have_innodb.inc;
 --echo #
 --echo # regression introduced by MDEV-14448
 --echo #
-source include/not_embedded.inc;
-source include/not_windows.inc;
-# this would need an instrumented ncurses library
-source include/not_msan.inc;
 
 write_file $MYSQL_TMP_DIR/mysql_in;
 delimiter $
@@ -46,3 +47,46 @@ exec socat -t10 EXEC:"$MYSQL",pty STDIO < $MYSQL_TMP_DIR/mysql_in;
 remove_file $MYSQL_TMP_DIR/mysql_in;
 
 --echo # End of 10.11 tests
+
+--echo #
+--echo # MDEV-38922 CLI incorrectly adds "stage done" on REPAIR TABLE output
+--echo #
+write_file $MYSQL_TMP_DIR/mysql_in;
+CREATE TABLE t (c INT) ENGINE=InnoDB;
+REPAIR TABLE t;
+DROP TABLE t;
+exit
+EOF
+let TERM=dumb;
+replace_regex /id is \d+/id is X/ /Server version: .*/Server version: Y/ / \(\d+\.\d+ sec\)// /Stage: \d+ of \d+ '.*?'\s+[0-9.]+% of stage done/Stage: X of Y 'Z' P% of stage done/ / +\r//;
+error 0,127;
+exec socat -t30 EXEC:"$MYSQL test",pty STDIO < $MYSQL_TMP_DIR/mysql_in;
+if ($sys_errno == 127)
+{
+  remove_file $MYSQL_TMP_DIR/mysql_in;
+  skip no socat;
+}
+remove_file $MYSQL_TMP_DIR/mysql_in;
+
+--echo #
+--echo # repair table output in unbuffered (--quick) mode
+--echo #
+write_file $MYSQL_TMP_DIR/mysql_in;
+CREATE TABLE t (c INT) ENGINE=InnoDB;
+INSERT INTO t SELECT * FROM seq_1_to_10;
+REPAIR TABLE t;
+DROP TABLE t;
+exit
+EOF
+let TERM=dumb;
+replace_regex /id is \d+/id is X/ /Server version: .*/Server version: Y/ / \(\d+\.\d+ sec\)// /Stage: \d+ of \d+ '.*?'\s+[0-9.]+% of stage done/Stage: X of Y 'Z' P% of stage done/ / +\r//;
+error 0,127;
+exec socat -t30 EXEC:"$MYSQL test -q --quick-max-column-width 6",pty STDIO < $MYSQL_TMP_DIR/mysql_in;
+if ($sys_errno == 127)
+{
+  remove_file $MYSQL_TMP_DIR/mysql_in;
+  skip no socat;
+}
+remove_file $MYSQL_TMP_DIR/mysql_in;
+
+--echo # End of 11.8 tests


### PR DESCRIPTION
The client shows "stage done" immediately after sending the query, before results were fetched. Move report_progress_end() into the result processing path so the message appears only after the stage actually completes.

Meant to fix https://jira.mariadb.org/browse/MDEV-38922