### PR TITLE
oqgraph: remove openquery.com refs and broken LP links

### DIFF
--- a/storage/oqgraph/README
+++ b/storage/oqgraph/README
@@ -8,9 +8,7 @@ friend-of-a-friend style searches can now be done using standard SQL
 syntax, and results joined onto other tables.
 
 Based on a concept by Arjen Lentz
-v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-For more information, documentation, support, enhancement engineering,
-see http://openquery.com/graph or contact graph@openquery.com
+v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
 
 INSTALLATION
 

--- a/storage/oqgraph/graphcore-config.h
+++ b/storage/oqgraph/graphcore-config.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 #ifndef oq_graphcore_config_h_

--- a/storage/oqgraph/graphcore-graph.cc
+++ b/storage/oqgraph/graphcore-graph.cc
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/graphcore-graph.h
+++ b/storage/oqgraph/graphcore-graph.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnella.
    ======================================================================
 */
 

--- a/storage/oqgraph/graphcore-types.h
+++ b/storage/oqgraph/graphcore-types.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/graphcore.cc
+++ b/storage/oqgraph/graphcore.cc
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/graphcore.h
+++ b/storage/oqgraph/graphcore.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/ha_oqgraph.cc
+++ b/storage/oqgraph/ha_oqgraph.cc
@@ -18,9 +18,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 
@@ -1326,8 +1324,7 @@ void ha_oqgraph::update_create_info(HA_CREATE_INFO *create_info)
 
 
 static const char oqgraph_description[]=
-  "Open Query Graph Computation Engine "
-  "(http://openquery.com/graph)";
+  "Open Query Graph Computation Engine";
 
 struct st_mysql_storage_engine oqgraph_storage_engine=
 { MYSQL_HANDLERTON_INTERFACE_VERSION };

--- a/storage/oqgraph/ha_oqgraph.h
+++ b/storage/oqgraph/ha_oqgraph.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/mysql-test/oqgraph/boundary_conditions.test
+++ b/storage/oqgraph/mysql-test/oqgraph/boundary_conditions.test
@@ -102,9 +102,8 @@ SELECT * FROM graph WHERE latch='Ω Ohms Tennis Ball 〄' and origid=666;
 SELECT * FROM graph WHERE latch='Ω Ohms Tennis Ball 〄' and origid is NULL;
 
 #--echo # Expect no result, because of NULL latch
-#-- FIXME - in v2 according to http://openquery.com/graph/doc NULL latch should
-#-- FIXME - return same as select * from graph;
-#--https://bugs.launchpad.net/oqgraph/+bug/1196021
+#-- FIXME - in v2, NULL latch should
+#-- FIXME - return same as select * from graph.
 --echo # Return all edges when latch is NULL
 SELECT * FROM graph WHERE latch is NULL;
 SELECT * FROM graph WHERE latch is NULL and destid=2 and origid=1;
@@ -118,14 +117,13 @@ SELECT * FROM graph WHERE latch is NULL and origid is NULL;
 INSERT INTO graph_base(from_id, to_id) VALUES (1,2);
 
 DELETE FROM graph_base;
-#-- Uncomment the following after fixing https://bugs.launchpad.net/oqgraph/+bug/1195735
 SELECT * FROM graph;
 
 FLUSH TABLES;
 
 TRUNCATE TABLE graph_base;
-#-- Uncomment the following after fixing https://bugs.launchpad.net/oqgraph/+bug/xxxxxxx - Causes the later select to not fail!
-#-- For now don't report a separate bug as it may be a manifestation of https://bugs.launchpad.net/oqgraph/+bug/1195735
+#-- Uncomment the following after fixing - Causes the later select to not fail!
+#-- For now don't report a separate bug as it may be a manifestation of above FIXME
 SELECT * FROM graph;
 
 #-- Expect error if we pull the table out from under

--- a/storage/oqgraph/mysql-test/oqgraph/general.inc
+++ b/storage/oqgraph/mysql-test/oqgraph/general.inc
@@ -100,7 +100,6 @@ SELECT linkid as `from`, destid as `to` FROM graph where latch='' and destid = 6
 
 # The following returns a result that makes no sense...
 #-- what happens when we combined orig and dest?
-#-- Bug https://bugs.launchpad.net/oqgraph/+bug/1195778
 #SELECT * FROM graph where latch='' and origid = 1;
 #SELECT * FROM graph where latch='' and destid = 2;
 #SELECT * FROM graph where latch='' and origid=1 and destid = 2;
@@ -658,7 +657,6 @@ TRUNCATE TABLE graph_base;
 DROP TABLE graph_base;
 DROP TABLE graph;
 
-#-- Reminder - the basic spec is at http://openquery.com/graph/doc
 #--    Query edges stored in graph engine (latch=NULL)
 #--    SELECT * FROM foo;
 #--    Results:

--- a/storage/oqgraph/oqgraph_judy.cc
+++ b/storage/oqgraph/oqgraph_judy.cc
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/oqgraph_judy.h
+++ b/storage/oqgraph/oqgraph_judy.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/oqgraph_shim.cc
+++ b/storage/oqgraph/oqgraph_shim.cc
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/oqgraph_shim.h
+++ b/storage/oqgraph/oqgraph_shim.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/oqgraph_thunk.cc
+++ b/storage/oqgraph/oqgraph_thunk.cc
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 

--- a/storage/oqgraph/oqgraph_thunk.h
+++ b/storage/oqgraph/oqgraph_thunk.h
@@ -16,9 +16,7 @@
 
 /* ======================================================================
    Open Query Graph Computation Engine, based on a concept by Arjen Lentz
-   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell
-   For more information, documentation, support, enhancement engineering,
-   see http://openquery.com/graph or contact graph@openquery.com
+   v3 implementation by Antony Curtis, Arjen Lentz, Andrew McDonnell.
    ======================================================================
 */
 


### PR DESCRIPTION
As requested by Arjen, openquery.com former OQ owner, the domain is no longer existing and neither is the launchpad project. There isn't a company that does support/engineering, so remove those references too.