### PR TITLE
Rework MDL enum constants values

### DIFF
--- a/mysql-test/main/backup_lock.result
+++ b/mysql-test/main/backup_lock.result
@@ -51,9 +51,9 @@ WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_DDL	Backup lock		
 MDL_BACKUP_FLUSH	Backup lock		
-MDL_SHARED_WRITE	Table metadata lock	test	t1
-MDL_SHARED_UPGRADABLE	Table metadata lock	test	t1
 MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
+MDL_SHARED_UPGRADABLE	Table metadata lock	test	t1
+MDL_SHARED_WRITE	Table metadata lock	test	t1
 SET STATEMENT max_statement_time=1 FOR backup stage block_ddl;
 ERROR 70100: Query was interrupted: execution time limit 1.0 sec exceeded
 backup stage block_ddl;
@@ -88,9 +88,9 @@ WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_ALTER_COPY	Backup lock		
 MDL_BACKUP_FLUSH	Backup lock		
-MDL_SHARED_WRITE	Table metadata lock	test	t1
-MDL_SHARED_UPGRADABLE	Table metadata lock	test	t1
 MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
+MDL_SHARED_UPGRADABLE	Table metadata lock	test	t1
+MDL_SHARED_WRITE	Table metadata lock	test	t1
 backup stage block_ddl;
 backup stage block_commit;
 connection default;
@@ -124,8 +124,8 @@ SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.me
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_WAIT_DDL	Backup lock		
-MDL_SHARED_WRITE	Table metadata lock	test	t1
 MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
+MDL_SHARED_WRITE	Table metadata lock	test	t1
 backup stage end;
 connection default;
 commit;

--- a/mysql-test/main/backup_lock.test
+++ b/mysql-test/main/backup_lock.test
@@ -18,14 +18,19 @@ WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 --source ../suite/innodb/include/wait_all_purged.inc
 
 BACKUP STAGE START;
+--sorted_result
 eval SELECT $mdl;
 BACKUP STAGE FLUSH;
+--sorted_result
 eval SELECT $mdl;
 BACKUP STAGE BLOCK_DDL;
+--sorted_result
 eval SELECT $mdl;
 BACKUP STAGE BLOCK_COMMIT;
+--sorted_result
 eval SELECT $mdl;
 BACKUP STAGE END;
+--sorted_result
 eval SELECT $mdl;
 
 --echo #
@@ -62,6 +67,7 @@ let $wait_condition=
     where state = "Waiting for table metadata lock";
 --source include/wait_condition.inc
 backup stage flush;
+--sorted_result
 eval SELECT $mdl;
 #
 # Do first test with max_statement_time, other tests later are done with
@@ -111,10 +117,12 @@ let $wait_condition=
 --source include/wait_condition.inc
 backup stage start;
 backup stage flush;
+--sorted_result
 eval SELECT $mdl;
 backup stage block_ddl;
 backup stage block_commit;
 connection default;
+--sorted_result
 SELECT * FROM t1;
 --send commit
 connection con2;
@@ -155,6 +163,7 @@ let $wait_condition=
 SET STATEMENT lock_wait_timeout=0 FOR SELECT * FROM t1;
 
 backup stage block_ddl;
+--sorted_result
 eval SELECT $mdl;
 backup stage end;
 

--- a/mysql-test/main/backup_locks.result
+++ b/mysql-test/main/backup_locks.result
@@ -34,8 +34,8 @@ drop table t1;
 connection default;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
-MDL_SHARED_HIGH_PRIO	Table metadata lock	test	t1
 MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
+MDL_SHARED_HIGH_PRIO	Table metadata lock	test	t1
 select * from t1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 backup unlock;

--- a/mysql-test/main/backup_locks.test
+++ b/mysql-test/main/backup_locks.test
@@ -14,13 +14,17 @@
 --echo #
 
 BACKUP LOCK test.t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP UNLOCK;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP LOCK t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP UNLOCK;
 BACKUP LOCK non_existing.t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP UNLOCK;
 
@@ -42,6 +46,7 @@ let $wait_condition=
     select count(*) = 1 from information_schema.processlist
     where state = "Waiting for table metadata lock";
 --source include/wait_condition.inc
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 --error ER_LOCK_DEADLOCK
 select * from t1;
@@ -239,8 +244,10 @@ show grants for user1@localhost;
 # This should work we have RELOAD privilege
 BACKUP UNLOCK;
 BACKUP LOCK db1.t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP UNLOCK;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 
 # Add LOCK TABLES DB privileges (all privileges for BACKUP LOCK are there)
@@ -252,8 +259,10 @@ show grants for user1@localhost;
 # This should work we have RELOAD & LOCK privilege
 BACKUP UNLOCK;
 BACKUP LOCK db1.t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 BACKUP UNLOCK;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 
 # Remove reload privilege, leave only LOCK TABLES privilege
