### PR TITLE
MDEV-38329 Named parameters in stored procedure CALL

### DIFF
--- a/mysql-test/main/sp_named_params.result
+++ b/mysql-test/main/sp_named_params.result
@@ -1,0 +1,272 @@
+#
+# MDEV-38329: Named Parameters in Invocation of Stored Routines
+#
+# Test setup
+CREATE PROCEDURE p1(a INT, b INT, c INT)
+BEGIN
+SELECT a, b, c;
+END;
+$$
+# All positional (existing behavior)
+CALL p1(1, 2, 3);
+a	b	c
+1	2	3
+# All named
+CALL p1(a => 1, b => 2, c => 3);
+a	b	c
+1	2	3
+# Named in different order
+CALL p1(c => 3, a => 1, b => 2);
+a	b	c
+1	2	3
+# Mixed positional and named
+CALL p1(1, b => 2, c => 3);
+a	b	c
+1	2	3
+# Mixed: first two positional, last named
+CALL p1(1, 2, c => 3);
+a	b	c
+1	2	3
+# Positional after named should fail
+CALL p1(a => 1, 2, 3);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ' 3)' at line 1
+# Unknown parameter name
+CALL p1(a => 1, b => 2, x => 3);
+ERROR 42000: Undeclared variable: x
+# Duplicate parameter name
+CALL p1(a => 1, a => 2, b => 3);
+ERROR 42000: Duplicate parameter: a
+# Positional fills 'a', then 'a' again by name
+CALL p1(1, a => 2, c => 3);
+ERROR 42000: Duplicate parameter: a
+DROP PROCEDURE p1;
+#
+# Test with default values
+#
+CREATE PROCEDURE p2(a INT, b INT DEFAULT 20, c INT DEFAULT 30)
+BEGIN
+SELECT a, b, c;
+END;
+$$
+# Skip middle param (use default for b)
+CALL p2(a => 1, c => 3);
+a	b	c
+1	20	3
+# Only required param
+CALL p2(a => 1);
+a	b	c
+1	20	30
+# All named with defaults overridden
+CALL p2(a => 10, b => 20, c => 30);
+a	b	c
+10	20	30
+# Missing required param should fail
+CALL p2(b => 2, c => 3);
+ERROR 42000: Incorrect number of arguments for PROCEDURE test.p2; expected 3, got 2
+DROP PROCEDURE p2;
+#
+# Stored functions with named parameters
+#
+CREATE FUNCTION f1(a INT, b INT, c INT) RETURNS INT
+BEGIN
+RETURN a * 10000 + b * 100 + c;
+END;
+$$
+# Positional function call
+SELECT f1(1, 2, 3);
+f1(1, 2, 3)
+10203
+# All named with =>
+SELECT f1(a => 1, b => 2, c => 3);
+f1(a => 1, b => 2, c => 3)
+10203
+# Named in different order
+SELECT f1(c => 3, a => 1, b => 2);
+f1(c => 3, a => 1, b => 2)
+10203
+# Mixed positional and named
+SELECT f1(1, b => 2, c => 3);
+f1(1, b => 2, c => 3)
+10203
+# AS alias syntax also names arguments
+SELECT f1(1 AS a, 2 AS b, 3 AS c);
+f1(1 AS a, 2 AS b, 3 AS c)
+10203
+SELECT f1(3 AS c, 1 AS a, 2 AS b);
+f1(3 AS c, 1 AS a, 2 AS b)
+10203
+# Unknown parameter name
+SELECT f1(a => 1, b => 2, x => 3);
+ERROR 42000: Undeclared variable: x
+# Duplicate parameter name
+SELECT f1(a => 1, a => 2, b => 3);
+ERROR 42000: Duplicate parameter: a
+DROP FUNCTION f1;
+#
+# Stored function with default values
+#
+CREATE FUNCTION f2(a INT, b INT DEFAULT 20, c INT DEFAULT 30) RETURNS INT
+BEGIN
+RETURN a * 10000 + b * 100 + c;
+END;
+$$
+# Skip middle param (use default for b)
+SELECT f2(a => 1, c => 3);
+f2(a => 1, c => 3)
+12003
+# Only required param
+SELECT f2(a => 1);
+f2(a => 1)
+12030
+# Missing required param should fail
+SELECT f2(b => 2, c => 3);
+ERROR 42000: Incorrect number of arguments for FUNCTION test.f2; expected 3, got 2
+DROP FUNCTION f2;
+#
+# OUT/INOUT parameters with named args
+#
+CREATE PROCEDURE p_out(OUT x INT, IN y INT)
+BEGIN
+SET x = y * 10;
+END;
+$$
+SET @result = 0;
+CALL p_out(x => @result, y => 5);
+SELECT @result;
+@result
+50
+SET @result = 0;
+CALL p_out(y => 5, x => @result);
+SELECT @result;
+@result
+50
+SET @result = 0;
+CALL p_out(@result, y => 5);
+SELECT @result;
+@result
+50
+DROP PROCEDURE p_out;
+CREATE PROCEDURE p_inout(INOUT a INT, IN b INT)
+BEGIN
+SET a = a + b;
+END;
+$$
+SET @val = 10;
+CALL p_inout(a => @val, b => 5);
+SELECT @val;
+@val
+15
+DROP PROCEDURE p_inout;
+#
+# Prepared statements with named parameters
+#
+CREATE PROCEDURE p_prep(a INT, b INT, c INT DEFAULT 30)
+BEGIN
+SELECT a, b, c;
+END;
+$$
+PREPARE stmt FROM 'CALL p_prep(a => ?, b => ?)';
+SET @a = 1, @b = 2;
+EXECUTE stmt USING @a, @b;
+a	b	c
+1	2	30
+DEALLOCATE PREPARE stmt;
+PREPARE stmt2 FROM 'CALL p_prep(b => ?, a => ?)';
+EXECUTE stmt2 USING @b, @a;
+a	b	c
+1	2	30
+DEALLOCATE PREPARE stmt2;
+# Re-execute prepared statement
+PREPARE stmt3 FROM 'CALL p_prep(a => ?, b => ?)';
+SET @a = 10, @b = 20;
+EXECUTE stmt3 USING @a, @b;
+a	b	c
+10	20	30
+SET @a = 100, @b = 200;
+EXECUTE stmt3 USING @a, @b;
+a	b	c
+100	200	30
+DEALLOCATE PREPARE stmt3;
+DROP PROCEDURE p_prep;
+#
+# Nested calls with named parameters
+#
+CREATE PROCEDURE p_inner(x INT, y INT)
+BEGIN
+SELECT x, y;
+END;
+$$
+CREATE PROCEDURE p_outer(a INT, b INT)
+BEGIN
+CALL p_inner(x => b, y => a);
+END;
+$$
+CALL p_outer(a => 100, b => 200);
+x	y
+200	100
+DROP PROCEDURE p_outer;
+DROP PROCEDURE p_inner;
+#
+# Reserved words as parameter names
+#
+CREATE PROCEDURE p_reserved(`select` INT, `from` INT)
+BEGIN
+SELECT `select`, `from`;
+END;
+$$
+CALL p_reserved(`select` => 1, `from` => 2);
+`select`	`from`
+1	2
+DROP PROCEDURE p_reserved;
+#
+# NULL and expression values
+#
+CREATE PROCEDURE p_expr(a INT, b VARCHAR(50) DEFAULT 'hello', c INT DEFAULT NULL)
+BEGIN
+SELECT a, b, c;
+END;
+$$
+CALL p_expr(a => 1+2, b => CONCAT('world', '!'));
+a	b	c
+3	world!	NULL
+CALL p_expr(a => NULL);
+a	b	c
+NULL	hello	NULL
+CALL p_expr(a => 1, c => NULL, b => 'test');
+a	b	c
+1	test	NULL
+DROP PROCEDURE p_expr;
+#
+# Function with expression arguments
+#
+CREATE FUNCTION f_expr(a INT, b INT DEFAULT 10) RETURNS INT
+BEGIN
+RETURN a + b;
+END;
+$$
+SELECT f_expr(a => 1+2);
+f_expr(a => 1+2)
+13
+SELECT f_expr(a => 5, b => 20);
+f_expr(a => 5, b => 20)
+25
+DROP FUNCTION f_expr;
+#
+# Mixed positional and named for functions
+#
+CREATE FUNCTION f_mix(a INT, b INT, c INT) RETURNS INT
+BEGIN
+RETURN a * 10000 + b * 100 + c;
+END;
+$$
+# Positional first, then named
+SELECT f_mix(1, b => 2, c => 3);
+f_mix(1, b => 2, c => 3)
+10203
+# Named first then positional conflicts with slot 0
+SELECT f_mix(a => 1, 2);
+ERROR 42000: Duplicate parameter: a
+DROP FUNCTION f_mix;
+#
+# End of tests
+#

