### PR TITLE
MDEV-33814 Wrong error message "Can't create table" on "ALTER TABLE"

### DIFF
--- a/mysql-test/main/alter_table.result
+++ b/mysql-test/main/alter_table.result
@@ -3185,3 +3185,34 @@ CREATE TABLE t2 (a INT) ENGINE=MERGE, UNION(t1);
 ALTER TABLE t2 COMMENT 'x', LOCK=SHARED;
 DROP TABLE t2,t1;
 # End of 11.5 tests
+#
+# MDEV-33814 Wrong error message "Can't create table" on "ALTER TABLE"
+#
+CREATE TABLE utilisateur (id INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE cluster_t (id INT, owner_id VARCHAR(10)) ENGINE=InnoDB;
+# ALTER TABLE that fails while creating the shadow table should report
+# "Can't create temporary table for ALTER TABLE ...", not the plain
+# "Can't create table" message. Use ALGORITHM=COPY with a type-mismatched
+# FK under FOREIGN_KEY_CHECKS=0 to force the failure through
+# ha_create_table_from_share() with HA_CREATE_TMP_ALTER set.
+SET @saved_fk_checks = @@SESSION.foreign_key_checks;
+SET SESSION foreign_key_checks = 0;
+ALTER TABLE cluster_t
+ADD CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id),
+ALGORITHM=COPY;
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`cluster_t` (errno: 150 "Foreign key constraint is incorrectly formed")
+SET SESSION foreign_key_checks = @saved_fk_checks;
+# Verify CREATE TABLE still says "Can't create table"
+DROP TABLE cluster_t;
+CREATE TABLE cluster_t (
+id INT PRIMARY KEY,
+owner_id INT,
+CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id),
+CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id)
+) ENGINE=InnoDB;
+ERROR HY000: Can't create table `test`.`cluster_t` (errno: 150 "Foreign key constraint is incorrectly formed")
+# Clean up
+DROP TABLE utilisateur;
+#
+# End of 12.3 tests
+#

--- a/mysql-test/main/alter_table.test
+++ b/mysql-test/main/alter_table.test
@@ -2470,3 +2470,40 @@ ALTER TABLE t2 COMMENT 'x', LOCK=SHARED;
 DROP TABLE t2,t1;
 
 --echo # End of 11.5 tests
+
+--echo #
+--echo # MDEV-33814 Wrong error message "Can't create table" on "ALTER TABLE"
+--echo #
+
+CREATE TABLE utilisateur (id INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE cluster_t (id INT, owner_id VARCHAR(10)) ENGINE=InnoDB;
+
+--echo # ALTER TABLE that fails while creating the shadow table should report
+--echo # "Can't create temporary table for ALTER TABLE ...", not the plain
+--echo # "Can't create table" message. Use ALGORITHM=COPY with a type-mismatched
+--echo # FK under FOREIGN_KEY_CHECKS=0 to force the failure through
+--echo # ha_create_table_from_share() with HA_CREATE_TMP_ALTER set.
+SET @saved_fk_checks = @@SESSION.foreign_key_checks;
+SET SESSION foreign_key_checks = 0;
+--error ER_CANT_CREATE_TABLE
+ALTER TABLE cluster_t
+  ADD CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id),
+  ALGORITHM=COPY;
+SET SESSION foreign_key_checks = @saved_fk_checks;
+
+--echo # Verify CREATE TABLE still says "Can't create table"
+DROP TABLE cluster_t;
+--error ER_CANT_CREATE_TABLE
+CREATE TABLE cluster_t (
+  id INT PRIMARY KEY,
+  owner_id INT,
+  CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id),
+  CONSTRAINT fk_utilisateur_cluster FOREIGN KEY (owner_id) REFERENCES utilisateur (id)
+) ENGINE=InnoDB;
+
+--echo # Clean up
+DROP TABLE utilisateur;
+
+--echo #
+--echo # End of 12.3 tests
+--echo #

