### PR TITLE
MDEV-5479: Prevent mysqld from stealing Unix socket of another active instance

### DIFF
--- a/mysql-test/main/socket_conflict.result
+++ b/mysql-test/main/socket_conflict.result
@@ -1,0 +1,17 @@
+#
+# MDEV-5479: Prevent mysqld from unlinking a Unix socket
+#            file actively used by another process
+#
+#
+# Test 1: Server must refuse to start when a listener is
+#         already present on the socket path
+#
+FOUND 1 /\[ERROR\] Another process is already listening on the socket file/ in socket_conflict.err
+#
+# Test 2: Stale socket file must be cleaned up at startup
+#
+# restart
+SELECT 1;
+1
+1
+# End of 10.11 tests

--- a/mysql-test/main/socket_conflict.test
+++ b/mysql-test/main/socket_conflict.test
@@ -1,0 +1,60 @@
+--source include/not_windows.inc
+--source include/not_embedded.inc
+
+--echo #
+--echo # MDEV-5479: Prevent mysqld from unlinking a Unix socket
+--echo #            file actively used by another process
+--echo #
+
+# Shut down the server once; both tests run while it is down.
+--source include/shutdown_mysqld.inc
+
+--echo #
+--echo # Test 1: Server must refuse to start when a listener is
+--echo #         already present on the socket path
+--echo #
+
+# Create a fake listener on the default socket path.
+# The parent creates the socket, then exits (fork and exit).
+# The child blocks on accept(); when mysqld's connect() probe
+# hits the socket, accept() returns and the child exits,
+# leaving a stale socket file for Test 2.
+perl;
+  use IO::Socket::UNIX;
+  my $path= $ENV{MASTER_MYSOCK};
+  unlink $path;
+  close STDOUT;
+  my $srv= IO::Socket::UNIX->new(
+    Local  => $path,
+    Listen => 1,
+  ) or die "IO::Socket::UNIX->new($path): $!";
+  fork and exit;
+  exit if $srv->accept();
+EOF
+
+--let errorlog=$MYSQL_TMP_DIR/socket_conflict.err
+--let SEARCH_FILE=$errorlog
+
+# Use --loose-skip-innodb to skip InnoDB initialization, which
+# runs before network_init() and would otherwise be slow on CI.
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --loose-skip-innodb --log-error=$errorlog
+
+--let SEARCH_PATTERN=\[ERROR\] Another process is already listening on the socket file
+--source include/search_pattern_in_file.inc
+
+--remove_file $SEARCH_FILE
+
+--echo #
+--echo # Test 2: Stale socket file must be cleaned up at startup
+--echo #
+
+# The socket file from Test 1 is still on disk but has no
+# listener. The server should detect it as stale, remove it,
+# and bind successfully.
+--source include/start_mysqld.inc
+
+# Verify the server is operational
+SELECT 1;
+
+--echo # End of 10.11 tests

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2677,6 +2677,57 @@ err:
 }
 
 
+#ifdef HAVE_SYS_UN_H
+/*
+  Unlink an existing Unix socket file if no process is listening
+  on it, or abort startup if the socket is still active.
+*/
+static void unlink_socket_or_abort(const char *path)
+{
+  struct sockaddr_un addr;
+  MY_STAT stat_buf;
+  int fd;
+
+  if (!my_stat(path, &stat_buf, MYF(0)))
+    return;
+
+  if (!S_ISSOCK(stat_buf.st_mode))
+    goto do_unlink;
+
+  fd= socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0)
+  {
+    sql_print_error("Cannot create a socket: %M. Aborting.",
+                    errno);
+    unireg_abort(1);
+  }
+
+  bzero((char*) &addr, sizeof(addr));
+  addr.sun_family= AF_UNIX;
+  strmov(addr.sun_path, path);
+  if (connect(fd, (struct sockaddr *) &addr, sizeof(addr)) == 0)
+  {
+    close(fd);
+    sql_print_error("Another process is already listening "
+                    "on the socket file '%s'. Aborting.",
+                    path);
+    unireg_abort(1);
+  }
+  if (errno != ECONNREFUSED && errno != ENOENT)
+  {
+    close(fd);
+    sql_print_error("Error checking socket file '%s': %M. "
+                    "Aborting.", path, errno);
+    unireg_abort(1);
+  }
+  close(fd);
+
+do_unlink:
+  (void) unlink(path);
+}
+#endif /* HAVE_SYS_UN_H */
+
+
 static void network_init(void)
 {
 #ifdef HAVE_SYS_UN_H
@@ -2754,7 +2805,7 @@ static void network_init(void)
     else
 #endif
     {
-      (void) unlink(mysqld_unix_port);
+      unlink_socket_or_abort(mysqld_unix_port);
       port_len= sizeof(UNIXaddr);
     }
     arg= 1;


### PR DESCRIPTION
When two MariaDB server instances are configured with the same Unix socket path but different TCP ports, the second instance starting up would unconditionally unlink() the first instance's active socket file in network_init(). This silently broke the first instance's ability to accept local socket connections, with no error or warning.

Root cause:
The call `(void) unlink(mysqld_unix_port)` in network_init() (sql/mysqld.cc) removed any existing socket file without checking whether another running server process was actively listening on it. Notably, the bind() error handler immediately following the unlink already prints "Do you already have another server running on socket: %s ?" -- but this message could never trigger, because the unconditional unlink() removed the socket before bind() had a chance to fail.

Fix:
Before unlinking an existing socket file, attempt to connect() to it:
- If connect() succeeds, another server is actively using the socket. Print an error message and abort startup via unireg_abort(1).
- If connect() fails (ECONNREFUSED or similar), the socket is stale from a previous unclean shutdown. Proceed to unlink() as before.
- If the socket file does not exist at all, skip directly to bind().
- If the file exists but is not a socket (S_ISSOCK check), treat it as removable to preserve the previous behavior for non-socket files.

Before this patch:
  $ mysqld --port=13306 --socket=/tmp/mysql.sock   # starts fine
  $ mysqld --port=13307 --socket=/tmp/mysql.sock
  # starts, steals socket
  # First instance can no longer accept socket connections

After this patch:
  $ mysqld --port=13306 --socket=/tmp/mysql.sock   # starts fine
  $ mysqld --port=13307 --socket=/tmp/mysql.sock   # refuses to start:
  # "Another server process is already using the socket file
  #  '/tmp/mysql.sock'. Aborting."
  # First instance continues to operate normally

Test plan:
1. Start first MariaDB instance with --socket=/tmp/test.sock --port=13306
2. Verify it is listening: mysql --socket=/tmp/test.sock -e "SELECT 1"
3. Attempt to start second instance: --socket=/tmp/test.sock --port=13307
4. Verify second instance aborts with the new error message in error log
5. Verify first instance still accepts connections via the socket
6. Stop the first instance, verify a new instance can start (stale socket cleanup still works)