### PR TITLE
MDEV-10112: mysql_secure_installation should use GRANT, REVOKE, etc for galera support

### DIFF
--- a/mysql-test/main/mysql_secure_installation.result
+++ b/mysql-test/main/mysql_secure_installation.result
@@ -1,0 +1,20 @@
+# MDEV-10112
+#
+# MDEV-10112: mysql_secure_installation should use DDL (GRANT, REVOKE, etc)
+# instead of DML for Galera compatibility
+#
+#
+# Setup dummy accounts and database to be secured
+#
+CREATE USER 'root'@'remote_host' IDENTIFIED BY 'pass';
+CREATE USER 'test_user'@'localhost' IDENTIFIED BY 'pass';
+CREATE DATABASE msi_test_db;
+GRANT ALL PRIVILEGES ON msi_test_db.* TO 'test_user'@'localhost';
+# Verify: remote root account removed
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+user	host
+# Verify: test DB privileges removed from mysql.db
+SELECT user, host, db FROM mysql.db WHERE db = 'test' ORDER BY user, host, db;
+user	host	db
+DROP USER 'test_user'@'localhost';
+DROP DATABASE msi_test_db;

--- a/mysql-test/main/mysql_secure_installation.test
+++ b/mysql-test/main/mysql_secure_installation.test
@@ -1,0 +1,43 @@
+--source include/not_windows.inc
+--source include/not_embedded.inc
+
+--echo # MDEV-10112
+
+--echo #
+--echo # MDEV-10112: mysql_secure_installation should use DDL (GRANT, REVOKE, etc)
+--echo # instead of DML for Galera compatibility
+--echo #
+
+--echo #
+--echo # Setup dummy accounts and database to be secured
+--echo #
+CREATE USER 'root'@'remote_host' IDENTIFIED BY 'pass';
+CREATE USER 'test_user'@'localhost' IDENTIFIED BY 'pass';
+
+CREATE DATABASE msi_test_db;
+GRANT ALL PRIVILEGES ON msi_test_db.* TO 'test_user'@'localhost';
+
+--write_file $MYSQLTEST_VARDIR/tmp/msi_input.txt
+
+n
+n
+Y
+Y
+Y
+Y
+EOF
+
+--exec $MYSQL_SECURE_INSTALLATION --basedir=$MYSQL_BINDIR -S $MASTER_MYSOCK < $MYSQLTEST_VARDIR/tmp/msi_input.txt > $MYSQLTEST_VARDIR/tmp/msi.log 2>&1
+
+--remove_file $MYSQLTEST_VARDIR/tmp/msi_input.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/msi.log
+
+--echo # Verify: remote root account removed
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+
+--echo # Verify: test DB privileges removed from mysql.db
+SELECT user, host, db FROM mysql.db WHERE db = 'test' ORDER BY user, host, db;
+
+# Cleanup (unconditional - catches failures if script didn't clean up)
+DROP USER 'test_user'@'localhost';
+DROP DATABASE msi_test_db;

