### PR TITLE
MDEV-39002: Diagnostics area assertion failure upon CREATE TABLE (ER_CANT_AGGREGATE_2COLLATIONS)

### DIFF
--- a/mysql-test/main/create.result
+++ b/mysql-test/main/create.result
@@ -2066,3 +2066,16 @@ SHOW CREATE DATABASE `#testone#￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭�
 ERROR 42000: Incorrect database name '#testone#￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭...'
 SET NAMES DEFAULT;
 # End of 10.5 Test
+#
+# MDEV-39002: Diagnostics area assertion failure upon CREATE TABLE
+#
+CREATE TABLE t1 (a INT, b VARCHAR(8) DEFAULT (IFNULL(a,''))) CHARSET swe7;
+ERROR HY000: Illegal mix of collations (latin1_swedish_ci,NUMERIC) and (swe7_swedish_ci,COERCIBLE) for operation 'ifnull'
+# Test Item_func_case_abbreviation2 (IF, NVL2, IFNULL) with collation mismatch in DEFAULT
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (IFNULL(_latin1'x', _swe7'y'))) CHARSET utf8;
+ERROR HY000: Illegal mix of collations (latin1_swedish_ci,COERCIBLE) and (swe7_swedish_ci,COERCIBLE) for operation 'ifnull'
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (IF(1, _latin1'x', _swe7'y'))) CHARSET utf8;
+ERROR HY000: Illegal mix of collations (latin1_swedish_ci,COERCIBLE) and (swe7_swedish_ci,COERCIBLE) for operation 'if'
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (NVL2(1, _latin1'x', _swe7'y'))) CHARSET utf8;
+ERROR HY000: Illegal mix of collations (latin1_swedish_ci,COERCIBLE) and (swe7_swedish_ci,COERCIBLE) for operation 'nvl2'
+End of 10.11 tests

--- a/mysql-test/main/create.test
+++ b/mysql-test/main/create.test
@@ -1945,3 +1945,20 @@ SHOW CREATE DATABASE `#testone#￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭￭�
 SET NAMES DEFAULT;
 
 --echo # End of 10.5 Test
+
+--echo #
+--echo # MDEV-39002: Diagnostics area assertion failure upon CREATE TABLE
+--echo #
+
+--error ER_CANT_AGGREGATE_2COLLATIONS
+CREATE TABLE t1 (a INT, b VARCHAR(8) DEFAULT (IFNULL(a,''))) CHARSET swe7;
+
+--echo # Test Item_func_case_abbreviation2 (IF, NVL2, IFNULL) with collation mismatch in DEFAULT
+--error ER_CANT_AGGREGATE_2COLLATIONS
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (IFNULL(_latin1'x', _swe7'y'))) CHARSET utf8;
+--error ER_CANT_AGGREGATE_2COLLATIONS
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (IF(1, _latin1'x', _swe7'y'))) CHARSET utf8;
+--error ER_CANT_AGGREGATE_2COLLATIONS
+CREATE TABLE t1 (a VARCHAR(8) CHARSET latin1, b VARCHAR(8) DEFAULT (NVL2(1, _latin1'x', _swe7'y'))) CHARSET utf8;
+
+--echo End of 10.11 tests

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -1207,9 +1207,9 @@ public:
   bool fix_length_and_dec(THD *thd) override
   {
     update_nullability_post_fix_fields();
-    if (aggregate_for_result(func_name_cstring(), args, arg_count, true))
+    if (aggregate_for_result(func_name_cstring(), args, arg_count, true) ||
+        fix_attributes(args, arg_count))
       return TRUE;
-    fix_attributes(args, arg_count);
     return FALSE;
   }
   LEX_CSTRING func_name_cstring() const override
@@ -1236,9 +1236,9 @@ class Item_func_case_abbreviation2 :public Item_func_case_expression
 protected:
   bool fix_length_and_dec2(Item **items)
   {
-    if (aggregate_for_result(func_name_cstring(), items, 2, true))
+    if (aggregate_for_result(func_name_cstring(), items, 2, true) ||
+        fix_attributes(items, 2))
       return TRUE;
-    fix_attributes(items, 2);
     return FALSE;
   }
 


### PR DESCRIPTION
#### Description
Resolves an assertion failure in Diagnostics_area::set_ok_status that correctly triggered when CREATE TABLE operations involving mismatched collations incorrectly signaled success. 

**Root Cause:** 
Methods like Item_func_ifnull::fix_length_and_dec and Item_func_if::fix_length_and_dec were previously ignoring the boolean return value from internal [fix_attributes()](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/sql/item_func.cc:726:0-734:1) calls. During functions such as IFNULL encountering collation aggregation failures (e.g., INT paired with a default fallback like swe7_swedish_ci), [fix_attributes()](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/sql/item_func.cc:726:0-734:1) properly stored an ER_CANT_AGGREGATE_2COLLATIONS error in the Diagnostics Area. By ignoring [fix_attributes()](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/sql/item_func.cc:726:0-734:1)'s failure flag, the parser assumed the step prevailed and eventually hit the assertion while assigning an OK diagnostics status over the stored error.

**Solution:**
Propagated the boolean return values natively from [fix_attributes()](cci:1://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/sql/item_func.cc:726:0-734:1) calls upwards to parser handlers in [sql/item_cmpfunc.h](cci:7://file:///Users/mohammedjarirkhan/Desktop/GSOC26/server/sql/item_cmpfunc.h:0:0-0:0):
* Propagated boolean correctly inside Item_func_coalesce::fix_length_and_dec.
* Handled boolean evaluations faithfully within Item_func_case_abbreviation2::fix_length_and_dec2.
* Ensured boolean transmission through Item_func_if::fix_length_and_dec and Item_func_nvl2::fix_length_and_dec.
