### PR TITLE
MDEV-38349 Fix assert thd->abort_on_warning == 0 in mysql_insert

### DIFF
--- a/mysql-test/main/vector_innodb.result
+++ b/mysql-test/main/vector_innodb.result
@@ -375,4 +375,16 @@ Warning	4078	Cannot cast 'int' as 'vector' in assignment of `test`.`t1`.`v`
 Warning	1292	Incorrect vector value: '1' for column `test`.`t1`.`v` at row 1
 drop table t1;
 set sql_mode=default;
+#
+# MDEV-38349 Fix assert thd->abort_on_warning == 0 in mysql_insert
+#
+CREATE TABLE t1 (id INT KEY,v VECTOR (8) NOT NULL,VECTOR INDEX (v)) ENGINE=INNODB;
+CREATE TABLE t2 (id INT KEY,t_id INT,INDEX par_ind (t_id),FOREIGN KEY(t_id) REFERENCES t1 (id) ON DELETE CASCADE) ENGINE=INNODB;
+DROP TABLE t1;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
+INSERT INTO t1 VALUES (0,'');
+ERROR 42S02: Table 'test.t1' doesn't exist in engine
+DROP TABLE t2,t1;
+Warnings:
+Warning	1932	Table 'test.t1' doesn't exist in engine
 # End of 11.8 tests

--- a/mysql-test/main/vector_innodb.test
+++ b/mysql-test/main/vector_innodb.test
@@ -369,4 +369,17 @@ insert t1 values (1);
 drop table t1;
 set sql_mode=default;
 
+--echo #
+--echo # MDEV-38349 Fix assert thd->abort_on_warning == 0 in mysql_insert
+--echo #
+CREATE TABLE t1 (id INT KEY,v VECTOR (8) NOT NULL,VECTOR INDEX (v)) ENGINE=INNODB;
+CREATE TABLE t2 (id INT KEY,t_id INT,INDEX par_ind (t_id),FOREIGN KEY(t_id) REFERENCES t1 (id) ON DELETE CASCADE) ENGINE=INNODB;
+--ERROR ER_ROW_IS_REFERENCED_2
+DROP TABLE t1;
+--ERROR ER_NO_SUCH_TABLE_IN_ENGINE
+INSERT INTO t1 VALUES (0,'');
+ 
+# cleanup
+DROP TABLE t2,t1;
+
 --echo # End of 11.8 tests

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -988,7 +988,8 @@ bool mysql_insert(THD *thd, TABLE_LIST *table_list,
 #endif /* EMBEDDED_LIBRARY */
   {
     if (prepare_for_replace(table, info.handle_duplicates, info.ignore))
-      DBUG_RETURN(1);
+      goto abort;
+    
     /**
       This is a simple check for the case when the table has a trigger
       that reads from it, or when the statement invokes a stored function


### PR DESCRIPTION
When prepare_for_replace() fails, the code returned early via DBUG_RETURN(1), bypassing the abort label which resets thd->abort_on_warning to 0. This left the THD in a dirty state, triggering the dispatch_command assertion at end of command dispatch.

Meant to fix https://jira.mariadb.org/browse/MDEV-38349