### PR TITLE
MDEV-39218: Master_ssl_verify_server_cert value is not set correctly

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_ssl_verify_server_cert.result
+++ b/mysql-test/suite/rpl/r/rpl_ssl_verify_server_cert.result
@@ -1,0 +1,53 @@
+include/master-slave.inc
+[connection master]
+#
+# Test 1: master_ssl_verify_server_cert=0 should PASS
+# (verification disabled, simulated cert failure should not matter)
+#
+connection slave;
+include/stop_slave.inc
+SET @saved_dbug = @@GLOBAL.debug_dbug;
+SET GLOBAL debug_dbug = '+d,simulate_ssl_unable_to_get_issuer_cert';
+CHANGE MASTER TO
+master_host='127.0.0.1',
+master_port=MASTER_PORT,
+master_user='root',
+master_ssl=1,
+master_ssl_verify_server_cert=0;
+Master_SSL_Allowed = 'Yes'
+Master_SSL_Verify_Server_Cert = 'No'
+START SLAVE IO_THREAD;
+include/wait_for_slave_param.inc [Slave_IO_Running]
+# IO thread started successfully - verification was correctly disabled
+#
+# Test 2: master_ssl_verify_server_cert=1 should FAIL
+# (verification enabled, simulated cert failure should be caught)
+#
+STOP SLAVE IO_THREAD;
+include/wait_for_slave_io_to_stop.inc
+CHANGE MASTER TO
+master_host='127.0.0.1',
+master_port=MASTER_PORT,
+master_user='root',
+master_ssl=1,
+master_ssl_verify_server_cert=1;
+Master_SSL_Allowed = 'Yes'
+Master_SSL_Verify_Server_Cert = 'Yes'
+START SLAVE IO_THREAD;
+include/wait_for_slave_param.inc [Last_IO_Errno]
+# IO thread failed as expected - verification correctly caught the failure
+#
+# Cleanup
+#
+STOP SLAVE IO_THREAD;
+include/wait_for_slave_io_to_stop.inc
+SET GLOBAL debug_dbug = @saved_dbug;
+RESET SLAVE ALL;
+CHANGE MASTER TO
+master_host='127.0.0.1',
+master_port=MASTER_PORT,
+master_user='root',
+master_ssl=1,
+master_ssl_verify_server_cert=0;
+include/rpl_end.inc
+# End of rpl_ssl_verify_server_cert.test

--- a/mysql-test/suite/rpl/t/rpl_ssl_verify_server_cert.test
+++ b/mysql-test/suite/rpl/t/rpl_ssl_verify_server_cert.test
@@ -1,0 +1,105 @@
+#
+# Test for master_ssl_verify_server_cert option
+#
+# This test verifies that master_ssl_verify_server_cert correctly controls
+# SSL certificate verification during replication.
+#
+# Test strategy:
+# - Use debug point to simulate SSL certificate verification failure
+# - Test 1: master_ssl_verify_server_cert=0 -> connection succeeds (no verification)
+# - Test 2: master_ssl_verify_server_cert=1 -> connection fails (verification enabled)
+#
+
+--source include/have_debug.inc
+--source include/have_ssl_communication.inc
+--source include/master-slave.inc
+
+--echo #
+--echo # Test 1: master_ssl_verify_server_cert=0 should PASS
+--echo # (verification disabled, simulated cert failure should not matter)
+--echo #
+
+--connection slave
+--source include/stop_slave.inc
+
+# Enable debug point to simulate SSL certificate verification failure
+SET @saved_dbug = @@GLOBAL.debug_dbug;
+SET GLOBAL debug_dbug = '+d,simulate_ssl_unable_to_get_issuer_cert';
+
+# Use SSL with verification disabled - simulated cert failure should not matter
+--replace_result $MASTER_MYPORT MASTER_PORT
+eval CHANGE MASTER TO
+  master_host='127.0.0.1',
+  master_port=$MASTER_MYPORT,
+  master_user='root',
+  master_ssl=1,
+  master_ssl_verify_server_cert=0;
+
+--let $status_items= Master_SSL_Allowed, Master_SSL_Verify_Server_Cert
+--source include/show_slave_status.inc
+
+START SLAVE IO_THREAD;
+
+# Wait for the connection to establish
+--let $slave_param= Slave_IO_Running
+--let $slave_param_value= Yes
+--let $slave_timeout= 30
+--source include/wait_for_slave_param.inc
+
+--echo # IO thread started successfully - verification was correctly disabled
+
+--echo #
+--echo # Test 2: master_ssl_verify_server_cert=1 should FAIL
+--echo # (verification enabled, simulated cert failure should be caught)
+--echo #
+
+STOP SLAVE IO_THREAD;
+--source include/wait_for_slave_io_to_stop.inc
+
+# Use SSL with verification enabled - connection should fail
+# because of simulated certificate verification failure
+--replace_result $MASTER_MYPORT MASTER_PORT
+eval CHANGE MASTER TO
+  master_host='127.0.0.1',
+  master_port=$MASTER_MYPORT,
+  master_user='root',
+  master_ssl=1,
+  master_ssl_verify_server_cert=1;
+
+--let $status_items= Master_SSL_Allowed, Master_SSL_Verify_Server_Cert
+--source include/show_slave_status.inc
+
+START SLAVE IO_THREAD;
+
+# Wait for SSL connection error (2026 = CR_SSL_CONNECTION_ERROR)
+# The slave will keep retrying, so we check Last_IO_Errno instead of waiting for IO thread to stop
+--let $slave_param= Last_IO_Errno
+--let $slave_param_value= 2026
+--let $slave_timeout= 30
+--source include/wait_for_slave_param.inc
+
+--echo # IO thread failed as expected - verification correctly caught the failure
+
+--echo #
+--echo # Cleanup
+--echo #
+
+STOP SLAVE IO_THREAD;
+--source include/wait_for_slave_io_to_stop.inc
+
+SET GLOBAL debug_dbug = @saved_dbug;
+
+RESET SLAVE ALL;
+
+--replace_result $MASTER_MYPORT MASTER_PORT
+eval CHANGE MASTER TO
+  master_host='127.0.0.1',
+  master_port=$MASTER_MYPORT,
+  master_user='root',
+  master_ssl=1,
+  master_ssl_verify_server_cert=0;
+
+--let $rpl_only_running_threads= 1
+--source include/rpl_end.inc
+
+--echo # End of rpl_ssl_verify_server_cert.test

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1613,7 +1613,9 @@ static int ssl_verify_server_cert(MYSQL *mysql, const char **errptr, int is_loca
     goto error;
   }
 
