### PR TITLE
MDEV-38792: Fix inconsistent separator treatment in TO_DATE

### DIFF
--- a/mysql-test/suite/compat/oracle/r/func_to_date.result
+++ b/mysql-test/suite/compat/oracle/r/func_to_date.result
@@ -298,14 +298,10 @@ NULL
 #
 SELECT TO_DATE('2001 - - 10','YYYY - MM');
 TO_DATE('2001 - - 10','YYYY - MM')
-NULL
-Warnings:
-Warning	1411	Incorrect datetime value: '2001 - - 10' for function to_date
+2001-10-09 00:00:00
 SELECT TO_DATE('02#/07','MM/YY');
 TO_DATE('02#/07','MM/YY')
-NULL
-Warnings:
-Warning	1411	Incorrect datetime value: '02#/07' for function to_date
+2007-02-09 00:00:00
 SELECT TO_DATE('2023-01-02 helloa 03:04:05', 'YYYY-MM-DD "hello" HH24:MI:SS');
 TO_DATE('2023-01-02 helloa 03:04:05', 'YYYY-MM-DD "hello" HH24:MI:SS')
 NULL
@@ -491,9 +487,7 @@ Warning	1411	Incorrect datetime value: '08:30:25 PX' for function to_date
 # Wrong quoting
 select TO_DATE('2023-01-02 "03:04:05"', 'YYYY-MM-DD """"HH24:MI:SS""""');
 TO_DATE('2023-01-02 "03:04:05"', 'YYYY-MM-DD """"HH24:MI:SS""""')
-NULL
-Warnings:
-Warning	1411	Incorrect datetime value: '2023-01-02 "03:04:05"' for function to_date
+2023-01-02 03:04:05
 select TO_DATE('2023-01-02 hello 03:04:05', 'YYYY-MM-DD HH24:MI:SS');
 TO_DATE('2023-01-02 hello 03:04:05', 'YYYY-MM-DD HH24:MI:SS')
 NULL
@@ -506,9 +500,7 @@ Warnings:
 Warning	1411	Incorrect datetime value: '2023-01-02 03:04:05' for function to_date
 select TO_DATE('2023-01-02 "03:04:05"', 'YYYY-MM-DD ""HH24:MI:SS""');
 TO_DATE('2023-01-02 "03:04:05"', 'YYYY-MM-DD ""HH24:MI:SS""')
-NULL
-Warnings:
-Warning	1411	Incorrect datetime value: '2023-01-02 "03:04:05"' for function to_date
+2023-01-02 03:04:05
 SELECT TO_DATE('1920-12','YYYY"--"MM');
 TO_DATE('1920-12','YYYY"--"MM')
 NULL
@@ -945,4 +937,27 @@ TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY', 'NLS_DATE_LANGUAGE=ar_
 NULL
 Warnings:
 Warning	1411	Incorrect datetime value: 'Wednesday, June 2, 2014' for function to_date
+#
+# MDEV-38792: TO_DATE Inconsistent treatment of different separators in the date and format strings
+#
+SET lc_time_names='en_US';
+SET timestamp=UNIX_TIMESTAMP('2001-01-01 10:00:00');
+SELECT TO_DATE('2002 - AD', 'YYYY AD') AS t;
+t
+2002-01-01 00:00:00
+SELECT TO_DATE('2024---01---01', 'YYYYMMDD') AS t;
+t
+2024-01-01 00:00:00
+SELECT TO_DATE('2024 . 05 . 10', 'YYYYMMDD') AS t;
+t
+2024-05-10 00:00:00
+SELECT TO_DATE('2002 February 10', 'YYYY MONTH DD') AS t;
+t
+2002-02-10 00:00:00
+# Testing negative year (SYYYY) with separators
+SELECT TO_DATE('-2024-05-10', 'SYYYY-MM-DD') AS t;
+t
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: '-2024-05-10' for function to_date
 # End of 12.3 tests

