### PR TITLE
MDEV-36621: galera.GCF-360 test: IST failure

### DIFF
--- a/mysql-test/suite/galera/t/GCF-360.cnf
+++ b/mysql-test/suite/galera/t/GCF-360.cnf
@@ -1,17 +1,4 @@
 !include ../galera_4nodes.cnf
 
-[mysqld.1]
-wsrep_provider_options='base_port=@mysqld.1.#galera_port'
-wsrep_ignore_apply_errors=0
-
-[mysqld.2]
-wsrep_provider_options='base_port=@mysqld.2.#galera_port'
-wsrep_ignore_apply_errors=0
-
-[mysqld.3]
-wsrep_provider_options='base_port=@mysqld.3.#galera_port'
-wsrep_ignore_apply_errors=0
-
-[mysqld.4]
-wsrep_provider_options='base_port=@mysqld.4.#galera_port'
+[mysqld]
 wsrep_ignore_apply_errors=0


### PR DESCRIPTION
Removed redundant per-node wsrep_provider_options overrides that were dropping all timeout settings.