### PR TITLE
MDEV-39035 IN Subquery String Value Retrieval Failure (val_str)

### DIFF
--- a/mysql-test/main/subselect_crash_39035.result
+++ b/mysql-test/main/subselect_crash_39035.result
@@ -1,0 +1,16 @@
+CREATE TABLE v0 (v1 INT, v2 INT, v3 INT);
+SELECT ( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) ) FROM v0;
+( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) )
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: 'x'
+INSERT INTO v0 VALUES (1, 2, 3);
+SELECT ( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) ) FROM v0;
+( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) )
+1
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: 'x'
+SELECT 1 IN (SELECT v3 FROM v0) FROM v0 GROUP BY v1;
+1 IN (SELECT v3 FROM v0)
+0
+DROP TABLE v0;

--- a/mysql-test/main/subselect_crash_39035.test
+++ b/mysql-test/main/subselect_crash_39035.test
@@ -1,0 +1,13 @@
+# Test for fix of MDEV-39035: Item_copy_string wrapping Item_in_subselect
+
+CREATE TABLE v0 (v1 INT, v2 INT, v3 INT);
+
+# Original test case (crash): AVG + row + NOT IN subquery
+SELECT ( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) ) FROM v0;
+
+INSERT INTO v0 VALUES (1, 2, 3);
+SELECT ( AVG ( 69 ) , - 'x' ) NOT IN ( SELECT v3 , v1 = -1 OR ( v3 , v2 , v1 ) < ( 255 , 3 , 0 ) ) FROM v0;
+
+SELECT 1 IN (SELECT v3 FROM v0) FROM v0 GROUP BY v1;
+
+DROP TABLE v0;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -5520,10 +5520,22 @@ int Item_copy_string::save_in_field(Field *field, bool no_conversions)
 
 void Item_copy_string::copy()
 {
-  String *res=item->val_str(&str_value);
-  if (res && res != &str_value)
-    str_value.copy(*res);
-  null_value=item->null_value;
+  Item *real_item= item->real_item();
+  if (real_item->type() == Item::SUBSELECT_ITEM &&
+      static_cast<Item_subselect *>(real_item)->substype() == Item_subselect::IN_SUBS)
+  {
+    double d= item->val_real();
+    null_value= item->null_value;
+    if (!null_value)
+      str_value.set_real(d, 0, &my_charset_bin);
+  }
+  else
+  {
+    String *res= item->val_str(&str_value);
+    if (res && res != &str_value)
+      str_value.copy(*res);
+    null_value= item->null_value;
+  }
 #ifndef DBUG_OFF
   copied_in= 1;
 #endif


### PR DESCRIPTION
The issue was caused by Item_in_subselect::val_str() which contained DBUG_ASSERT(0). To fix the problem, we use val_real() instead of the val_str() method, and then convert the numeric result to string.