### PR TITLE
MDEV-28911: Add --init-command option to mariadb-{,admin,dump,binlog,check,import, show,slap,test}

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -242,7 +242,7 @@ static MYSQL mysql;			/* The connection */
 static my_bool ignore_errors=0,wait_flag=0,quick=0,
                connected=0,opt_raw_data=0,unbuffered=0,output_tables=0,
 	       opt_rehash=1,skip_updates=0,safe_updates=0,one_database=0,
-	       opt_compress=0, using_opt_local_infile=0,
+	       using_opt_local_infile=0,
 	       vertical=0, line_numbers=1, column_names=1,opt_html=0,
                opt_xml=0,opt_nopager=1, opt_outfile=0, named_cmds= 0,
 	       tty_password= 0, opt_nobeep=0, opt_reconnect=1,
@@ -258,9 +258,8 @@ static my_bool preserve_comments= 0;
 static my_bool in_com_source, aborted= 0;
 static ulong opt_max_allowed_packet, opt_net_buffer_length;
 unsigned long quick_max_column_width= LONG_MAX;
-static uint verbose=0,opt_silent=0,opt_mysql_port=0, opt_local_infile=0;
+static uint verbose=0,opt_silent=0, opt_local_infile=0;
 static uint my_end_arg;
-static char * opt_mysql_unix_port=0;
 static int connect_flag=CLIENT_INTERACTIVE;
 static my_bool opt_binary_mode= FALSE;
 static my_bool opt_connect_expired_password= FALSE;
@@ -268,10 +267,9 @@ static int interrupted_query= 0;
 #ifdef USE_LIBEDIT_INTERFACE
 static int sigint_received= 0;
 #endif
-static char *current_host,*current_db,*current_user=0,*opt_password=0,
+static char *current_db, *opt_password=0,
             *current_prompt=0, *delimiter_str= 0,
-            *default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME,
-            *opt_init_command= 0;
+            *default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME;
 static char *histfile;
 static char *histfile_tmp;
 static String glob_buffer,old_buffer;