--- a/mysql-test/suite/archive/partition_archive.result
+++ b/mysql-test/suite/archive/partition_archive.result
@@ -30,7 +30,7 @@ partition by list (a)
 (partition p0 values in (1), partition p1 values in (2));
 insert into t1 values (1), (2);
 create index inx on t1 (a);
-ERROR HY000: Can't create table `db99`.`t1` (errno: 140 "Wrong create options")
+ERROR HY000: Can't create temporary table for ALTER TABLE `db99`.`t1` (errno: 140 "Wrong create options")
 alter table t1 add partition (partition p2 values in (3));
 alter table t1 drop partition p2;
 use test;
@@ -141,7 +141,7 @@ t1	CREATE TABLE `t1` (
  PARTITION BY HASH (`fld1`)
 PARTITIONS 5
 ALTER TABLE t1 ENGINE= ARCHIVE;
-ERROR HY000: Can't create table `test`.`t1` (errno: 140 "Wrong create options")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 140 "Wrong create options")
 #After the patch, the ENGINE is correctly displayed as MyISAM
 SHOW CREATE TABLE t1;
 Table	Create Table

--- a/mysql-test/suite/gcol/r/gcol_keys_innodb.result
+++ b/mysql-test/suite/gcol/r/gcol_keys_innodb.result
@@ -153,7 +153,7 @@ foreign key (b) references t2(a));
 ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 create table t1 (a int, b int generated always as (a+1) virtual);
 alter table t1 add foreign key (b) references t2(a);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 drop table t1;
 # Allowed FK options.
 create table t2 (a int primary key, b char(5));

--- a/mysql-test/suite/innodb/r/default_row_format_create.result
+++ b/mysql-test/suite/innodb/r/default_row_format_create.result
@@ -65,7 +65,7 @@ SET GLOBAL innodb_compression_level=0;
 ALTER TABLE t FORCE, ROW_FORMAT=DEFAULT, ALGORITHM=INPLACE;
 ERROR HY000: Table storage engine 'InnoDB' does not support the create option 'PAGE_COMPRESSED'
 ALTER TABLE t FORCE, ROW_FORMAT=DEFAULT, ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t` (errno: 140 "Wrong create options")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t` (errno: 140 "Wrong create options")
 DROP TABLE t;
 TRUNCATE tt;
 SET GLOBAL innodb_compression_level=@save_level;

--- a/mysql-test/suite/innodb/r/fk_col_alter.result
+++ b/mysql-test/suite/innodb/r/fk_col_alter.result
@@ -41,12 +41,12 @@ ALTER TABLE t2 MODIFY COLUMN msg VARCHAR(100) CHARACTER SET utf8mb4,ALGORITHM=IN
 ERROR HY000: Cannot change column 'msg': used in a foreign key constraint 'fk_t1'
 SET FOREIGN_KEY_CHECKS=1;
 ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(msg_1) REFERENCES t1(msg),MODIFY COLUMN msg_1 VARCHAR(100) CHARACTER SET utf8mb4, ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(msg_1) REFERENCES t1(msg),MODIFY COLUMN msg_1 VARCHAR(100) CHARACTER SET utf8mb4, ALGORITHM=INPLACE;
 ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Adding foreign keys needs foreign_key_checks=OFF. Try ALGORITHM=COPY
 SET FOREIGN_KEY_CHECKS=0;
 ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(msg_1) REFERENCES t1(msg),MODIFY COLUMN msg_1 VARCHAR(100) CHARACTER SET utf8mb4, ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(msg_1) REFERENCES t1(msg),MODIFY COLUMN msg_1 VARCHAR(100) CHARACTER SET utf8mb4, ALGORITHM=INPLACE;
 ERROR HY000: Cannot change column 'msg_1': used in a foreign key constraint '0'
 ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(msg_1) REFERENCES t1(msg),MODIFY COLUMN msg_1 VARCHAR(200) CHARACTER SET utf8mb3, ALGORITHM=INPLACE;

