### PR TITLE
MDEV-39271: SIGSEGV in `check_word`|(`extract_date_time`|`extract_oracle_date_time`)

### DIFF
--- a/mysql-test/main/date_formats.result
+++ b/mysql-test/main/date_formats.result
@@ -806,6 +806,24 @@ str_to_date('1 Tháng 9 2026', '%d %M %Y','vi_VN')	2026-09-01
 str_to_date('1 Tháng 10 2026', '%d %M %Y','vi_VN')	2026-10-01
 str_to_date('1 Tháng 11 2026', '%d %M %Y','vi_VN')	2026-11-01
 str_to_date('1 Tháng 12 2026', '%d %M %Y','vi_VN')	2026-12-01
+#
+# MDEV-39721: SIGSEGV in check_word|(extract_date_time|extract_oracle_date_time)
+#
+# locale as a session var
+SET SESSION lc_time_names='ar_DZ';
+SELECT STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y');
+STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y')	NULL
+Warnings:
+Level	Warning
+Code	1411
+Message	Incorrect datetime value: 'Wednesday, June 2, 2014' for function str_to_date
+# locale as third param to STR_TO_DATE
+SELECT STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y', 'ar_DZ');
+STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y', 'ar_DZ')	NULL
+Warnings:
+Level	Warning
+Code	1411
+Message	Incorrect datetime value: 'Wednesday, June 2, 2014' for function str_to_date
 # End of 12.3 test
 SET @@lc_time_names=DEFAULT;
 SET NAMES latin1;

--- a/mysql-test/main/date_formats.test
+++ b/mysql-test/main/date_formats.test
@@ -418,6 +418,17 @@ str_to_date('1 Tháng 10 2026', '%d %M %Y','vi_VN'),
 str_to_date('1 Tháng 11 2026', '%d %M %Y','vi_VN'),
 str_to_date('1 Tháng 12 2026', '%d %M %Y','vi_VN');
 
+--echo #
+--echo # MDEV-39721: SIGSEGV in check_word|(extract_date_time|extract_oracle_date_time)
+--echo #
+
+--echo # locale as a session var
+SET SESSION lc_time_names='ar_DZ';
+SELECT STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y');
+
+--echo # locale as third param to STR_TO_DATE
+SELECT STR_TO_DATE('Wednesday, June 2, 2014', '%W, %M %e, %Y', 'ar_DZ');
+
 --echo # End of 12.3 test
 
 SET @@lc_time_names=DEFAULT;

--- a/mysql-test/suite/compat/oracle/r/func_to_date.result
+++ b/mysql-test/suite/compat/oracle/r/func_to_date.result
@@ -927,4 +927,22 @@ ERROR HY000: Invalid argument error: date format not recognized at FF in functio
 SELECT TO_DATE('2026 100', 'YYYY DDD') FROM DUAL;
 TO_DATE('2026 100', 'YYYY DDD')
 2026-04-10 00:00:00
+#
+# MDEV-39721: SIGSEGV in check_word|(extract_date_time|extract_oracle_date_time)
+#
+# Oracle Mode
+SET sql_mode=ORACLE;
+# locale as session var
+SET SESSION lc_time_names='ar_DZ';
+SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY');
+TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY')
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: 'Wednesday, June 2, 2014' for function to_date
+# locale as param to TO_DATE
+SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY', 'NLS_DATE_LANGUAGE=ar_DZ');
+TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY', 'NLS_DATE_LANGUAGE=ar_DZ')
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: 'Wednesday, June 2, 2014' for function to_date
 # End of 12.3 tests

--- a/mysql-test/suite/compat/oracle/t/func_to_date.test
+++ b/mysql-test/suite/compat/oracle/t/func_to_date.test
@@ -478,4 +478,18 @@ SELECT TO_DATE('123 456', 'FF FF') FROM DUAL;
 --echo # YYYY and DDD are compatible (Year + Day of Year)
 SELECT TO_DATE('2026 100', 'YYYY DDD') FROM DUAL;
 
+--echo #
+--echo # MDEV-39721: SIGSEGV in check_word|(extract_date_time|extract_oracle_date_time)
+--echo #
+
+--echo # Oracle Mode
+SET sql_mode=ORACLE;
+
+--echo # locale as session var
+SET SESSION lc_time_names='ar_DZ';
+SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY');
+
+--echo # locale as param to TO_DATE
+SELECT TO_DATE('Wednesday, June 2, 2014', 'Day, Month DD, YYYY', 'NLS_DATE_LANGUAGE=ar_DZ');
+
 --echo # End of 12.3 tests

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4017,7 +4017,7 @@ static int init_common_variables()
 
   my_tzset();
   my_tzname(system_time_zone, sizeof(system_time_zone));
-  init_oracle_data_locale();                    // For TO_DATE()
+  init_locale();                    // For TO_DATE()
 
   /*
     We set SYSTEM time zone as reasonable default and

--- a/sql/sql_locale.cc
+++ b/sql/sql_locale.cc
@@ -4801,16 +4801,15 @@ static void update_lengths_in_typelib(TYPELIB *typelib)
 }
 
 
-void init_oracle_data_locale()
+void init_locale()
 {
-  ORACLE_DATE_LOCALE *locale;
-  for (locale= Oracle_date_locale; locale->locale ; locale++)
+  for (MY_LOCALE **locale= my_locales; *locale ; locale++)
   {
-    update_lengths_in_typelib(locale->locale->month_names);
-    update_lengths_in_typelib(locale->locale->month_names_formatting);
-    update_lengths_in_typelib(locale->locale->ab_month_names);
-    update_lengths_in_typelib(locale->locale->day_names);
-    update_lengths_in_typelib(locale->locale->ab_day_names);
+    update_lengths_in_typelib((*locale)->month_names);
+    update_lengths_in_typelib((*locale)->month_names_formatting);
+    update_lengths_in_typelib((*locale)->ab_month_names);
+    update_lengths_in_typelib((*locale)->day_names);
+    update_lengths_in_typelib((*locale)->ab_day_names);
   }
 
 }

--- a/sql/sql_locale.h
+++ b/sql/sql_locale.h
@@ -104,6 +104,6 @@ MY_LOCALE *my_locale_by_name(const LEX_CSTRING &name);
 MY_LOCALE *my_locale_by_number(uint number);
 MY_LOCALE  *my_locale_by_oracle_name(const LEX_CSTRING &name);
 void cleanup_errmsgs(void);
-void init_oracle_data_locale();
+void init_locale();
 
 #endif /* SQL_LOCALE_INCLUDED */


### PR DESCRIPTION
fixes [MDEV-39271](https://jira.mariadb.org/browse/MDEV-39271)

### Problem:
Date and time functions - `STR_TO_DATE` and `TO_DATE` (in Oracle mode) use `check_word` to check if a string token matches a valid locale-specific day or month name. Server crashed because of an un-initialized typelib member(`type_lengths`) for date locales which are not present in `Oracle_date_locale` (e.g: `ar_DZ`). 

### Fix:
Initialize `type_lengths` for all supported locales by iterating over `my_locales` array instead of `Oracle_date_locale` during server startup.