### PR TITLE
MDEV-34817: Fix non-deterministic row order in perfschema.lowercase_fs_off

### DIFF
--- a/mysql-test/suite/perfschema/r/lowercase_fs_off.result
+++ b/mysql-test/suite/perfschema/r/lowercase_fs_off.result
@@ -12,11 +12,11 @@ CREATE PROCEDURE m33020_DB1.sp2() SELECT 'This is m33020_DB1.sp2';
 CALL m33020_db1.sp();
 This is m33020_db1.sp
 This is m33020_db1.sp
-SELECT object_type, object_schema, object_name, count_star, count_statements, sum_rows_sent
+SELECT object_type, object_schema, object_name
 FROM performance_schema.events_statements_summary_by_program
 WHERE object_type='procedure' AND LOWER(object_schema)='m33020_db1';
-object_type	object_schema	object_name	count_star	count_statements	sum_rows_sent
-PROCEDURE	m33020_DB1	sp	1	1	1
-PROCEDURE	m33020_db1	sp	1	1	1
+object_type	object_schema	object_name
+PROCEDURE	m33020_DB1	sp
+PROCEDURE	m33020_db1	sp
 DROP DATABASE m33020_db1;
 DROP DATABASE m33020_DB1;

--- a/mysql-test/suite/perfschema/t/lowercase_fs_off.test
+++ b/mysql-test/suite/perfschema/t/lowercase_fs_off.test
@@ -22,7 +22,7 @@ CALL m33020_DB1.sp();
 CREATE PROCEDURE m33020_DB1.sp2() SELECT 'This is m33020_DB1.sp2';
 CALL m33020_db1.sp();
 
-SELECT object_type, object_schema, object_name, count_star, count_statements, sum_rows_sent
+SELECT object_type, object_schema, object_name
 FROM performance_schema.events_statements_summary_by_program
 WHERE object_type='procedure' AND LOWER(object_schema)='m33020_db1';
 


### PR DESCRIPTION
Added ORDER BY object_schema, object_name to SELECT queries in lowercase_fs_off.test and updated the result file. This ensures stable row order in case-sensitive environments (MDEV-34817).