### PR TITLE
MDEV-39219: buffer overflow in PROXY protocol v1 header parsing

### DIFF
--- a/sql/proxy_protocol.cc
+++ b/sql/proxy_protocol.cc
@@ -174,7 +174,7 @@ bool has_proxy_protocol_header(NET *net)
 */
 int parse_proxy_protocol_header(NET *net, proxy_peer_info *peer_info)
 {
-  uchar hdr[MAX_PROXY_HEADER_LEN];
+  uchar hdr[MAX_PROXY_HEADER_LEN + 1];
   size_t pos= 0;
 
   DBUG_ASSERT(!net->compress);
@@ -200,7 +200,7 @@ int parse_proxy_protocol_header(NET *net, proxy_peer_info *peer_info)
       long len= (long)vio_read(vio, hdr + pos, 1);
       if (len <= 0)
         return -1;
-      pos++;
+      pos += len;
       if (hdr[pos-1] == '\n')
         break;
     }

--- a/sql/proxy_protocol.cc
+++ b/sql/proxy_protocol.cc
@@ -195,10 +195,10 @@ int parse_proxy_protocol_header(NET *net, proxy_peer_info *peer_info)
   if (have_v1_header)
   {
     /* Read until end of header (newline character)*/
-    while(pos < sizeof(hdr))
+    while(pos < sizeof(hdr) - 1)
     {
       long len= (long)vio_read(vio, hdr + pos, 1);
-      if (len < 0)
+      if (len <= 0)
         return -1;
       pos++;
       if (hdr[pos-1] == '\n')

--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -20755,14 +20755,15 @@ static void test_proxy_header_limits()
 {
   MYSQL *m;
   char text_header[256];
+  const char *prefix = "PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678";
+  size_t prefix_len;
 
   myheader("test_proxy_header_limits");
 
   /* Test maximum length PROXY header (256 bytes) to ensure no overflow */
   memset(text_header, ' ', sizeof(text_header));
 
-  const char *prefix = "PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678";
-  size_t prefix_len = strlen(prefix);
+  prefix_len = strlen(prefix);
 
   memcpy(text_header, prefix, prefix_len);
   text_header[sizeof(text_header) - 1] = '\n';

--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -20750,6 +20750,39 @@ static void test_proxy_header_ignore()
 }
 
 
+#ifndef EMBEDDED_LIBRARY
+static void test_proxy_header_limits()
+{
+  MYSQL *m;
+  char text_header[256];
+
+  myheader("test_proxy_header_limits");
+
+  /* Test maximum length PROXY header (256 bytes) to ensure no overflow */
+  memset(text_header, ' ', sizeof(text_header));
+
+  const char *prefix = "PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678";
+  size_t prefix_len = strlen(prefix);
+
+  memcpy(text_header, prefix, prefix_len);
+  text_header[sizeof(text_header) - 1] = '\n';
+
+  m = mysql_client_init(NULL);
+  DIE_UNLESS(m);
+
+  mysql_optionsv(m, MARIADB_OPT_PROXY_HEADER, text_header, sizeof(text_header));
+
+  if (mysql_real_connect(m, opt_host, "root", "", NULL, opt_port, opt_unix_socket, 0))
+  {
+    mysql_close(m);
+  }
+  else
+  {
+    /* Connection failure is acceptable, but server must remain stable */
+  }
+}
+#endif
+
 static void test_proxy_header()
 {
   myheader("test_proxy_header");
@@ -20758,6 +20791,9 @@ static void test_proxy_header()
   test_proxy_header_tcp("::ffff:192.0.2.1",2222);
   test_proxy_header_localhost();
   test_proxy_header_ignore();
+#ifndef EMBEDDED_LIBRARY
+  test_proxy_header_limits();
+#endif
 }
 
 


### PR DESCRIPTION
This fixes a buffer overflow issue in the PROXY protocol v1 header parsing.

The loop that reads the header could fill the entire buffer and then add a null terminator past the boundary, which leads to an off-by-one overflow.

I updated the loop condition to make sure there is always space left for the null terminator.

Also added a small check to handle cases where the connection closes early, so we don’t process incomplete data.

This change does not affect normal behavior, it just makes the parsing safer.