--- a/mysql-test/main/sp_named_params.test
+++ b/mysql-test/main/sp_named_params.test
@@ -1,0 +1,293 @@
+--echo #
+--echo # MDEV-38329: Named Parameters in Invocation of Stored Routines
+--echo #
+
+--echo # Test setup
+delimiter $$;
+CREATE PROCEDURE p1(a INT, b INT, c INT)
+BEGIN
+  SELECT a, b, c;
+END;
+$$
+delimiter ;$$
+
+--echo # All positional (existing behavior)
+CALL p1(1, 2, 3);
+
+--echo # All named
+CALL p1(a => 1, b => 2, c => 3);
+
+--echo # Named in different order
+CALL p1(c => 3, a => 1, b => 2);
+
+--echo # Mixed positional and named
+CALL p1(1, b => 2, c => 3);
+
+--echo # Mixed: first two positional, last named
+CALL p1(1, 2, c => 3);
+
+--echo # Positional after named should fail
+--error ER_PARSE_ERROR
+CALL p1(a => 1, 2, 3);
+
+--echo # Unknown parameter name
+--error ER_SP_UNDECLARED_VAR
+CALL p1(a => 1, b => 2, x => 3);
+
+--echo # Duplicate parameter name
+--error ER_SP_DUP_PARAM
+CALL p1(a => 1, a => 2, b => 3);
+
+--echo # Positional fills 'a', then 'a' again by name
+--error ER_SP_DUP_PARAM
+CALL p1(1, a => 2, c => 3);
+
+DROP PROCEDURE p1;
+
+--echo #
+--echo # Test with default values
+--echo #
+delimiter $$;
+CREATE PROCEDURE p2(a INT, b INT DEFAULT 20, c INT DEFAULT 30)
+BEGIN
+  SELECT a, b, c;
+END;
+$$
+delimiter ;$$
+
+--echo # Skip middle param (use default for b)
+CALL p2(a => 1, c => 3);
+
+--echo # Only required param
+CALL p2(a => 1);
+
+--echo # All named with defaults overridden
+CALL p2(a => 10, b => 20, c => 30);
+
+--echo # Missing required param should fail
+--error ER_SP_WRONG_NO_OF_ARGS
+CALL p2(b => 2, c => 3);
+
+DROP PROCEDURE p2;
+
+--echo #
+--echo # Stored functions with named parameters
+--echo #
+delimiter $$;
+CREATE FUNCTION f1(a INT, b INT, c INT) RETURNS INT
+BEGIN
+  RETURN a * 10000 + b * 100 + c;
+END;
+$$
+delimiter ;$$
+
+--echo # Positional function call
+SELECT f1(1, 2, 3);
+
+--echo # All named with =>
+SELECT f1(a => 1, b => 2, c => 3);
+
+--echo # Named in different order
+SELECT f1(c => 3, a => 1, b => 2);
+
+--echo # Mixed positional and named
+SELECT f1(1, b => 2, c => 3);
+
+--echo # AS alias syntax also names arguments
+SELECT f1(1 AS a, 2 AS b, 3 AS c);
+SELECT f1(3 AS c, 1 AS a, 2 AS b);
+
+--echo # Unknown parameter name
+--error ER_SP_UNDECLARED_VAR
+SELECT f1(a => 1, b => 2, x => 3);
+
+--echo # Duplicate parameter name
+--error ER_SP_DUP_PARAM
+SELECT f1(a => 1, a => 2, b => 3);
+
+DROP FUNCTION f1;
+
+--echo #
+--echo # Stored function with default values
+--echo #
+delimiter $$;
+CREATE FUNCTION f2(a INT, b INT DEFAULT 20, c INT DEFAULT 30) RETURNS INT
+BEGIN
+  RETURN a * 10000 + b * 100 + c;
+END;
+$$
+delimiter ;$$
+
+--echo # Skip middle param (use default for b)
+SELECT f2(a => 1, c => 3);
+
+--echo # Only required param
+SELECT f2(a => 1);
+
+--echo # Missing required param should fail
+--error ER_SP_WRONG_NO_OF_ARGS
+SELECT f2(b => 2, c => 3);
+
+DROP FUNCTION f2;
+
+--echo #
+--echo # OUT/INOUT parameters with named args
+--echo #
+delimiter $$;
+CREATE PROCEDURE p_out(OUT x INT, IN y INT)
+BEGIN
+  SET x = y * 10;
+END;
+$$
+delimiter ;$$
+
+SET @result = 0;
+CALL p_out(x => @result, y => 5);
+SELECT @result;
+
+SET @result = 0;
+CALL p_out(y => 5, x => @result);
+SELECT @result;
+
+SET @result = 0;
+CALL p_out(@result, y => 5);
+SELECT @result;
+
+DROP PROCEDURE p_out;
+
+delimiter $$;
+CREATE PROCEDURE p_inout(INOUT a INT, IN b INT)
+BEGIN
+  SET a = a + b;
+END;
+$$
+delimiter ;$$
+
+SET @val = 10;
+CALL p_inout(a => @val, b => 5);
+SELECT @val;
+
+DROP PROCEDURE p_inout;
+
+--echo #
+--echo # Prepared statements with named parameters
+--echo #
+delimiter $$;
+CREATE PROCEDURE p_prep(a INT, b INT, c INT DEFAULT 30)
+BEGIN
+  SELECT a, b, c;
+END;
+$$
+delimiter ;$$
+
+PREPARE stmt FROM 'CALL p_prep(a => ?, b => ?)';
+SET @a = 1, @b = 2;
+EXECUTE stmt USING @a, @b;
+DEALLOCATE PREPARE stmt;
+
+PREPARE stmt2 FROM 'CALL p_prep(b => ?, a => ?)';
+EXECUTE stmt2 USING @b, @a;
+DEALLOCATE PREPARE stmt2;
+
+--echo # Re-execute prepared statement
+PREPARE stmt3 FROM 'CALL p_prep(a => ?, b => ?)';
+SET @a = 10, @b = 20;
+EXECUTE stmt3 USING @a, @b;
+SET @a = 100, @b = 200;
+EXECUTE stmt3 USING @a, @b;
+DEALLOCATE PREPARE stmt3;
+
+DROP PROCEDURE p_prep;
+
+--echo #
+--echo # Nested calls with named parameters
+--echo #
+delimiter $$;
+CREATE PROCEDURE p_inner(x INT, y INT)
+BEGIN
+  SELECT x, y;
+END;
+$$
+CREATE PROCEDURE p_outer(a INT, b INT)
+BEGIN
+  CALL p_inner(x => b, y => a);
+END;
+$$
+delimiter ;$$
+
+CALL p_outer(a => 100, b => 200);
+
+DROP PROCEDURE p_outer;
+DROP PROCEDURE p_inner;
+
+--echo #
+--echo # Reserved words as parameter names
+--echo #
+delimiter $$;
+CREATE PROCEDURE p_reserved(`select` INT, `from` INT)
+BEGIN
+  SELECT `select`, `from`;
+END;
+$$
+delimiter ;$$
+
+CALL p_reserved(`select` => 1, `from` => 2);
+
+DROP PROCEDURE p_reserved;
+
+--echo #
+--echo # NULL and expression values
+--echo #
+delimiter $$;
+CREATE PROCEDURE p_expr(a INT, b VARCHAR(50) DEFAULT 'hello', c INT DEFAULT NULL)
+BEGIN
+  SELECT a, b, c;
+END;
+$$
+delimiter ;$$
+
+CALL p_expr(a => 1+2, b => CONCAT('world', '!'));
+CALL p_expr(a => NULL);
+CALL p_expr(a => 1, c => NULL, b => 'test');
+
+DROP PROCEDURE p_expr;
+
+--echo #
+--echo # Function with expression arguments
+--echo #
+delimiter $$;
+CREATE FUNCTION f_expr(a INT, b INT DEFAULT 10) RETURNS INT
+BEGIN
+  RETURN a + b;
+END;
+$$
+delimiter ;$$
+
+SELECT f_expr(a => 1+2);
+SELECT f_expr(a => 5, b => 20);
+
+DROP FUNCTION f_expr;
+
+--echo #
+--echo # Mixed positional and named for functions
+--echo #
+delimiter $$;
+CREATE FUNCTION f_mix(a INT, b INT, c INT) RETURNS INT
+BEGIN
+  RETURN a * 10000 + b * 100 + c;
+END;
+$$
+delimiter ;$$
+
+--echo # Positional first, then named
+SELECT f_mix(1, b => 2, c => 3);
+
+--echo # Named first then positional conflicts with slot 0
+--error ER_SP_DUP_PARAM
+SELECT f_mix(a => 1, 2);
+
+DROP FUNCTION f_mix;
+
+--echo #
+--echo # End of tests
+--echo #

