### PR TITLE
MDEV-39278 Validate .cfg file parser string lengths in InnoDB import

### DIFF
--- a/mysql-test/suite/innodb/r/import_cfg_corrupt.result
+++ b/mysql-test/suite/innodb/r/import_cfg_corrupt.result
@@ -1,0 +1,71 @@
+#
+# MDEV-39278 Validate .cfg file parser string lengths
+#
+# Test that IMPORT TABLESPACE rejects .cfg files with
+# invalid string lengths in the metadata header.
+#
+call mtr.add_suppression("InnoDB: Importing tablespace for table `test`\\.`t1`");
+call mtr.add_suppression("Index for table 't1' is corrupt; try to repair it");
+call mtr.add_suppression("InnoDB: Discarding tablespace of table `test`\\.`t1`");
+# Export a valid .ibd/.cfg pair to reuse across tests.
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+#
+# Test 1: Corrupt hostname length in .cfg
+# .cfg format: [4 bytes version][4 bytes hostname_len]...
+# Patch offset 4 to 0x00001000 (4096), exceeding
+# HOSTNAME_LENGTH + 1 (256).
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg hostname length.
+DROP TABLE t1;
+#
+# Test 2: Zero hostname length in .cfg
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg hostname length.
+DROP TABLE t1;
+#
+# Test 3: Table name length zero in .cfg
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg table name length.
+DROP TABLE t1;
+#
+# Test 4: Hostname length just over limit (257)
+# HOSTNAME_LENGTH + 1 = 256 is the max valid value.
+# 257 should be rejected.
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg hostname length.
+DROP TABLE t1;
+#
+# Test 5: Hostname length 0xFFFFFFFF (max uint32)
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg hostname length.
+DROP TABLE t1;
+#
+# Test 6: Corrupt table name length in .cfg
+# The table name length field follows the hostname string.
+# We need to find and patch it dynamically.
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: IO Read error: (0, Invalid argument) while reading .cfg table name length.
+DROP TABLE t1;
+# End of 10.11 tests