@@ -267,9 +276,11 @@ show grants for user1@localhost;
 BACKUP UNLOCK;
 # BACKUP LOCK should work, since we have LOCK privilege
 BACKUP LOCK db1.t1;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 # This works since there was taken mdl_backup_lock before
 BACKUP UNLOCK;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info where table_name not like "innodb_%";
 
 # Remove LOCK TABLES privilege

--- a/mysql-test/main/mdl.result
+++ b/mysql-test/main/mdl.result
@@ -19,8 +19,8 @@ SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.me
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_TRANS_DML	Backup lock		
-MDL_SHARED_WRITE	Table metadata lock	test	t1
 MDL_SHARED_READ_ONLY	Table metadata lock	test	t1
+MDL_SHARED_WRITE	Table metadata lock	test	t1
 UNLOCK TABLES;
 LOCK TABLES t1 WRITE CONCURRENT, t3 WRITE;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
@@ -47,11 +47,11 @@ SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.me
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_DDL	Backup lock		
+MDL_INTENTION_EXCLUSIVE	Schema metadata lock	mysql	
+MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
+MDL_SHARED_NO_READ_WRITE	Table metadata lock	mysql	global_priv
 MDL_SHARED_NO_READ_WRITE	Table metadata lock	mysql	user
 MDL_SHARED_NO_READ_WRITE	Table metadata lock	test	t1
-MDL_INTENTION_EXCLUSIVE	Schema metadata lock	mysql	
-MDL_SHARED_NO_READ_WRITE	Table metadata lock	mysql	global_priv
-MDL_INTENTION_EXCLUSIVE	Schema metadata lock	test	
 UNLOCK TABLES;
 LOCK TABLES mysql.general_log WRITE;
 ERROR HY000: You can't use locks with log tables

--- a/mysql-test/main/mdl.test
+++ b/mysql-test/main/mdl.test
@@ -12,10 +12,12 @@
 CREATE TABLE t1(a INT) ENGINE=InnoDB;
 CREATE TABLE t3(a INT) ENGINE=myisam;
 LOCK TABLES t1 WRITE CONCURRENT, t1 AS t2 READ;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 UNLOCK TABLES;
 LOCK TABLES t1 AS t2 READ, t1 WRITE CONCURRENT;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 UNLOCK TABLES;
@@ -30,6 +32,7 @@ SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.me
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 UNLOCK TABLES;
 LOCK TABLES t1 WRITE, mysql.user WRITE;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 UNLOCK TABLES;
@@ -62,6 +65,7 @@ let $wait_condition=
   where state = "Waiting for backup lock";
 --source include/wait_condition.inc
 connection default;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 unlock tables;
@@ -80,6 +84,7 @@ let $wait_condition=
   where state = "Waiting for backup lock";
 --source include/wait_condition.inc
 connection default;
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info
 WHERE TABLE_NAME NOT LIKE 'innodb_%_stats';
 unlock tables;

--- a/mysql-test/main/mdl_sync.test
+++ b/mysql-test/main/mdl_sync.test
@@ -3072,6 +3072,7 @@ SET DEBUG_SYNC= 'now WAIT_FOR table_opened';
 --echo # Check that FLUSH must wait to get the GRL
 --echo # and let DROP PROCEDURE continue
 --source ../suite/innodb/include/wait_all_purged.inc
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 SET DEBUG_SYNC= 'mdl_acquire_lock_wait SIGNAL grlwait';
 --send FLUSH TABLES WITH READ LOCK
@@ -3137,6 +3138,7 @@ FLUSH TABLES WITH READ LOCK;
 let $wait_condition= SELECT COUNT(*)=1 FROM information_schema.metadata_lock_info;
 --source include/wait_condition.inc
 --source ../suite/innodb/include/wait_all_purged.inc
+--sorted_result
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 
 unlock tables;

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -394,10 +394,6 @@ public:
     Note that although there isn't metadata locking on triggers,
     it's necessary to have a separate namespace for them since
     MDL_key is also used outside of the MDL subsystem.
-
-    TODO (newbie): NOT_INITIALIZED=0 as default bzero() sets wrongly type to
-    BACKUP. But dozens switch() cases for NOT_INITIALIZED must be added to
-    pacify the compiler.
   */
   enum enum_mdl_namespace { BACKUP=0,
                             SCHEMA,


### PR DESCRIPTION
fixes [MDEV-39184](https://jira.mariadb.org/browse/MDEV-39184)
### Problem:
MDL tests results ordering is not deterministic.

### Fix
Added --sorted_result to the MDL tests to ensure deterministic ordering of metadata_lock_info output. Since MDL lock iteration order depends on hash_value() and underlying Split-Ordered List behavior, it may vary with
internal changes such as enum value shifts.