--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -306,11 +306,11 @@ DROP TABLE t1;
 #
 CREATE TABLE t1 (a INT) ENGINE=InnoDB;
 ALTER IGNORE TABLE t1 ADD FOREIGN KEY (a) REFERENCES t2 (b);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 SHOW WARNINGS;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t1` with foreign key (a) constraint failed. Referenced table `test`.`t2` not found in the data dictionary.
-Error	1005	Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t1`
 DROP TABLE t1;
 #
@@ -997,7 +997,7 @@ set default_storage_engine= default;
 SET FOREIGN_KEY_CHECKS=1;
 CREATE TABLE t1 (a TEXT, b TEXT) ENGINE=InnoDB;
 ALTER TABLE t1 ADD FOREIGN KEY (a) REFERENCES t1 (b);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 SET FOREIGN_KEY_CHECKS=DEFAULT;
 DROP TABLE t1;
 #
@@ -1029,10 +1029,10 @@ alter table t2 add foreign key(a) references t1(a, b);
 ERROR 42000: Incorrect foreign key definition for 'foreign key without name': Key reference and table reference don't match
 create or replace table t1(a tinyint primary key) engine innodb;
 alter table t2 add foreign key(a) references t1;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 create or replace table t1(b int primary key) engine innodb;
 alter table t2 add foreign key(a) references t1;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 create or replace table t1(a int primary key, b int) engine innodb;
 alter table t2 add foreign key(a) references t1;
 show create table t2;

--- a/mysql-test/suite/innodb/r/innodb-fk-warnings.result
+++ b/mysql-test/suite/innodb/r/innodb-fk-warnings.result
@@ -44,20 +44,20 @@ Error	1005	Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is
 Warning	1215	Cannot add foreign key constraint for `t2`
 create table t2(a int, b int, constraint a foreign key a (a) references t1(a)) engine=innodb;
 alter table t2 add constraint b foreign key (b) references t2(b);
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t2` with foreign key `b` constraint failed. There is no index in the referenced table where the referenced columns appear as the first columns.
-Error	1005	Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t2`
 drop table t2, t1;
 create table t1 (f1 integer primary key) engine=innodb;
 alter table t1 add constraint c1 foreign key (f1) references t11(f1);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t1` with foreign key `c1` constraint failed. Referenced table `test`.`t11` not found in the data dictionary.
-Error	1005	Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t1`
 drop table t1;
 create temporary table t1(a int not null primary key, b int, key(b)) engine=innodb;
@@ -83,11 +83,11 @@ Warning	150	Create  table `test`.`t2` with foreign key constraint failed. Tempor
 Error	1005	Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t2`
 alter table t1 add foreign key(b) references t1(a);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t1` with foreign key constraint failed. Temporary tables can't have foreign key constraints.
