### PR TITLE
MDEV-39290 mytop use invoking login as default user on Unix

### DIFF
--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -72,6 +72,11 @@ sub cmd_s;
 sub cmd_S;
 sub cmd_q;
 
+## Default username, matching mysql/mariadb on Unix
+my $default_db_user = $WIN
+    ? 'root'
+    : ((getpwuid($<))[0] || $ENV{LOGNAME} || $ENV{USER} || 'root');
+
 ## Default Config Values
 
 my %config = (
@@ -99,7 +104,7 @@ my %config = (
     slow          => 10,        ## slow query time
     socket        => '',
     sort          => 1,         ## default or reverse sort ("s")
-    user          => 'root',
+    user          => $default_db_user,
     fullqueries   => 0,         ## shows untruncated queries
     usercol_width => 8,         ## User column width
     dbcol_width   => 9,         ## DB column width
@@ -285,7 +290,7 @@ if (not ref $dbh)
 Cannot connect to MariaDB/MySQL server. Please check the:
 
   * database you specified "$config{db}" (default is "")
-  * username you specified "$config{user}" (default is "root")
+  * username you specified "$config{user}" (default is "$default_db_user")
   * password you specified "$config{pass}" (default is "")
   * hostname you specified "$config{host}" (default is "localhost")
   * port you specified "$config{port}" (default is 3306)
@@ -2252,7 +2257,9 @@ have two dashes `--'. Short arguments only have one '-'.
 
 =item B<-u> or B<--user> username
 
-Username to use when logging in to the MariaDB server. Default: ``B<root>''.
+Username to use when logging in to the MariaDB server. On Unix, the default
+is your login name (same as the C<mysql>/C<mariadb> client). On Windows, the
+default is ``B<root>''.
 
 =item B<-p> or B<--pass> or B<--password> I<password>
 
@@ -2386,8 +2393,9 @@ command-line arguments are processed, so your command-line arguments
 will override directives in the config file.
 
 
-Here is a sample config file C<~/.mytop> which implements the defaults
-described above.
+Here is a sample config file C<~/.mytop>. Omit C<user> to keep the built-in
+default (Unix login on non-Windows, same as C<mysql>/C<mariadb>), the line
+below is only if you want to connect as C<root> explicitly.
 
   user=root
   pass=


### PR DESCRIPTION
`mytop` defaults the database user to `root`.

On Unix, the `mysql` and `mariadb` clients use the current OS login when no user is specified. Because of that difference, `mytop` may try to connect as `root@localhost` and fail on setups where local `unix_socket` access is configured for the normal user instead of `root`.

This patch changes the default on non-Windows systems to the invoking login name, using `getpwuid($<)` first, then `LOGNAME`, then `USER`, and finally `root`. Windows keeps the existing default of `root`.

It also updates the connection failure message and POD so the documented defaults match the actual behavior.

**Jira ticket:** Fixes [MDEV-39290](https://jira.mariadb.org/browse/MDEV-39290).

## Testing

Manual checks on Debian 13 with MariaDB 11.8.6 client:

1. As non-root, with no `~/.mytop` and no `-u`:
   `mytop -h 127.0.0.1 -P 65534 -b -s 1`
   Result: error text shows `username ... "testuser"` and `(default is "testuser")`.

2. With both `root@localhost` and `testuser@localhost` using `unix_socket`:
   `su - testuser -c 'mytop -b -s 1'`
   Result: connects and prints status.

3. As `testuser`, forcing `-u root`:
   `su - testuser -c 'mytop -b -s 1 -u root'`
   Result: uses `root` as requested, message still shows `(default is "testuser")`.

4. As root:
   `sudo mytop -b -s 1`
   Result: works with socket-authenticated `root`.