-  switch (SSL_get_verify_result(ssl))
+  switch (DBUG_IF("simulate_ssl_unable_to_get_issuer_cert")
+              ? X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+              : SSL_get_verify_result(ssl))
   {
   case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:     /* OpenSSL */
   case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:       /* OpenSSL */

--- a/sql/rpl_mi.cc
+++ b/sql/rpl_mi.cc
@@ -1646,8 +1646,17 @@ void setup_mysql_connection_for_master(MYSQL *mysql, Master_info *mi,
                   mi->master_ssl_capath, mi->master_ssl_cipher);
     mysql_options(mysql, MYSQL_OPT_SSL_CRL, mi->master_ssl_crl);
     mysql_options(mysql, MYSQL_OPT_SSL_CRLPATH, mi->master_ssl_crlpath);
+    /*
+      mysql_options() expects a pointer to my_bool. master_ssl_verify_server_cert
+      is a trilean that can be -1 (default), 0 (no), or 1 (yes). When the default
+      value is used, the bool() conversion operator redirects to the global option
+      ::master_ssl_verify_server_cert. We must use this conversion rather than
+      passing a pointer directly, as (my_bool*)&trilean would not handle the
+      default case correctly.
+    */
+    bool ssl_verify_server_cert= mi->master_ssl_verify_server_cert;
     mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT,
-                  &mi->master_ssl_verify_server_cert);
+                  &ssl_verify_server_cert);
   }
   else
 #endif


### PR DESCRIPTION
## Description

In MariaDB 12.3.1, MariaDB made this change to refactor ssl_verify_server_cert to master_ssl_verify_server_cert in commit 89bd6b0.

However, these values are different types. While ssl_verify_server_cert is my_bool type, the master_ssl_verify_server_cert is trilean type which accepts three possible values (Yes/No/Default). When reading the value of the argument using !*(my_bool*)arg in mysql_options, trilean type value can't be retrieved because it accesses the wrong memory address by just passing the master_ssl_verify_server_cert, causing the master_ssl_verify_server_cert still behaves as "ON" when it's set to "OFF".

This commit changes the implementation to `master_ssl_verify_server_cert.value` to retrieve the correct value.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.

## How can this PR be tested?

Execute MTR test `rpl_ssl_verify_server_cert_trilean_bug` in the `rpl` suite.

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch_

## Backward compatibility

This is a fix for the bug which only exists in 12.3 version. It's shouldn't be back-ported because they don't have the similar issue.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.