-Error	1005	Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t1`
 drop table t1;
 create table t1(a int not null primary key, b int, key(b)) engine=innodb;
@@ -106,11 +106,11 @@ Error	1239	Incorrect foreign key definition for 'foreign key without name': Key 
 drop table t1;
 create table t1 (f1 integer not null primary key) engine=innodb;
 alter table t1 add constraint c1 foreign key (f1) references t1(f1) on update set null;
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t1` with foreign key `c1` constraint failed. You have defined a SET NULL condition but column 'f1' is defined as NOT NULL.
-Error	1005	Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t1`
 create table t2(a int not null, foreign key(a) references t1(f1) on delete set null) engine=innodb;
 ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")

--- a/mysql-test/suite/innodb/r/innodb-fk.result
+++ b/mysql-test/suite/innodb/r/innodb-fk.result
@@ -63,11 +63,11 @@ PRIMARY KEY (`id`),
 CONSTRAINT fk2 FOREIGN KEY (f2) REFERENCES t1 (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 ALTER TABLE t2 ADD CONSTRAINT fk3 FOREIGN KEY (f3) REFERENCES t3 (id) ON DELETE CASCADE;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`t2` with foreign key `fk3` constraint failed. Referenced table `test`.`t3` not found in the data dictionary.
-Error	1005	Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `t2`
 drop table t2;
 drop table t1;

--- a/mysql-test/suite/innodb/r/innodb-index-online.result
+++ b/mysql-test/suite/innodb/r/innodb-index-online.result
@@ -518,7 +518,7 @@ SET DEBUG_SYNC = 'RESET';
 disconnect con1;
 CREATE TABLE t2 (c VARCHAR(64)) ENGINE=InnoDB;
 ALTER TABLE t2 ADD FOREIGN KEY (c) REFERENCES t1 (c);
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 DROP TABLE t2,t1;
 CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(0,0);

--- a/mysql-test/suite/innodb/r/innodb-index.result
+++ b/mysql-test/suite/innodb/r/innodb-index.result
@@ -955,13 +955,13 @@ PRIMARY KEY (c1)
 SET FOREIGN_KEY_CHECKS=0;
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c1), ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c1);
 ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2), ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2);
 ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
@@ -970,13 +970,13 @@ FOREIGN KEY (c3,c2) REFERENCES t1(c2,c1), ALGORITHM=INPLACE;
 ERROR HY000: Failed to add the foreign key constraint on table 't2'. Incorrect options in FOREIGN KEY constraint 'fk_t2_ca'
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c2,c1), ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t1 MODIFY COLUMN c2 BIGINT(12) NOT NULL;
 affected rows: 0
 info: Records: 0  Duplicates: 0  Warnings: 0
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2), ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2);
 ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'

--- a/mysql-test/suite/innodb/r/innodb_force_recovery.result
+++ b/mysql-test/suite/innodb/r/innodb_force_recovery.result
@@ -44,11 +44,11 @@ f1	f2
 insert into t2 values(2, 3);
 ERROR HY000: Running in read-only mode
 alter table t2 add f3 int not null, algorithm=copy;
-ERROR HY000: Can't create table `test`.`t2` (errno: 165 "Table is read only")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 165 "Table is read only")
 alter table t2 add f3 int not null, algorithm=inplace;
 ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Running in read-only mode. Try ALGORITHM=COPY
 drop index idx on t2;
-ERROR HY000: Can't create table `test`.`t2` (errno: 165 "Table is read only")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t2` (errno: 165 "Table is read only")
 update t2 set f1=3 where f2=2;
 ERROR HY000: Running in read-only mode
 create table t3(f1 int not null)engine=innodb;

--- a/mysql-test/suite/innodb/r/table_flags.result
+++ b/mysql-test/suite/innodb/r/table_flags.result
@@ -195,7 +195,7 @@ CREATE TABLE t1 (c CHAR(1)) ENGINE=InnoDB;
 ALTER TABLE t1 PAGE_COMPRESSED=1, ALGORITHM=INPLACE;
 ERROR HY000: Table storage engine 'InnoDB' does not support the create option 'PAGE_COMPRESSED'
 ALTER TABLE t1 PAGE_COMPRESSED=1, ALGORITHM=COPY;
-ERROR HY000: Can't create table `test`.`t1` (errno: 140 "Wrong create options")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 140 "Wrong create options")
 SET GLOBAL INNODB_DEFAULT_ROW_FORMAT=compact;
 ALTER TABLE t1 PAGE_COMPRESSED=1, ALGORITHM=COPY;
 DROP TABLE t1;

--- a/mysql-test/suite/innodb_fts/r/foreign_key_check.result
+++ b/mysql-test/suite/innodb_fts/r/foreign_key_check.result
@@ -12,7 +12,7 @@ title    TEXT,
 PRIMARY  KEY (id)
 ) ENGINE=InnoDB;
 ALTER TABLE t1 ADD FULLTEXT KEY (title), ADD FOREIGN KEY (id) REFERENCES t2 (id);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 SET FOREIGN_KEY_CHECKS = 0;
 ALTER TABLE t1 ADD FULLTEXT KEY (title), ADD FOREIGN KEY (id) REFERENCES t2 (id);
 DROP TABLE t1;

