### PR TITLE
MDEV-39008 FederatedX: set time_zone on connection change

### DIFF
--- a/mysql-test/suite/federated/timezone_after_reconnect.result
+++ b/mysql-test/suite/federated/timezone_after_reconnect.result
@@ -1,0 +1,33 @@
+connect  master,127.0.0.1,root,,test,$MASTER_MYPORT,;
+connect  slave,127.0.0.1,root,,test,$SLAVE_MYPORT,;
+connection master;
+CREATE DATABASE federated;
+connection slave;
+CREATE DATABASE federated;
+connection slave;
+set time_zone='+00:00';
+create table federated.t1 (id int primary key, ts timestamp);
+insert into federated.t1 values (1, '2020-06-15 12:00:00');
+connection master;
+create table t1 engine=federated connection='mysql://root@127.0.0.1:SLAVE_PORT/federated/t1';
+select * from t1;
+id	ts
+1	2020-06-15 12:00:00
+connection slave;
+# restart
+connection master;
+select * from t1;
+select * from t1;
+id	ts
+1	2020-06-15 12:00:00
+connection master;
+drop table t1;
+connection slave;
+drop table federated.t1;
+set time_zone=default;
+connection master;
+DROP TABLE IF EXISTS federated.t1;
+DROP DATABASE IF EXISTS federated;
+connection slave;
+DROP TABLE IF EXISTS federated.t1;
+DROP DATABASE IF EXISTS federated;

--- a/mysql-test/suite/federated/timezone_after_reconnect.test
+++ b/mysql-test/suite/federated/timezone_after_reconnect.test
@@ -1,0 +1,51 @@
+# MDEV-39008: After remote server restart (or connection change), FederatedX must
+# set time_zone again so TIMESTAMP values remain correct.
+#
+# Debug builds (DBUG/SAFEMALLOC): reconnect path can leave a small allocation
+# reported as "Warning: Memory not freed" at server exit; MTR shutdown checks
+# then fail. Skip on debug per review (PR #4791); track root cause in a
+# follow-up JIRA if needed.
+#
+# 1) Create table on backend with TIMESTAMP, insert row
+# 2) Federated table on master, SELECT (establishes connection, sets time_zone)
+# 3) Restart backend server
+# 4) SELECT again via federated (reconnect; time_zone must be set again)
+# 5) Verify we get the same timestamp (no TZ shift)
+
+source include/not_debug.inc;
+source have_federatedx.inc;
+source include/federated.inc;
+
+connection slave;
+set time_zone='+00:00';
+create table federated.t1 (id int primary key, ts timestamp);
+insert into federated.t1 values (1, '2020-06-15 12:00:00');
+
+connection master;
+replace_result $SLAVE_MYPORT SLAVE_PORT;
+eval create table t1 engine=federated connection='mysql://root@127.0.0.1:$SLAVE_MYPORT/federated/t1';
+
+# First read: establishes connection, sets time_zone='+00:00'
+select * from t1;
+
+# Restart backend so next query may hit stale connection (ER_NET_READ_ERROR) or reconnect
+connection slave;
+source include/restart_mysqld.inc;
+
+# First query after restart may fail (ER_NET_READ_ERROR) or succeed; accept both. Do not compare output.
+connection master;
+--disable_result_log
+--error 0,ER_NET_READ_ERROR
+select * from t1;
+--enable_result_log
+
+# Second query: (re)connect and time_zone set again (MDEV-39008 fix). Same timestamp.
+select * from t1;
+
+# Verify correct timestamp (no TZ shift)
+connection master;
+drop table t1;
+connection slave;
+drop table federated.t1;
+set time_zone=default;
+source include/federated_cleanup.inc;

--- a/storage/federatedx/federatedx_io_mysql.cc
+++ b/storage/federatedx/federatedx_io_mysql.cc
@@ -68,6 +68,10 @@ class federatedx_io_mysql :public federatedx_io
   DYNAMIC_ARRAY savepoints;
   bool requested_autocommit;
   bool actual_autocommit;
+  /** If true, send SET time_zone before next query (e.g. after reset). */
+  bool needs_to_set_timezone;
+  /** VIO for which time_zone was set; when it changes (reconnect/LB), set again. */
+  void *time_zone_set_vio;
 
   int actual_query(const char *buffer, size_t length);
   bool test_all_restrict() const;
@@ -134,7 +138,8 @@ federatedx_io *instantiate_io_mysql(MEM_ROOT *server_root,
 
 federatedx_io_mysql::federatedx_io_mysql(FEDERATEDX_SERVER *aserver)
   : federatedx_io(aserver),
-    requested_autocommit(TRUE), actual_autocommit(TRUE)
+    requested_autocommit(TRUE), actual_autocommit(TRUE),
+    needs_to_set_timezone(TRUE), time_zone_set_vio(NULL)
 {
   DBUG_ENTER("federatedx_io_mysql::federatedx_io_mysql");
 
@@ -162,7 +167,9 @@ void federatedx_io_mysql::reset()
 {
   reset_dynamic(&savepoints);
   set_active(FALSE);
-  
+  needs_to_set_timezone= TRUE;
+  time_zone_set_vio= NULL;
+
   requested_autocommit= TRUE;
   mysql.reconnect= 1;
 }
@@ -452,10 +459,25 @@ int federatedx_io_mysql::actual_query(const char *buffer, size_t length)
                             get_socket(), 0))
       DBUG_RETURN(ER_CONNECT_TO_FOREIGN_DATA_SOURCE);
 
+    needs_to_set_timezone= TRUE;
+    mysql.reconnect= 1;
+  }
+  else if (mysql.net.vio != time_zone_set_vio)
+  {
+    /* Connection changed (reconnect/LB); time_zone must be set again. */
+    needs_to_set_timezone= TRUE;
+  }
+
+  if (needs_to_set_timezone)
+  {
+    /*
+      Session state lost (reset) or connection changed. Set time_zone so
+      TIMESTAMP is consistent.
+    */
     if ((error= mysql_real_query(&mysql, STRING_WITH_LEN("set time_zone='+00:00'"))))
       DBUG_RETURN(error);
-
-    mysql.reconnect= 1;
+    needs_to_set_timezone= FALSE;
+    time_zone_set_vio= mysql.net.vio;
   }
 
   error= mysql_real_query(&mysql, buffer, (ulong)length);


### PR DESCRIPTION
When the underlying connection to the remote server changes (e.g. load balancer switching nodes or driver reconnect), the session variable time_zone was not set again. TIMESTAMP values could then be wrong.

Track the connection (mysql.net.vio) and re-send SET time_zone='+00:00' when the vio changes so TIMESTAMP remains consistent.