@@ -281,7 +279,6 @@ static int wait_time = 5;
 static STATUS status;
 static ulong select_limit,max_join_size,opt_connect_timeout=0;
 static char mysql_charsets_dir[FN_REFLEN+1];
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
 static char *script_dir = NULL;
 static const char *xmlmeta[] = {
   "&", "&amp;",
@@ -304,9 +301,7 @@ static char delimiter[16]= DEFAULT_DELIMITER;
 static uint delimiter_length= 1;
 unsigned short terminal_width= 80;
 
-static uint opt_protocol=0;
-static const char *opt_protocol_type= "";
-
+#include "common-cli-vars.h"
 #include "sslopt-vars.h"
 
 const char *default_dbug_option="d:t:o,/tmp/mariadb.trace";
@@ -1391,7 +1386,7 @@ int main(int argc,char *argv[])
   completion_hash_init(&ht, 128);
   init_alloc_root(PSI_NOT_INSTRUMENTED, &hash_mem_root, 16384, 0, MYF(0));
 
-  if (sql_connect(current_host,current_db,current_user,opt_password,
+  if (sql_connect(opt_host,current_db,opt_user,opt_password,
 		  opt_silent))
   {
     quick= 1;					// Avoid history
@@ -1542,14 +1537,12 @@ sig_handler mysql_end(int sig)
   glob_buffer.free();
   old_buffer.free();
   processed_prompt.free();
+  free_common_cli_vars();
   my_free(server_version);
   my_free(opt_password);
-  my_free(opt_mysql_unix_port);
   my_free(histfile);
   my_free(histfile_tmp);
   my_free(current_db);
-  my_free(current_host);
-  my_free(current_user);
   my_free(full_username);
   my_free(part_username);
   my_free(default_prompt);
@@ -1611,13 +1604,6 @@ static bool do_connect(MYSQL *mysql, const char *host, const char *user,
   if (opt_secure_auth)
     mysql_options(mysql, MYSQL_SECURE_AUTH, (char *) &opt_secure_auth);
   SET_SSL_OPTS_WITH_CHECK(mysql);
-  if (opt_protocol)
-    mysql_options(mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
 
   mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
@@ -1656,7 +1642,8 @@ bool kill_query(const char *reason)
   MYSQL *kill_mysql= NULL;
 
   kill_mysql= mysql_init(kill_mysql);
-  if (!do_connect(kill_mysql,current_host, current_user, opt_password, "", 0))
+  set_common_cli_vars(kill_mysql);
+  if (!do_connect(kill_mysql,opt_host, opt_user, opt_password, "", 0))
   {
     tee_fprintf(stdout, "%s -- sorry, cannot connect to server to kill query, giving up ...\n", reason);
     return true;
@@ -1797,9 +1784,6 @@ static struct my_option my_long_options[] =
    " The default is --skip-comments (discard comments), enable with --comments.",
    &preserve_comments, &preserve_comments,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"connect-expired-password", 0,
    "Notify the server that this client is prepared to handle expired "
    "password sandbox mode even if --batch was specified.",
@@ -1822,9 +1806,7 @@ static struct my_option my_long_options[] =
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"debug-info", 'T', "Print some debug info at exit.", &debug_info_flag,
    &debug_info_flag, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"default-auth", 0, "Default authentication client-side plugin to use.",
-    &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include "common-cli-longopts.h"
   {"default-character-set", 0,
    "Set the default character set.", &default_charset,
    &default_charset, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -1838,17 +1820,10 @@ static struct my_option my_long_options[] =
   {"force", 'f',
     "Continue even if we get an SQL error. Sets abort-source-on-error to 0",
     &ignore_errors, &ignore_errors, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, $MYSQL_HOST, and then localhost",
-   &current_host, &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"html", 'H', "Produce HTML output.", &opt_html, &opt_html,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-spaces", 'i', "Ignore space after function names.",
    &ignore_spaces, &ignore_spaces, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"init-command", 0,
-   "SQL Command to execute when connecting to MariaDB server. Will "
-   "automatically be re-executed when reconnecting.", &opt_init_command,
-   &opt_init_command, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"line-numbers", 0, "Write line numbers for errors.",
    &line_numbers, &line_numbers, 0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
   {"skip-line-numbers", 'L', "Don't write line number for errors.", 0, 0, 0,
@@ -1896,15 +1871,6 @@ static struct my_option my_long_options[] =
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"plugin-dir", 0, "Directory for client-side plugins.", &opt_plugin_dir,
-    &opt_plugin_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").", &opt_mysql_port,
-   &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"print-query-on-error", 0,
    "Print the query if there was an error. Is only enabled in --batch mode if verbose is not set (as then the query would be printed anyway)",
    &opt_print_query_on_error, &opt_print_query_on_error, 0, GET_BOOL, NO_ARG,
@@ -1916,9 +1882,6 @@ static struct my_option my_long_options[] =
   {"prompt", 0, "Set the command line prompt to this value.",
    &current_prompt, &current_prompt, 0, GET_STR_ALLOC,
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"protocol", OPT_MYSQL_PROTOCOL, "The protocol to use for connection (tcp, socket, pipe).",
-   &opt_protocol_type, &opt_protocol_type, 0, GET_STR,  REQUIRED_ARG,
-   0, 0, 0, 0, 0, 0},
   {"quick", 'q',
    "Don't cache result, print it row by row. This may slow down the server "
    "if the output is suspended. Doesn't use history file.",
@@ -1956,9 +1919,6 @@ static struct my_option my_long_options[] =
     &opt_sigint_ignore, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"silent", 's', "Be more silent. Print results with a tab as separator, "
    "each row on new line.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR_ALLOC,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include "sslopt-longopts.h"
   {"table", 't', "Output in table format.", &output_tables,
    &output_tables, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -1969,10 +1929,6 @@ static struct my_option my_long_options[] =
    0, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"unbuffered", 'n', "Flush buffer after each query.", &unbuffered,
    &unbuffered, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &current_user,
-   &current_user, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v', "Write more. (-v -v -v gives the table output format).", 0,
    0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"version", 'V', "Output version information and exit.", 0, 0, 0,
@@ -2226,16 +2182,11 @@ get_one_option(const struct my_option *opt, const char *argument,
 
 static int get_options(int argc, char **argv)
 {
-  char *tmp, *pagpoint;
+  char *pagpoint;
   int ho_error;
   MYSQL_PARAMETERS *mysql_params= mysql_get_parameters();
 
-  //MARIADB_HOST will be preferred over MYSQL_HOST.
-  tmp= getenv("MARIADB_HOST");
-  if (tmp == NULL)
-    tmp= getenv("MYSQL_HOST");
-  if (tmp)
-    current_host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
+  set_common_cli_host_from_env();
 
   pagpoint= getenv("PAGER");
   if (!((char*) (pagpoint)))
@@ -4816,8 +4767,8 @@ static int com_connect(String *buffer, char *line)
       tmp= get_arg(buff, GET_NEXT);
       if (tmp)
       {
-	my_free(current_host);
-	current_host=my_strdup(PSI_NOT_INSTRUMENTED, tmp,MYF(MY_WME));
+	my_free(opt_host);
+	opt_host=my_strdup(PSI_NOT_INSTRUMENTED, tmp,MYF(MY_WME));
       }
     }
     else
@@ -4829,7 +4780,7 @@ static int com_connect(String *buffer, char *line)
   }
   else
     opt_rehash= 0;
-  error=sql_connect(current_host,current_db,current_user,opt_password,0);
+  error=sql_connect(opt_host,current_db,opt_user,opt_password,0);
   opt_rehash= save_rehash;
 
   if (connected)
@@ -5171,18 +5122,16 @@ sql_real_connect(char *host,char *database,char *user,char *password,
     mysql_close(&mysql);
   }
   mysql_init(&mysql);
+  set_common_cli_vars_with_init_command(&mysql);
+
   if (!one_database)
     mysql_optionsv(&mysql, MARIADB_OPT_STATUS_CALLBACK, status_info_cb, NULL);
-  if (opt_init_command)
-    mysql_options(&mysql, MYSQL_INIT_COMMAND, opt_init_command);
   if (opt_connect_timeout)
   {
     uint timeout=opt_connect_timeout;
     mysql_options(&mysql,MYSQL_OPT_CONNECT_TIMEOUT,
 		  (char*) &timeout);
   }
-  if (opt_compress)
-    mysql_options(&mysql,MYSQL_OPT_COMPRESS,NullS);
   if (using_opt_local_infile)
     mysql_options(&mysql,MYSQL_OPT_LOCAL_INFILE, (char*) &opt_local_infile);
   if (safe_updates)
@@ -5750,7 +5699,7 @@ static const char *construct_prompt()
 	if (!full_username)
 	  init_username();
         name= (full_username ? full_username :
-               (current_user ?  current_user : "(unknown)"));
+               (opt_user ?  opt_user : "(unknown)"));
         processed_prompt.append(name, strlen(name));
 	break;
       }
@@ -5760,7 +5709,7 @@ static const char *construct_prompt()
 	if (!full_username)
 	  init_username();
         name= (part_username ? part_username :
-               (current_user ?  current_user : "(unknown)"));
+               (opt_user ?  opt_user : "(unknown)"));
         processed_prompt.append(name, strlen(name));
 	break;
       }

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -32,26 +32,23 @@
 #define MAX_MYSQL_VAR 512
 #define SHUTDOWN_DEF_TIMEOUT 3600		/* Wait for shutdown */
 
-char *host= NULL, *user= 0, *opt_password= 0,
+char *opt_password= 0,
      *default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME;
 ulonglong last_values[MAX_MYSQL_VAR+100];
 static int interval=0;
-static my_bool option_force=0,interrupted=0,new_line=0, opt_compress= 0,
+static my_bool option_force=0,interrupted=0,new_line=0,
                opt_local= 0, opt_relative= 0, tty_password= 0, opt_nobeep,
                opt_shutdown_wait_for_slaves= 0, opt_not_used;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
-static uint opt_mysql_port = 0, option_wait = 0, option_silent=0, nr_iterations;
+static uint option_wait = 0, option_silent=0, nr_iterations;
 static uint opt_count_iterations= 0, my_end_arg, opt_verbose= 0;
 static ulong opt_connect_timeout, opt_shutdown_timeout;
-static char * unix_port=0;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
 static bool sql_log_bin_off= false;
-
-static uint opt_protocol=0;
 static myf error_flags; /* flags to pass to my_printf_error, like ME_BELL */
 
 static my_bool ex_status_printed = 0; /* First output is not relative. */
 
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 
 static void print_version(void);
@@ -129,14 +126,12 @@ static struct my_option my_long_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"force", 'f',
    "Don't ask for confirmation on drop database; with multiple commands, "
    "continue even if an error occurs.",
    &option_force, &option_force, 0, GET_BOOL, NO_ARG, 0, 0,
    0, 0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"character-sets-dir", OPT_CHARSETS_DIR,
    "Directory for character set files.", &charsets_dir,
    &charsets_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -145,9 +140,6 @@ static struct my_option my_long_options[] =
    &default_charset, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"local", 'l', "Local command, don't write to binlog.",
    &opt_local, &opt_local, 0, GET_BOOL, NO_ARG, 0, 0, 0,
    0, 0, 0},
@@ -160,15 +152,6 @@ static struct my_option my_long_options[] =
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_mysql_port, &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"protocol", OPT_MYSQL_PROTOCOL, "The protocol to use for connection (tcp, socket, pipe).",
-    0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"relative", 'r',
    "Show difference between current and previous values when used with -i. "
    "Currently only works with extended-status.",
@@ -176,17 +159,10 @@ static struct my_option my_long_options[] =
   0, 0, 0},
   {"silent", 's', "Silently exit if one can't connect to server.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &unix_port, &unix_port, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
-   0, 0, 0},
   {"sleep", 'i', "Execute commands repeatedly with a sleep between.",
    &interval, &interval, 0, GET_INT, REQUIRED_ARG, 0, 0, 0, 0,
    0, 0},
 #include <sslopt-longopts.h>
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &user,
-   &user, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v', "Write more information."
   "Using it will print more information for 'processlist."
   "Using it 2 times will print even more information for 'processlist'.",
@@ -206,13 +182,6 @@ static struct my_option my_long_options[] =
    "all connected slaves", &opt_shutdown_wait_for_slaves,
    &opt_shutdown_wait_for_slaves, 0, GET_BOOL, NO_ARG, 0, 0, 0,
    0, 0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-    &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   { 0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
 
@@ -256,6 +225,7 @@ get_one_option(const struct my_option *opt, const char *argument,
   case 'W':
 #ifdef _WIN32
     opt_protocol = MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
 #endif
     break;
   case '#':
@@ -327,8 +297,7 @@ int main(int argc,char *argv[])
   MYSQL mysql;
   char **commands, **save_argv, **temp_argv;
 
-  if (host == NULL)
-    host= getenv("MARIADB_HOST");
+  set_common_cli_host_from_env();
 
   MY_INIT(argv[0]);
   sf_leaking_memory=1; /* don't report memory leaks on early exits */
@@ -364,8 +333,7 @@ int main(int argc,char *argv[])
   sf_leaking_memory=0; /* from now on we cleanup properly */
 
   mysql_init(&mysql);
-  if (opt_compress)
-    mysql_options(&mysql,MYSQL_OPT_COMPRESS,NullS);
+  set_common_cli_vars_with_init_command(&mysql);
   if (opt_connect_timeout)
   {
     uint tmp=opt_connect_timeout;
@@ -374,19 +342,11 @@ int main(int argc,char *argv[])
 
   SET_SSL_OPTS_WITH_CHECK(&mysql);
 
-  if (opt_protocol)
-    mysql_options(&mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
   if (!strcmp(default_charset,MYSQL_AUTODETECT_CHARSET_NAME))
     default_charset= (char *)my_default_csname();
   my_set_console_cp(default_charset);
   mysql_options(&mysql, MYSQL_SET_CHARSET_NAME, default_charset);
   error_flags= (myf)(opt_nobeep ? 0 : ME_BELL);
-
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(&mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(&mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
 
   mysql_options(&mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(&mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
@@ -503,8 +463,8 @@ int main(int argc,char *argv[])
   my_free(temp_argv);
 err2:
   mysql_library_end();
+  free_common_cli_vars();
   my_free(opt_password);
-  my_free(user);
   free_defaults(save_argv);
   my_end(my_end_arg);
   return error;
@@ -534,8 +494,8 @@ static my_bool sql_connect(MYSQL *mysql, uint wait)
 
   for (;;)
   {
-    if (mysql_real_connect(mysql,host,user,opt_password,NullS,opt_mysql_port,
-			   unix_port, CLIENT_REMEMBER_OPTIONS))
+    if (mysql_real_connect(mysql,opt_host,opt_user,opt_password,NullS,opt_mysql_port,
+			   opt_mysql_unix_port, CLIENT_REMEMBER_OPTIONS))
     {
       my_bool reconnect= 1;
       mysql_options(mysql, MYSQL_OPT_RECONNECT, &reconnect);
@@ -551,24 +511,22 @@ static my_bool sql_connect(MYSQL *mysql, uint wait)
     {
       if (!option_silent)                       // print diagnostics
       {
-	if (!host)
-	  host= (char*) LOCAL_HOST;
 	my_printf_error(0,"connect to server at '%s' failed\nerror: '%s'",
-			error_flags, host, mysql_error(mysql));
+			error_flags, opt_host ? opt_host : LOCAL_HOST, mysql_error(mysql));
 	if (mysql_errno(mysql) == CR_CONNECTION_ERROR)
 	{
 	  fprintf(stderr,
 		  "Check that mariadbd is running and that the socket: '%s' exists!\n",
-		  unix_port ? unix_port : mysql_unix_port);
+		  opt_mysql_unix_port ? opt_mysql_unix_port : mysql_unix_port);
 	}
 	else if (mysql_errno(mysql) == CR_CONN_HOST_ERROR ||
 		 mysql_errno(mysql) == CR_UNKNOWN_HOST)
 	{
-	  fprintf(stderr,"Check that mariadbd is running on %s",host);
+	  fprintf(stderr,"Check that mariadbd is running on %s",opt_host ? opt_host : LOCAL_HOST);
 	  fprintf(stderr," and that the port is %d.\n",
 		  opt_mysql_port ? opt_mysql_port: mysql_port);
 	  fprintf(stderr,"You can check this by doing 'telnet %s %d'\n",
-		  host, opt_mysql_port ? opt_mysql_port: mysql_port);
+		  opt_host ? opt_host : LOCAL_HOST, opt_mysql_port ? opt_mysql_port: mysql_port);
 	}
       }
       return 1;

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -38,6 +38,7 @@
 #include "client_priv.h"
 #undef MYSQL_TYPE_TIME2
 #include <my_time.h>
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 /* That one is necessary for defines of OPTION_NO_FOREIGN_KEY_CHECKS etc */
 #include "sql_priv.h"
@@ -95,7 +96,6 @@ ulong open_files_limit;
 ulong opt_binlog_rows_event_max_size;
 ulonglong test_flags = 0;
 ulong opt_binlog_rows_event_max_encoded_size= MAX_MAX_ALLOWED_PACKET;
-static uint opt_protocol= 0;
 static FILE *result_file;
 static char *result_file_name= 0;
 static const char *output_prefix= "";
@@ -132,13 +132,7 @@ my_bool opt_gtid_strict_mode= true;
 static ulong opt_stop_never_slave_server_id= 0;
 static my_bool opt_verify_binlog_checksum= 1;
 static ulonglong offset = 0;
-static char* host = 0;
-static int opt_mysql_port= 0;
 static uint my_end_arg;
-static const char* sock= 0;
-static char *opt_plugindir= 0, *opt_default_auth= 0;
-
-static char* user = 0;
 static char* opt_password = 0;
 static char *charset= 0;
 
@@ -1313,8 +1307,8 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
           int  tmp_sql_offset;
 
           conn = mysql_init(NULL);
-          if (!mysql_real_connect(conn, host, user, opt_password,
-                map->get_db_name(), opt_mysql_port, sock, 0))
+          if (!mysql_real_connect(conn, opt_host, opt_user, opt_password,
+                map->get_db_name(), opt_mysql_port, opt_mysql_unix_port, 0))
           {
             fprintf(stderr, "%s\n", mysql_error(conn));
             exit(1);
@@ -1593,10 +1587,7 @@ static struct my_option my_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"disable-log-bin", 'D', "Disable binary log. This is useful, if you "
     "enabled --to-last-log and are sending the output to the same MariaDB server. "
     "This way you could avoid an endless loop. You would also like to use it "
@@ -1620,9 +1611,6 @@ static struct my_option my_options[] =
   {"hexdump", 'H', "Augment output with hexadecimal and ASCII event dump.",
    &opt_hexdump, &opt_hexdump, 0, GET_BOOL, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Get the binlog from server. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &host, &host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"local-load", 'l', "Prepare local temporary files for LOAD DATA INFILE in the specified directory.",
    &dirname_for_local_load, &dirname_for_local_load, 0,
    GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -1630,20 +1618,6 @@ static struct my_option my_options[] =
    0, GET_ULL, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"password", 'p', "Password to connect to remote server.",
    0, 0, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-    &opt_plugindir, &opt_plugindir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_mysql_port, &opt_mysql_port, 0, GET_INT, REQUIRED_ARG,
-   0, 0, 0, 0, 0, 0},
-  {"protocol", OPT_MYSQL_PROTOCOL,
-   "The protocol to use for connection (tcp, socket, pipe).",
-   0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"read-from-remote-server", 'R', "Read binary logs from a MariaDB server.",
    &remote_opt, &remote_opt, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
@@ -1723,9 +1697,6 @@ static struct my_option my_options[] =
    "use --base64-output=never",
    &short_form, &short_form, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &sock, &sock, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0,
-   0, 0},
 #include <sslopt-longopts.h>
   {"start-datetime", OPT_START_DATETIME,
    "Start reading the binlog at first event having a datetime equal or "
@@ -1786,9 +1757,6 @@ binlog of the MariaDB server. If you send the output to the same MariaDB server,
 that may lead to an endless loop.",
    &to_last_remote_log, &to_last_remote_log, 0, GET_BOOL,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"user", 'u', "Connect to the remote server as username.",
-   &user, &user, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0,
-   0, 0},
   {"verbose", 'v', "Reconstruct SQL statements out of row events. "
                    "-v -v adds comments on column data types. "
                    "-v -v -v adds diagnostic warnings about event "
@@ -1906,11 +1874,10 @@ static void warning(const char *format,...)
 static void cleanup()
 {
   DBUG_ENTER("cleanup");
+  free_common_cli_vars();
   my_free(opt_password);
   my_free(database);
   my_free(table);
-  my_free(host);
-  my_free(user);
   my_free(const_cast<char*>(dirname_for_local_load));
   my_free(start_datetime_str);
   my_free(stop_datetime_str);
@@ -2403,11 +2370,7 @@ get_one_option(const struct my_option *opt, const char *argument,
 static int parse_args(int *argc, char*** argv)
 {
   int ho_error;
-  char *tmp;
-
-  tmp= getenv("MARIADB_HOST");
-  if (tmp && host == NULL)
-    host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
+  set_common_cli_host_from_env();
 
   if ((ho_error=handle_options(argc, argv, my_options, get_one_option)))
   {
@@ -2490,20 +2453,13 @@ static Exit_status safe_connect()
     return ERROR_STOP;
   }
 
+  set_common_cli_vars_with_init_command(mysql);
   SET_SSL_OPTS_WITH_CHECK(mysql);
 
-  if (opt_plugindir && *opt_plugindir)
-    mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugindir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
-
-  if (opt_protocol)
-    mysql_options(mysql, MYSQL_OPT_PROTOCOL, (char*) &opt_protocol);
   mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
                  "program_name", "mysqlbinlog");
-  if (!mysql_real_connect(mysql, host, user, opt_password, 0, opt_mysql_port, sock, 0))
+  if (!mysql_real_connect(mysql, opt_host, opt_user, opt_password, 0, opt_mysql_port, opt_mysql_unix_port, 0))
   {
     error("Failed on connect: %s", mysql_error(mysql));
     return ERROR_STOP;

--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -24,6 +24,7 @@
 #include <m_ctype.h>
 #include <mysql_version.h>
 #include <mysqld_error.h>
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 #include <welcome_copyright_notice.h> /* ORACLE_WELCOME_COPYRIGHT_NOTICE */
 
@@ -38,25 +39,20 @@
 
 static MYSQL mysql_connection, *sock = 0;
 static my_bool opt_alldbs = 0, opt_check_only_changed = 0, opt_extended = 0,
-               opt_compress = 0, opt_databases = 0, opt_fast = 0,
+               opt_databases = 0, opt_fast = 0,
                opt_medium_check = 0, opt_quick = 0, opt_all_in_1 = 0,
                opt_silent = 0, opt_auto_repair = 0, ignore_errors = 0,
                tty_password= 0, opt_frm= 0, debug_info_flag= 0, debug_check_flag= 0,
                opt_fix_table_names= 0, opt_fix_db_names= 0, opt_upgrade= 0,
                opt_persistent_all= 0, opt_do_tables= 1;
 static my_bool opt_write_binlog= 1, opt_flush_tables= 0;
-static uint verbose = 0, opt_mysql_port=0;
+static uint verbose = 0;
 static int my_end_arg;
-static char * opt_mysql_unix_port = 0;
-static char *opt_password = 0, *current_user = 0, 
-	    *default_charset= 0, *current_host= 0;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
+static char *opt_password = 0, *default_charset= 0;
 static int first_error = 0;
 static char *opt_skip_database;
 DYNAMIC_ARRAY tables4repair, tables4rebuild, alter_table_cmds;
 DYNAMIC_ARRAY views4repair;
-static uint opt_protocol=0;
-
 enum operations { DO_CHECK=1, DO_REPAIR, DO_ANALYZE, DO_OPTIMIZE, DO_FIX_NAMES };
 const char *operation_name[]=
 {
@@ -96,9 +92,6 @@ static struct my_option my_long_options[] =
   {"check-upgrade", 'g',
    "Check tables for version-dependent changes. May be used with --auto-repair to correct tables requiring version-dependent updates.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"compress", 0, "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"databases", 'B',
    "Check several databases. Note the difference in usage; in this case no tables are given. All name arguments are regarded as database names.",
    &opt_databases, &opt_databases, 0, GET_BOOL, NO_ARG,
@@ -116,13 +109,10 @@ static struct my_option my_long_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"default-character-set", 0,
    "Set the default character set.", &default_charset,
    &default_charset, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"fast",'F', "Check only tables that haven't been closed properly.",
    &opt_fast, &opt_fast, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0,
    0},
@@ -144,9 +134,6 @@ static struct my_option my_long_options[] =
    0, 0 },
   {"help", '?', "Display this help message and exit.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host",'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &current_host, &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"medium-check", 'm',
    "Faster than extended-check, but only finds 99.99 percent of all errors. Should be good enough for most cases.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -168,19 +155,6 @@ static struct my_option my_long_options[] =
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-   &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_mysql_port, &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0,
-   0},
-  {"protocol", OPT_MYSQL_PROTOCOL, "The protocol to use for connection (tcp, socket, pipe).",
-   0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"quick", 'q',
    "If you are using this option with CHECK TABLE, it prevents the check from scanning the rows to check for wrong links. This is the fastest check. If you are using this option with REPAIR TABLE, it will try to repair only the index tree. This is the fastest repair method for a table.",
    &opt_quick, &opt_quick, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0,
@@ -193,9 +167,6 @@ static struct my_option my_long_options[] =
   {"skip_database", 0, "Don't process the database specified as argument", 
    &opt_skip_database, &opt_skip_database, 0, GET_STR, REQUIRED_ARG, 
    0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include <sslopt-longopts.h>
   {"tables", OPT_TABLES, "Overrides option --databases (-B).", 0, 0, 0,
    GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -203,10 +174,6 @@ static struct my_option my_long_options[] =
    "When used with REPAIR, get table structure from .frm file, so the table can be repaired even if .MYI header is corrupted.",
    &opt_frm, &opt_frm, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0,
    0},
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &current_user,
-   &current_user, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v', "Print info about the various stages; Using it 3 times will print out all CHECK, RENAME and ALTER TABLE during the check phase.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"version", 'V', "Output version information and exit.", 0, 0, 0, GET_NO_ARG,
@@ -351,6 +318,7 @@ get_one_option(const struct my_option *opt,
   case 'W':
 #ifdef _WIN32
     opt_protocol = MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
 #endif
     break;
   case '#':
@@ -413,8 +381,7 @@ static int get_options(int *argc, char ***argv)
   int ho_error;
   DBUG_ENTER("get_options");
 
-  if (current_host == NULL)
-    current_host= getenv("MARIADB_HOST");
+  set_common_cli_host_from_env();
 
   if (*argc == 1)
   {
@@ -1130,18 +1097,8 @@ static int dbConnect(char *host, char *user, char *passwd)
     fprintf(stderr, "# Connecting to %s...\n", host ? host : "localhost");
   }
   mysql_init(&mysql_connection);
-  if (opt_compress)
-    mysql_options(&mysql_connection, MYSQL_OPT_COMPRESS, NullS);
+  set_common_cli_vars_with_init_command(&mysql_connection);
   SET_SSL_OPTS(&mysql_connection);
-  if (opt_protocol)
-    mysql_options(&mysql_connection,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
-
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(&mysql_connection, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(&mysql_connection, MYSQL_DEFAULT_AUTH, opt_default_auth);
-
   mysql_options(&mysql_connection, MYSQL_SET_CHARSET_NAME, default_charset);
   mysql_options(&mysql_connection, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(&mysql_connection, MYSQL_OPT_CONNECT_ATTR_ADD,
@@ -1214,7 +1171,7 @@ int main(int argc, char **argv)
   sf_leaking_memory=0; /* from now on we cleanup properly */
 
   ret= EX_MYSQLERR;
-  if (dbConnect(current_host, current_user, opt_password))
+  if (dbConnect(opt_host, opt_user, opt_password))
     goto end1;
 
   ret= 1;
@@ -1270,7 +1227,7 @@ int main(int argc, char **argv)
   ret= MY_TEST(first_error);
 
  end:
-  dbDisconnect(current_host);
+  dbDisconnect(opt_host);
   if (opt_auto_repair)
   {
     delete_dynamic(&views4repair);
@@ -1279,6 +1236,7 @@ int main(int argc, char **argv)
     delete_dynamic(&alter_table_cmds);
   }
  end1:
+  free_common_cli_vars();
   my_free(opt_password);;
   mysql_library_end();
   free_defaults(defaults_argv);

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -116,7 +116,7 @@ static void field_escape(DYNAMIC_STRING* in, const char *from);
 static my_bool  verbose= 0, opt_no_create_info= 0, opt_no_data= 0, opt_no_data_med= 1,
                 quick= 1, extended_insert= 1,
                 lock_tables=1,ignore_errors=0,flush_logs=0,flush_privileges=0,
-                opt_drop=1,opt_keywords=0,opt_lock=1,opt_compress=0,
+                opt_drop=1,opt_keywords=0,opt_lock=1,
                 opt_copy_s3_tables=0,
                 opt_delayed=0,create_options=1,opt_quoted=0,opt_databases=0,
                 opt_alldbs=0,opt_create_db=0,opt_lock_all_tables=0,
@@ -152,8 +152,8 @@ static double opt_max_statement_time= 0.0;
 static MYSQL *mysql=0;
 static DYNAMIC_STRING insert_pat, select_field_names, field_flags,
                       select_field_names_for_header, insert_field_names;
-static char  *opt_password=0,*current_user=0,
-             *current_host=0,*path=0,*fields_terminated=0,
+static char  *opt_password=0,
+             *path=0,*fields_terminated=0,
              *lines_terminated=0, *enclosed=0, *opt_enclosed=0, *escaped=0,
              *where=0, *order_by=0,
              *err_ptr= 0,
@@ -168,11 +168,10 @@ static ulong opt_compatible_mode= 0;
 #define MYSQL_OPT_MASTER_DATA_COMMENTED_SQL 2
 #define MYSQL_OPT_SLAVE_DATA_EFFECTIVE_SQL 1
 #define MYSQL_OPT_SLAVE_DATA_COMMENTED_SQL 2
-static uint opt_mysql_port= 0, opt_master_data;
+static uint opt_master_data;
 static uint opt_slave_data;
 static uint opt_use_gtid;
 static uint my_end_arg;
-static char * opt_mysql_unix_port=0;
 static int   first_error=0;
 /**
   `true` for 11.6 or above servers, `false` otherwise.
@@ -186,12 +185,11 @@ static MEM_ROOT glob_root;
 static MYSQL_RES *routine_res, *routine_list_res, *slave_status_res= NULL;
 
 
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 FILE *md_result_file= 0;
 FILE *stderror_file=0;
 
-static uint opt_protocol= 0;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
 static uint opt_parallel= 0;
 static char *opt_dir;
 
@@ -315,8 +313,6 @@ static struct my_option my_long_options[] =
   {"complete-insert", 'c', "Use complete insert statements.",
    &opt_complete_insert, &opt_complete_insert, 0, GET_BOOL,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"copy_s3_tables", 0,
    "If 'no' S3 tables will be ignored, otherwise S3 tables will be copied as "
    " Aria tables and then altered to S3",
@@ -346,6 +342,7 @@ static struct my_option my_long_options[] =
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"debug-info", 0, "Print some debug info at exit.", &debug_info_flag,
     &debug_info_flag, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"default-character-set", OPT_DEFAULT_CHARSET,
    "Set the default character set.", &default_charset,
    &default_charset, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -440,9 +437,6 @@ static struct my_option my_long_options[] =
   {"hex-blob", 0, "Dump binary strings (BINARY, "
     "VARBINARY, BLOB) in hexadecimal format.",
    &opt_hex_blob, &opt_hex_blob, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &current_host, &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-database", OPT_IGNORE_DATABASE,
    "Do not dump the specified database. To specify more than one database to ignore, "
    "use the directive multiple times, once for each database. Only takes effect "
@@ -544,12 +538,6 @@ static struct my_option my_long_options[] =
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"port", 'P', "Port number to use for connection.", &opt_mysql_port,
-   &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0,
-   0},
-  {"protocol", OPT_MYSQL_PROTOCOL, 
-   "The protocol to use for connection (tcp, socket, pipe).",
-   0, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"quick", 'q', "Don't buffer query, dump directly to stdout.",
    &quick, &quick, 0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
   {"quote-names",'Q', "Quote table and column names with backticks (`).",
@@ -587,9 +575,6 @@ static struct my_option my_long_options[] =
   {"skip-opt", OPT_SKIP_OPTIMIZATION,
    "Disable --opt. Disables --add-drop-table, --add-locks, --create-options, --quick, --extended-insert, --lock-tables, --set-charset, and --disable-keys.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, 
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include <sslopt-longopts.h>
   {"system", 0, "Dump system tables as portable SQL",
    &opt_system, &opt_system, &opt_system_types, GET_SET, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -607,10 +592,6 @@ static struct my_option my_long_options[] =
    "Set connection time zone to UTC before commencing the dump and add "
    "SET TIME_ZONE=´+00:00´ to the top of the dump file.",
     &opt_tz_utc, &opt_tz_utc, 0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &current_user,
-    &current_user, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v', "Print info about the various stages.",
    &verbose, &verbose, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"version",'V', "Output version information and exit.", 0, 0, 0,
@@ -619,12 +600,6 @@ static struct my_option my_long_options[] =
    &where, &where, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"xml", 'X', "Dump a database as well formed XML.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-   &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0, "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
 
@@ -796,7 +771,7 @@ static void write_header(FILE *sql_file, const char *db_name)
       print_comment(sql_file, 0, "-- MariaDB dump %s-%s, for %s (%s)\n--\n",
                     VER, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
       print_comment(sql_file, 0, "-- Host: %s    ",
-                    fix_for_comment(current_host ? current_host : "localhost"));
+                    fix_for_comment(opt_host ? opt_host : "localhost"));
       print_comment(sql_file, 0, "Database: %s\n",
                     fix_for_comment(db_name ? db_name : ""));
       print_comment(sql_file, 0,
@@ -931,6 +906,7 @@ get_one_option(const struct my_option *opt,
   case 'W':
 #ifdef _WIN32
     opt_protocol= MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
 #endif
     break;
   case 'N':
@@ -1113,13 +1089,9 @@ get_one_option(const struct my_option *opt,
 
 static int get_options(int *argc, char ***argv)
 {
-  char *tmp;
   int ho_error;
   MYSQL_PARAMETERS *mysql_params= mysql_get_parameters();
-
-  tmp= getenv("MARIADB_HOST");
-  if (tmp && current_host == NULL)
-    current_host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
+  set_common_cli_host_from_env();
 
   opt_max_allowed_packet= *mysql_params->p_max_allowed_packet;
   opt_net_buffer_length= *mysql_params->p_net_buffer_length;
@@ -2042,9 +2014,9 @@ static void free_resources()
     mysql_close(mysql);
     mysql= 0;
   }
+  free_common_cli_vars();
   my_free(order_by);
   my_free(opt_password);
-  my_free(current_host);
   free_root(&glob_root, MYF(0));
   if (my_hash_inited(&ignore_database))
     my_hash_free(&ignore_database);
@@ -2092,18 +2064,9 @@ static MYSQL* connect_to_db(char *host, char *user,char *passwd)
 
   verbose_msg("-- Connecting to %s...\n", host ? host : "localhost");
   MYSQL* con = mysql_init(NULL);
-  if (opt_compress)
-    mysql_options(con,MYSQL_OPT_COMPRESS,NullS);
+  set_common_cli_vars_with_init_command(con);
   SET_SSL_OPTS_WITH_CHECK(con);
-  if (opt_protocol)
-    mysql_options(con,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
   mysql_options(con, MYSQL_SET_CHARSET_NAME, default_charset);
-
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(con, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(con, MYSQL_DEFAULT_AUTH, opt_default_auth);
 
   mysql_options(con, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(con, MYSQL_OPT_CONNECT_ATTR_ADD,
@@ -2986,9 +2949,9 @@ static uint dump_routines_for_db(char *db)
                           query_buff);
             print_comment(sql_file, 1,
                           "-- does %s have permissions on mysql.proc?\n\n",
-                          fix_for_comment(current_user));
+                          fix_for_comment(opt_user));
             maybe_die(EX_MYSQLERR,"%s has insufficient privileges to %s!",
-                      current_user, query_buff);
+                      opt_user, query_buff);
           }
           else if (strlen(row[2]))
           {
@@ -7275,7 +7238,7 @@ static void init_connection_pool(uint n_connections)
 
   for (uint i= 0; i < n_connections; i++)
   {
-    MYSQL *c= connect_to_db(current_host, current_user, opt_password);
+    MYSQL *c= connect_to_db(opt_host, opt_user, opt_password);
     if (!c)
     {
       for (uint j= 0; j < i; j++)
@@ -7628,7 +7591,7 @@ int main(int argc, char **argv)
     }
   }
 
-  mysql= connect_to_db(current_host, current_user, opt_password);
+  mysql= connect_to_db(opt_host, opt_user, opt_password);
   if (!mysql)
   {
     free_resources();
@@ -7837,7 +7800,7 @@ err:
   if (opt_slave_data)
     do_start_slave_sql(mysql);
 
-  dbDisconnect(current_host);
+  dbDisconnect(opt_host);
   if (!multi_file_output)
     write_footer(md_result_file);
   free_resources();

--- a/client/mysqlimport.cc
+++ b/client/mysqlimport.cc
@@ -61,21 +61,19 @@ static std::string parse_sql_script(const char *filepath, bool *tz_utc,
 
 static my_bool  verbose=0,lock_tables=0,ignore_errors=0,opt_delete=0,
                 replace, silent, ignore, ignore_foreign_keys,
-                opt_compress, opt_low_priority, tty_password;
+                opt_low_priority, tty_password;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
 static uint opt_use_threads=0, opt_local_file=0, my_end_arg= 0;
-static char	*opt_password=0, *current_user=0,
-		*current_host=0, *current_db=0, *fields_terminated=0,
+static char	*opt_password=0,
+		*current_db=0, *fields_terminated=0,
 		*lines_terminated=0, *enclosed=0, *opt_enclosed=0,
 		*escaped=0, *opt_columns=0, 
 		*default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME;
-static uint     opt_mysql_port= 0, opt_protocol= 0;
-static char * opt_mysql_unix_port=0;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
 static longlong opt_ignore_lines= -1;
 static char *opt_dir;
 static char opt_innodb_optimize_keys;
 
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 
 static char **argv_to_free;
@@ -166,9 +164,6 @@ static struct my_option my_long_options[] =
    "Use only these columns to import the data to. Give the column names in a comma separated list. This is same as giving columns to LOAD DATA INFILE.",
    &opt_columns, &opt_columns, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
    0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"debug",'#', "Output debug log. Often this is 'd:t:o,filename'.", 0, 0, 0,
    GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
   {"debug-check", 0, "Check memory and open file usage at exit.",
@@ -177,10 +172,7 @@ static struct my_option my_long_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"delete", 'd', "First delete all rows from table.", &opt_delete,
    &opt_delete, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"fields-terminated-by", 0,
@@ -204,9 +196,6 @@ static struct my_option my_long_options[] =
    0, 0, 0, 0},
   {"help", '?', "Displays this help and exits.", 0, 0, 0, GET_NO_ARG, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &current_host, &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore", 'i', "If duplicate unique key was found, keep old row.",
    &ignore, &ignore, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-foreign-keys", 'k',
@@ -253,27 +242,10 @@ static struct my_option my_long_options[] =
   {"parallel", 'j', "Number of LOAD DATA jobs executed in parallel",
    &opt_use_threads, &opt_use_threads, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0,
    0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-   &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_mysql_port,
-   &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0,
-   0},
-  {"protocol", OPT_MYSQL_PROTOCOL, "The protocol to use for connection (tcp, socket, pipe).",
-   0, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"replace", 'r', "If duplicate unique key was found, replace old row.",
    &replace, &replace, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"silent", 's', "Be more silent.", &silent, &silent, 0,
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"table", OPT_TABLES,
    "Restore the specified table ignoring others. Use --table=dbname.tablename with this option. "
    "To specify more than one table to include, use the directive multiple times, once for each "
@@ -284,10 +256,6 @@ static struct my_option my_long_options[] =
   {"use-threads", 0, "Synonym for --parallel option",
    &opt_use_threads, &opt_use_threads, 0,
    GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &current_user,
-   &current_user, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v', "Print info about the various stages.", &verbose,
    &verbose, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"version", 'V', "Output version information and exit.", 0, 0, 0, GET_NO_ARG,
@@ -352,6 +320,7 @@ get_one_option(const struct my_option *opt, const char *argument,
 #ifdef _WIN32
   case 'W':
     opt_protocol = MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
     break;
 #endif
   case OPT_MYSQL_PROTOCOL:
@@ -426,8 +395,7 @@ static int get_options(int *argc, char ***argv)
 {
   int ho_error;
 
-  if (current_host == NULL)
-    current_host= getenv("MARIADB_HOST");
+  set_common_cli_host_from_env();
 
   if ((ho_error=handle_options(argc, argv, my_long_options, get_one_option)))
     exit(ho_error);
@@ -886,20 +854,11 @@ static MYSQL *db_connect(char *host, char *database,
   else
     if (!(mysql= mysql_init(NULL)))
       return 0;
-  if (opt_compress)
-    mysql_options(mysql,MYSQL_OPT_COMPRESS,NullS);
   if (opt_local_file)
     mysql_options(mysql,MYSQL_OPT_LOCAL_INFILE,
 		  (char*) &opt_local_file);
+  set_common_cli_vars_with_init_command(mysql);
   SET_SSL_OPTS(mysql);
-  if (opt_protocol)
-    mysql_options(mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
-
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
   mysql_options(mysql, MYSQL_SET_CHARSET_NAME, default_charset);
   mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
@@ -982,6 +941,7 @@ static void safe_exit(int error, MYSQL *mysql)
   }
   mysql_library_end();
   free_defaults(argv_to_free);
+  free_common_cli_vars();
   my_free(opt_password);
   my_end(my_end_arg); /* clean exit */
   exit(error);
@@ -1097,7 +1057,7 @@ static void init_tp_connections(size_t n)
   for (size_t i= 0; i < n; i++)
   {
     MYSQL *mysql=
-        db_connect(current_host, current_db, current_user, opt_password);
+        db_connect(opt_host, current_db, opt_user, opt_password);
     all_tp_connections.push_back(mysql);
   }
 }
@@ -1106,7 +1066,7 @@ static void close_tp_connections()
 {
   for (auto &conn : all_tp_connections)
   {
-    db_disconnect(current_host, conn);
+    db_disconnect(opt_host, conn);
   }
   all_tp_connections.clear();
 }
@@ -1327,7 +1287,7 @@ int main(int argc, char **argv)
     return 1;
   }
   MYSQL *mysql=
-      db_connect(current_host, current_db, current_user, opt_password);
+      db_connect(opt_host, current_db, opt_user, opt_password);
   if (!mysql)
   {
     free_defaults(argv_to_free);

--- a/client/mysqlshow.c
+++ b/client/mysqlshow.c
@@ -27,22 +27,20 @@
 #include <mysqld_error.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 #include <welcome_copyright_notice.h>   /* ORACLE_WELCOME_COPYRIGHT_NOTICE */
 
-static char * host=0, *opt_password=0, *user=0;
-static my_bool opt_show_keys= 0, opt_compress= 0, opt_count=0, opt_status= 0;
+static char *opt_password=0;
+static my_bool opt_show_keys= 0, opt_count=0, opt_status= 0;
 static my_bool tty_password= 0, opt_table_type= 0;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
 static uint my_end_arg= 0;
 static uint opt_verbose=0;
 static char *default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
 
-static uint opt_protocol=0;
 
 static void get_options(int *argc,char ***argv);
-static uint opt_mysql_port=0;
 static int list_dbs(MYSQL *mysql,const char *wild);
 static int list_tables(MYSQL *mysql,const char *db,const char *table);
 static int list_table_status(MYSQL *mysql,const char *db,const char *table);
@@ -58,7 +56,6 @@ static void print_res_row(MYSQL_RES *result,MYSQL_ROW cur);
 static const char *load_default_groups[]=
 { "mysqlshow", "mariadb-show", "client", "client-server", "client-mariadb",
   0 };
-static char * opt_mysql_unix_port=0;
 
 int main(int argc, char **argv)
 {
@@ -118,27 +115,18 @@ int main(int argc, char **argv)
     exit(1);
   }
   mysql_init(&mysql);
-  if (opt_compress)
-    mysql_options(&mysql,MYSQL_OPT_COMPRESS,NullS);
+  set_common_cli_vars_with_init_command(&mysql);
   SET_SSL_OPTS(&mysql);
-  if (opt_protocol)
-    mysql_options(&mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
 
   if (!strcmp(default_charset,MYSQL_AUTODETECT_CHARSET_NAME))
     default_charset= (char *)my_default_csname();
   my_set_console_cp(default_charset);
   mysql_options(&mysql, MYSQL_SET_CHARSET_NAME, default_charset);
 
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(&mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(&mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
-
   mysql_options(&mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(&mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
                  "program_name", "mysqlshow");
-  if (!(mysql_real_connect(&mysql,host,user,opt_password,
+  if (!(mysql_real_connect(&mysql,opt_host,opt_user,opt_password,
 			   (first_argument_uses_wildcards) ? "" :
                            argv[0],opt_mysql_port,opt_mysql_unix_port,
 			   0)))
@@ -167,6 +155,7 @@ int main(int argc, char **argv)
   }
 error:
   mysql_close(&mysql);			/* Close & free connection */
+  free_common_cli_vars();
   my_free(opt_password);
   mysql_server_end();
   free_defaults(defaults_argv);
@@ -187,9 +176,6 @@ static struct my_option my_long_options[] =
    "Show number of rows per table (may be slow for non-MyISAM tables).",
    &opt_count, &opt_count, 0, GET_BOOL, NO_ARG, 0, 0, 0,
    0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"debug", '#', "Output debug log. Often this is 'd:t:o,filename'.",
    0, 0, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
   {"debug-check", 0, "Check memory and open file usage at exit.",
@@ -198,15 +184,9 @@ static struct my_option my_long_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"status", 'i', "Shows a lot of extra information about each table.",
    &opt_status, &opt_status, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
@@ -216,36 +196,14 @@ static struct my_option my_long_options[] =
    "Password to use when connecting to server. If password is not given, it's "
    "solicited on the tty.",
    0, 0, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-   &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_mysql_port,
-   &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0,
-   0},
 #ifdef _WIN32
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"protocol", OPT_MYSQL_PROTOCOL, 
-   "The protocol to use for connection (tcp, socket, pipe).",
-   0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"show-table-type", 't', "Show table type column.",
    &opt_table_type, &opt_table_type, 0, GET_BOOL,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include <sslopt-longopts.h>
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &user,
-   &user, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v',
    "More verbose output; you can use this multiple times to get even more "
    "verbose output.",
@@ -309,6 +267,7 @@ get_one_option(const struct my_option *opt, const char *argument,
   case 'W':
 #ifdef _WIN32
     opt_protocol = MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
 #endif
     break;
   case OPT_MYSQL_PROTOCOL:
@@ -364,8 +323,7 @@ get_options(int *argc,char ***argv)
 {
   int ho_error;
 
-  if (host == NULL)
-    host= getenv("MARIADB_HOST");
+  set_common_cli_host_from_env();
 
   if ((ho_error=handle_options(argc, argv, my_long_options, get_one_option)))
     exit(ho_error);

--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -85,6 +85,7 @@ TODO:
 #include <mysqld_error.h>
 #include <my_dir.h>
 #include <signal.h>
+#include <common-cli-vars.h>
 #include <sslopt-vars.h>
 #ifndef _WIN32
 #include <sys/wait.h>
@@ -111,16 +112,13 @@ static char **defaults_argv;
 char **primary_keys;
 unsigned long long primary_keys_number_of;
 
-static char *host= NULL, *opt_password= NULL, *user= NULL,
+static char *opt_password= NULL,
             *user_supplied_query= NULL,
             *user_supplied_pre_statements= NULL,
             *user_supplied_post_statements= NULL,
             *default_engine= NULL,
             *pre_system= NULL,
-            *post_system= NULL,
-            *opt_mysql_unix_port= NULL,
-            *opt_init_command= NULL;
-static char *opt_plugin_dir= 0, *opt_default_auth= 0;
+            *post_system= NULL;
 
 const char *delimiter= "\n";
 
@@ -129,7 +127,7 @@ const char *create_schema_string= "mysqlslap";
 static my_bool opt_preserve= TRUE, opt_no_drop= FALSE;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
 static my_bool opt_only_print= FALSE;
-static my_bool opt_compress= FALSE, tty_password= FALSE,
+static my_bool tty_password= FALSE,
                opt_silent= FALSE,
                auto_generate_sql_autoincrement= FALSE,
                auto_generate_sql_guid_primary= FALSE,
@@ -170,10 +168,7 @@ const char *default_dbug_option="d:t:o,/tmp/mariadb-slap.trace";
 const char *opt_csv_str;
 File csv_file;
 
-static uint opt_protocol= 0;
-
 static int get_options(int *argc,char ***argv);
-static uint opt_mysql_port= 0;
 
 static const char *load_default_groups[]=
 { "mysqlslap", "mariadb-slap", "client", "client-server", "client-mariadb",
@@ -293,11 +288,7 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 
 void set_mysql_connect_options(MYSQL *mysql)
 {
-  if (opt_compress)
-    mysql_options(mysql,MYSQL_OPT_COMPRESS,NullS);
   SET_SSL_OPTS(mysql);
-  if (opt_protocol)
-    mysql_options(mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
   mysql_options(mysql, MYSQL_SET_CHARSET_NAME, default_charset);
 }
 
@@ -336,20 +327,16 @@ int main(int argc, char **argv)
     exit(1);
   }
   mysql_init(&mysql);
+  set_common_cli_vars(&mysql);
   set_mysql_connect_options(&mysql);
 
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(&mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(&mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
 
   mysql_options(&mysql, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
   mysql_options4(&mysql, MYSQL_OPT_CONNECT_ATTR_ADD,
                  "program_name", "mysqlslap");
   if (!opt_only_print) 
   {
-    if (!(mysql_real_connect(&mysql, host, user, opt_password,
+    if (!(mysql_real_connect(&mysql, opt_host, opt_user, opt_password,
                              NULL, opt_mysql_port,
                              opt_mysql_unix_port, connect_flags)))
     {
@@ -404,6 +391,7 @@ int main(int argc, char **argv)
   mysql_close(&mysql); /* Close & free connection */
 
   /* now free all the strings we created */
+  free_common_cli_vars();
   my_free(opt_password);
   my_free(concurrency);
 
@@ -568,9 +556,6 @@ static struct my_option my_long_options[] =
   {"commit", 0, "Commit records every X number of statements.",
     &commit_rate, &commit_rate, 0, GET_UINT, REQUIRED_ARG,
     0, 0, 0, 0, 0, 0},
-  {"compress", 'C', "Use compression in server/client protocol.",
-    &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-    0, 0, 0},
   {"concurrency", 'c', "Number of clients to simulate for query to run.",
    (char**) &concurrency_str, (char**) &concurrency_str, 0, GET_STR,
     REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -596,10 +581,7 @@ static struct my_option my_long_options[] =
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"debug-info", 'T', "Print some debug info at exit.", &debug_info_flag,
    &debug_info_flag, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"default_auth", 0,
-   "Default authentication client-side plugin to use.",
-   &opt_default_auth, &opt_default_auth, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include <common-cli-longopts.h>
   {"delimiter", 'F',
     "Delimiter to use in SQL statements supplied in file or command line.",
    (char**) &delimiter, (char**) &delimiter, 0, GET_STR, REQUIRED_ARG,
@@ -614,14 +596,6 @@ static struct my_option my_long_options[] =
    "engine after a `:', like memory:max_row=2300",
    &default_engine, &default_engine, 0,
     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host. Defaults in the following order: "
-  "$MARIADB_HOST, and then localhost",
-   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"init-command", 0,
-   "SQL Command to execute when connecting to MariaDB server. Will "
-   "automatically be re-executed when reconnecting.",
-   &opt_init_command, &opt_init_command, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"iterations", 'i', "Number of times to run the tests.", &iterations,
     &iterations, 0, GET_UINT, REQUIRED_ARG, 1, 0, 0, 0, 0, 0},
   {"no-drop", 0, "Do not drop the schema after the test.",
@@ -650,12 +624,6 @@ static struct my_option my_long_options[] =
   {"pipe", 'W', "Use named pipes to connect to server.", 0, 0, 0, GET_NO_ARG,
     NO_ARG, 0, 0, 0, 0, 0, 0},
 #endif
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-   &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection.", &opt_mysql_port,
-    &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, MYSQL_PORT, 0, 0, 0, 0,
-    0},
   {"post-query", 0,
     "Query to run or file containing query to execute after tests have completed.",
     &user_supplied_post_statements, &user_supplied_post_statements,
@@ -672,23 +640,13 @@ static struct my_option my_long_options[] =
     "system() string to execute before running tests.",
     &pre_system, &pre_system,
     0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"protocol", OPT_MYSQL_PROTOCOL,
-    "The protocol to use for connection (tcp, socket, pipe).",
-    0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"query", 'q', "Query to run or file containing query to run.",
     &user_supplied_query, &user_supplied_query,
     0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"silent", 's', "Run program in silent mode - no output.",
     &opt_silent, &opt_silent, 0, GET_BOOL,  NO_ARG,
     0, 0, 0, 0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-    &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR,
-    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include <sslopt-longopts.h>
-#ifndef DONT_ALLOW_USER_CHANGE
-  {"user", 'u', "User for login if not current user.", &user,
-    &user, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-#endif
   {"verbose", 'v',
    "More verbose output; you can use this multiple times to get even more "
    "verbose output.", &verbose, &verbose, 0, GET_NO_ARG, NO_ARG,
@@ -745,6 +703,7 @@ get_one_option(const struct my_option *opt, const char *argument,
   case 'W':
 #ifdef _WIN32
     opt_protocol= MYSQL_PROTOCOL_PIPE;
+    opt_protocol_type= "pipe";
 #endif
     break;
   case OPT_MYSQL_PROTOCOL:
@@ -1190,8 +1149,7 @@ get_options(int *argc,char ***argv)
   if (debug_check_flag)
     my_end_arg= MY_CHECK_ERROR;
 
-  if (host == NULL)
-    host= getenv("MARIADB_HOST");
+  set_common_cli_host_from_env();
 
   /*
     If something is created and --no-drop is not specified, we drop the
@@ -1885,9 +1843,10 @@ pthread_handler_t run_task(void *p)
     exit(0);
   }
 
+  set_common_cli_vars(mysql);
   set_mysql_connect_options(mysql);
 
-  DBUG_PRINT("info", ("trying to connect to host %s as user %s", host, user));
+  DBUG_PRINT("info", ("trying to connect to host %s as user %s", opt_host, opt_user));
 
   if (!opt_only_print)
   {
@@ -2297,9 +2256,8 @@ slap_connect(MYSQL *mysql)
   for (x= 0; x < 10; x++)
   {
     set_mysql_connect_options(mysql);
-    if (opt_init_command)
-      mysql_options(mysql, MYSQL_INIT_COMMAND, opt_init_command);
-    if (mysql_real_connect(mysql, host, user, opt_password,
+    set_common_cli_vars_with_init_command(mysql);
+    if (mysql_real_connect(mysql, opt_host, opt_user, opt_password,
                            create_schema_string,
                            opt_mysql_port,
                            opt_mysql_unix_port,

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -110,15 +110,14 @@ enum {
 
 static int record= 0, opt_sleep= -1;
 static char *opt_db= 0, *opt_pass= 0;
-const char *opt_user= 0, *opt_host= 0, *unix_sock= 0, *opt_basedir= "./";
+const char *opt_basedir= "./";
 const char *opt_logdir= "";
 const char *opt_prologue= 0, *opt_charsets_dir;
-static int opt_port= 0;
 static int opt_max_connect_retries;
 static int opt_result_format_version;
 static int opt_max_connections= DEFAULT_MAX_CONN;
 static int error_count= 0;
-static my_bool opt_compress= 0, silent= 0, verbose= 0;
+static my_bool silent= 0, verbose= 0;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
 static my_bool tty_password= 0;
 static my_bool opt_mark_progress= 0;
@@ -267,7 +266,6 @@ static ulonglong timer_now(void);
 
 static ulong connection_retry_sleep= 100000; /* Microseconds */
 
-static const char *opt_plugin_dir;
 static const char *opt_suite_dir, *opt_overlay_dir;
 static size_t suite_dir_len, overlay_dir_len;
 
@@ -288,10 +286,9 @@ static int replace(DYNAMIC_STRING *ds_str,
                    const char *search_str, size_t search_len,
                    const char *replace_str, size_t replace_len);
 
-static uint opt_protocol=0;
-
 DYNAMIC_ARRAY q_lines;
 
+#include "common-cli-vars.h"
 #include "sslopt-vars.h"
 
 #if defined(HAVE_OPENSSL) && !defined(EMBEDDED_LIBRARY)
@@ -1930,6 +1927,7 @@ ATTRIBUTE_NORETURN static void cleanup_and_exit(int exit_code,
 #endif
 
   free_used_memory();
+  free_common_cli_vars();
 
   /* Only call mysql_server_end if mysql_server_init has been called */
   if (server_initialized)
@@ -8903,7 +8901,7 @@ enum use_ssl
 void do_connect(struct st_command *command)
 {
   uint protocol= opt_protocol;
-  int con_port= opt_port;
+  int con_port= (int)opt_mysql_port;
   char *con_options;
   char *ssl_cipher __attribute__((unused))= 0;
   enum use_ssl con_ssl __attribute__((unused))= USE_SSL_IF_POSSIBLE;
@@ -8970,7 +8968,7 @@ void do_connect(struct st_command *command)
   else
   {
     /* No socket specified, use default */
-    dynstr_set(&ds_sock, unix_sock);
+    dynstr_set(&ds_sock, opt_mysql_unix_port);
   }
   DBUG_PRINT("info", ("socket: %s", ds_sock.str));
 
@@ -9119,8 +9117,8 @@ void do_connect(struct st_command *command)
   else
     default_db= 0;
 
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(con_slot->mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
+  if (opt_client_plugin_dir && *opt_client_plugin_dir)
+    mysql_options(con_slot->mysql, MYSQL_PLUGIN_DIR, opt_client_plugin_dir);
 
   if (ds_default_auth.length)
     mysql_options(con_slot->mysql, MYSQL_DEFAULT_AUTH, ds_default_auth.str);
@@ -10151,9 +10149,6 @@ static struct my_option my_long_options[] =
   {"character-sets-dir", 0,
    "Directory for character set files.", &opt_charsets_dir,
    &opt_charsets_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"compress", 'C', "Use the compressed server/client protocol.",
-   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0,
-   0, 0, 0},
   {"continue-on-error", 0,
    "Continue test even if we got an error. "
    "This is mostly useful when testing a storage engine to see what from a test file it can execute, "
@@ -10178,8 +10173,7 @@ static struct my_option my_long_options[] =
   {"debug-info", 0, "Print some debug info at exit.",
    &debug_info_flag, &debug_info_flag,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &opt_host, &opt_host, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#include "common-cli-longopts.h"
   {"prologue", 0, "Include SQL before each test case.", &opt_prologue,
    &opt_prologue, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"logdir", OPT_LOG_DIR, "Directory for log files", &opt_logdir,
@@ -10198,15 +10192,6 @@ static struct my_option my_long_options[] =
    GET_INT, REQUIRED_ARG, DEFAULT_MAX_CONN, 8, 5120, 0, 0, 0},
   {"password", 'p', "Password to use when connecting to server.",
    0, 0, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
-  {"protocol", OPT_MYSQL_PROTOCOL, "The protocol of connection (tcp,socket,pipe).",
-   0, 0, 0, GET_STR,  REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"port", 'P', "Port number to use for connection or 0 for default to, in "
-   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
-#if MYSQL_PORT_DEFAULT == 0
-   "/etc/services, "
-#endif
-   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-   &opt_port, &opt_port, 0, GET_INT, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ps-protocol", 0, 
    "Use prepared-statement protocol for communication.",
    &ps_protocol, &ps_protocol, 0,
@@ -10236,9 +10221,6 @@ static struct my_option my_long_options[] =
   {"sleep", 'T', "Always sleep this many seconds on sleep commands.",
    &opt_sleep, &opt_sleep, 0, GET_INT, REQUIRED_ARG, -1, -1, 0,
    0, 0, 0},
-  {"socket", 'S', "The socket file to use for connection.",
-   &unix_sock, &unix_sock, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
-   0, 0, 0},
   {"sp-protocol", 0, "Use stored procedures for select.",
    &sp_protocol, &sp_protocol, 0,
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -10253,8 +10235,6 @@ static struct my_option my_long_options[] =
    0, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"tmpdir", 't', "Temporary directory where sockets are put.",
    0, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"user", 'u', "User for login.", &opt_user, &opt_user, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"verbose", 'v', "Write more.", &verbose, &verbose, 0,
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"version", 'V', "Output version information and exit.",
@@ -10270,9 +10250,6 @@ static struct my_option my_long_options[] =
    "Number of seconds to wait for master_pos_wait",
    &opt_wait_for_pos_timeout, &opt_wait_for_pos_timeout, 0, GET_UINT,
    REQUIRED_ARG, default_wait_for_pos_timeout, 0, 3600 * 12, 0, 0, 0},
-  {"plugin_dir", 0, "Directory for client-side plugins.",
-    &opt_plugin_dir, &opt_plugin_dir, 0,
-   GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"overlay-dir", 0, "Overlay directory.", &opt_overlay_dir,
     &opt_overlay_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"suite-dir", 0, "Suite directory.", &opt_suite_dir,
@@ -13155,20 +13132,13 @@ int main(int argc, char **argv)
   if (opt_connect_timeout)
     mysql_options(con->mysql, MYSQL_OPT_CONNECT_TIMEOUT,
                   (void *) &opt_connect_timeout);
-  if (opt_compress)
-    mysql_options(con->mysql,MYSQL_OPT_COMPRESS,NullS);
   mysql_options(con->mysql, MYSQL_SET_CHARSET_NAME,
                 charset_info->cs_name.str);
   if (opt_charsets_dir)
     mysql_options(con->mysql, MYSQL_SET_CHARSET_DIR,
                   opt_charsets_dir);
 
-  if (opt_protocol)
-    mysql_options(con->mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
-
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(con->mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
-
+  set_common_cli_vars_with_init_command(con->mysql);
   SET_SSL_OPTS(con->mysql);
 
   if (!(con->name = my_strdup(PSI_NOT_INSTRUMENTED, "default", MYF(MY_WME))))
@@ -13176,7 +13146,7 @@ int main(int argc, char **argv)
   mysql_options(con->mysql, MYSQL_OPT_NONBLOCK, 0);
 
   safe_connect(con->mysql, con->name, opt_host, opt_user, opt_pass,
-               opt_db, opt_port, unix_sock);
+               opt_db, (int)opt_mysql_port, opt_mysql_unix_port);
 
   /* Use all time until exit if no explicit 'start_timer' */
   timer_start= timer_now();

--- a/include/common-cli-longopts.h
+++ b/include/common-cli-longopts.h
@@ -1,0 +1,40 @@
+#ifndef COMMON_CLI_LONGOPTS_INCLUDED
+#define COMMON_CLI_LONGOPTS_INCLUDED
+
+  {"host", 'h',
+   "Connect to host. Defaults in the following order: "
+   "$MARIADB_HOST, $MYSQL_HOST, and then localhost",
+   &opt_host, &opt_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"port", 'P', "Port number to use for connection or 0 for default to, in "
+   "order of preference, my.cnf, $MYSQL_TCP_PORT, "
+#if MYSQL_PORT_DEFAULT == 0
+   "/etc/services, "
+#endif
+   "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
+   &opt_mysql_port, &opt_mysql_port, 0, GET_UINT, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"socket", 'S', "The socket file to use for connection.",
+   &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR_ALLOC,
+   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"protocol", OPT_MYSQL_PROTOCOL,
+   "The protocol to use for connection (tcp, socket, pipe).",
+   &opt_protocol_type, &opt_protocol_type, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"compress", 0, "Use compression in server/client protocol.",
+   &opt_compress, &opt_compress, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+  {"plugin-dir", 0, "Directory for client-side plugins.",
+   &opt_client_plugin_dir, &opt_client_plugin_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"plugin_dir", 0, "Alias for --plugin-dir.",
+   &opt_client_plugin_dir, &opt_client_plugin_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"default-auth", 0, "Default authentication client-side plugin to use.",
+   &opt_default_auth, &opt_default_auth, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"default_auth", 0, "Alias for --default-auth.",
+   &opt_default_auth, &opt_default_auth, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"init-command", 0,
+   "SQL Command to execute when connecting to MariaDB server. Will "
+   "automatically be re-executed when reconnecting.",
+   &opt_init_command, &opt_init_command, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#ifndef DONT_ALLOW_USER_CHANGE
+  {"user", 'u', "User for login if not current user.",
+   &opt_user, &opt_user, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+#endif
+
+#endif /* COMMON_CLI_LONGOPTS_INCLUDED */

--- a/include/common-cli-vars.h
+++ b/include/common-cli-vars.h
@@ -1,0 +1,58 @@
+#ifndef COMMON_CLI_VARS_INCLUDED
+#define COMMON_CLI_VARS_INCLUDED
+
+/*
+  Common CLI option variables and a helper to apply them to a MYSQL handle.
+  These are intended to be shared across multiple client programs.
+*/
+
+/* Connection options */
+static uint opt_mysql_port;
+static char *opt_host, *opt_user, *opt_mysql_unix_port;
+
+/* Other common options */
+static my_bool opt_compress;
+static uint opt_protocol;
+static const char *opt_protocol_type = "";
+static char *opt_init_command, *opt_client_plugin_dir, *opt_default_auth;
+
+static inline void set_common_cli_host_from_env(void)
+{
+  // MARIADB_HOST will be preferred over MYSQL_HOST.
+  if (!opt_host)
+  {
+    const char *tmp= getenv("MARIADB_HOST");
+    if (!tmp)
+      tmp= getenv("MYSQL_HOST");
+    if (tmp)
+      opt_host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
+  }
+}
+
+static inline void set_common_cli_vars(MYSQL *mysql)
+{
+  if (opt_compress)
+    mysql_options(mysql, MYSQL_OPT_COMPRESS, NullS);
+  if (opt_protocol)
+    mysql_options(mysql, MYSQL_OPT_PROTOCOL, (char *)&opt_protocol);
+  if (opt_client_plugin_dir && *opt_client_plugin_dir)
+    mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_client_plugin_dir);
+  if (opt_default_auth && *opt_default_auth)
+    mysql_options(mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
+}
+
+static inline void set_common_cli_vars_with_init_command(MYSQL *mysql)
+{
+  set_common_cli_vars(mysql);
+  if (opt_init_command && *opt_init_command)
+    mysql_options(mysql, MYSQL_INIT_COMMAND, opt_init_command);
+}
+
+static inline void free_common_cli_vars(void)
+{
+  my_free(opt_host);
+  my_free(opt_user);
+  my_free(opt_mysql_unix_port);
+}
+
+#endif /* COMMON_CLI_VARS_INCLUDED */

--- a/man/mariadb-admin.1
+++ b/man/mariadb-admin.1
@@ -1009,6 +1009,22 @@ Connect to the MariaDB server on the given host\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-admin: init-command option
+.\" init-command option: mariadb-admin
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-admin: local option
 .\" local option: mariadb-admin
 \fB\-\-local\fR,

--- a/man/mariadb-binlog.1
+++ b/man/mariadb-binlog.1
@@ -655,6 +655,22 @@ Get the binary log from the MariaDB server on the given host\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-binlog: init-command option
+.\" init-command option: mariadb-binlog
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-binlog: local-load option
 .\" local-load option: mariadb-binlog
 \fB\-\-local\-load=\fR\fB\fIpath\fR\fR,

--- a/man/mariadb-check.1
+++ b/man/mariadb-check.1
@@ -599,6 +599,22 @@ Connect to the MariaDB server on the given host\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-check: init-command option
+.\" init-command option: mariadb-check
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-check: medium-check option
 .\" medium-check option: mariadb-check
 \fB\-\-medium\-check\fR,

--- a/man/mariadb-dump.1
+++ b/man/mariadb-dump.1
@@ -1089,6 +1089,22 @@ localhost\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-dump: init-command option
+.\" init-command option: mariadb-dump
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-dump: ignore-table option
 .\" ignore-table option: mariadb-dump
 \fB\-\-ignore\-table=\fR\fB\fIdb_name\&.tbl_name\fR\fR

--- a/man/mariadb-import.1
+++ b/man/mariadb-import.1
@@ -326,6 +326,22 @@ localhost\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-import: init-command option
+.\" init-command option: mariadb-import
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-import: ignore option
 .\" ignore option: mariadb-import
 \fB\-\-ignore\fR,

--- a/man/mariadb-show.1
+++ b/man/mariadb-show.1
@@ -327,6 +327,22 @@ Connect to the MariaDB server on the given host\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-show: init-command option
+.\" init-command option: mariadb-show
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-show: keys option
 .\" keys option: mariadb-show
 \fB\-\-keys\fR,

--- a/man/mariadb-test.1
+++ b/man/mariadb-test.1
@@ -327,6 +327,22 @@ Connect to the MariaDB server on the given host\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mariadb-test: init-command option
+.\" init-command option: mariadb-test
+\fB\-\-init\-command=\fR\fB\fIstmt\fR\fR
+.sp
+SQL command to execute when connecting to MariaDB server\&.
+Will automatically be re\-executed when reconnecting\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mariadb-test: logdir option
 .\" logdir option: mariadb-test
 \fB\-\-logdir=\fR\fB\fIdir_name\fR\fR

--- a/mysql-test/main/common-cli-vars.result
+++ b/mysql-test/main/common-cli-vars.result
@@ -1,0 +1,26 @@
+#
+# MDEV-28911: Add --init-command option to mariadb-{admin,dump,binlog,check,import, show,slap,test}
+#
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_schema='test'
+  AND table_name IN ('mysql',
+'mysqladmin',
+'mysqlbinlog',
+'mysqlcheck',
+'mysqldump',
+'mysqlimport',
+'mysqlshow',
+'mysqlslap',
+'mysqltest');
+COUNT(*)
+9
+DROP TABLE test.mysql;
+DROP TABLE test.mysqladmin;
+DROP TABLE test.mysqlbinlog;
+DROP TABLE test.mysqlcheck;
+DROP TABLE test.mysqldump;
+DROP TABLE test.mysqlimport;
+DROP TABLE test.mysqlshow;
+DROP TABLE test.mysqlslap;
+DROP TABLE test.mysqltest;
+End of 13.0 tests

--- a/mysql-test/main/common-cli-vars.test
+++ b/mysql-test/main/common-cli-vars.test
@@ -1,0 +1,57 @@
+--source include/not_embedded.inc
+--source include/have_log_bin.inc
+
+--echo #
+--echo # MDEV-28911: Add --init-command option to mariadb-{admin,dump,binlog,check,import, show,slap,test}
+--echo #
+
+--disable_query_log
+CREATE TABLE test.import_target(a INT);
+--write_file $MYSQLTEST_VARDIR/tmp/import_target.txt
+1
+EOF
+--write_file $MYSQLTEST_VARDIR/tmp/mysqltest.sql
+SELECT 1;
+EOF
+RESET MASTER;
+--enable_query_log
+
+--exec $MYSQL --init-command="CREATE TABLE test.mysql(a INT)" -e "SELECT 1" > /dev/null 2>&1
+--exec $MYSQLADMIN --init-command="CREATE TABLE test.mysqladmin(a INT)" ping > /dev/null 2>&1
+--exec $MYSQL_DUMP --init-command="CREATE TABLE test.mysqldump(a INT)" --skip-comments test mysqldump > /dev/null 2>&1
+--exec $MYSQL_SHOW --init-command="CREATE TABLE test.mysqlshow(a INT)" test > /dev/null 2>&1
+--exec $MYSQL_CHECK --init-command="CREATE TABLE test.mysqlcheck(a INT)" test mysqlcheck > /dev/null 2>&1
+--exec $MYSQL_IMPORT --silent --init-command="CREATE TABLE test.mysqlimport(a INT)" test $MYSQLTEST_VARDIR/tmp/import_target.txt > /dev/null 2>&1
+--exec $MYSQL_BINLOG --read-from-remote-server --user=root --host=127.0.0.1 --port=$MASTER_MYPORT --init-command="CREATE TABLE test.mysqlbinlog(a INT)" master-bin.000001 > /dev/null 2>&1
+--exec $MYSQL_SLAP --create-schema=test --init-command="CREATE TABLE test.mysqlslap(a INT)" --silent --concurrency=1 --iterations=1 > /dev/null 2>&1
+--exec $MYSQL_TEST --init-command="CREATE TABLE test.mysqltest(a INT)" < $MYSQLTEST_VARDIR/tmp/mysqltest.sql > /dev/null 2>&1
+
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_schema='test'
+  AND table_name IN ('mysql',
+                     'mysqladmin',
+                     'mysqlbinlog',
+                     'mysqlcheck',
+                     'mysqldump',
+                     'mysqlimport',
+                     'mysqlshow',
+                     'mysqlslap',
+                     'mysqltest');
+
+--remove_file $MYSQLTEST_VARDIR/tmp/import_target.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/mysqltest.sql
+DROP TABLE test.mysql;
+DROP TABLE test.mysqladmin;
+DROP TABLE test.mysqlbinlog;
+DROP TABLE test.mysqlcheck;
+DROP TABLE test.mysqldump;
+DROP TABLE test.mysqlimport;
+DROP TABLE test.mysqlshow;
+DROP TABLE test.mysqlslap;
+DROP TABLE test.mysqltest;
+
+--disable_query_log
+DROP TABLE test.import_target;
+--enable_query_log
+
+--echo End of 13.0 tests


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-28911](https://jira.mariadb.org/browse/MDEV-28911)*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
A quick note on the implementation: I set it up so the command runs before mariadb-dump initializes its own default session settings. I originally thought it made more sense to put it after (so users could override the tool's internal defaults), but looking at the rest of the codebase, doing it before seems to be the established pattern. I decided to stick with the existing convention to keep things consistent. I also added a small MTR test file to verify the flag works as expected. Do you agree with this order of execution?

Right now, only the last `init-command` option will run. Is it desirable to allow users to specify multiple `init` commands?

## Release Notes
Add --init-command option to `mysqldump` 

## How can this PR be tested?

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