--- a/mysql-test/main/udf.result
+++ b/mysql-test/main/udf.result
@@ -130,9 +130,9 @@ a	c
 1	1
 2	2
 SELECT a, fn(MIN(b) xx) as c FROM t1 GROUP BY a;
-ERROR 42000: Incorrect parameters in the call to stored function 'fn'
+ERROR 42000: Undeclared variable: xx
 SELECT myfunc_int(fn(MIN(b) xx)) as c FROM t1 GROUP BY a;
-ERROR 42000: Incorrect parameters in the call to stored function 'fn'
+ERROR 42000: Undeclared variable: xx
 SELECT myfunc_int(test.fn(MIN(b) xx)) as c FROM t1 GROUP BY a;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'xx)) as c FROM t1 GROUP BY a' at line 1
 SELECT myfunc_int(fn(MIN(b)) xx) as c FROM t1 GROUP BY a;

--- a/mysql-test/main/udf.test
+++ b/mysql-test/main/udf.test
@@ -152,9 +152,12 @@ EXPLAIN EXTENDED SELECT myfunc_int(a AS attr_name) FROM t1;
 EXPLAIN EXTENDED SELECT myfunc_int(a) FROM t1;
 SELECT a,c FROM v1;
 
---error ER_WRONG_PARAMETERS_TO_STORED_FCT
+# Since MDEV-38329 stored functions accept named arguments, so an
+# attribute name that does not match any formal parameter is reported
+# as an unknown parameter name instead of ER_WRONG_PARAMETERS_TO_STORED_FCT
+--error ER_SP_UNDECLARED_VAR
 SELECT a, fn(MIN(b) xx) as c FROM t1 GROUP BY a;
