### PR TITLE
MDEV-38819 Wrong result of "Range checked for each record" after pushdown from HAVING

### DIFF
--- a/mysql-test/main/having_cond_pushdown.result
+++ b/mysql-test/main/having_cond_pushdown.result
@@ -6147,57 +6147,6 @@ EXPLAIN
     }
   }
 }
-SET SESSION debug_dbug="+d,clone_failure";
-SELECT t2.b, t1.a, t1.b
-FROM t2 STRAIGHT_JOIN t1
-GROUP BY t2.b, t1.a, t1.b
-HAVING t1.b < t2.b;
-b	a	b
-4	1	2
-6	1	2
-explain format=json SELECT t2.b, t1.a, t1.b
-FROM t2 STRAIGHT_JOIN t1
-GROUP BY t2.b, t1.a, t1.b
-HAVING t1.b < t2.b;
-EXPLAIN
-{
-  "query_block": {
-    "select_id": 1,
-    "filesort": {
-      "sort_key": "t2.b, t1.a, t1.b",
-      "temporary_table": {
-        "nested_loop": [
-          {
-            "table": {
-              "table_name": "t2",
-              "access_type": "index",
-              "key": "b",
-              "key_length": "5",
-              "used_key_parts": ["b"],
-              "rows": 2,
-              "filtered": 100,
-              "using_index": true
-            }
-          },
-          {
-            "block-nl-join": {
-              "table": {
-                "table_name": "t1",
-                "access_type": "ALL",
-                "rows": 1,
-                "filtered": 100
-              },
-              "buffer_type": "flat",
-              "buffer_size": "65",
-              "join_type": "BNL"
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-SET GLOBAL debug_dbug=@orig_debug;
 SELECT b, a, b1
 FROM (
 SELECT
@@ -6264,7 +6213,8 @@ EXPLAIN
                         },
                         "buffer_type": "flat",
                         "buffer_size": "65",
-                        "join_type": "BNL"
+                        "join_type": "BNL",
+                        "attached_condition": "t1.b < t2.b <> 0"
                       }
                     }
                   ]

--- a/mysql-test/main/having_cond_pushdown.result
+++ b/mysql-test/main/having_cond_pushdown.result
@@ -6090,4 +6090,135 @@ EXPLAIN
   }
 }
 drop table t1, t2;
+#
+# MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+#
+CREATE TABLE t0(c0 INT, c1 INT UNIQUE);
+CREATE TABLE t1(c0 VARCHAR(100), c1 INT UNIQUE);
+INSERT INTO t1 VALUES ('C', -1833670268);
+INSERT INTO t1 VALUES ('\\', 1046230419);
+INSERT INTO t0 VALUES (500, -1016012686);
+SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
+FROM t1 STRAIGHT_JOIN t0
+GROUP BY t1.c1, t0.c0, t0.c1
+HAVING g2 NOT IN (g0, g0 != g1);
+g0	g1	g2
+-1833670268	500	-1016012686
+1046230419	500	-1016012686
+explain format=json SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
+FROM t1 STRAIGHT_JOIN t0
+GROUP BY t1.c1, t0.c0, t0.c1
+HAVING g2 NOT IN (g0, g0 != g1);
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "filesort": {
+      "sort_key": "t1.c1, t0.c0, t0.c1",
+      "temporary_table": {
+        "nested_loop": [
+          {
+            "table": {
+              "table_name": "t1",
+              "access_type": "index",
+              "key": "c1",
+              "key_length": "5",
+              "used_key_parts": ["c1"],
+              "rows": 2,
+              "filtered": 100,
+              "using_index": true
+            }
+          },
+          {
+            "range-checked-for-each-record": {
+              "keys": ["c1"],
+              "table": {
+                "table_name": "t0",
+                "access_type": "ALL",
+                "possible_keys": ["c1"],
+                "rows": 1,
+                "filtered": 100
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+SELECT g0, g1, g2
+FROM (
+SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
+t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
+FROM t1 STRAIGHT_JOIN t0
+GROUP BY t1.c1, t0.c0, t0.c1
+) AS s
+WHERE ref1;
+g0	g1	g2
+-1833670268	500	-1016012686
+1046230419	500	-1016012686
+explain format=json SELECT g0, g1, g2
+FROM (
+SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
+t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
+FROM t1 STRAIGHT_JOIN t0
+GROUP BY t1.c1, t0.c0, t0.c1
+) AS s
+WHERE ref1;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "nested_loop": [
+      {
+        "table": {
+          "table_name": "<derived2>",
+          "access_type": "ALL",
+          "rows": 2,
+          "filtered": 100,
+          "attached_condition": "s.ref1 <> 0",
+          "materialized": {
+            "query_block": {
+              "select_id": 2,
+              "filesort": {
+                "sort_key": "t1.c1, t0.c0, t0.c1",
+                "temporary_table": {
+                  "nested_loop": [
+                    {
+                      "table": {
+                        "table_name": "t1",
+                        "access_type": "index",
+                        "key": "c1",
+                        "key_length": "5",
+                        "used_key_parts": ["c1"],
+                        "rows": 2,
+                        "filtered": 100,
+                        "using_index": true
+                      }
+                    },
+                    {
+                      "block-nl-join": {
+                        "table": {
+                          "table_name": "t0",
+                          "access_type": "ALL",
+                          "rows": 1,
+                          "filtered": 100
+                        },
+                        "buffer_type": "flat",
+                        "buffer_size": "65",
+                        "join_type": "BNL",
+                        "attached_condition": "t0.c1 not in (t1.c1,t1.c1 <> t0.c0) <> 0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+drop table t0, t1;
 # End of 10.11 tests

--- a/mysql-test/main/having_cond_pushdown.result
+++ b/mysql-test/main/having_cond_pushdown.result
@@ -6093,37 +6093,38 @@ drop table t1, t2;
 #
 # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
 #
-CREATE TABLE t0(c0 INT, c1 INT UNIQUE);
-CREATE TABLE t1(c0 VARCHAR(100), c1 INT UNIQUE);
-INSERT INTO t1 VALUES ('C', -1833670268);
-INSERT INTO t1 VALUES ('\\', 1046230419);
-INSERT INTO t0 VALUES (500, -1016012686);
-SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
-FROM t1 STRAIGHT_JOIN t0
-GROUP BY t1.c1, t0.c0, t0.c1
-HAVING g2 NOT IN (g0, g0 != g1);
-g0	g1	g2
--1833670268	500	-1016012686
-1046230419	500	-1016012686
-explain format=json SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
-FROM t1 STRAIGHT_JOIN t0
-GROUP BY t1.c1, t0.c0, t0.c1
-HAVING g2 NOT IN (g0, g0 != g1);
+CREATE TABLE t1(a INT, b INT UNIQUE);
+CREATE TABLE t2 LIKE t1;
+INSERT INTO t1 VALUES (1, 2);
+INSERT INTO t2 VALUES (3, 4);
+INSERT INTO t2 VALUES (5, 6);
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+b	a	b
+4	1	2
+6	1	2
+explain format=json SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
 EXPLAIN
 {
   "query_block": {
     "select_id": 1,
     "filesort": {
-      "sort_key": "t1.c1, t0.c0, t0.c1",
+      "sort_key": "t2.b, t1.a, t1.b",
       "temporary_table": {
         "nested_loop": [
           {
             "table": {
-              "table_name": "t1",
+              "table_name": "t2",
               "access_type": "index",
-              "key": "c1",
+              "possible_keys": ["b"],
+              "key": "b",
               "key_length": "5",
-              "used_key_parts": ["c1"],
+              "used_key_parts": ["b"],
               "rows": 2,
               "filtered": 100,
               "using_index": true
@@ -6131,11 +6132,11 @@ EXPLAIN
           },
           {
             "range-checked-for-each-record": {
-              "keys": ["c1"],
+              "keys": ["b"],
               "table": {
-                "table_name": "t0",
+                "table_name": "t1",
                 "access_type": "ALL",
-                "possible_keys": ["c1"],
+                "possible_keys": ["b"],
                 "rows": 1,
                 "filtered": 100
               }
@@ -6146,23 +6147,80 @@ EXPLAIN
     }
   }
 }
-SELECT g0, g1, g2
+SET SESSION debug_dbug="+d,clone_failure";
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+b	a	b
+4	1	2
+6	1	2
+explain format=json SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "filesort": {
+      "sort_key": "t2.b, t1.a, t1.b",
+      "temporary_table": {
+        "nested_loop": [
+          {
+            "table": {
+              "table_name": "t2",
+              "access_type": "index",
+              "key": "b",
+              "key_length": "5",
+              "used_key_parts": ["b"],
+              "rows": 2,
+              "filtered": 100,
+              "using_index": true
+            }
+          },
+          {
+            "block-nl-join": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "rows": 1,
+                "filtered": 100
+              },
+              "buffer_type": "flat",
+              "buffer_size": "65",
+              "join_type": "BNL"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+SET GLOBAL debug_dbug=@orig_debug;
+SELECT b, a, b1
 FROM (
-SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
-t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
-FROM t1 STRAIGHT_JOIN t0
-GROUP BY t1.c1, t0.c0, t0.c1
+SELECT
+t2.b AS b,
+t1.a AS a,
+t1.b AS b1,
+t1.b < t2.b AS ref1
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
 ) AS s
 WHERE ref1;
-g0	g1	g2
--1833670268	500	-1016012686
-1046230419	500	-1016012686
-explain format=json SELECT g0, g1, g2
+b	a	b1
+4	1	2
+6	1	2
+explain format=json SELECT b, a, b1
 FROM (
-SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
-t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
-FROM t1 STRAIGHT_JOIN t0
-GROUP BY t1.c1, t0.c0, t0.c1
+SELECT
+t2.b AS b,
+t1.a AS a,
+t1.b AS b1,
+t1.b < t2.b AS ref1
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
 ) AS s
 WHERE ref1;
 EXPLAIN
@@ -6181,16 +6239,16 @@ EXPLAIN
             "query_block": {
               "select_id": 2,
               "filesort": {
-                "sort_key": "t1.c1, t0.c0, t0.c1",
+                "sort_key": "t2.b, t1.a, t1.b",
                 "temporary_table": {
                   "nested_loop": [
                     {
                       "table": {
-                        "table_name": "t1",
+                        "table_name": "t2",
                         "access_type": "index",
-                        "key": "c1",
+                        "key": "b",
                         "key_length": "5",
-                        "used_key_parts": ["c1"],
+                        "used_key_parts": ["b"],
                         "rows": 2,
                         "filtered": 100,
                         "using_index": true
@@ -6199,15 +6257,14 @@ EXPLAIN
                     {
                       "block-nl-join": {
                         "table": {
-                          "table_name": "t0",
+                          "table_name": "t1",
                           "access_type": "ALL",
                           "rows": 1,
                           "filtered": 100
                         },
                         "buffer_type": "flat",
                         "buffer_size": "65",
-                        "join_type": "BNL",
-                        "attached_condition": "t0.c1 not in (t1.c1,t1.c1 <> t0.c0) <> 0"
+                        "join_type": "BNL"
                       }
                     }
                   ]
@@ -6220,5 +6277,5 @@ EXPLAIN
     ]
   }
 }
-drop table t0, t1;
+drop table t1, t2;
 # End of 10.11 tests

--- a/mysql-test/main/having_cond_pushdown.result
+++ b/mysql-test/main/having_cond_pushdown.result
@@ -6091,7 +6091,7 @@ EXPLAIN
 }
 drop table t1, t2;
 #
-# MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+# MDEV-38819: Wrong result of "Range checked for each record" after pushdown from HAVING
 #
 CREATE TABLE t1(a INT, b INT UNIQUE);
 CREATE TABLE t2 LIKE t1;

--- a/mysql-test/main/having_cond_pushdown.test
+++ b/mysql-test/main/having_cond_pushdown.test
@@ -1677,13 +1677,6 @@ HAVING t1.b < t2.b;
 eval $q;
 eval explain format=json $q;
 
-SET SESSION debug_dbug="+d,clone_failure";
-
-eval $q;
-eval explain format=json $q;
-
-SET GLOBAL debug_dbug=@orig_debug;
-
 let $q=
 SELECT b, a, b1
 FROM (

--- a/mysql-test/main/having_cond_pushdown.test
+++ b/mysql-test/main/having_cond_pushdown.test
@@ -1658,7 +1658,7 @@ execute stmt;
 drop table t1, t2;
 
 --echo #
---echo # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+--echo # MDEV-38819: Wrong result of "Range checked for each record" after pushdown from HAVING
 --echo #
 
 

--- a/mysql-test/main/having_cond_pushdown.test
+++ b/mysql-test/main/having_cond_pushdown.test
@@ -1657,4 +1657,37 @@ execute stmt;
 
 drop table t1, t2;
 
+--echo #
+--echo # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+--echo #
+
+CREATE TABLE t0(c0 INT, c1 INT UNIQUE);
+CREATE TABLE t1(c0 VARCHAR(100), c1 INT UNIQUE);
+INSERT INTO t1 VALUES ('C', -1833670268);
+INSERT INTO t1 VALUES ('\\', 1046230419);
+INSERT INTO t0 VALUES (500, -1016012686);
+
+let $q=
+SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
+FROM t1 STRAIGHT_JOIN t0
+GROUP BY t1.c1, t0.c0, t0.c1
+HAVING g2 NOT IN (g0, g0 != g1);
+eval $q;
+eval explain format=json $q;
+
+let $q=
+SELECT g0, g1, g2
+FROM (
+  SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
+         t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
+  FROM t1 STRAIGHT_JOIN t0
+  GROUP BY t1.c1, t0.c0, t0.c1
+) AS s
+WHERE ref1;
+
+eval $q;
+eval explain format=json $q;
+
+drop table t0, t1;
+
 --echo # End of 10.11 tests

--- a/mysql-test/main/having_cond_pushdown.test
+++ b/mysql-test/main/having_cond_pushdown.test
@@ -1661,33 +1661,46 @@ drop table t1, t2;
 --echo # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
 --echo #
 
-CREATE TABLE t0(c0 INT, c1 INT UNIQUE);
-CREATE TABLE t1(c0 VARCHAR(100), c1 INT UNIQUE);
-INSERT INTO t1 VALUES ('C', -1833670268);
-INSERT INTO t1 VALUES ('\\', 1046230419);
-INSERT INTO t0 VALUES (500, -1016012686);
+
+CREATE TABLE t1(a INT, b INT UNIQUE);
+CREATE TABLE t2 LIKE t1;
+ 
+INSERT INTO t1 VALUES (1, 2);
+INSERT INTO t2 VALUES (3, 4);
+INSERT INTO t2 VALUES (5, 6);
 
 let $q=
-SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2
-FROM t1 STRAIGHT_JOIN t0
-GROUP BY t1.c1, t0.c0, t0.c1
-HAVING g2 NOT IN (g0, g0 != g1);
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
 eval $q;
 eval explain format=json $q;
 
+SET SESSION debug_dbug="+d,clone_failure";
+
+eval $q;
+eval explain format=json $q;
+
+SET GLOBAL debug_dbug=@orig_debug;
+
 let $q=
-SELECT g0, g1, g2
+SELECT b, a, b1
 FROM (
-  SELECT t1.c1 AS g0, t0.c0 AS g1, t0.c1 AS g2,
-         t0.c1 NOT IN (t1.c1, t1.c1 != t0.c0) AS ref1
-  FROM t1 STRAIGHT_JOIN t0
-  GROUP BY t1.c1, t0.c0, t0.c1
+  SELECT
+  t2.b AS b,
+  t1.a AS a,
+  t1.b AS b1,
+  t1.b < t2.b AS ref1
+  FROM t2 STRAIGHT_JOIN t1
+  GROUP BY t2.b, t1.a, t1.b
 ) AS s
 WHERE ref1;
 
 eval $q;
 eval explain format=json $q;
 
-drop table t0, t1;
+
+drop table t1, t2;
 
 --echo # End of 10.11 tests

--- a/mysql-test/main/having_cond_pushdown_debug.result
+++ b/mysql-test/main/having_cond_pushdown_debug.result
@@ -1,0 +1,110 @@
+#
+# MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+#
+CREATE TABLE t1(a INT, b INT UNIQUE);
+CREATE TABLE t2 LIKE t1;
+INSERT INTO t1 VALUES (1, 2);
+INSERT INTO t2 VALUES (3, 4);
+INSERT INTO t2 VALUES (5, 6);
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+b	a	b
+4	1	2
+6	1	2
+explain format=json SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "filesort": {
+      "sort_key": "t2.b, t1.a, t1.b",
+      "temporary_table": {
+        "nested_loop": [
+          {
+            "table": {
+              "table_name": "t2",
+              "access_type": "index",
+              "possible_keys": ["b"],
+              "key": "b",
+              "key_length": "5",
+              "used_key_parts": ["b"],
+              "rows": 2,
+              "filtered": 100,
+              "using_index": true
+            }
+          },
+          {
+            "range-checked-for-each-record": {
+              "keys": ["b"],
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "possible_keys": ["b"],
+                "rows": 1,
+                "filtered": 100
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+SET SESSION debug_dbug="+d,clone_failure";
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+b	a	b
+4	1	2
+6	1	2
+explain format=json SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "filesort": {
+      "sort_key": "t2.b, t1.a, t1.b",
+      "temporary_table": {
+        "nested_loop": [
+          {
+            "table": {
+              "table_name": "t2",
+              "access_type": "index",
+              "key": "b",
+              "key_length": "5",
+              "used_key_parts": ["b"],
+              "rows": 2,
+              "filtered": 100,
+              "using_index": true
+            }
+          },
+          {
+            "block-nl-join": {
+              "table": {
+                "table_name": "t1",
+                "access_type": "ALL",
+                "rows": 1,
+                "filtered": 100
+              },
+              "buffer_type": "flat",
+              "buffer_size": "65",
+              "join_type": "BNL"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+SET GLOBAL debug_dbug=@orig_debug;
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/main/having_cond_pushdown_debug.result
+++ b/mysql-test/main/having_cond_pushdown_debug.result
@@ -1,5 +1,5 @@
 #
-# MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+# MDEV-38819: Wrong result of "Range checked for each record" after pushdown from HAVING
 #
 CREATE TABLE t1(a INT, b INT UNIQUE);
 CREATE TABLE t2 LIKE t1;

--- a/mysql-test/main/having_cond_pushdown_debug.test
+++ b/mysql-test/main/having_cond_pushdown_debug.test
@@ -1,0 +1,32 @@
+--source include/have_debug.inc
+
+--echo #
+--echo # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+--echo #
+
+
+CREATE TABLE t1(a INT, b INT UNIQUE);
+CREATE TABLE t2 LIKE t1;
+ 
+INSERT INTO t1 VALUES (1, 2);
+INSERT INTO t2 VALUES (3, 4);
+INSERT INTO t2 VALUES (5, 6);
+
+let $q=
+SELECT t2.b, t1.a, t1.b
+FROM t2 STRAIGHT_JOIN t1
+GROUP BY t2.b, t1.a, t1.b
+HAVING t1.b < t2.b;
+eval $q;
+eval explain format=json $q;
+
+# Optimization and aborted on clone failure
+SET SESSION debug_dbug="+d,clone_failure";
+
+eval $q;
+eval explain format=json $q;
+
+SET GLOBAL debug_dbug=@orig_debug;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/main/having_cond_pushdown_debug.test
+++ b/mysql-test/main/having_cond_pushdown_debug.test
@@ -1,7 +1,7 @@
 --source include/have_debug.inc
 
 --echo #
---echo # MDEV-38819: Logic Inconsistency between Direct HAVING Query and Derived Table Relocation
+--echo # MDEV-38819: Wrong result of "Range checked for each record" after pushdown from HAVING
 --echo #
 
 

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -11574,7 +11574,7 @@ Item *st_select_lex::pushdown_from_having_into_where(THD *thd, Item *having)
        list of all its conjuncts saved in attach_to_conds. Otherwise,
        the condition is put into attach_to_conds as the only its element.
   */
-  List_iterator_fast<Item> it(attach_to_conds);
+  List_iterator<Item> it(attach_to_conds);
   Item *item;
   check_cond_extraction_for_grouping_fields(thd, having);
   if (build_pushable_cond_for_having_pushdown(thd, having))
@@ -11634,9 +11634,11 @@ Item *st_select_lex::pushdown_from_having_into_where(THD *thd, Item *having)
   it.rewind();
   while ((item=it++))
   {
-    item= item->transform(thd,
-                          &Item::field_transformer_for_having_pushdown,
-                          (uchar *)this);
+    Item *cloned_item= item->deep_copy_with_checks(thd);
+    if (!cloned_item)
+      cloned_item= item;
+    item= cloned_item->transform(
+        thd, &Item::field_transformer_for_having_pushdown, (uchar *) this);
 
     if (item->walk(&Item::cleanup_excluding_immutables_processor, 0, STOP_PTR)
         || item->fix_fields(thd, NULL))
@@ -11644,6 +11646,7 @@ Item *st_select_lex::pushdown_from_having_into_where(THD *thd, Item *having)
       attach_to_conds.empty();
       goto exit;
     }
+    it.replace(item);
   }
 
   /*

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -11635,18 +11635,29 @@ Item *st_select_lex::pushdown_from_having_into_where(THD *thd, Item *having)
   while ((item=it++))
   {
     Item *cloned_item= item->deep_copy_with_checks(thd);
+    DBUG_EXECUTE_IF("clone_failure", cloned_item= NULL;);
     if (!cloned_item)
-      cloned_item= item;
-    item= cloned_item->transform(
+    {
+      bool has_subquery= item->walk(&Item::is_subquery_processor, 0, NULL);
+      if (has_subquery)
+        cloned_item= item;
+      else
+      {
+        attach_to_conds.empty();
+        goto exit;
+      }
+    }
+    cloned_item= cloned_item->transform(
         thd, &Item::field_transformer_for_having_pushdown, (uchar *) this);
 
-    if (item->walk(&Item::cleanup_excluding_immutables_processor, 0, STOP_PTR)
-        || item->fix_fields(thd, NULL))
+    if (cloned_item->walk(&Item::cleanup_excluding_immutables_processor, 0,
+                          STOP_PTR) ||
+        cloned_item->fix_fields(thd, NULL))
     {
       attach_to_conds.empty();
       goto exit;
     }
-    it.replace(item);
+    it.replace(cloned_item);
   }
 
   /*


### PR DESCRIPTION
- Fixes [MDEV-38819](https://jira.mariadb.org/browse/MDEV-38819)

The inconsistency is caused because the dynamic range scan wrongly attempts to read from an unpopulated temporary table, fails to inject the correct value from the outer table to the inner for the dynamic scan, resulting in a `TREE::IMPOSSIBLE` in execution time and giving 0 rows.

Tracing through the execution showed that manually modifying the injected value to the inner table led to correct behavior, so the fix was as simple as an **if condition** in execution time, checking if the temp_table is empty and getting the original value instead, however this scales linearly with the number of rows since it's in execution.

Further investigation showed the root cause lies in the Optimizer's `HAVING clause pushdown`. When pushing conditions down to the WHERE clause, the optimizer simply shares pointers to the original `Item` fields. Later in the optimization phase, these original fields are mutated (their `result_field` is set to point to the empty temp_table, possibly to collect final results). The solution is to copy the fields instead into the pushed down condition, so that they don't undergo the mutation and thus, inject the correct values in the range scan of the inner table.