--- a/mysql-test/suite/innodb/t/import_cfg_corrupt.test
+++ b/mysql-test/suite/innodb/t/import_cfg_corrupt.test
@@ -1,0 +1,220 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-39278 Validate .cfg file parser string lengths
+--echo #
+--echo # Test that IMPORT TABLESPACE rejects .cfg files with
+--echo # invalid string lengths in the metadata header.
+--echo #
+
+call mtr.add_suppression("InnoDB: Importing tablespace for table `test`\\.`t1`");
+call mtr.add_suppression("Index for table 't1' is corrupt; try to repair it");
+call mtr.add_suppression("InnoDB: Discarding tablespace of table `test`\\.`t1`");
+
+let MYSQLD_DATADIR = `SELECT @@datadir`;
+
+--echo # Export a valid .ibd/.cfg pair to reuse across tests.
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+
+FLUSH TABLES t1 FOR EXPORT;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd $MYSQLD_DATADIR/test/t1.ibd.bak
+--copy_file $MYSQLD_DATADIR/test/t1.cfg $MYSQLD_DATADIR/test/t1.cfg.bak
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo #
+--echo # Test 1: Corrupt hostname length in .cfg
+--echo # .cfg format: [4 bytes version][4 bytes hostname_len]...
+--echo # Patch offset 4 to 0x00001000 (4096), exceeding
+--echo # HOSTNAME_LENGTH + 1 (256).
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+# Write 0x00001000 (4096) in big-endian
+print FILE pack("N", 4096);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test 2: Zero hostname length in .cfg
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+# Write 0 in big-endian
+print FILE pack("N", 0);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test 3: Table name length zero in .cfg
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+# Read hostname length at offset 4
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+my $buf;
+read(FILE, $buf, 4) == 4 or die "Cannot read: $!";
+my $hostname_len = unpack("N", $buf);
+# Table name length is at offset 4 + 4 + hostname_len
+my $tablename_offset = 4 + 4 + $hostname_len;
+seek(FILE, $tablename_offset, 0) or die "Cannot seek: $!";
+# Write 0 in big-endian
+print FILE pack("N", 0);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test 4: Hostname length just over limit (257)
+--echo # HOSTNAME_LENGTH + 1 = 256 is the max valid value.
+--echo # 257 should be rejected.
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+# Write 257 (HOSTNAME_LENGTH + 2) in big-endian
+print FILE pack("N", 257);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test 5: Hostname length 0xFFFFFFFF (max uint32)
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+# Write 0xFFFFFFFF in big-endian
+print FILE pack("N", 0xFFFFFFFF);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test 6: Corrupt table name length in .cfg
+--echo # The table name length field follows the hostname string.
+--echo # We need to find and patch it dynamically.
+--echo #
+
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.bak $MYSQLD_DATADIR/test/t1.cfg.corrupt
+
+perl;
+use strict;
+my $file = "$ENV{MYSQLD_DATADIR}/test/t1.cfg.corrupt";
+open(FILE, "+<", $file) or die "Cannot open $file: $!";
+binmode FILE;
+# Read hostname length at offset 4
+seek(FILE, 4, 0) or die "Cannot seek: $!";
+my $buf;
+read(FILE, $buf, 4) == 4 or die "Cannot read: $!";
+my $hostname_len = unpack("N", $buf);
+# Table name length is at offset 4 + 4 + hostname_len
+my $tablename_offset = 4 + 4 + $hostname_len;
+seek(FILE, $tablename_offset, 0) or die "Cannot seek: $!";
+# Write 0x10000000 (268 million) in big-endian
+print FILE pack("N", 0x10000000);
+close FILE or die "Cannot close: $!";
+EOF
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.bak $MYSQLD_DATADIR/test/t1.ibd
+--move_file $MYSQLD_DATADIR/test/t1.cfg.corrupt $MYSQLD_DATADIR/test/t1.cfg
+
+--error ER_IO_READ_ERROR
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TABLE t1;
+
+--remove_files_wildcard $MYSQLD_DATADIR/test t1.*
+
+--echo # End of 10.11 tests

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -2577,6 +2577,15 @@ row_import_cfg_read_index_fields(
 		/* Include the NUL byte in the length. */
 		ulint	len = mach_read_from_4(ptr);
 
+		if (len == 0 || len > NAME_LEN + 1) {
+			ib_senderrf(
+				thd, IB_LOG_LEVEL_ERROR, ER_IO_READ_ERROR,
+				0UL, strerror(EINVAL),
+				"while reading .cfg field name length.");
+
+			return(DB_CORRUPTION);
+		}
+
 		byte*	name = UT_NEW_ARRAY_NOKEY(byte, len);
 
 		/* Trigger OOM */
@@ -2713,7 +2722,7 @@ row_import_read_index_data(
 		/* The NUL byte is included in the name length. */
 		ulint	len = mach_read_from_4(ptr);
 
-		if (len > OS_FILE_MAX_PATH) {
+		if (len == 0 || len > NAME_LEN + 1) {
 			ib_errf(thd, IB_LOG_LEVEL_ERROR,
 				ER_INNODB_INDEX_CORRUPT,
 				"Index name length (" ULINTPF ") is too long, "
@@ -2901,12 +2910,11 @@ row_import_read_columns(
 
 		ulint		len = mach_read_from_4(ptr);
 
-		/* FIXME: What is the maximum column name length? */
-		if (len == 0 || len > 128) {
-			ib_errf(thd, IB_LOG_LEVEL_ERROR,
-				ER_IO_READ_ERROR,
-				"Column name length " ULINTPF ", is invalid",
-				len);
+		if (len == 0 || len > NAME_LEN + 1) {
+			ib_senderrf(
+				thd, IB_LOG_LEVEL_ERROR, ER_IO_READ_ERROR,
+				0UL, strerror(EINVAL),
+				"while reading .cfg column name length.");
 
 			return(DB_CORRUPTION);
 		}
@@ -2972,6 +2980,15 @@ row_import_read_v1(
 
 	ulint	len = mach_read_from_4(value);
 
+	if (len == 0 || len > HOSTNAME_LENGTH + 1) {
+		ib_senderrf(
+			thd, IB_LOG_LEVEL_ERROR, ER_IO_READ_ERROR,
+			0UL, strerror(EINVAL),
+			"while reading .cfg hostname length.");
+
+		return(DB_CORRUPTION);
+	}
+
 	/* NUL byte is part of name length. */
 	cfg->m_hostname = UT_NEW_ARRAY_NOKEY(byte, len);
 
@@ -3013,6 +3030,15 @@ row_import_read_v1(
 	}
 
 	len = mach_read_from_4(value);
+
+	if (len == 0 || len > MAX_FULL_NAME_LEN + 1) {
+		ib_senderrf(
+			thd, IB_LOG_LEVEL_ERROR, ER_IO_READ_ERROR,
+			0UL, strerror(EINVAL),
+			"while reading .cfg table name length.");
+
+		return(DB_CORRUPTION);
+	}
 
 	/* NUL byte is part of name length. */
 	cfg->m_table_name = UT_NEW_ARRAY_NOKEY(byte, len);


### PR DESCRIPTION
Replace overly permissive or missing length limits in the .cfg metadata file parser (used by ALTER TABLE ... IMPORT TABLESPACE) with correct constants:

- Field/index/column names: NAME_LEN + 1 (193 bytes including NUL), matching the maximum identifier length defined in mysql_com.h. Replaces the hardcoded 128 for columns (with FIXME) and OS_FILE_MAX_PATH (4000) for index names. Adds missing validation for field names.

- Hostname: HOSTNAME_LENGTH + 1 (256), consistent with MariaDB's own hostname limit defined in mysql_com.h. RFC 1035 defines the textual DNS name limit as 253 characters (254 with NUL), but HOSTNAME_LENGTH (255) is based on the RFC 1034 wire-format limit of 255 octets. Using HOSTNAME_LENGTH avoids rejecting .cfg files exported from servers with valid 254-255 character hostnames.

- Table name: MAX_FULL_NAME_LEN + 1 (655 bytes including NUL), since the .cfg file stores the full db/table name (written by row0quiesce.cc as table->name.m_name).

Without these checks, a crafted .cfg file could specify lengths up to 2^32 via the 4-byte mach_read_from_4() length prefix, causing excessive memory allocation.