### PR TITLE
MDEV-38412 System tablespace fails to shrink due to legacy tables

### DIFF
--- a/mysql-test/suite/innodb/r/sys_defragment_fail.result
+++ b/mysql-test/suite/innodb/r/sys_defragment_fail.result
@@ -18,7 +18,6 @@ DROP TABLE t2;
 InnoDB		0 transactions not purged
 # restart
 FOUND 1 /InnoDB: Found unexpected table in system tablespace: test\/t1/ in mysqld.1.err
-FOUND 1 /InnoDB: Unexpected table exists in the system tablespace/ in mysqld.1.err
 DROP TABLE t1;
 InnoDB		0 transactions not purged
 # restart: --debug_dbug=+d,fail_after_level_defragment

--- a/mysql-test/suite/innodb/r/sys_truncate_debug.result
+++ b/mysql-test/suite/innodb/r/sys_truncate_debug.result
@@ -54,3 +54,42 @@ InnoDB	YES	Supports transactions, row-level locking, foreign keys and encryption
 SELECT NAME, FILE_SIZE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE SPACE=0;
 NAME	FILE_SIZE
 innodb_system	3145728
+#
+# MDEV-38412 System tablespace fails to shrink due to legacy tables
+#
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/old_datadir --debug_dbug=d,create_sys_tablespaces
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE SPACE= 0;
+NAME
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE SPACE=0 AND NAME LIKE 'DUMMY_IND%';
+NAME
+DUMMY_IND
+DUMMY_IND_1
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_FIELDS WHERE NAME LIKE 'DUMMY_ID%';
+NAME
+DUMMY_ID
+DUMMY_ID_1
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_COLUMNS WHERE NAME LIKE 'DUMMY_ID%';
+NAME
+DUMMY_ID
+DUMMY_ID_1
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/old_datadir --innodb_data_file_path=ibdata1:10M:autoextend:autoshrink --innodb_fast_shutdown=0
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE SPACE= 0;
+NAME
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_VIRTUAL
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE SPACE=0 AND NAME LIKE 'DUMMY_IND%';
+NAME
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_FIELDS WHERE NAME LIKE 'DUMMY_ID%';
+NAME
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_COLUMNS WHERE NAME LIKE 'DUMMY_ID%';
+NAME
+FOUND 1 /InnoDB: Found an unknown table SYS_TABLESPACES/ in mysqld.1.err
+FOUND 1 /InnoDB: Found orphaned index for table_id .*/ in mysqld.1.err
+FOUND 1 /InnoDB: Dropping 2 orphaned table/ in mysqld.1.err
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/old_datadir --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/old_datadir --innodb_data_file_path=ibdata1:10M:autoextend:autoshrink
+# restart

--- a/mysql-test/suite/innodb/t/sys_defragment_fail.test
+++ b/mysql-test/suite/innodb/t/sys_defragment_fail.test
@@ -31,8 +31,6 @@ let $restart_parameters=;
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 let SEARCH_PATTERN=InnoDB: Found unexpected table in system tablespace: test\/t1;
 --source include/search_pattern_in_file.inc
-let SEARCH_PATTERN=InnoDB: Unexpected table exists in the system tablespace;
---source include/search_pattern_in_file.inc
 DROP TABLE t1;
 
 --source include/wait_all_purged.inc

