### PR TITLE
MDEV-17677: Fix keyword parsing that treated as identifier when immediately followed by dot

### DIFF
--- a/mysql-test/main/parser.result
+++ b/mysql-test/main/parser.result
@@ -2269,3 +2269,44 @@ $$
 #
 # End of 10.6 tests
 #
+#
+# MDEV-17677 : Keywords are parsed as identifiers when followed by a dot
+#
+SET NAMES utf8;
+test for Nd (should work)
+SELECT.1;
+.1
+0.1
+SELECT.123+0;
+.123+0
+0.123
+SELECT.5 * 2;
+.5 * 2
+1.0
+test for Mn
+SELECT.́1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.́1' at line 1
+SELECT.̈abc;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.̈abc' at line 1
+test for Mc
+SELECT.ःtest;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.ःtest' at line 1
+test for Pc
+SELECT.‿a;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.‿a' at line 1
+test for Cf
+SELECT.‎abc;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.‎abc' at line 1
+test for Middle-dot and underscore
+SELECT.·123;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELECT.·123' at line 1
+ٍSELECT._1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'ٍSELECT._1' at line 1
+still work as identifier
+CREATE TABLE `SELECT` (a INT);
+INSERT INTO `SELECT` VALUES (5);
+SELECT `SELECT`.a FROM `SELECT`;
+a
+5
+DROP TABLE `SELECT`;
+SET NAMES DEFAULT;

--- a/mysql-test/main/parser.test
+++ b/mysql-test/main/parser.test
@@ -2067,3 +2067,49 @@ DELIMITER ;$$
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-17677 : Keywords are parsed as identifiers when followed by a dot
+--echo #
+
+SET NAMES utf8;
+
+--echo  test for Nd (should work)
+SELECT.1;
+SELECT.123+0;
+SELECT.5 * 2;
+
+--character_set utf8mb4
+--echo  test for Mn
+--error ER_PARSE_ERROR
+SELECT.́1;
+
+--error ER_PARSE_ERROR
+SELECT.̈abc;
+
+
+-- echo  test for Mc
+--error ER_PARSE_ERROR
+SELECT.ःtest;
+
+--echo  test for Pc
+--error ER_PARSE_ERROR
+SELECT.‿a;
+
+--echo  test for Cf
+--error ER_PARSE_ERROR
+SELECT.‎abc;
+
+--echo  test for Middle-dot and underscore
+--error ER_PARSE_ERROR
+SELECT.·123;
+--error ER_PARSE_ERROR
+ٍSELECT._1;
+
+--echo  still work as identifier
+CREATE TABLE `SELECT` (a INT);
+INSERT INTO `SELECT` VALUES (5);
+SELECT `SELECT`.a FROM `SELECT`;
+DROP TABLE `SELECT`;
+
+SET NAMES DEFAULT;

--- a/mysql-test/suite/funcs_1/r/innodb_trig_0407.result
+++ b/mysql-test/suite/funcs_1/r/innodb_trig_0407.result
@@ -138,7 +138,7 @@ create table t1_433a (f1a char (5)) engine = <engine_to_be_used>;
 CREATE TRIGGER trg3 BEFORE INSERT on t1_433 for each row
 set new.f1 = 'Trigger 3.5.4.3';
 Drop trigger t1.433.trg3;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.trg3' at line 1
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger db_drop3.t1.433.trg3;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger mysql.trg3;

--- a/mysql-test/suite/funcs_1/r/memory_trig_0407.result
+++ b/mysql-test/suite/funcs_1/r/memory_trig_0407.result
@@ -138,7 +138,7 @@ create table t1_433a (f1a char (5)) engine = <engine_to_be_used>;
 CREATE TRIGGER trg3 BEFORE INSERT on t1_433 for each row
 set new.f1 = 'Trigger 3.5.4.3';
 Drop trigger t1.433.trg3;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.trg3' at line 1
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger db_drop3.t1.433.trg3;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger mysql.trg3;

--- a/mysql-test/suite/funcs_1/r/myisam_trig_0407.result
+++ b/mysql-test/suite/funcs_1/r/myisam_trig_0407.result
@@ -138,7 +138,7 @@ create table t1_433a (f1a char (5)) engine = <engine_to_be_used>;
 CREATE TRIGGER trg3 BEFORE INSERT on t1_433 for each row
 set new.f1 = 'Trigger 3.5.4.3';
 Drop trigger t1.433.trg3;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.trg3' at line 1
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger db_drop3.t1.433.trg3;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.433.trg3' at line 1
 Drop trigger mysql.trg3;

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -2853,7 +2853,7 @@ int Lex_input_stream::scan_ident_middle(THD *thd, Lex_ident_cli_st *str,
         yylineno++;
     }
   }
-  if (start == get_ptr() && c == '.' && ident_map[(uchar) yyPeek()])
+  if (start == get_ptr() && c == '.' && ident_map[(uchar) yyPeek()] && !my_isdigit(cs, yyPeek()))
     next_state= MY_LEX_IDENT_SEP;
   else
   {                                    // '(' must follow directly if function


### PR DESCRIPTION
**problem :** 
Keywords immediately followed by a dot ('.') were incorrectly parsed as identifiers instead of keywords. This caused syntax errors for  "SELECT.1" which should be parsed as keyword SELECT followed by decimal .1 
<img width="1138" height="65" alt="image" src="https://github.com/user-attachments/assets/56515c56-dd4b-43a4-bb16-f2030be2cf64" />

**How we fix it :**  
we check if a token is a keyword  before skipping keyword lookup for qualified identifiers. This
allows keywords to still treated as keywords when followed by dot.
Now it works 
<img width="849" height="149" alt="image" src="https://github.com/user-attachments/assets/c2a8bccb-bf63-4320-8832-c90a754a367b" /> 


**Test:** 
Add some cases in Parser test

bug : 
[MDEV-17677](https://jira.mariadb.org/browse/MDEV-17677)