---error ER_WRONG_PARAMETERS_TO_STORED_FCT
+--error ER_SP_UNDECLARED_VAR
 SELECT myfunc_int(fn(MIN(b) xx)) as c FROM t1 GROUP BY a;
 --error ER_PARSE_ERROR
 SELECT myfunc_int(test.fn(MIN(b) xx)) as c FROM t1 GROUP BY a;

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -3015,21 +3015,6 @@ Create_sp_func::create_with_db(THD *thd,
   const Sp_handler *sph= &sp_handler_function;
   Database_qualified_name pkgname;
 
-  if (unlikely(has_named_parameters(item_list)))
-  {
-    /*
-      The syntax "db.foo(expr AS p1, expr AS p2, ...) is invalid,
-      and has been rejected during syntactic parsing already,
-      because a stored function call may not have named parameters.
-
-      The syntax "foo(expr AS p1, expr AS p2, ...)" is correct,
-      because it can refer to a User Defined Function call.
-      For a Stored Function however, this has no semantic.
-    */
-    my_error(ER_WRONG_PARAMETERS_TO_STORED_FCT, MYF(0), name.str);
-    return NULL;
-  }
-
   if (item_list != NULL)
     arg_count= item_list->elements;
 

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -6894,6 +6894,96 @@ Item_func_sp::fix_fields(THD *thd, Item **ref)
     DBUG_RETURN(TRUE);
   }
 
