### PR TITLE
MDEV-35717: UBSAN: runtime error: applying zero offset to null pointer in `my_strnncoll_utf8mb3_general1400_as_ci`

### DIFF
--- a/mysql-test/main/ctype_utf8mb3_geeral1400_as_ci.result
+++ b/mysql-test/main/ctype_utf8mb3_geeral1400_as_ci.result
@@ -23,3 +23,10 @@ DROP TABLE t1;
 #
 # End of 11.5 tests
 #
+#
+# MDEV-35717: UBSAN: runtime error: applying zero offset to null pointer in `my_strnncoll_utf8mb3_general1400_as_ci`
+#
+CREATE TABLE t (c INT,c2 CHAR,c3 DATE,CHECK (c>0));
+ALTER TABLE t ADD INDEX (c2) USING HASH;
+DROP TABLE t;
+# End of 11.8 tests

--- a/mysql-test/main/ctype_utf8mb3_geeral1400_as_ci.test
+++ b/mysql-test/main/ctype_utf8mb3_geeral1400_as_ci.test
@@ -23,3 +23,14 @@ DROP TABLE t1;
 --echo #
 --echo # End of 11.5 tests
 --echo #
+
+--echo #
+--echo # MDEV-35717: UBSAN: runtime error: applying zero offset to null pointer in `my_strnncoll_utf8mb3_general1400_as_ci`
+--echo #
+
+CREATE TABLE t (c INT,c2 CHAR,c3 DATE,CHECK (c>0));
+ALTER TABLE t ADD INDEX (c2) USING HASH;
+
+DROP TABLE t;
+
+--echo # End of 11.8 tests

--- a/sql/lex_ident.h
+++ b/sql/lex_ident.h
@@ -128,6 +128,37 @@ public:
     DBUG_ASSERT(b.is_valid_ident());
     return Compare().charset_info()->streq(*this, b);
   }
+  /*
+   Compare two identifiers safely, handling NULL and empty identifiers.
+
+   Returns true if both are empty (length=0), false if one of them is empty.
+   Otherwise calls streq() for a deep character-set based comparison.
+   Treats "NULL identifier" and "empty identifier" as equal.
+
+   Replacement for streq calls that resulted in UBSAN error: applying
+   zero/non-zero offset to null pointer.
+  */
+  static bool streq_safe(const LEX_CSTRING &a, const LEX_CSTRING &b)
+  {
+    if (a.length == 0 || b.length == 0)
+      return a.length == b.length;
+    return Lex_ident::streq(a, b);
+  }
+  bool streq_safe(const LEX_CSTRING &rhs) const
+  {
+    DBUG_ASSERT(is_valid_ident());
+    if (length == 0 || rhs.length == 0)
+      return length == rhs.length;
+    return streq(rhs);
+  }
+  bool streq_safe(const Lex_ident &b) const
+  {
+    DBUG_ASSERT(is_valid_ident());
+    DBUG_ASSERT(b.is_valid_ident());
+    if (length == 0 || b.length == 0)
+      return length == b.length;
+    return streq(b);
+  }
 };
 
 extern MYSQL_PLUGIN_IMPORT CHARSET_INFO *table_alias_charset;

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -306,7 +306,7 @@ uint Alter_info::check_vcol_field(Item_field *item) const
   }
   for (Create_field &cf: create_list)
   {
-    if (item->field_name.streq(cf.field_name))
+    if (item->field_name.streq_safe(cf.field_name))
       return cf.vcol_info ? cf.vcol_info->flags : 0;
   }
   return 0;

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -100,7 +100,7 @@ static inline bool
 cmp_db_names(const Lex_ident_db &db1_name, const Lex_ident_db &db2_name)
 {
   return (db1_name.length == 0 && db2_name.length == 0) ||
-         db1_name.streq(db2_name);
+         db1_name.streq_safe(db2_name);
 }
 
 #ifdef HAVE_PSI_INTERFACE

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -4704,7 +4704,7 @@ public:
 
     Table_period_info &info= create_info.period_info;
 