--- a/mysql-test/suite/compat/oracle/t/func_to_date.test
+++ b/mysql-test/suite/compat/oracle/t/func_to_date.test
@@ -492,4 +492,19 @@ SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY');
 --echo # locale as param to TO_DATE
 SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY', 'NLS_DATE_LANGUAGE=ar_DZ');
 
+--echo #
+--echo # MDEV-38792: TO_DATE Inconsistent treatment of different separators in the date and format strings
+--echo #
+
+SET lc_time_names='en_US';
+SET timestamp=UNIX_TIMESTAMP('2001-01-01 10:00:00');
+
+SELECT TO_DATE('2002 - AD', 'YYYY AD') AS t;
+SELECT TO_DATE('2024---01---01', 'YYYYMMDD') AS t;
+SELECT TO_DATE('2024 . 05 . 10', 'YYYYMMDD') AS t;
+SELECT TO_DATE('2002 February 10', 'YYYY MONTH DD') AS t;
+
+--echo # Testing negative year (SYYYY) with separators
+SELECT TO_DATE('-2024-05-10', 'SYYYY-MM-DD') AS t;
+
 --echo # End of 12.3 tests

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -717,10 +717,24 @@ extract_oracle_date_time(THD *thd, uint16 *format_ptr,
             continue;
           }
         }
+        continue;
       }
-      continue;
     }
 
+    /*
+      Skip non-alphanumeric separators in the input before parsing each
+      format token. This allows extra or mismatched separators in the value,
+      matching Oracle's flexible parsing behaviour.
+      Preserve a leading '-' or '+' when the format is SYYYY and it is
+      followed by a digit, so signed years are parsed correctly.
+    */
+    while (val < val_end && !my_isalnum(val_cs, *val))
+    {
+      if ((*val == '-' || *val == '+') && format == FMT_SYYYY &&
+          (val + 1 < val_end) && my_isdigit(val_cs, *(val + 1)))
+        break;
+      val++;
+    }
     error= 0;
     if (!(val_len= (uint) (val_end - val)))
       goto error;
@@ -729,13 +743,26 @@ extract_oracle_date_time(THD *thd, uint16 *format_ptr,
       /* Year */
     case FMT_YYYY:
     case FMT_SYYYY:
-      tmp= (char*) val + MY_MIN(4, val_len);
+    {
+      uint max_len= 4;
+      if (format == FMT_SYYYY && (*val == '-' || *val == '+'))
+      {
+        max_len= 5;
+        const char *temp_val = val + 1;
+        while (temp_val < val_end && my_isspace(val_cs, *temp_val))
+        {
+          temp_val++;
+          max_len++;
+        }
+      }
+      tmp= (char*) val + MY_MIN(max_len, val_len);
       l_time->year= (int) val_cs->cset->strtoll10(val_cs, val, &tmp, &error);
       if (part_of_digits && (tmp-val) != 4)
         goto error;
       val= tmp;
       part_of_digits= 1;
       break;
+    }
     case FMT_YYY:
       tmp= (char*) val + MY_MIN(3, val_len);
       l_time->year= ((int) val_cs->cset->strtoll10(val_cs, val, &tmp, &error) +
@@ -970,6 +997,12 @@ extract_oracle_date_time(THD *thd, uint16 *format_ptr,
   if (check_date(l_time, fuzzydate, &was_cut))
     goto error;
 
+  /* Consume trailing non-alphanumeric chars to avoid false "truncated" warnings */
+  while (val < val_end && !my_isalnum(val_cs, *val))
+  {
+    val++;
+  }
+
   if (val != val_end)
   {
     /* There was more data than the format allowed.
@@ -988,7 +1021,7 @@ extract_oracle_date_time(THD *thd, uint16 *format_ptr,
         make_truncated_value_warning(thd, Sql_condition::WARN_LEVEL_WARN,
                                      &err, l_time->time_type,
                                      nullptr, nullptr, nullptr);
-	break;
+        break;
       }
     } while (++val != val_end);
   }


### PR DESCRIPTION
Fixed MDEV-38792: Added a loop to skip non-alphanumeric separators in TO_DATE, ensuring flexible data parsing matching Oracle's expected behavior.

Reported-by: Elena Stepanova <elenastepanova@github>