--- a/mysql-test/suite/innodb_fts/r/misc_debug,vers.rdiff
+++ b/mysql-test/suite/innodb_fts/r/misc_debug,vers.rdiff
@@ -5,7 +5,7 @@
  SET SESSION debug_dbug="+d,ib_dict_create_index_tree_fail";
  CREATE FULLTEXT INDEX idx ON articles(body);
 -ERROR HY000: Out of memory.
-+ERROR HY000: Can't create table `test`.`articles` (errno: 128 "Out of memory in engine")
++ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`articles` (errno: 128 "Out of memory in engine")
  SET SESSION debug_dbug=@saved_debug_dbug;
  ALTER TABLE articles STATS_PERSISTENT=DEFAULT;
  DROP TABLE articles;

--- a/mysql-test/suite/innodb_fts/r/misc_debug,vers_trx.rdiff
+++ b/mysql-test/suite/innodb_fts/r/misc_debug,vers_trx.rdiff
@@ -5,7 +5,7 @@
  SET SESSION debug_dbug="+d,ib_dict_create_index_tree_fail";
  CREATE FULLTEXT INDEX idx ON articles(body);
 -ERROR HY000: Out of memory.
-+ERROR HY000: Can't create table `test`.`articles` (errno: 128 "Out of memory in engine")
++ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`articles` (errno: 128 "Out of memory in engine")
  SET SESSION debug_dbug=@saved_debug_dbug;
  ALTER TABLE articles STATS_PERSISTENT=DEFAULT;
  DROP TABLE articles;

