### PR TITLE
MDEV-38721: refactor hierarchical read traversal into helper

### DIFF
--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1404,6 +1404,21 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
   return 0;
 }
 
+/*
+  Read-path hierarchical traversal:
+  descend upper layers with ef=1, then search layer 0 with requested limit.
+*/
+static int search_hierarchical_read(MHNSW_param *p, const FVector *target,
+                                    uint limit, Neighborhood *candidates)
+{
+  for (; p->layer > 0; p->layer--)
+  {
+    if (int err= search_layer(p, target, NEAREST, 1, candidates, false))
+      return err;
+  }
+  return search_layer(p, target, NEAREST, limit, candidates, false);
+}
+
 
 int mhnsw_insert(TABLE *table, KEY *keyinfo)
 {
@@ -1566,18 +1581,8 @@ int mhnsw_read_first(TABLE *table, KEY *keyinfo, Item *dist, ulonglong limit)
     return err;
 
   MHNSW_param p(ctx, graph, candidates.links[0]->max_layer);
-
-  for (; p.layer > 0; p.layer--)
-  {
-    if (int err= search_layer(&p, target, NEAREST, 1, &candidates, false))
-    {
-      graph->file->ha_rnd_end();
-      return err;
-    }
-  }
-
-  if (int err= search_layer(&p, target, NEAREST, static_cast<uint>(limit),
-                            &candidates, false))
+  if (int err= search_hierarchical_read(&p, target, static_cast<uint>(limit),
+                                        &candidates))
   {
     graph->file->ha_rnd_end();
     return err;


### PR DESCRIPTION
## Summary
Preparatory refactor for MDEV-38721 (VF-HNSW).

This change extracts the existing read-path hierarchical traversal from `mhnsw_read_first()` into a dedicated helper function. Behavior is intended to stay unchanged.

## Why
- Isolate current hierarchical read logic in one place.
- Make upcoming VF-HNSW traversal work easier to implement and review.

## Changes
- `sql/vector_mhnsw.cc`
  - Added `search_hierarchical_read(...)`
  - Replaced duplicated inline read-layer loop in `mhnsw_read_first()` with helper call

## Verification
```bash
cmake --build build -j4 --target sql
cd build/mysql-test
./mariadb-test-run.pl main.vector
```
Local result: pass (`aria`, `innodb`, `myisam`).
