### PR TITLE
MDEV-39126: Feedback plugin to use /etc/os-release

### DIFF
--- a/mysql-test/suite/plugins/r/feedback_os_release.result
+++ b/mysql-test/suite/plugins/r/feedback_os_release.result
@@ -1,0 +1,5 @@
+#
+# MDEV-39126: Feedback plugin to use /etc/os-release
+#
+Uname_distribution matches /etc/os-release
+# End of 10.11 tests

--- a/mysql-test/suite/plugins/t/feedback_os_release.opt
+++ b/mysql-test/suite/plugins/t/feedback_os_release.opt
@@ -1,0 +1,2 @@
+--loose-feedback
+--plugin-load-add=$FEEDBACK_SO

--- a/mysql-test/suite/plugins/t/feedback_os_release.test
+++ b/mysql-test/suite/plugins/t/feedback_os_release.test
@@ -1,0 +1,68 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # MDEV-39126: Feedback plugin to use /etc/os-release
+--echo #
+
+if (`select count(*) = 0 from information_schema.plugins
+     where plugin_name = 'feedback' and plugin_status='active'`)
+{
+  --skip Feedback plugin is not active
+}
+
+if (`select @@feedback_url = ""`)
+{
+  --skip Feedback plugin is not active
+}
+
+perl;
+  if (! -f '/etc/os-release') {
+    open(FILE, '>', $ENV{MYSQLTEST_VARDIR} . '/tmp/skip_mdev39126') or die;
+    close(FILE);
+  } else {
+    open(my $fh, '<', '/etc/os-release') or die "Cannot open /etc/os-release: $!";
+    my $pretty_name = '';
+    while (my $line = <$fh>) {
+      chomp $line;
+      if ($line =~ /^PRETTY_NAME=(.+)$/) {
+        $pretty_name = $1;
+        $pretty_name =~ s/^"(.*)"$/$1/;
+        last;
+      }
+    }
+    close($fh);
+    open(my $out, '>', $ENV{MYSQLTEST_VARDIR} . '/tmp/mdev39126_pretty_name') or die;
+    print $out "os-release: $pretty_name";
+    close($out);
+  }
+EOF
+
+# Skip if /etc/os-release was not found (written by perl block above)
+if (!`select LOAD_FILE('$MYSQLTEST_VARDIR/tmp/skip_mdev39126') IS NULL`)
+{
+  --skip /etc/os-release not available on this platform
+}
+
+let $plugin_val= `select variable_value from information_schema.feedback
+                  where variable_name = 'Uname_distribution'`;
+
+# Skip if plugin returned empty (e.g. FreeBSD with MTR_FEEDBACK_PLUGIN=0)
+if (`select '$plugin_val' = ''`)
+{
+  --skip Uname_distribution not available on this platform
+}
+
+let $expected_val= `select TRIM(LOAD_FILE('$MYSQLTEST_VARDIR/tmp/mdev39126_pretty_name'))`;
+
+if (`select '$plugin_val' != '$expected_val'`)
+{
+  --echo Mismatch! Plugin: '$plugin_val'
+  --echo Expected:         '$expected_val'
+  --die Uname_distribution does not match /etc/os-release PRETTY_NAME
+}
+
+--echo Uname_distribution matches /etc/os-release
+
+--remove_file $MYSQLTEST_VARDIR/tmp/mdev39126_pretty_name
+
+--echo # End of 10.11 tests