--- a/mysql-test/suite/innodb/t/sys_truncate_debug.test
+++ b/mysql-test/suite/innodb/t/sys_truncate_debug.test
@@ -74,3 +74,45 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 SELECT NAME, FILE_SIZE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE SPACE=0;
+
+--echo #
+--echo # MDEV-38412 System tablespace fails to shrink due to legacy tables
+--echo #
+let bugdir= $MYSQLTEST_VARDIR/tmp/old_datadir;
+--mkdir $bugdir
+let $dirs= --innodb-data-home-dir=$bugdir --innodb-log-group-home-dir=$bugdir --innodb_undo_directory=$bugdir;
+# Create a new data directory
+let $restart_parameters=$dirs --debug_dbug=d,create_sys_tablespaces;
+--source include/restart_mysqld.inc
+
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE SPACE= 0;
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE SPACE=0 AND NAME LIKE 'DUMMY_IND%';
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_FIELDS WHERE NAME LIKE 'DUMMY_ID%';
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_COLUMNS WHERE NAME LIKE 'DUMMY_ID%';
+
+# Drop the unknown table during slow shutdown
+let $restart_parameters=$dirs --innodb_data_file_path=ibdata1:10M:autoextend:autoshrink --innodb_fast_shutdown=0;
+--source include/restart_mysqld.inc
+
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE SPACE= 0;
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE SPACE=0 AND NAME LIKE 'DUMMY_IND%';
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_FIELDS WHERE NAME LIKE 'DUMMY_ID%';
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_COLUMNS WHERE NAME LIKE 'DUMMY_ID%';
+
+let SEARCH_PATTERN=InnoDB: Found an unknown table SYS_TABLESPACES;
+--source include/search_pattern_in_file.inc
+
+let SEARCH_PATTERN=InnoDB: Found orphaned index for table_id .*;
+--source include/search_pattern_in_file.inc
+
+let SEARCH_PATTERN=InnoDB: Dropping 2 orphaned table;
+--source include/search_pattern_in_file.inc
+
+# Shrink the system tablespace further
+let $restart_parameters=$dirs --innodb_data_file_path=ibdata1:10M:autoextend:autoshrink;
+--source include/restart_mysqld.inc
+
+# Cleanup
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+rmdir $bugdir;

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -1459,6 +1459,28 @@ err_exit:
     }
   }
 
+  DBUG_EXECUTE_IF("create_sys_tablespaces",
+                  {
+                    error= que_eval_sql(
+                      nullptr, "PROCEDURE CREATE_DUMMY_1() IS\n"
+                      "BEGIN\n"
+                      "CREATE TABLE\n"
+                      "SYS_TABLESPACES(DUMMY_ID BIGINT, POS INT);\n"
+                      "CREATE UNIQUE CLUSTERED INDEX DUMMY_IND"
+                      " ON SYS_TABLESPACES(DUMMY_ID, POS);\n"
+                      "CREATE TABLE\n"
+                      "SYS_METADATA(DUMMY_ID_1 BIGINT, POS INT);\n"
+                      "CREATE UNIQUE CLUSTERED INDEX DUMMY_IND_1"
+                      " ON SYS_METADATA(DUMMY_ID_1, POS);\n"
+                      "DELETE FROM SYS_TABLES WHERE NAME= 'SYS_METADATA';"
+                      "END;\n", trx);
+                    if (error)
+                    {
+                      tablename = "DUMMY";
+                      goto err_exit;
+                    }
+                  });
+
   trx->commit();
   row_mysql_unlock_data_dictionary(trx);
   trx->clear_and_free();

--- a/storage/innobase/dict/drop.cc
+++ b/storage/innobase/dict/drop.cc
@@ -139,6 +139,35 @@ dberr_t trx_t::drop_table_statistics(const table_name_t &name)
   return err;
 }
 