-    if (check_exists && info.name.streq(name))
+    if (check_exists && info.name.streq_safe(name))
       return 0;
 
     if (info.is_set())

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2586,7 +2586,7 @@ int show_create_table_ex(THD *thd, TABLE_LIST *table_list, const char *force_db,
     {
       Virtual_column_info *check= table->check_constraints[i];
       // period constraint is implicit
-      if (share->period.constr_name.streq(check->name))
+      if (share->period.constr_name.streq_safe(check->name))
         continue;
 
       str.set_buffer_if_not_allocated(&my_charset_utf8mb4_general_ci);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -4072,7 +4072,7 @@ mysql_prepare_create_table_finalize(THD *thd, HA_CREATE_INFO *create_info,
               key->type != Key::FOREIGN_KEY)
             continue;
 
-          if (check->name.streq(key->name))
+          if (check->name.streq_safe(key->name))
           {
             my_error(ER_DUP_CONSTRAINT_NAME, MYF(0), "CHECK", check->name.str);
             DBUG_RETURN(TRUE);
@@ -6441,7 +6441,7 @@ drop_create_field:
       }
       else if (drop->type == Alter_drop::PERIOD)
       {
-        if (table->s->period.name.streq(Lex_ident(drop->name)))
+        if (table->s->period.name.streq_safe(Lex_ident(drop->name)))
           remove_drop= FALSE;
       }
       else /* Alter_drop::KEY and Alter_drop::FOREIGN_KEY */
@@ -6752,7 +6752,7 @@ remove_key:
            c < share->table_check_constraints ; c++)
       {
         Virtual_column_info *dup= table->check_constraints[c];
-        if (check->name.streq(dup->name))
+        if (check->name.streq_safe(dup->name))
         {
           push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
             ER_DUP_CONSTRAINT_NAME, ER_THD(thd, ER_DUP_CONSTRAINT_NAME),
@@ -9477,7 +9477,7 @@ mysql_prepare_alter_table(THD *thd, TABLE *table,
         }
       }
 
-      if (share->period.constr_name.streq(check->name))
+      if (share->period.constr_name.streq_safe(check->name))
       {
         if (!drop_period && !keep)
         {

--- a/sql/table.h
+++ b/sql/table.h
@@ -3618,12 +3618,14 @@ extern Lex_ident_table MYSQL_PROC_NAME;
 
 inline bool is_infoschema_db(const LEX_CSTRING *name)
 {
-  return INFORMATION_SCHEMA_NAME.streq(*name);
+  DBUG_ASSERT(name->str || !name->length);
+  return name->length && INFORMATION_SCHEMA_NAME.streq(*name);
 }
 
 inline bool is_perfschema_db(const LEX_CSTRING *name)
 {
-  return PERFORMANCE_SCHEMA_DB_NAME.streq(*name);
+  DBUG_ASSERT(name->str || !name->length);
+  return name->length && PERFORMANCE_SCHEMA_DB_NAME.streq(*name);
 }
 
 inline void mark_as_null_row(TABLE *table)

--- a/strings/strcoll.inl
+++ b/strings/strcoll.inl
@@ -226,8 +226,12 @@ MY_FUNCTION_NAME(strnncoll)(CHARSET_INFO *cs __attribute__((unused)),
                             const uchar *b, size_t b_length,
                             my_bool b_is_prefix)
 {
-  const uchar *a_end= a + a_length;
-  const uchar *b_end= b + b_length;
+  const uchar *a_end, *b_end;
+  DBUG_ASSERT(a);
+  DBUG_ASSERT(b);
+
+  a_end= a + a_length;
+  b_end= b + b_length;
   for ( ; ; )
   {
     int a_weight, b_weight, res;


### PR DESCRIPTION
fixes [MDEV-35717](https://jira.mariadb.org/browse/MDEV-35717)
### Problem:
UBSAN reports runtime errors in string comparision functions where pointer arithmetic is done without checking NULL.
- runtime errors: applying zero offset to null pointer in `my_strnncoll_utf8mb3_general1400_as_ci`

### Fix:
- Add debug asserts in `strnncoll` function to catch NULL pointers.
- Define a new function `streq_safe` as a replacement for `streq`, capable of handling NULL pointers. Replace `streq` with `streq_safe` at multiple call sites, identified by the debug asserts.
- Add empty identifier checks in `is_infoschema_db` and `is_perfschema_db` before calling the deep character-set based comparison.
