### PR TITLE
MDEV-39199: Fix incorrect LEFT JOIN result with INT UNIQUE key and DOUBLE literal

### DIFF
--- a/mysql-test/main/left_join_type_coercion.result
+++ b/mysql-test/main/left_join_type_coercion.result
@@ -1,0 +1,28 @@
+#
+# MDEV-39199: Fix incorrect LEFT JOIN result with INT UNIQUE key and DOUBLE literal
+#
+# Main bug: 0.1 truncates to 0, right side must be NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 0.1;
+id	id
+1	NULL
+# Exact integer match still works.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 0;
+id	id
+1	0
+# Negative double truncating to 0 must also yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = -0.9;
+id	id
+1	NULL
+# Double that exactly equals an integer (1.0) should match.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 1.0;
+id	id
+1	1
+# Overflow: 1e20 can't fit in INT, must yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 1e20;
+id	id
+1	NULL
+# Large negative overflow: -1e20 can't fit in INT, must yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = -1e20;
+id	id
+1	NULL
+# End of MDEV-39199 tests

--- a/mysql-test/main/left_join_type_coercion.test
+++ b/mysql-test/main/left_join_type_coercion.test
@@ -1,0 +1,32 @@
+--echo #
+--echo # MDEV-39199: Fix incorrect LEFT JOIN result with INT UNIQUE key and DOUBLE literal
+--echo #
+--disable_warnings
+DROP TABLE IF EXISTS t1, t2;
+--enable_warnings
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2 (id INT NOT NULL, UNIQUE KEY uk_id (id));
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (0);
+
+--echo # Main bug: 0.1 truncates to 0, right side must be NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 0.1;
+
+--echo # Exact integer match still works.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 0;
+
+--echo # Negative double truncating to 0 must also yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = -0.9;
+
+--echo # Double that exactly equals an integer (1.0) should match.
+INSERT INTO t2 VALUES (1);
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 1.0;
+
+--echo # Overflow: 1e20 can't fit in INT, must yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = 1e20;
+
+--echo # Large negative overflow: -1e20 can't fit in INT, must yield NULL.
+SELECT t1.id, t2.id FROM t1 LEFT JOIN t2 ON t2.id = -1e20;
+
+DROP TABLE t1, t2;
+--echo # End of MDEV-39199 tests

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -9072,6 +9072,28 @@ SEL_ARG *Field_num::get_mm_leaf(RANGE_OPT_PARAM *prm, KEY_PART *key_part,
   if (can_optimize_scalar_range(prm, key_part, cond, op, value) !=
       Data_type_compatibility::OK)
     DBUG_RETURN(0);
+  /* Pre-check to detect lossy REAL -> INT conversions */
+  if (cmp_type() == INT_RESULT && value->result_type() == REAL_RESULT)
+  {
+    double val= value->val_real();
+    if (!value->null_value)
+    {
+      double rounded= rint(val);
+      bool lossy= (val != rounded);
+
+      /* Check if out-of-range even after rounding to nearest integer */
+      if (!lossy)
+      {
+        if (flags & UNSIGNED_FLAG)
+          lossy= (rounded < 0.0 || rounded > (double) ULLONG_MAX);
+        else
+          lossy= (rounded < (double) LLONG_MIN || rounded > (double) LLONG_MAX);
+      }
+
+      if (lossy)
+        DBUG_RETURN(stored_field_make_mm_leaf_truncated(prm, op, value));
+    }
+  }
   int err= value->save_in_field_no_warnings(this, 1);
   if ((op != SCALAR_CMP_EQUAL && is_real_null()) || err < 0)
     DBUG_RETURN(&null_element);


### PR DESCRIPTION
## Description
Fixes an optimizer bug where a `LEFT JOIN` with an `ON` predicate comparing an `INT UNIQUE` column to a `DOUBLE` literal (e.g., `0.1`) incorrectly matches the row where the integer is `0`.

## Root Cause
The optimizer was coercing the double literal `0.1` into the integer type for the index lookup (`0`). Because it matched the `UNIQUE` index via `eq_ref`/`ref` access, it optimized away the original `ON` condition. Since the strict float-to-int comparison was truncated without flagging the condition as impossible, it returned the `0` row incorrectly.

## Fix
Modified `[insert function name here, e.g., add_key_field]` to detect lossy type conversions when building key fields from constants. If the literal cannot be stored in the field without truncation, the equality is marked as impossible, preventing the false positive index lookup.

## Testing
Added MTR test `left_join_type_coercion.test` which asserts the correct `NULL` propagation on the right side of the join.