+  bool has_named_args= false;
+  for (uint i= 0; i < arg_count && !has_named_args; i++)
+    has_named_args= args[i]->is_explicit_name();
+  if (has_named_args && !m_args_reordered)
+  {
+    m_args_reordered= true;
+    sp_pcontext *pcont= m_sp->get_parse_context();
+    uint params= pcont->context_var_count();
+    /*
+      The reordered argument array replaces Item_args::args, so for
+      prepared statements it must survive re-execution: allocate it on
+      the statement arena, not on the execution arena.
+    */
+    Query_arena *arena, backup;
+    arena= thd->activate_stmt_arena_if_needed(&backup);
+    Item **arg_array= (Item**) thd->calloc(sizeof(Item*) * params);
+    bool *param_assigned= (bool*) thd->calloc(sizeof(bool) * params);
+    if (arena)
+      thd->restore_active_arena(arena, &backup);
+    if (!arg_array || !param_assigned)
+      DBUG_RETURN(TRUE);
+
+    uint positional_count= 0;
+    for (uint i= 0; i < arg_count; i++)
+    {
+      Item *item= args[i];
+      if (item->is_explicit_name())
+      {
+        bool found= false;
+        for (uint j= 0; j < params; j++)
+        {
+          sp_variable *spvar= pcont->get_context_variable(j);
+          if (spvar->name.streq(item->name))
+          {
+            if (param_assigned[j])
+            {
+              my_error(ER_SP_DUP_PARAM, MYF(0), item->name.str);
+              DBUG_RETURN(TRUE);
+            }
+            arg_array[j]= item;
+            param_assigned[j]= true;
+            found= true;
+            break;
+          }
+        }
+        if (!found)
+        {
+          my_error(ER_SP_UNDECLARED_VAR, MYF(0), item->name.str);
+          DBUG_RETURN(TRUE);
+        }
+      }
+      else
+      {
+        if (positional_count >= params)
+        {
+          my_error(ER_SP_WRONG_NO_OF_ARGS, MYF(0), "FUNCTION",
+                   ErrConvDQName(m_sp).ptr(), params, arg_count);
+          DBUG_RETURN(TRUE);
+        }
+        if (param_assigned[positional_count])
+        {
+          my_error(ER_SP_DUP_PARAM, MYF(0),
+                   pcont->get_context_variable(positional_count)->name.str);
+          DBUG_RETURN(TRUE);
+        }
+        arg_array[positional_count]= item;
+        param_assigned[positional_count]= true;
+        positional_count++;
+      }
+    }
+
+    for (uint j= 0; j < params; j++)
+    {
+      if (!param_assigned[j])
+      {
+        sp_variable *spvar= pcont->get_context_variable(j);
+        if (!spvar->default_value)
+        {
+          my_error(ER_SP_WRONG_NO_OF_ARGS, MYF(0), "FUNCTION",
+                   ErrConvDQName(m_sp).ptr(), params, arg_count);
+          DBUG_RETURN(TRUE);
+        }
+        arg_array[j]= spvar->default_value;
+      }
+    }
+
+    args= arg_array;
+    arg_count= params;
+  }
+
   Query_arena *arena, backup;
   /*
     Allocation an instance of Item_func_sp used for initialization of

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -4194,6 +4194,14 @@ class Item_func_sp :public Item_func,
 private:
   const Sp_handler *m_handler;
 
+  /*
+    True after named arguments have been reordered to formal parameter
+    positions in fix_fields(). The reordered args array is allocated on
+    the statement arena and persists across executions of a prepared
+    statement, so the reordering must not run again on re-execution.
+  */
+  bool m_args_reordered= false;
+
   bool execute();
 
 protected:

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2217,12 +2217,92 @@ sp_head::execute_procedure(THD *thd, List<Item> *args)
   if (m_parent && m_parent->instantiate_if_needed(thd))
     DBUG_RETURN(true);
 