+dberr_t dict_drop_table_metadata(table_id_t table_id, trx_t *trx) noexcept
+{
+  pars_info_t *info= pars_info_create();
+  pars_info_add_ull_literal(info, "id", table_id);
+  return que_eval_sql(info,
+                      "PROCEDURE DROP_TABLE() IS\n"
+                      "iid CHAR;\n"
+
+                      "DECLARE CURSOR idx IS\n"
+                      "SELECT ID FROM SYS_INDEXES\n"
+                      "WHERE TABLE_ID=:id FOR UPDATE;\n"
+
+                      "BEGIN\n"
+
+                      "DELETE FROM SYS_TABLES WHERE ID=:id;\n"
+                      "DELETE FROM SYS_COLUMNS WHERE TABLE_ID=:id;\n"
+
+                      "OPEN idx;\n"
+                      "WHILE 1 = 1 LOOP\n"
+                      "  FETCH idx INTO iid;\n"
+                      "  IF (SQL % NOTFOUND) THEN EXIT; END IF;\n"
+                      "  DELETE FROM SYS_INDEXES WHERE CURRENT OF idx;\n"
+                      "  DELETE FROM SYS_FIELDS WHERE INDEX_ID=iid;\n"
+                      "END LOOP;\n"
+                      "CLOSE idx;\n"
+
+                      "END;\n", trx);
+}
+
 /** Try to drop a persistent table.
 @param table       persistent table
 @param fk          whether to drop FOREIGN KEY metadata
@@ -201,31 +230,7 @@ dberr_t trx_t::drop_table(const dict_table_t &table)
   mod_tables.emplace(const_cast<dict_table_t*>(&table), undo_no).
     first->second.set_dropped();
 
-  pars_info_t *info= pars_info_create();
-  pars_info_add_ull_literal(info, "id", table.id);
-  return que_eval_sql(info,
-                      "PROCEDURE DROP_TABLE() IS\n"
-                      "iid CHAR;\n"
-
-                      "DECLARE CURSOR idx IS\n"
-                      "SELECT ID FROM SYS_INDEXES\n"
-                      "WHERE TABLE_ID=:id FOR UPDATE;\n"
-
-                      "BEGIN\n"
-
-                      "DELETE FROM SYS_TABLES WHERE ID=:id;\n"
-                      "DELETE FROM SYS_COLUMNS WHERE TABLE_ID=:id;\n"
-
-                      "OPEN idx;\n"
-                      "WHILE 1 = 1 LOOP\n"
-                      "  FETCH idx INTO iid;\n"
-                      "  IF (SQL % NOTFOUND) THEN EXIT; END IF;\n"
-                      "  DELETE FROM SYS_INDEXES WHERE CURRENT OF idx;\n"
-                      "  DELETE FROM SYS_FIELDS WHERE INDEX_ID=iid;\n"
-                      "END LOOP;\n"
-                      "CLOSE idx;\n"
-
-                      "END;\n", this);
+  return dict_drop_table_metadata(table.id, this);
 }
 
 /** Commit the transaction, possibly after drop_table().

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -45,6 +45,8 @@ Created 11/29/1995 Heikki Tuuri
 #include <unordered_map>
 #include <unordered_set>
 #include "trx0undo.h"
+#include <functional>
+#include "lock0lock.h"
 
 /** Returns the first extent descriptor for a segment.
 We think of the extent lists of the segment catenated in the order
@@ -5698,50 +5700,76 @@ dberr_t IndexDefragmenter::defragment(SpaceDefragmenter *space_defrag) noexcept
   return err;
 }
 
-/** check whether any user table exist in system tablespace
-@retval DB_SUCCESS_LOCKED_REC if user table exist
-@retval DB_SUCCESS if no user table exist
-@retval DB_CORRUPTION if any error encountered */
-static dberr_t user_tables_exists() noexcept
+/** Callback function for scanning system tablespace tables */
+using sysCallback= std::function<dberr_t(table_id_t, st_::span<const char>)>;
+
+/** Scan system tablespace metadata tables and invoke callback
+@param table         system table to scan (sys_tables or sys_indexes)
+@param callback      function to call for each non-system entry found
+@return DB_SUCCESS, DB_CORRUPTION, or error code */
+static dberr_t scan_system_tablespace_metadata(dict_table_t *table,
+                                               sysCallback callback) noexcept
 {
   mtr_t mtr{nullptr};
   btr_pcur_t pcur;
   dberr_t err= DB_SUCCESS;
+  const bool scan_indexes= (table == dict_sys.sys_indexes);
+
   mtr.start();
-  for (const rec_t *rec= dict_startscan_system(&pcur, &mtr,
-                                               dict_sys.sys_tables);
+
+  for (const rec_t *rec= dict_startscan_system(&pcur, &mtr, table);
        rec; rec= dict_getnext_system(&pcur, &mtr))
   {
     const byte *field= nullptr;
+    ulint field_no= 0;
     ulint len= 0;
+    table_id_t table_id= 0;
+
     if (rec_get_deleted_flag(rec, 0))
     {
 corrupt:
-      sql_print_error("InnoDB: Encountered corrupted record in SYS_TABLES");
+      sql_print_error("InnoDB: Encountered corrupted record in %s",
+                      scan_indexes ? "SYS_INDEXES" : "SYS_TABLES");
       err= DB_CORRUPTION;
       goto func_exit;
     }
-    field= rec_get_nth_field_old(rec, DICT_FLD__SYS_TABLES__SPACE, &len);
+
+    field_no= scan_indexes ? ulint(DICT_FLD__SYS_INDEXES__SPACE)
+                           : ulint(DICT_FLD__SYS_TABLES__SPACE);
+
+    field= rec_get_nth_field_old(rec, field_no, &len);
     if (len != 4)
       goto corrupt;
     if (mach_read_from_4(field) != 0)
       continue;
-    field= rec_get_nth_field_old(rec, DICT_FLD__SYS_TABLES__ID, &len);
+
+    field_no= scan_indexes ? ulint(DICT_FLD__SYS_INDEXES__TABLE_ID)
+                           : ulint(DICT_FLD__SYS_TABLES__ID);
+
+    field= rec_get_nth_field_old(rec, field_no, &len);
     if (len != 8)
       goto corrupt;
-    if (!dict_sys.is_sys_table(mach_read_from_8(field)))
+
+    table_id= mach_read_from_8(field);
+    if (dict_sys.is_sys_table(table_id))
+      continue;
+
+    if (scan_indexes)
+      err= callback(table_id, {});
+    else
     {
-      const byte *name_field = rec_get_nth_field_old(
-        rec, DICT_FLD__SYS_TABLES__NAME, &len);
-      if (len != UNIV_SQL_NULL && len > 0)
-      {
-        sql_print_information(
-          "InnoDB: Found unexpected table in system tablespace: %.*s",
-          (int)len, (const char *)name_field);
-      }
-      err= DB_SUCCESS_LOCKED_REC;
+      /* For tables, get the name */
+      field= rec_get_nth_field_old(rec, DICT_FLD__SYS_TABLES__NAME, &len);
+      if (len == UNIV_SQL_NULL || len == 0)
+        goto corrupt;
+
+      err= callback(table_id, {reinterpret_cast<const char*>(field), len});
+    }
+
+    if (err)
+    {
       btr_pcur_close(&pcur);
-      goto func_exit;
+      break;
     }
   }
 func_exit:
@@ -5749,10 +5777,100 @@ func_exit:
   return err;
 }
 
+/** Identify the legacy tables in the system tablespace
+and delete the table id from innodb system tables. A table is
+considered a legacy/unknown table if the table name does
+not contain '/' (indicating it's not a proper database/table name).
+Also delete the orphaned indexes from SYS_INDEXES in system
+tablespace.
+@retval DB_SUCCESS_LOCKED_REC if legacy table exists
+@return error code or DB_SUCCESS */
+static dberr_t drop_all_orphaned_tables()
+{
+  /* SELECT table_id,to_drop FROM SYS_TABLES WHERE SPACE=0 AND ... */
+  std::unordered_map<table_id_t,bool> system_tables;
+
+  /* Step 1: Scan SYS_TABLES for legacy tables */
+  dberr_t err= scan_system_tablespace_metadata(dict_sys.sys_tables,
+    [&](table_id_t table_id, st_::span<const char> name) -> dberr_t
+    {
+      const bool to_drop{!memchr(name.data(), '/', name.size())};
+      if (to_drop)
+        sql_print_information("InnoDB: Found an unknown table %.*s",
+                              int(name.size()), name.data());
+      system_tables.emplace(table_id, to_drop);
+      return DB_SUCCESS;
+    });
+
+  if (err != DB_SUCCESS)
+    return err;
+
+  /* Step 2: Scan SYS_INDEXES for orphaned indexes not in orphaned_tbl */
+  err= scan_system_tablespace_metadata(dict_sys.sys_indexes,
+    [&](table_id_t table_id, st_::span<const char>) -> dberr_t
+    {
+      if (!system_tables.emplace(table_id, true).second)
+        sql_print_information("InnoDB: Found orphaned index for table_id "
+                              UINT64PF, table_id);
+      return DB_SUCCESS;
+    });
+
+  if (err != DB_SUCCESS)
+    return err;
+
+  size_t count{0};
+  for (const auto &td : system_tables)
+    count+= td.second;
+  if (!count)
+    return DB_SUCCESS;
+
+  sql_print_information("InnoDB: Dropping %zu orphaned table(s)", count);
+
+  trx_t *trx= trx_create();
+  trx_start_for_ddl(trx);
+  err= lock_sys_tables(trx);
+  if (err)
+    goto err_exit;
+
+  dict_sys.lock(SRW_LOCK_CALL);
+
+  for (auto &td : system_tables)
+    if (td.second &&
+        (err= dict_drop_table_metadata(td.first, trx)) != DB_SUCCESS)
+      break;
+
+  dict_sys.unlock();
+
+  if (err == DB_SUCCESS)
+  {
+    trx->commit();
+    err= DB_SUCCESS_LOCKED_REC;
+  }
+  else
+  {
+err_exit:
+    trx->rollback();
+  }
+
+  trx->clear_and_free();
+  return err;
+}
+
 dberr_t fil_space_t::defragment() noexcept
 {
   ut_ad(this == fil_system.sys_space);
-  dberr_t err= user_tables_exists();
+  dberr_t err= DB_SUCCESS;
+
+  /* Check whether any user table exists in system tablespace */
+  err= scan_system_tablespace_metadata(dict_sys.sys_tables,
+    [](table_id_t, st_::span<const char> name) -> dberr_t
+  {
+    sql_print_information(
+      "InnoDB: Found unexpected table in system tablespace: %.*s",
+      int(name.size()), name.data());
+    return DB_SUCCESS_LOCKED_REC;
+  });
+
   if (err == DB_SUCCESS_LOCKED_REC)
   {
     sql_print_information(
@@ -5789,7 +5907,20 @@ void fsp_system_tablespace_truncate(bool shutdown)
 
   if (!shutdown)
   {
-    err= space->defragment();
+    err= drop_all_orphaned_tables();
+    if (err == DB_SUCCESS_LOCKED_REC)
+    {
+      /* Skip defragmentation when orphaned tables are delete-marked.
+      Both defragment() and purge would attempt to drop legacy tables,
+      causing double-free of segments. Proceed to shrinking only. */
+      sql_print_information("InnoDB: Defragmentation before "
+                            "autoshrink was skipped due to orphaned "
+                            "table removal.");
+      err= DB_SUCCESS;
+    }
+    else if (err == DB_SUCCESS)
+      err= space->defragment();
+
     if (err)
     {
       srv_sys_space.set_shrink_fail();

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1670,6 +1670,14 @@ public:
   dict_table_t *index() const noexcept { return index_stats; }
 };
 
+/** Delete the given table id entries from InnoDB system tables
+(like SYS_TABLES, SYS_COLUMNS, SYS_FIELDS, SYS_INDEXES)
+@param table_id table identifier to be removed
+@param trx      transaction
+@return DB_SUCCESS or error code */
+dberr_t dict_drop_table_metadata(table_id_t table_id,
+                                 trx_t *trx) noexcept;
+
 #include "dict0dict.inl"
 
 #endif


### PR DESCRIPTION
MDEV-38412 System tablespace fails to shrink due to legacy tables
Problem:
=======
 - InnoDB system tablespace fails to autoshrink when it contains
legacy internal tables. These are non-user tables and internal
table exist from older version. Because the current shrink logic
does recognize these entries as user table, they block the
defragmentation process required to reduce the tablespace size.

Solution:
=========
To enable successful shrinking, InnoDB has been updated to
identify and remove these legacy entries during the startup:

drop_all_orphaned_tables(): A new function that scans the InnoDB
system tables for entries lacking the / naming convention.
It triggers the removal of these table objects from InnoDB system
tables and ensures the purge thread subsequently drops any
associated index trees in SYS_INDEXES.

scan_system_tablespace_tables(): Scan the records in
SYS_TABLES and invoke callback(orphaned record, user table exist check)
on non-system tables in system tablespace

dict_drop_table_metadata(): Function is to remove specific
table IDs from internal system tables.

fsp_system_tablespace_truncate(): If legacy tables are detected,
InnoDB prioritizes their removal. To ensure data integrity and
complete the shrink, a two-restart sequence may be required:
1) purge the legacy table
2) Defragment the system tablespace and shrink the
system tablespace further