--- a/plugin/feedback/utils.cc
+++ b/plugin/feedback/utils.cc
@@ -266,27 +266,61 @@ int prepare_linux_info()
 
 #ifdef TARGET_OS_LINUX
   /*
-    let's try to find what linux distribution it is
-    we read *[-_]{release,version} file in /etc.
+    Let's try to find what Linux distribution it is.
+    We first check for the modern and portable /etc/os-release:
 
-    Either it will be /etc/lsb-release, such as
+      ==> /etc/os-release <==
+      PRETTY_NAME="Ubuntu 22.04.2 LTS"
+
+    If not found, we fall back to /etc/lsb-release:
 
       ==> /etc/lsb-release <==
-      DISTRIB_ID=Ubuntu
-      DISTRIB_RELEASE=8.04
-      DISTRIB_CODENAME=hardy
       DISTRIB_DESCRIPTION="Ubuntu 8.04.4 LTS"
 
-   Or a one-liner with the description (/etc/SuSE-release has more
-   than one line, but the description is the first, so it can be
-   treated as a one-liner).
+    Or a one-liner with the description (/etc/SuSE-release has more
+    than one line, but the description is the first, so it can be
+    treated as a one-liner).
 
-   We'll read lsb-release first, and if it's not found will search
-   for other files (*-version *-release *_version *_release)
-*/
+    We'll read os-release first, then lsb-release, and if neither is found
+    we will search for other files (*-version *-release *_version *_release).
+  */
   int fd;
   have_distribution= false;
-  if ((fd= my_open("/etc/lsb-release", O_RDONLY, MYF(0))) != -1)
+
+  /* 1. First try the modern portable way: /etc/os-release */
+  if ((fd= my_open("/etc/os-release", O_RDONLY, MYF(0))) != -1)
+  {
+    size_t len= my_read(fd, (uchar*)distribution, sizeof(distribution)-1, MYF(0));
+    my_close(fd, MYF(0));
+    if (len != (size_t)-1)
+    {
+      distribution[len]= 0; // safety
+      char *found= strstr(distribution, "PRETTY_NAME=");
+      if (found)
+      {
+        have_distribution= true;
+        char *end= strstr(found, "\n");
+        if (end == NULL)
+          end= distribution + len;
+        found+= 12; // Length of "PRETTY_NAME="
+
+        if (*found == '"' && end[-1] == '"')
+        {
+          found++;
+          end--;
+        }
+        *end= 0;
+
+        size_t val_len= (size_t)(end - found);
+        memmove(distribution + 12, found, val_len);
+        distribution[12 + val_len]= '\0';
+        memcpy(distribution, "os-release: ", 12);
+      }
+    }
+  }
+
+  /* 2. Fallback to older /etc/lsb-release if os-release is not found */
+  if (!have_distribution && (fd= my_open("/etc/lsb-release", O_RDONLY, MYF(0))) != -1)
   {
     /* Cool, LSB-compliant distribution! */
     size_t len= my_read(fd, (uchar*)distribution, sizeof(distribution)-1, MYF(0));
@@ -301,7 +335,7 @@ int prepare_linux_info()
         char *end= strstr(found, "\n");
         if (end == NULL)
           end= distribution + len;
-        found+= 20;
+        found+= 20; // Length of "DISTRIB_DESCRIPTION="
 
         if (*found == '"' && end[-1] == '"')
         {
@@ -315,6 +349,7 @@ int prepare_linux_info()
       }
     }
   }
+
 
   /* if not an LSB-compliant distribution */
   for (uint i= 0; !have_distribution && i < array_elements(masks); i++)


### PR DESCRIPTION
## Description
This PR resolves [MDEV-39126](https://jira.mariadb.org/browse/MDEV-39126) by updating the feedback plugin to use `/etc/os-release` instead of the obsolete `/etc/lsb-release` for OS discovery. 

As noted in the issue, `/etc/lsb-release` is outdated (Debian now isolates it to its own package), while `/etc/os-release` is the modern, portable standard across Linux distributions.

## Implementation Details
* **Primary Check:** Modified `prepare_linux_info()` in `plugin/feedback/utils.cc` to attempt opening `/etc/os-release` first.
* **Parsing:** Added logic to parse the `PRETTY_NAME=` field and safely strip the wrapping double quotes to extract a clean, human-readable distribution name.
* **Fallback Maintained:** To ensure backwards compatibility with older systems that may not have `/etc/os-release`, the original `/etc/lsb-release` and wildcard mask (`/etc/*-release`) checks have been retained as fallbacks.

## Testing
* Confirmed the C++ syntax and parsing logic.
* Relying on Buildbot CI to verify cross-platform compilation and ensure no regressions on older build environments.