-  if (args->elements < (params - default_params) ||
-      args->elements > params)
+  if (!thd->lex->has_named_call_param &&
+      (args->elements < (params - default_params) ||
+      args->elements > params))
   {
     my_error(ER_SP_WRONG_NO_OF_ARGS, MYF(0), "PROCEDURE",
              ErrConvDQName(this).ptr(), params, args->elements);
     DBUG_RETURN(TRUE);
+  }
+
+  /* Reorder named arguments to match formal parameter positions */
+  List<Item> reordered_args;
+  if (thd->lex->has_named_call_param)
+  {
+    Item **arg_array= (Item**) thd->calloc(sizeof(Item*) * params);
+    bool *param_assigned= (bool*) thd->calloc(sizeof(bool) * params);
+    if (!arg_array || !param_assigned)
+      DBUG_RETURN(TRUE);
+
+    List_iterator<Item> it(*args);
+    uint positional_count= 0;
+    Item *item;
+
+    while ((item= it++))
+    {
+      if (item->is_explicit_name())
+      {
+        bool found= false;
+        for (uint j= 0; j < params; j++)
+        {
+          sp_variable *spvar= m_pcont->get_context_variable(j);
+          if (spvar->name.streq(item->name))
+          {
+            if (param_assigned[j])
+            {
+              my_error(ER_SP_DUP_PARAM, MYF(0), item->name.str);
+              DBUG_RETURN(TRUE);
+            }
+            arg_array[j]= item;
+            param_assigned[j]= true;
+            found= true;
+            break;
+          }
+        }
+        if (!found)
+        {
+          my_error(ER_SP_UNDECLARED_VAR, MYF(0), item->name.str);
+          DBUG_RETURN(TRUE);
+        }
+      }
+      else
+      {
+        /*
+          Positional args come before named args (enforced by the parser),
+          so the slot at positional_count is always free. Guard only
+          against too many positional args overflowing the params array.
+        */
+        if (positional_count >= params)
+        {
+          my_error(ER_SP_WRONG_NO_OF_ARGS, MYF(0), "PROCEDURE",
+                   ErrConvDQName(this).ptr(), params, args->elements);
+          DBUG_RETURN(TRUE);
+        }
+        arg_array[positional_count]= item;
+        param_assigned[positional_count]= true;
+        positional_count++;
+      }
+    }
+
+    for (uint j= 0; j < params; j++)
+    {
+      if (!param_assigned[j])
+      {
+        sp_variable *spvar= m_pcont->get_context_variable(j);
+        if (!spvar->default_value)
+        {
+          my_error(ER_SP_WRONG_NO_OF_ARGS, MYF(0), "PROCEDURE",
+                   ErrConvDQName(this).ptr(), params, args->elements);
+          DBUG_RETURN(TRUE);
+        }
+        arg_array[j]= spvar->default_value;
+      }
+    }
+
+    for (uint j= 0; j < params; j++)
+      reordered_args.push_back(arg_array[j], thd->mem_root);
+    args= &reordered_args;
   }
 
   save_spcont= octx= thd->spcont;

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1297,6 +1297,7 @@ void LEX::start(THD *thd_arg)
   verbose= 0;
   safe_to_cache_query= 1;
   ignore= 0;
