### PR TITLE
MDEV-39086 MSAN/UBSAN/ASAN builds run without basic optimization (fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,12 +263,13 @@ ENDIF()
 
 # SANs, with their additional processing workload, should have a basic
 # but debuggable optimization unless user specifies otherwise.
-IF((WITH_ASAN OR WITH_UBSAN OR WITH_TSAN OR WITH_MSAN)
-	AND NOT CMAKE_C_FLAGS MATCHES "-O[0-9sgzf]"
-	AND NOT CMAKE_CXX_FLAGS MATCHES "-O[0-9sgzf]"
-	AND NOT CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE} MATCHES "-O[0-9sgzf]"
-	AND NOT CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE} MATCHES "-O[0-9sgzf]")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-Og")
+# -Og is supported in a limited number of compliers.
+IF(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang|AppleClang)"
+  AND (WITH_ASAN OR WITH_UBSAN OR WITH_MSAN))
+  SET(_all_lang_flags " ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
+  IF(NOT _all_lang_flags MATCHES " -O[0-9sgzf]")
+    ADD_COMPILE_OPTIONS($<$<CONFIG:Debug>:-Og>)
+  ENDIF()
 ENDIF()
 
 OPTION(WITH_GPROF "Enable profiling with gprof" OFF)


### PR DESCRIPTION
As noted the MSVC supports a different range of optimization flags and therefore not setting -Og.

When CMAKE_BUILD_TYPE is specified its in a mixed case, but the CMAKE_C{,XX}_FLAGS_${BUILD_TYPE} is always upper case.