### PR TITLE
Fix in condition pushdown code: don't pass List<Field_pair> by value.

### DIFF
--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -6863,7 +6863,7 @@ bool Item::pushable_equality_checker_for_subquery(uchar *arg)
   NULL if the matching Field_pair wasn't found.
 */
 
-Field_pair *find_matching_field_pair(Item *item, List<Field_pair> pair_list)
+Field_pair *find_matching_field_pair(Item *item, List<Field_pair> &pair_list)
 {
   Field_pair *field_pair= get_corresponding_field_pair(item, pair_list);
   if (field_pair)

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -11310,7 +11310,7 @@ st_select_lex::build_pushable_cond_for_having_pushdown(THD *thd, Item *cond)
 */
 
 Field_pair *get_corresponding_field_pair(Item *item,
-                                         List<Field_pair> pair_list)
+                                         List<Field_pair> &pair_list)
 {
   DBUG_ASSERT(item->type() == Item::DEFAULT_VALUE_ITEM ||
               item->type() == Item::FIELD_ITEM ||

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -1099,8 +1099,8 @@ public:
 };
 
 Field_pair *get_corresponding_field_pair(Item *item,
-                                         List<Field_pair> pair_list);
-Field_pair *find_matching_field_pair(Item *item, List<Field_pair> pair_list);
+                                         List<Field_pair> &pair_list);
+Field_pair *find_matching_field_pair(Item *item, List<Field_pair> & pair_list);
 
 
 #define TOUCHED_SEL_COND 1/* WHERE/HAVING/ON should be reinited before use */


### PR DESCRIPTION
Affected functions:
  find_matching_field_pair(Item *item, List<Field_pair> pair_list)
  get_corresponding_field_pair(Item *item, List<Field_pair> pair_list)

Both only traverse the pair_list.
They use List_iterator so we can't easily switch to using const-reference.