+  has_named_call_param= false;
   next_is_main= 0;
   next_is_down= 0;
   empty_field_list_on_rset= 0;
@@ -10520,6 +10521,7 @@ bool LEX::call_statement_start(THD *thd, sp_name *name)
   const Sp_handler *sph= &sp_handler_procedure;
   sql_command= SQLCOM_CALL;
   value_list.empty();
+  has_named_call_param= false;
 
   thd->variables.path.resolve(thd, sphead, name, &sph, &pkgname);
 
@@ -10559,6 +10561,7 @@ bool LEX::call_statement_start(THD *thd,
   Identifier_chain2 q_pkg_proc(*pkg, *proc);
   sp_name *spname;
   value_list.empty();
+  has_named_call_param= false;
   sql_command= SQLCOM_CALL;
 
   const Lex_ident_db_normalized dbn= thd->to_ident_db_normalized_with_error(*db);

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3580,6 +3580,7 @@ public:
   bool verbose:1, no_write_to_binlog:1;
   bool safe_to_cache_query:1;
   bool ignore:1;
+  bool has_named_call_param:1;
   bool next_is_main:1; // use "main" SELECT_LEX for nrxt allocation;
   bool next_is_down:1; // use "main" SELECT_LEX for nrxt allocation;
   /*

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1604,6 +1604,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
         boolean_test
         predicate bit_expr parenthesized_expr
         table_wild simple_expr column_default_non_parenthesized_expr udf_expr
+        sp_cparam
         primary_expr primary_base_expr string_factor_expr mysql_concatenation_expr
         select_sublist_qualified_asterisk
         expr_or_ignore expr_or_ignore_or_default
@@ -3514,13 +3515,32 @@ opt_sp_cparams:
         ;
 
 sp_cparams:
-          sp_cparams ',' expr
+          sp_cparams ',' sp_cparam
           {
             ($$= $1)->push_back($3, thd->mem_root);
           }
-        | expr
+        | sp_cparam
           {
             ($$= &Lex->value_list)->push_back($1, thd->mem_root);
+          }
+        ;
+
+sp_cparam:
+          expr
+          {
+            if (Lex->has_named_call_param)
+            {
+              thd->parse_error();
+              MYSQL_YYABORT;
+            }
+            $$= $1;
+          }
+        | ident ARROW_SYM expr
+          {
+            Lex->has_named_call_param= true;
+            $3->base_flags|= item_base_t::IS_EXPLICIT_NAME;
+            $3->set_name(thd, $1);
+            $$= $3;
           }
         ;
 
@@ -11679,6 +11699,20 @@ udf_expr:
                      $2->type() != Item::REF_ITEM /* For HAVING */ )
               $2->set_name(thd, $1, (uint) ($3 - $1), thd->charset());
             $$= $2;
+          }
+        /*
+          Named argument: ident => expr. The leading remember_name is a
+          dummy here (its value is unused), but it must be present: both
+          alternatives have to start with the same empty rule, otherwise
+          Bison gets a shift/reduce conflict on every token that can start
+          an ident, as it would have to decide whether to reduce
+          remember_name before seeing if ARROW_SYM follows the ident.
+        */
+        | remember_name ident ARROW_SYM expr
+          {
+            $4->base_flags|= item_base_t::IS_EXPLICIT_NAME;
+            $4->set_name(thd, $2);
+            $$= $4;
           }
         ;
 


