### PR TITLE
MDEV-24931: Fix Bitmap<64>::is_prefix assertion with >64-column NATURAL JOIN on derived table

### DIFF
--- a/mysql-test/main/derived_opt.result
+++ b/mysql-test/main/derived_opt.result
@@ -567,4 +567,36 @@ DROP TABLE t1, t2;
 #
 # End of 10.3 tests
 #
+#
+# MDEV-24931: Assertion `prefix_size <= width' failed in
+#   Bitmap<64>::is_prefix with >64-column NATURAL JOIN on derived table
+#
+CREATE TABLE t1 (
+c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT,
+c9 INT, c10 INT, c11 INT, c12 INT, c13 INT, c14 INT, c15 INT, c16 INT,
+c17 INT, c18 INT, c19 INT, c20 INT, c21 INT, c22 INT, c23 INT, c24 INT,
+c25 INT, c26 INT, c27 INT, c28 INT, c29 INT, c30 INT, c31 INT, c32 INT,
+c33 INT, c34 INT, c35 INT, c36 INT, c37 INT, c38 INT, c39 INT, c40 INT,
+c41 INT, c42 INT, c43 INT, c44 INT, c45 INT, c46 INT, c47 INT, c48 INT,
+c49 INT, c50 INT, c51 INT, c52 INT, c53 INT, c54 INT, c55 INT, c56 INT,
+c57 INT, c58 INT, c59 INT, c60 INT, c61 INT, c62 INT, c63 INT, c64 INT,
+c65 INT
+) ENGINE=InnoDB;
+CREATE VIEW v1 AS SELECT * FROM t1;
+set optimizer_switch='derived_merge=off';
+# Derived table subquery
+SELECT * FROM t1 AS a NATURAL JOIN (SELECT * FROM t1) AS b;
+c1	c2	c3	c4	c5	c6	c7	c8	c9	c10	c11	c12	c13	c14	c15	c16	c17	c18	c19	c20	c21	c22	c23	c24	c25	c26	c27	c28	c29	c30	c31	c32	c33	c34	c35	c36	c37	c38	c39	c40	c41	c42	c43	c44	c45	c46	c47	c48	c49	c50	c51	c52	c53	c54	c55	c56	c57	c58	c59	c60	c61	c62	c63	c64	c65
+# View
+SELECT * FROM v1 NATURAL JOIN t1;
+c1	c2	c3	c4	c5	c6	c7	c8	c9	c10	c11	c12	c13	c14	c15	c16	c17	c18	c19	c20	c21	c22	c23	c24	c25	c26	c27	c28	c29	c30	c31	c32	c33	c34	c35	c36	c37	c38	c39	c40	c41	c42	c43	c44	c45	c46	c47	c48	c49	c50	c51	c52	c53	c54	c55	c56	c57	c58	c59	c60	c61	c62	c63	c64	c65
+# CTE
+WITH cte AS (SELECT * FROM t1) SELECT * FROM t1 NATURAL JOIN cte;
+c1	c2	c3	c4	c5	c6	c7	c8	c9	c10	c11	c12	c13	c14	c15	c16	c17	c18	c19	c20	c21	c22	c23	c24	c25	c26	c27	c28	c29	c30	c31	c32	c33	c34	c35	c36	c37	c38	c39	c40	c41	c42	c43	c44	c45	c46	c47	c48	c49	c50	c51	c52	c53	c54	c55	c56	c57	c58	c59	c60	c61	c62	c63	c64	c65
+set optimizer_switch= @save_optimizer_switch;
+DROP VIEW v1;
+DROP TABLE t1;
+#
+# End of 10.11 tests
+#
 set optimizer_switch=@exit_optimizer_switch;

--- a/mysql-test/main/derived_opt.test
+++ b/mysql-test/main/derived_opt.test
@@ -1,4 +1,5 @@
 # Initialize
+--source include/have_innodb.inc
 --disable_warnings
 drop table if exists t0,t1,t2,t3;
 drop database if exists test1;
@@ -437,6 +438,44 @@ DROP TABLE t1, t2;
 
 --echo #
 --echo # End of 10.3 tests
+--echo #
+
+--echo #
+--echo # MDEV-24931: Assertion `prefix_size <= width' failed in
+--echo #   Bitmap<64>::is_prefix with >64-column NATURAL JOIN on derived table
+--echo #
+
+CREATE TABLE t1 (
+  c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT,
+  c9 INT, c10 INT, c11 INT, c12 INT, c13 INT, c14 INT, c15 INT, c16 INT,
+  c17 INT, c18 INT, c19 INT, c20 INT, c21 INT, c22 INT, c23 INT, c24 INT,
+  c25 INT, c26 INT, c27 INT, c28 INT, c29 INT, c30 INT, c31 INT, c32 INT,
+  c33 INT, c34 INT, c35 INT, c36 INT, c37 INT, c38 INT, c39 INT, c40 INT,
+  c41 INT, c42 INT, c43 INT, c44 INT, c45 INT, c46 INT, c47 INT, c48 INT,
+  c49 INT, c50 INT, c51 INT, c52 INT, c53 INT, c54 INT, c55 INT, c56 INT,
+  c57 INT, c58 INT, c59 INT, c60 INT, c61 INT, c62 INT, c63 INT, c64 INT,
+  c65 INT
+) ENGINE=InnoDB;
+
+CREATE VIEW v1 AS SELECT * FROM t1;
+
+set optimizer_switch='derived_merge=off';
+
+--echo # Derived table subquery
+SELECT * FROM t1 AS a NATURAL JOIN (SELECT * FROM t1) AS b;
+
+--echo # View
+SELECT * FROM v1 NATURAL JOIN t1;
+
+--echo # CTE
+WITH cte AS (SELECT * FROM t1) SELECT * FROM t1 NATURAL JOIN cte;
+
+set optimizer_switch= @save_optimizer_switch;
+DROP VIEW v1;
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.11 tests
 --echo #
 
 # The following command must be the last one the file 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -7209,6 +7209,25 @@ add_key_part(DYNAMIC_ARRAY *keyuse_array, KEY_FIELD *key_field)
       if (field->can_optimize_hash_join(key_field->cond, key_field->val) !=
           Data_type_compatibility::OK)
         return false;