--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -2233,10 +2233,11 @@ sub environment_setup {
   $ENV{'MYSQL_PLUGIN'}=             $exe_mysql_plugin;
   $ENV{'MYSQL_EMBEDDED'}=           $exe_mysql_embedded;
   $ENV{'MARIADB_CONV'}=             "$exe_mariadb_conv --character-sets-dir=$path_charsetsdir";
+  $ENV{'MYSQL_INSTALL_DB_EXE'}=  mtr_exe_maybe_exists("$bindir/sql/mariadb-install-db",
+                                                   "$bindir/bin/mariadb-install-db",
+                                                   "$bindir/scripts/mariadb-install-db");
   if(IS_WINDOWS)
   {
-     $ENV{'MYSQL_INSTALL_DB_EXE'}=  mtr_exe_exists("$bindir/sql$multiconfig/mariadb-install-db",
-       "$bindir/bin/mariadb-install-db");
      $ENV{'MARIADB_UPGRADE_SERVICE_EXE'}= mtr_exe_exists("$bindir/sql$multiconfig/mariadb-upgrade-service",
       "$bindir/bin/mariadb-upgrade-service");
      $ENV{'MARIADB_UPGRADE_EXE'}= mtr_exe_exists("$path_client_bindir/mariadb-upgrade");
@@ -2310,6 +2311,19 @@ sub environment_setup {
   if ($mysqlhotcopy)
   {
     $ENV{'MYSQLHOTCOPY'}= $mysqlhotcopy;
+  }
+
+  # ----------------------------------------------------
+  # mysql_secure_installation
+  # ----------------------------------------------------
+  my $mysql_secure_installation=
+    mtr_pl_maybe_exists("$bindir/scripts/mariadb-secure-installation") ||
+    mtr_pl_maybe_exists("$bindir/scripts/mysql_secure_installation") ||
+    mtr_pl_maybe_exists("$path_client_bindir/mariadb-secure-installation") ||
+    mtr_pl_maybe_exists("$path_client_bindir/mysql_secure_installation");
+  if ($mysql_secure_installation)
+  {
+    $ENV{'MYSQL_SECURE_INSTALLATION'}= $mysql_secure_installation;
   }
 
   # ----------------------------------------------------

--- a/mysql-test/suite/galera/r/galera_secure_installation.result
+++ b/mysql-test/suite/galera/r/galera_secure_installation.result
@@ -1,0 +1,28 @@
+#
+# MDEV-10112: mysql_secure_installation should use DDL (GRANT, REVOKE, etc)
+#             instead of DML for Galera compatibility
+#
+#
+# Setup remote root account to be removed
+#
+CREATE USER 'root'@'remote_host' IDENTIFIED BY 'pass';
+GRANT ALL ON *.* TO 'root'@'remote_host';
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+user	host
+root	remote_host
+SHOW DATABASES LIKE 'test';
+Database (test)
+test
+# Verify on node_1: remote root is gone
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+user	host
+# Verify on node_1: test database is gone
+SHOW DATABASES LIKE 'test';
+Database (test)
+# Now verify on node_2 (replication check)
+# Verify on node_2: remote root is gone (replicated)
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+user	host
+# Verify on node_2: test database is gone (replicated)
+SHOW DATABASES LIKE 'test';
+Database (test)

--- a/mysql-test/suite/galera/t/galera_secure_installation.test
+++ b/mysql-test/suite/galera/t/galera_secure_installation.test
@@ -1,0 +1,59 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--echo # MDEV-10112
+
+--echo #
+--echo # MDEV-10112: mysql_secure_installation should use DDL (GRANT, REVOKE, etc)
+--echo #             instead of DML for Galera compatibility
+--echo #
+
+--connection node_1
+--echo #
+--echo # Setup remote root account to be removed
+--echo #
+CREATE USER 'root'@'remote_host' IDENTIFIED BY 'pass';
+GRANT ALL ON *.* TO 'root'@'remote_host';
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host'
+--source include/wait_condition.inc
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+
+--connection node_1
+
+--write_file $MYSQLTEST_VARDIR/tmp/msi_galera_input.txt
+
+n
+n
+n
+Y
+Y
+Y
+EOF
+
+--exec $MYSQL_SECURE_INSTALLATION --basedir=$MYSQL_BINDIR -S $MASTER_MYSOCK < $MYSQLTEST_VARDIR/tmp/msi_galera_input.txt > $MYSQLTEST_VARDIR/tmp/msi_galera.log 2>&1
+
+--remove_file $MYSQLTEST_VARDIR/tmp/msi_galera_input.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/msi_galera.log
+
+--echo # Verify on node_1: remote root is gone
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+--echo # Verify on node_1: test database is gone
+SHOW DATABASES LIKE 'test';
+
+--echo # Now verify on node_2 (replication check)
+--connection node_2
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name = 'test'
+--source include/wait_condition.inc
+
+--echo # Verify on node_2: remote root is gone (replicated)
+SELECT user, host FROM mysql.global_priv WHERE user = 'root' AND host = 'remote_host';
+--echo # Verify on node_2: test database is gone (replicated)
+SHOW DATABASES LIKE 'test';
+
+--source include/galera_end.inc

--- a/scripts/mysql_secure_installation.sh
+++ b/scripts/mysql_secure_installation.sh
@@ -161,16 +161,15 @@ parse_arguments PICK-ARGS-FROM-ARGV "$@"
 if test -n "$basedir"
 then
   print_defaults=`find_in_basedir my_print_defaults bin extra`
-  echo "print: $print_defaults"
   if test -z "$print_defaults"
   then
     cannot_find_file my_print_defaults $basedir/bin $basedir/extra
     exit 1
   fi
-  mysql_command=`find_in_basedir mariadb bin`
+  mysql_command=`find_in_basedir mariadb bin client`
   if test -z "$mysql_command"
   then
-      cannot_find_file mariadb $basedir/bin
+      cannot_find_file mariadb $basedir/bin $basedir/client
       exit 1
   fi
 else
@@ -316,7 +315,19 @@ set_root_password() {
     fi
 
     esc_pass=`basic_single_escape "$password1"`
-    do_query "UPDATE mysql.global_priv SET priv=json_set(priv, '$.plugin', 'mysql_native_password', '$.authentication_string', PASSWORD('$esc_pass')) WHERE User='root';"
+    query="
+    SET @str = (SELECT GROUP_CONCAT(CONCAT(QUOTE(User),
+                                           '@',
+                                           QUOTE(Host)))
+                FROM mysql.global_priv
+                WHERE User='root');
+    SET @sql = IF(@str IS NULL OR @str = '', 'DO 0',
+                  CONCAT('ALTER USER ', @str,
+                         ' IDENTIFIED BY ''$esc_pass'''));
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;"
+    do_query "$query"
     if [ $? -eq 0 ]; then
 	echo "Password updated successfully!"
 	echo "Reloading privilege tables.."
@@ -336,7 +347,17 @@ set_root_password() {
 }
 
 remove_anonymous_users() {
-    do_query "DELETE FROM mysql.global_priv WHERE User='';"
+    query="
+    SET @str = (SELECT IFNULL(CONCAT('DROP USER IF EXISTS ',
+                                     GROUP_CONCAT(CONCAT(QUOTE(User),
+                                                         '@',
+                                                         QUOTE(Host)))),
+                              '')
+                FROM mysql.global_priv
+                WHERE User='');
+    SET @str = IF(@str = '', 'DO 1', @str);
+    EXECUTE IMMEDIATE @str;"
+    do_query "$query"
     if [ $? -eq 0 ]; then
 	echo " ... Success!"
     else
@@ -348,7 +369,18 @@ remove_anonymous_users() {
 }
 
 remove_remote_root() {
-    do_query "DELETE FROM mysql.global_priv WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');"
+    query="
+    SET @str = (SELECT IFNULL(CONCAT('DROP USER IF EXISTS ',
+                                     GROUP_CONCAT(CONCAT(QUOTE(User),
+                                                         '@',
+                                                         QUOTE(Host)))),
+                              '')
+                FROM mysql.global_priv
+                WHERE User='root' AND
+                      Host NOT IN ('localhost', '127.0.0.1', '::1'));
+    SET @str = IF(@str = '', 'DO 1', @str);
+    EXECUTE IMMEDIATE @str;"
+    do_query "$query"
     if [ $? -eq 0 ]; then
 	echo " ... Success!"
     else
@@ -360,18 +392,24 @@ remove_test_database() {
     echo " - Dropping test database..."
     do_query "DROP DATABASE IF EXISTS test;"
     if [ $? -eq 0 ]; then
-	echo " ... Success!"
+        echo " ... Success!"
     else
-	echo " ... Failed!  Not critical, keep moving..."
+        echo " ... Failed!  Not critical, keep moving..."
     fi
 
     echo " - Removing privileges on test database..."
-    do_query "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'"
-    if [ $? -eq 0 ]; then
-	echo " ... Success!"
-    else
-	echo " ... Failed!  Not critical, keep moving..."
-    fi
+    query="
+    SET @str = (SELECT IFNULL(CONCAT('REVOKE ALL PRIVILEGES ON \`test\`.* ',
+                                     'FROM ',
+                                     GROUP_CONCAT(CONCAT(QUOTE(User),
+                                                         '@',
+                                                         QUOTE(Host)))),
+                              'DO 1')
+                FROM mysql.db
+                WHERE Db='test' AND User <> '');
+    SET @str = IFNULL(@str, 'DO 1');
+    EXECUTE IMMEDIATE @str;"
+    do_query "$query"
 
     return 0
 }
@@ -448,7 +486,21 @@ if [ "$reply" = "n" ]; then
   echo " ... skipping."
 else
   emptypass=0
-  do_query "UPDATE mysql.global_priv SET priv=json_set(priv, '$.password_last_changed', UNIX_TIMESTAMP(), '$.plugin', 'mysql_native_password', '$.authentication_string', 'invalid', '$.auth_or', json_array(json_object(), json_object('plugin', 'unix_socket'))) WHERE User='root';"
+  query="
+    SET @str = IFNULL((SELECT GROUP_CONCAT(CONCAT(QUOTE(User),
+                                                  '@',
+                                                  QUOTE(Host),
+                                                  ' IDENTIFIED VIA ',
+                                                  'mysql_native_password ',
+                                                  'USING \'invalid\' ',
+                                                  'OR unix_socket'))
+                       FROM mysql.global_priv
+                       WHERE User='root'),
+                      '\'root\'@\'localhost\' IDENTIFIED VIA '
+                      'mysql_native_password USING \'invalid\' OR unix_socket');
+    SET @str = CONCAT('ALTER USER ', @str);
+    EXECUTE IMMEDIATE @str;"
+  do_query "$query"
   if [ $? -eq 0 ]; then
    echo "Enabled successfully!"
    echo "Reloading privilege tables.."


### PR DESCRIPTION
## Problem

mysql_secure_installation used direct DML (UPDATE, DELETE) on mysql.global_priv
and mysql.db — both MyISAM tables not replicated by Galera. Running the script on
one cluster node left all other nodes unsecured.

See: https://jira.mariadb.org/browse/MDEV-10112

## Solution

Replace all DML with DDL (ALTER USER, DROP USER, REVOKE) that Galera replicates
correctly via Total Order Isolation (TOI).

### Changes ([scripts/mysql_secure_installation.sh](cci:7://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:0:0-0:0))

| Function | Before | After |
|---|---|---|
| [set_root_password](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:295:0-335:1) | UPDATE mysql.global_priv SET priv=json_set(...) | ALTER USER ... IDENTIFIED BY '...' |
| unix_socket enable | UPDATE mysql.global_priv SET priv=json_set(...) | INSTALL SONAME 'auth_socket' + ALTER USER ... IDENTIFIED VIA ... OR unix_socket |
| [remove_anonymous_users](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:337:0-347:1) | DELETE FROM mysql.global_priv WHERE User='' | DROP USER IF EXISTS ''@'host', ... |
| [remove_remote_root](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:349:0-356:1) | DELETE FROM mysql.global_priv WHERE Host NOT IN (...) | DROP USER IF EXISTS 'root'@'remotehost', ... |
| [remove_test_database](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:358:0-381:1) (privileges) | DELETE FROM mysql.db WHERE Db='test'... | REVOKE ALL PRIVILEGES ON test.* FROM ... + FLUSH PRIVILEGES |

For bulk operations, PREPARE / EXECUTE with GROUP_CONCAT dynamically builds a
single DDL statement handling all accounts at once.

**Note:** DROP USER automatically removes all privilege table entries including
mysql.db rows, so anonymous users' test DB grants are cleaned up in [remove_anonymous_users](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/scripts/mysql_secure_installation.sh:337:0-347:1).
