### PR TITLE
MDEV-39005: Assertion failure on hint-forced Split-Materialized plan

### DIFF
--- a/mysql-test/main/opt_hints_split_materialized.result
+++ b/mysql-test/main/opt_hints_split_materialized.result
@@ -779,3 +779,59 @@ drop table one_k, t1000;
 #
 # End 12.1 tests
 #
+#
+# MDEV-39005: Assertion failure on hint-forced Split-Materialized plan
+#
+create table t1 (
+groups_20 int not null,
+groups_20_2 int not null,
+b int,
+primary key (groups_20, groups_20_2)
+) engine=innodb;
+insert into t1 select 0, seq, seq from seq_1_to_10;
+create table t2 (a int, b int, index(a));
+insert into t2 select seq, seq from seq_0_to_10;
+analyze table t1, t2;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	Table is already up to date
+# Query plan without the hint:
+analyze
+select a, sum(b)
+from
+(
+select groups_20 from t1
+group by groups_20
+having count(*) != 1
+) dt
+join
+t2 on a = groups_20
+group by a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
+1	PRIMARY	t2	ALL	a	NULL	NULL	NULL	11	11.00	100.00	100.00	Using where; Using temporary; Using filesort
+1	PRIMARY	<derived2>	ref	key0	key0	4	test.t2.a	1	0.09	100.00	100.00	
+2	DERIVED	t1	index	PRIMARY	PRIMARY	8	NULL	10	10.00	100.00	100.00	
+# Query plan with the hint.  Note that in this case, the
+# hint doesn't force the split because of the clamping
+# behavior introduced in this patch.
+analyze
+select /*+ split_materialized(dt) */ a, sum(b)
+from
+(
+select groups_20 from t1
+group by groups_20
+having count(*) != 1
+) dt
+join
+t2 on a = groups_20
+group by a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	1.00	100.00	100.00	Using temporary; Using filesort
+1	PRIMARY	t2	ref	a	a	5	dt.groups_20	1	1.00	100.00	100.00	
+2	DERIVED	t1	index	PRIMARY	PRIMARY	8	NULL	10	10.00	100.00	100.00	
+drop table t1, t2;
+#
+# End 12.3 tests
+#

--- a/mysql-test/main/opt_hints_split_materialized.test
+++ b/mysql-test/main/opt_hints_split_materialized.test
@@ -523,3 +523,54 @@ drop table one_k, t1000;
 --echo #
 --echo # End 12.1 tests
 --echo #
+
+--echo #
+--echo # MDEV-39005: Assertion failure on hint-forced Split-Materialized plan
+--echo #
+create table t1 (
+  groups_20 int not null,
+  groups_20_2 int not null,
+  b int,
+  primary key (groups_20, groups_20_2)
+) engine=innodb;
+insert into t1 select 0, seq, seq from seq_1_to_10;
+
+create table t2 (a int, b int, index(a));
+insert into t2 select seq, seq from seq_0_to_10;
+
+analyze table t1, t2;
+
+--echo # Query plan without the hint:
+analyze
+  select a, sum(b)
+  from
+    (
+      select groups_20 from t1
+      group by groups_20
+      having count(*) != 1
+    ) dt
+    join
+    t2 on a = groups_20
+  group by a;
+
+
+--echo # Query plan with the hint.  Note that in this case, the
+--echo # hint doesn't force the split because of the clamping
+--echo # behavior introduced in this patch.
+analyze
+  select /*+ split_materialized(dt) */ a, sum(b)
+  from
+    (
+      select groups_20 from t1
+      group by groups_20
+      having count(*) != 1
+    ) dt
+    join
+    t2 on a = groups_20
+  group by a;
+
+drop table t1, t2;
+
+--echo #
+--echo # End 12.3 tests
+--echo #

--- a/sql/opt_split.cc
+++ b/sql/opt_split.cc
@@ -1249,6 +1249,17 @@ SplM_plan_info * JOIN_TAB::choose_best_splitting(uint idx,
     */
     startup_cost= refills * spl_plan->cost;
     records= (ha_rows) (spl_opt_info->unsplit_card * spl_plan->split_sel);
+    /*
+      If the split is chosen because a hint forced it, then we need to
+      ensure that we don't violate the assertion in the
+      if (use_cond_selectivity > 1) branch of apply_selectivity_for_table()
+      by clamping records to
+        min(unsplit_card, spl_opt_info->unsplit_card * spl_plan->split_sel).
+      If we don't clamp the value of records, then sel exceeds exceeds
+      s->table->opt_range_condition_rows / table_records.
+    */
+    if (spl_opt_info->hint_forced_split)
+      set_if_smaller(records, (ha_rows) spl_opt_info->unsplit_card);
     if (unlikely(thd->trace_started()) && ! already_printed)
     {
       Json_writer_object trace(thd, "split_materialized");


### PR DESCRIPTION
Using a hint to force splitting can force the optimizer to choose a split plan that would otherwise be considered invalid. SPLIT_MATERIALIZED(DT) forces splitting but the optimizer must still respect the invariants checked by apply_selectivity_for_table() for what would otherwise be a splitting that would never be chosen naturally.

In the attached test case, a derived table DT performs GROUP BY/HAVING and is then joined to t2. With the hint forcing a split, the splitting code can compute a `records` estimate that makes the effective selectivity (`sel`) exceed the bound assumed in
apply_selectivity_for_table() (specifically the
`use_cond_selectivity > 1` assertion path), i.e. it can exceed:

  s->table->opt_range_condition_rows / table_records

To fix this, when a split is hint-forced, clamp `records` to the unsplit derived cardinality (`spl_opt_info->unsplit_card`). This effectively bounds `records` to:

  min(unsplit_card, unsplit_card * split_sel)

and prevents `sel` from exceeding the range-condition-rows ratio in the assertion.