### PR TITLE
MDEV-31527: Add --validate-config option to check configuration without starting the server

### DIFF
--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -1731,6 +1731,9 @@ The following specify which files/extra groups are read (specified before remain
  --userstat          Enables statistics gathering for USER_STATISTICS,
  CLIENT_STATISTICS, INDEX_STATISTICS and TABLE_STATISTICS
  tables in the INFORMATION_SCHEMA
+ --validate-config   Validate the server configuration specified by the user
+ and exit with an exit code of 0 for success or non-zero
+ for failure, without starting the server
  -v, --verbose       Used with --help option for detailed help
  -V, --version[=name] 
  Output version information and exit
@@ -2172,6 +2175,7 @@ transaction-read-only FALSE
 updatable-views-with-limit YES
 use-stat-tables PREFERABLY_FOR_QUERIES
 userstat FALSE
+validate-config FALSE
 verbose TRUE
 wait-timeout 28800
 

--- a/mysql-test/main/validate_config.result
+++ b/mysql-test/main/validate_config.result
@@ -1,0 +1,69 @@
+#
+# MDEV-31527: Add --validate-config option to check configuration
+#             without starting the server
+#
+#
+# Test 1: --validate-config with valid configuration should succeed (exit 0)
+#
+FOUND 1 /Configuration is valid/ in mdev-31527-test1.log
+#
+# Test 2: --validate-config with unknown option should fail (exit 2)
+#
+FOUND 1 /unknown option '--nonexistentoption'/ in mdev-31527-test2.log
+#
+# Test 3: --validate-config should not start the server (no pid file)
+#
+#
+# Test 4: --validate-config should not produce help output
+#
+NOT FOUND /Starts the MariaDB database server/ in mdev-31527-test4.log
+#
+# Test 5: --validate-config with bad option in config file should fail
+#
+FOUND 1 /unknown variable 'zzz_bogus_option=123'/ in mdev-31527-test5.log
+#
+# Test 6: --validate-config with valid config file should succeed
+#
+FOUND 1 /Configuration is valid/ in mdev-31527-test6.log
+#
+# Test 7: --validate-config with --help (help takes precedence,
+#         'Configuration is valid' should NOT be printed)
+#
+FOUND 1 /Starts the MariaDB database server/ in mdev-31527-test7.log
+NOT FOUND /Configuration is valid/ in mdev-31527-test7.log
+#
+# Test 8: --validate-config with --verbose should still succeed (exit 0)
+#
+FOUND 1 /Configuration is valid/ in mdev-31527-test8.log
+#
+# Test 9: --validate-config with --bootstrap should succeed (exit 0)
+#
+FOUND 1 /Configuration is valid/ in mdev-31527-test9.log
+#
+# Test 10: --validate-config with --version (version takes precedence,
+#          'Configuration is valid' should NOT be printed)
+#
+FOUND 1 /Ver [0-9]/ in mdev-31527-test10.log
+NOT FOUND /Configuration is valid/ in mdev-31527-test10.log
+#
+# Test 11: --help --validate-config --invalid-config should print help
+#          and exit cleanly (help takes precedence)
+#
+FOUND 1 /Starts the MariaDB database server/ in mdev-31527-test11.log
+NOT FOUND /unknown option/ in mdev-31527-test11.log
+#
+# Test 12: --version --validate-config --invalid-config should print version
+#          and exit cleanly (version takes precedence)
+#
+FOUND 1 /Ver [0-9]/ in mdev-31527-test12.log
+NOT FOUND /unknown option/ in mdev-31527-test12.log
+#
+# Test 13: --validate-config --log-bin should not create binlog index file
+#
+FOUND 1 /Configuration is valid/ in mdev-31527-test13.log
+#
+# Test 14: --validate-config with adjusted option value should warn and succeed
+#
+FOUND 1 /option 'table_open_cache': unsigned value 0 adjusted/ in mdev-31527-test14.log
+FOUND 1 /Configuration is valid, but warnings were reported/ in mdev-31527-test14.log
+# End of 13.0 tests

--- a/mysql-test/main/validate_config.test
+++ b/mysql-test/main/validate_config.test
@@ -1,0 +1,183 @@
+#
+# MDEV-31527: Add --validate-config option to check configuration
+#             without starting the server
+#
+
+--source include/not_embedded.inc
+
+# mysqld refuses to run as root normally.
+--source include/not_as_root.inc
+
+--echo #
+--echo # MDEV-31527: Add --validate-config option to check configuration
+--echo #             without starting the server
+--echo #
+
+--echo #
+--echo # Test 1: --validate-config with valid configuration should succeed (exit 0)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test1.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test1.log
+--let SEARCH_PATTERN=Configuration is valid
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test1.log
+
+--echo #
+--echo # Test 2: --validate-config with unknown option should fail (exit 2)
+--echo #
+--error 2
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --nonexistentoption >$MYSQLTEST_VARDIR/tmp/mdev-31527-test2.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test2.log
+--let SEARCH_PATTERN=unknown option '--nonexistentoption'
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test2.log
+
+--echo #
+--echo # Test 3: --validate-config should not start the server (no pid file)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --pid-file=$MYSQLTEST_VARDIR/tmp/mdev-31527-validate.pid >$MYSQLTEST_VARDIR/tmp/mdev-31527-test3.log 2>&1
+--error 1
+--file_exists $MYSQLTEST_VARDIR/tmp/mdev-31527-validate.pid
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test3.log
+
+--echo #
+--echo # Test 4: --validate-config should not produce help output
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test4.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test4.log
+--let SEARCH_PATTERN=Starts the MariaDB database server
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test4.log
+
+--echo #
+--echo # Test 5: --validate-config with bad option in config file should fail
+--echo #
+--write_file $MYSQLTEST_VARDIR/tmp/mdev-31527-bad.cnf
+[mariadb]
+zzz_bogus_option=123
+EOF
+--error 7
+--exec $MYSQLD --defaults-file=$MYSQLTEST_VARDIR/tmp/mdev-31527-bad.cnf --validate-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test5.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test5.log
+--let SEARCH_PATTERN=unknown variable 'zzz_bogus_option=123'
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test5.log
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-bad.cnf
+
+--echo #
+--echo # Test 6: --validate-config with valid config file should succeed
+--echo #
+--write_file $MYSQLTEST_VARDIR/tmp/mdev-31527-good.cnf
+[mariadb]
+max_connections=50
+EOF
+--exec $MYSQLD --defaults-file=$MYSQLTEST_VARDIR/tmp/mdev-31527-good.cnf --validate-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test6.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test6.log
+--let SEARCH_PATTERN=Configuration is valid
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test6.log
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-good.cnf
+
+--echo #
+--echo # Test 7: --validate-config with --help (help takes precedence,
+--echo #         'Configuration is valid' should NOT be printed)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --help >$MYSQLTEST_VARDIR/tmp/mdev-31527-test7.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test7.log
+--let SEARCH_PATTERN=Starts the MariaDB database server
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=Configuration is valid
+--let SEARCH_ABORT=FOUND
+--source include/search_pattern_in_file.inc
+--let SEARCH_ABORT=
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test7.log
+
+--echo #
+--echo # Test 8: --validate-config with --verbose should still succeed (exit 0)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --verbose >$MYSQLTEST_VARDIR/tmp/mdev-31527-test8.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test8.log
+--let SEARCH_PATTERN=Configuration is valid
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test8.log
+
+--echo #
+--echo # Test 9: --validate-config with --bootstrap should succeed (exit 0)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --bootstrap >$MYSQLTEST_VARDIR/tmp/mdev-31527-test9.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test9.log
+--let SEARCH_PATTERN=Configuration is valid
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test9.log
+
+--echo #
+--echo # Test 10: --validate-config with --version (version takes precedence,
+--echo #          'Configuration is valid' should NOT be printed)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --version >$MYSQLTEST_VARDIR/tmp/mdev-31527-test10.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test10.log
+--let SEARCH_PATTERN=Ver [0-9]
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=Configuration is valid
+--let SEARCH_ABORT=FOUND
+--source include/search_pattern_in_file.inc
+--let SEARCH_ABORT=
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test10.log
+
+--echo #
+--echo # Test 11: --help --validate-config --invalid-config should print help
+--echo #          and exit cleanly (help takes precedence)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --help --validate-config --invalid-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test11.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test11.log
+--let SEARCH_PATTERN=Starts the MariaDB database server
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=unknown option
+--let SEARCH_ABORT=FOUND
+--source include/search_pattern_in_file.inc
+--let SEARCH_ABORT=
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test11.log
+
+--echo #
+--echo # Test 12: --version --validate-config --invalid-config should print version
+--echo #          and exit cleanly (version takes precedence)
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --version --validate-config --invalid-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test12.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test12.log
+--let SEARCH_PATTERN=Ver [0-9]
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=unknown option
+--let SEARCH_ABORT=FOUND
+--source include/search_pattern_in_file.inc
+--let SEARCH_ABORT=
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test12.log
+
+--echo #
+--echo # Test 13: --validate-config --log-bin should not create binlog index file
+--echo #
+--exec $MYSQLD_BOOTSTRAP_CMD --validate-config --log-bin=$MYSQLTEST_VARDIR/tmp/mdev-31527-binlog >$MYSQLTEST_VARDIR/tmp/mdev-31527-test13.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test13.log
+--let SEARCH_PATTERN=Configuration is valid
+--source include/search_pattern_in_file.inc
+--error 1
+--file_exists $MYSQLTEST_VARDIR/tmp/mdev-31527-binlog.index
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test13.log
+
+--echo #
+--echo # Test 14: --validate-config with adjusted option value should warn and succeed
+--echo #
+--write_file $MYSQLTEST_VARDIR/tmp/mdev-31527-adjusted.cnf
+[mariadb]
+table_open_cache=0
+EOF
+--exec $MYSQLD --defaults-file=$MYSQLTEST_VARDIR/tmp/mdev-31527-adjusted.cnf --validate-config >$MYSQLTEST_VARDIR/tmp/mdev-31527-test14.log 2>&1
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/mdev-31527-test14.log
+--let SEARCH_PATTERN=option 'table_open_cache': unsigned value 0 adjusted
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=Configuration is valid, but warnings were reported
+--source include/search_pattern_in_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-test14.log
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev-31527-adjusted.cnf
+
+--echo # End of 13.0 tests
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -381,10 +381,15 @@ handlerton *opt_binlog_engine_hton;
 bool opt_bin_log_compress;
 uint opt_bin_log_compress_min_len;
 my_bool opt_log, debug_assert_if_crashed_table= 0, opt_help= 0;
+my_bool opt_validate_config= 0;
+static my_bool validate_config_has_warnings= 0;
 my_bool debug_assert_on_not_freed_memory= 0;
 my_bool disable_log_notes, opt_support_flashback= 0;
 my_bool opt_silent_startup= 0;
 static my_bool opt_abort;
+#ifndef EMBEDDED_LIBRARY
+static my_bool opt_version;
+#endif
 ulonglong log_output_options;
 my_bool opt_userstat_running;
 bool opt_error_log= IF_WIN(1,0);
@@ -4189,7 +4194,7 @@ static int init_common_variables()
   sf_leaking_memory= 0; // no memory leaks from now on
 
 #ifndef EMBEDDED_LIBRARY
-  if (opt_abort && !opt_verbose)
+  if ((opt_help || opt_version) && !opt_verbose)
     unireg_abort(0);
 #endif /*!EMBEDDED_LIBRARY*/
 
@@ -5375,7 +5380,7 @@ static int init_server_components()
   }
 #endif /* WITH_WSREP */
 
