### PR TITLE
MDEV-39274: Document invariant ensuring passwd stays within packet bounds

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -14495,6 +14495,8 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   }
   else if (!(thd->client_capabilities & CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA))
   {
+    /* Packet buffer is null-terminated by the network layer, so strend(user)
+       stays within bounds and passwd remains within the packet. */
     passwd_len= (uchar)(*passwd++);
     db= thd->client_capabilities & CLIENT_CONNECT_WITH_DB ?
       passwd + passwd_len : 0;


### PR DESCRIPTION
## Summary
Add a debug assertion in `parse_client_handshake_packet` to ensure that `passwd` stays within the packet buffer.

## Background
In the secure-connection branch, `passwd` is derived from the username field and then dereferenced to read the password length.

The parser relies on the assumption that `passwd` remains within the packet bounds, as ensured by the surrounding parsing logic.

## Change
- Add a `DBUG_ASSERT` to validate that `passwd` does not exceed the packet boundary