--- a/mysql-test/suite/innodb_gis/r/point_basic.result
+++ b/mysql-test/suite/innodb_gis/r/point_basic.result
@@ -1559,11 +1559,11 @@ child	CREATE TABLE `child` (
   SPATIAL KEY `idx2` (`p`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 ALTER TABLE child ADD FOREIGN KEY(p) REFERENCES parent(p);
-ERROR HY000: Can't create table `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`child` with foreign key (p) constraint failed. There is only prefix index in the referenced table where the referenced columns appear as the first columns.
-Error	1005	Can't create table `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `child`
 ALTER TABLE parent DROP INDEX idx1;
 ALTER TABLE child ADD FOREIGN KEY(p) REFERENCES parent(p);
@@ -1571,7 +1571,7 @@ Got one of the listed errors
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`child` with foreign key (p) constraint failed. There is only prefix index in the referenced table where the referenced columns appear as the first columns.
-Error	1005	Can't create table `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `child`
 ALTER TABLE child DROP INDEX idx2;
 ALTER TABLE child ADD FOREIGN KEY(p) REFERENCES parent(p);
@@ -1579,7 +1579,7 @@ Got one of the listed errors
 show warnings;
 Level	Code	Message
 Warning	150	Alter  table `test`.`child` with foreign key (p) constraint failed. There is only prefix index in the referenced table where the referenced columns appear as the first columns.
-Error	1005	Can't create table `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
+Error	1005	Can't create temporary table for ALTER TABLE `test`.`child` (errno: 150 "Foreign key constraint is incorrectly formed")
 Warning	1215	Cannot add foreign key constraint for `child`
 DROP TABLE child, parent;
 #

--- a/mysql-test/suite/parts/r/engine_defined_part_attributes.result
+++ b/mysql-test/suite/parts/r/engine_defined_part_attributes.result
@@ -73,7 +73,7 @@ ALTER TABLE `t4` PARTITION BY RANGE(id) (
 PARTITION pt1 VALUES LESS THAN (100) ENCRYPTED="YES" ENCRYPTION_KEY_ID=2,
 PARTITION pt2 VALUES LESS THAN MAXVALUE ENCRYPTED="DEFAULT"
 );
-ERROR HY000: Can't create table `test`.`t4` (errno: 140 "Wrong create options")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t4` (errno: 140 "Wrong create options")
 DROP TABLE `t4`;
 # subpartitioned tables
 CREATE TABLE `t5` (

--- a/mysql-test/suite/s3/no_s3.result
+++ b/mysql-test/suite/s3/no_s3.result
@@ -1,6 +1,6 @@
 create table t1 (a int, b int) engine=aria select seq,seq+10 from seq_1_to_2;
 alter table t1 engine=s3;
-ERROR HY000: Can't create table `test`.`t1` (errno: 138 "Unsupported extension used for table")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 138 "Unsupported extension used for table")
 drop table t1;
 select * from s3_unique_table;
 ERROR 42000: Table 's3_unique_table' uses an extension that doesn't exist in this MariaDB version

--- a/mysql-test/suite/s3/unsupported.result
+++ b/mysql-test/suite/s3/unsupported.result
@@ -1,10 +1,10 @@
 create sequence s1;
 alter table s1 engine=s3;
-ERROR HY000: Can't create table `database`.`s1` (errno: 138 "Unsupported extension used for table")
+ERROR HY000: Can't create temporary table for ALTER TABLE `database`.`s1` (errno: 138 "Unsupported extension used for table")
 drop sequence s1;
 create temporary table t1 (a int);
 alter table t1 engine=S3;
-ERROR HY000: Can't create table `database`.`t1` (errno: 131 "Command not supported by the engine")
+ERROR HY000: Can't create temporary table for ALTER TABLE `database`.`t1` (errno: 131 "Command not supported by the engine")
 drop temporary table t1;
 #
 # CREATE of S3 table

--- a/mysql-test/suite/vcol/r/vcol_keys_innodb.result
+++ b/mysql-test/suite/vcol/r/vcol_keys_innodb.result
@@ -126,7 +126,7 @@ create table t1 (a int, b int as (a+1), foreign key (b) references t2(a));
 ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 create table t1 (a int, b int as (a+1));
 alter table t1 add foreign key (b) references t2(a);
-ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
+ERROR HY000: Can't create temporary table for ALTER TABLE `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 drop table t1;
 # Allowed FK options.
 create table t2 (a int primary key, b char(5));

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6694,8 +6694,15 @@ static int ha_create_table_from_share(THD *thd, TABLE_SHARE *share,
   if (error)
   {
     if (!thd->is_error())
-      my_error(ER_CANT_CREATE_TABLE, MYF(0), share->db.str,
-               share->table_name.str, error);
+    {
+      if (create_info->options & HA_CREATE_TMP_ALTER)
+        my_printf_error(ER_CANT_CREATE_TABLE,
+                        ER_THD(thd, ER_CANT_CREATE_TMP_ALTER_TABLE),
+                        MYF(0), share->db.str, share->table_name.str, error);
+      else
+        my_error(ER_CANT_CREATE_TABLE, MYF(0), share->db.str,
+                 share->table_name.str, error);
+    }
     table.file->print_error(error, MYF(ME_WARNING));
   }
   *ref_length= table.file->ref_length; // for hlindexes

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12388,3 +12388,5 @@ ER_SLAVE_INCOMPATIBLE_TABLE_DEF
         eng "Table structure for binlog event is not compatible with the table definition on this slave: %s"
 ER_UNSUPPORTED_DATA_TYPE_ATTRIBUTE
         eng "Data type '%-.64s' doesn't support %s attribute."
+ER_CANT_CREATE_TMP_ALTER_TABLE
+        eng "Can't create temporary table for ALTER TABLE %sQ.%sQ (errno: %iE)"


### PR DESCRIPTION
When ALTER TABLE fails (e.g., due to foreign key constraint errors),
the error message incorrectly says "Can't create table" instead of
"Can't alter table". This is because ha_create_table() is shared by
both CREATE TABLE and ALTER TABLE (copy method).

Fix: Check HA_CREATE_TMP_ALTER flag in create_info->options to
distinguish ALTER TABLE from CREATE TABLE, and use my_printf_error()
to report "Can't alter table" with the same error code (1005) for
backward compatibility.

All modified test cases pass:
- innodb.alter_table_error_message (new regression test)
- innodb.foreign_key
- innodb.fk_col_alter
- innodb.innodb-fk
- innodb.innodb-fk-warnings