-  if (!opt_help && !binlog_engine_used && opt_bin_log)
+  if (!opt_abort && !binlog_engine_used && opt_bin_log)
   {
     if (mysql_bin_log.open_index_file(opt_binlog_index_name, opt_bin_logname,
                                       TRUE))
@@ -5637,7 +5642,17 @@ static int init_server_components()
   }
 
   if (opt_abort)
+  {
+    if (opt_validate_config)
+    {
+      if (validate_config_has_warnings)
+        sql_print_information("Configuration is valid, but warnings were "
+                              "reported; see above.");
+      else
+        sql_print_information("Configuration is valid.");
+    }
     unireg_abort(0);
+  }
 
   if (init_io_cache_encryption())
     unireg_abort(1);
@@ -6849,6 +6864,11 @@ struct my_option my_long_options[]=
   {"help", '?', "Display this help and exit", 
    &opt_help, &opt_help, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
+  {"validate-config", 0, "Validate the server configuration specified by the user "
+   "and exit with an exit code of 0 for success or non-zero for failure, "
+   "without starting the server",
+   &opt_validate_config, &opt_validate_config, 0, GET_BOOL, NO_ARG, 0, 0, 0,
+   0, 0, 0},
   {"ansi", 'a', "Use ANSI SQL syntax instead of MariaDB syntax. This mode "
    "will also set transaction isolation level 'serializable'", 0, 0, 0,
    GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -8588,6 +8608,7 @@ mysqld_get_one_option(const struct my_option *opt, const char *argument,
     {
       print_version();
       opt_abort= 1;                    // Abort after parsing all options
+      opt_version= 1;
     }
 #endif /*EMBEDDED_LIBRARY*/
     break;
@@ -9080,6 +9101,9 @@ static void option_error_reporter(enum loglevel level, const char *format, ...)
   va_list args;
   va_start(args, format);
 
+  if (level == WARNING_LEVEL)
+    validate_config_has_warnings= 1;
+
   /*
     Don't print warnings for --loose options during bootstrap if
     log_warnings <= 2 (2 is default) as warnings during bootstrap
@@ -9133,7 +9157,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr)
                                 mysqld_get_one_option)))
     return ho_error;
 
-  if (!opt_help)
+  if (!opt_help && !opt_validate_config)
     delete_dynamic(&all_options);
   else
     opt_abort= 1;


### PR DESCRIPTION
## MDEV-31527: Add --validate-config option

### Summary
Add a new `--validate-config` command-line option that validates the server
configuration (from config files and command line) and exits with exit code
0 on success or non-zero on failure, without actually starting the server.

### Use case
mariadbd --defaults-file=/etc/my.cnf --validate-config

DBAs can verify configuration changes before restarting production servers.

### Test cases (`mysql-test/main/validate_config.test`):
1. Valid config → exit 0
2. Unknown CLI option → exit non-zero
3. No pid file created (server doesn't start)
4. No help text output
5. Bad option in config file → exit non-zero with error message
6. Valid config file → exit 0 with success message

### Exit codes
| Scenario | Exit code |
|----------|-----------|
| Valid configuration | 0 |
| Unknown option | 2 |
| Unknown variable | 7 |

### How to use

# Validate a config file before restarting
mariadbd --defaults-file=/etc/my.cnf --validate-config

# Validate with additional command-line overrides
mariadbd --defaults-file=/etc/my.cnf --validate-config --max-connections=500

### Matching MySQL 8.0 behavior
This is equivalent to MySQL 8.0's `--validate-config` option, adapted for
MariaDB's parsing architecture.