### PR DESCRIPTION
The Jira issue number for this PR is: [MDEV-38329](https://jira.mariadb.org/browse/MDEV-38329)

## Description

Stored routines currently require all arguments to be passed positionally.
When a routine has many parameters with defaults, there is no way to skip
middle parameters — only trailing ones can be omitted.

This patch adds named parameter invocation using the `=>` syntax for both
stored procedures and stored functions:

```sql
CALL proc(a => 1, b => 2, c => 3);       -- all named
CALL proc(c => 3, a => 1, b => 2);       -- any order
CALL proc(1, b => 2, c => 3);            -- mixed positional + named
CALL proc(a => 1, c => 3);               -- skip middle param with default

SELECT func(a => 1, b => 2);             -- functions too
SELECT func(c => 3, a => 1, b => 2);     -- any order
```

This brings MariaDB in line with Oracle, PostgreSQL, SQL Server, and Firebird,
all of which already support named parameter invocation.

**Parser changes (`sql/sql_yacc.yy`):**

Added `sp_cparam` rule to accept `ident ARROW_SYM expr` alongside plain `expr`
in CALL argument lists, and a second `udf_expr` alternative for function calls.
In `udf_expr` both alternatives start with `remember_name`: it is a dummy in
the named-argument alternative (its value is unused), but it must be present
so both alternatives share the same empty-rule prefix — otherwise bison
reports a shift/reduce conflict on every token that can start an `ident`,
as it would have to decide whether to reduce `remember_name` before seeing
if `ARROW_SYM` follows. No new grammar conflicts are introduced.

Named arguments set `IS_EXPLICIT_NAME` on the Item and store the parameter
name in `Item::name`, reusing the mechanism that UDF named arguments (the
WL#1017 `AS` attribute syntax) already use — that syntax continues to work
and names arguments the same way. Positional arguments after a named argument
are rejected at parse time for CALL.

**Reordering for procedures (`sql/sp_head.cc`):**

In `sp_head::execute_procedure()`, before the binding loop, named arguments
are matched against `sp_pcontext`'s formal parameter list by name and
reordered to their declared positions. Omitted parameters with defaults are
filled from `sp_variable::default_value`.

**Reordering for functions (`sql/item_func.cc`, `sql/item_create.cc`):**

In `Item_func_sp::fix_fields()`, after the sp_head is resolved, arguments
marked with `IS_EXPLICIT_NAME` are matched and reordered the same way. The
`has_named_parameters()` rejection in `Create_sp_func::create_with_db()` is
removed.

**Error handling:**

- Unknown parameter name (`ER_SP_UNDECLARED_VAR`)
- Duplicate parameter name, including positional/named collisions (`ER_SP_DUP_PARAM`)
- Missing required parameter without default (`ER_SP_WRONG_NO_OF_ARGS`)

**Test suite change (`mysql-test/main/udf.test`):**

An unknown attribute name on a stored function call, e.g. `fn(MIN(b) xx)`,
is now reported as `ER_SP_UNDECLARED_VAR` instead of
`ER_WRONG_PARAMETERS_TO_STORED_FCT`, because stored functions now accept
named arguments.

## Current status

**Done:**
- [x] Parser: `CALL proc(a => 1, b => 2)` syntax accepted
- [x] Named params for stored functions: `SELECT func(a => 1)`
- [x] Mixed positional + named: `CALL proc(1, b => 2)`
- [x] Parse-time rejection of positional after named
- [x] Argument reordering in `execute_procedure()` and `Item_func_sp::fix_fields()`
- [x] Default value filling for omitted parameters
- [x] OUT/INOUT parameter support with named args (`CALL p(x => @var)`)
- [x] Prepared statement support (`PREPARE stmt FROM 'CALL p(a => ?)'`, re-execution)
- [x] Error detection: unknown name, duplicate name, missing required param
- [x] MTR test coverage: nested calls, reserved words as param names, NULLs, expressions

**Still working on:**
- [ ] Defaults referencing earlier parameters (`b INT DEFAULT a+1`) fail with
  named invocation (`CALL p(a => 5)` → `Unknown column 'a'`), while positional
  `CALL p(5)` works. Filling from `sp_variable::default_value` in the caller's
  context bypasses `sp_instr_set_default_param`, which normally evaluates
  defaults inside the routine context based on
  `sp_rcontext::m_inited_params_count`. A fix keeping default evaluation
  inside the routine (making the inited-params tracking hole-aware for named
  args) is in progress.

This PR is a **work in progress**. Reviews and feedback on the current approach are welcome.

## Release Notes

Stored procedures and stored functions now support named parameter invocation
using the `=>` syntax. Arguments can be passed by name in any order, and
parameters with default values can be skipped: `CALL proc(a => 1, c => 3)`,
`SELECT func(b => 2, a => 1)`.

## How can this PR be tested?

```
./mtr main.sp_named_params
```

The test covers:
- All positional (no regression)
- All named in declared order and different order, for CALL and SELECT
- Mixed positional + named
- Positional after named (syntax error)
- Unknown parameter name, duplicate name (named twice, positional then named)
- Default value: skip middle param, only required param, override all defaults
- Missing required parameter without default
- OUT/INOUT parameters with named args
- Prepared statements with named args, including re-execution
- Nested CALLs, reserved words as parameter names, NULL and expression values

## Basing the PR against the correct MariaDB version

This is a new feature. The PR targets `main`.

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