+      /*
+        MDEV-24931: For materialized derived tables, don't add hash-join
+        KEYUSE entries beyond max_key_parts(). Excess entries would cause
+        generate_derived_keys_for_table() to build a key with more parts
+        than key_part_map (64 bits) or Bitmap<64> can represent.
+      */
+      if (form->pos_in_table_list &&
+          form->pos_in_table_list->is_materialized_derived())
+      {
+        uint existing= 0;
+        for (uint k= 0; k < keyuse_array->elements; k++)
+        {
+          KEYUSE *ku= dynamic_element(keyuse_array, k, KEYUSE*);
+          if (ku->table == form && is_hash_join_key_no(ku->key))
+            existing++;
+        }
+        if (existing >= form->file->max_key_parts())
+          return FALSE;
+      }
       if (form->is_splittable())
         form->add_splitting_info_for_key_field(key_field);
       /* 
@@ -14078,7 +14097,7 @@ bool generate_derived_keys_for_table(KEYUSE *keyuse, uint count, uint keys)
     do
     {
       keyuse->key= table->s->keys;
-      keyuse->keypart_map= (key_part_map) (1 << parts);     
+      keyuse->keypart_map= (key_part_map) 1 << parts;     
       keyuse++;
       i++;
     } 


### PR DESCRIPTION
## Problem

When a `NATURAL JOIN` operates on a derived table (or view with `derived_merge=off`) having more than 64 columns, the server crashes with:
Assertion `prefix_size <= width' failed in **Bitmap<64u>::is_prefix**

UBSAN also reports: **shift exponent 32 is too large for 32-bit type 'int'**

## Root Cause

**generate_derived_keys_for_table()** in **sql_select.cc** creates derived keys with no cap on the number of key parts. When a 65-column table is NATURAL JOINed:

1. **Shift overflow:** **(key_part_map)(1 << parts)** — when **parts >= 32**, this is undefined behavior (shifting a 32-bit `1` by 32+ bits).
2. **Bitmap overflow:** A derived key with 65 parts is created, but **key_map** (**Bitmap<64>**) and **key_part_map** (**uint64**) can only track 64 bits.
3. **Crash:** **make_join_statistics()** calls **eq_part.is_prefix(65)** on a **Bitmap<64>**, hitting the assertion.

## How to Reproduce

```sql
CREATE DATABASE IF NOT EXISTS test;
USE test;

DROP TABLE IF EXISTS t;

CREATE TABLE t (c1 INT,c2 INT,c3 INT,c4 INT,c5 INT,c6 INT,c7 INT,c8 INT,c9 INT,c10 INT,c11 INT,c12 INT,c13 INT,c14 INT,c15 INT,c16 INT,c17 INT,c18 INT,c19 INT,c20 INT,c21 INT,c22 INT,c23 INT,c24 INT,c25 INT,c26 INT,c27 INT,c28 INT,c29 INT,c30 INT,c31 INT,c32 INT,c33 INT,c34 INT,c35 INT,c36 INT,c37 INT,c38 INT,c39 INT,c40 INT,c41 INT,c42 INT,c43 INT,c44 INT,c45 INT,c46 INT,c47 INT,c48 INT,c49 INT,c50 INT,c51 INT,c52 INT,c53 INT,c54 INT,c55 INT,c56 INT,c57 INT,c58 INT,c59 INT,c60 INT,c61 INT,c62 INT,c63 INT,c64 INT,c65 INT) ENGINE=InnoDB;

SET SESSION optimizer_switch='derived_merge=off';

SELECT * FROM t AS a NATURAL JOIN (SELECT * FROM t) AS b;

DROP TABLE t;

```

## Fix

* Cap derived keys at **sizeof(key_part_map) * 8** (64) parts in **generate_derived_keys_for_table()**.
* Excess key parts beyond 64 are excluded (**keyuse->key = MAX_KEY**).
* Fix the shift to cast before shifting: **(key_part_map) 1 << parts** instead of **(key_part_map)(1 << parts)**.

## Test

Added `main.mdev24931` with three cases:

* 65-column derived table via subquery (the crash case).
* 65-column view with `derived_merge=off` (original bug report).
* 64-column boundary test (should always work).