### PR TITLE
MDEV-30953: Add MariaDB-server-galera (RPM) fix

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -309,32 +309,33 @@ IF(WIN32)
     INSTALL_SCRIPT(${CMAKE_CURRENT_BINARY_DIR}/${file}.pl COMPONENT Server_Scripts)
   ENDFOREACH()
 ELSE()
-  IF(WITH_WSREP)
+  IF(WITH_WSREP AND NOT WITHOUT_SERVER)
     SET(WSREP_SCRIPTS
       wsrep_sst_mysqldump
       wsrep_sst_rsync
       wsrep_sst_mariabackup
       wsrep_sst_backup
     )
-    # The following script is sourced from other SST scripts, so it should
-    # not be made executable.
-    SET(WSREP_SOURCE
-      wsrep_sst_common
-    )
-
     INSTALL_LINK(wsrep_sst_rsync wsrep_sst_rsync_wan ${INSTALL_BINDIR} server-galera)
-    FOREACH(file ${WSREP_SOURCE})
+    FOREACH(file ${WSREP_SCRIPTS})
       CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${file}.sh
         ${CMAKE_CURRENT_BINARY_DIR}/${file} ESCAPE_QUOTES @ONLY)
-      IF(NOT ${file}_COMPONENT)
-        SET(${file}_COMPONENT Server)
-      ENDIF()
-      INSTALL(FILES
+      INSTALL_SCRIPT(
         ${CMAKE_CURRENT_BINARY_DIR}/${file}
         DESTINATION ${INSTALL_BINDIR}
-        COMPONENT ${${file}_COMPONENT}
+        COMPONENT server-galera
       )
     ENDFOREACH()
+
+    # The following script is sourced from other SST scripts, so it should
+    # not be made executable.
+    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/wsrep_sst_common.sh
+      ${CMAKE_CURRENT_BINARY_DIR}/wsrep_sst_common ESCAPE_QUOTES @ONLY)
+    INSTALL(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/wsrep_sst_common
+      DESTINATION ${INSTALL_BINDIR}
+      COMPONENT server-galera
+    )
   ENDIF()
   IF (NOT WITHOUT_SERVER)
     SET(SERVER_SCRIPTS
@@ -362,7 +363,6 @@ ELSE()
     mytop
     mariadb-hotcopy
     ${SERVER_SCRIPTS}
-    ${WSREP_SCRIPTS}
   )
 
   FOREACH(file ${BIN_SCRIPTS})


### PR DESCRIPTION
The wsrep SST scripts weren't part of the server-galera component so CPack didn't put them in the MariaDB-server-galera package.

The previous existing per file component wasn't used so this was simplified.

Noticed thanks to @FaramosCZ in #4871.

````
$ cmake --install . --prefix /tmp/sd --component server-galera
-- Install configuration: "RelWithDebInfo"
-- Installing: /tmp/sd/lib/plugin/wsrep_info.so
-- Installing: /tmp/sd/bin/wsrep_sst_rsync_wan
-- Installing: /tmp/sd/bin/wsrep_sst_mysqldump
-- Installing: /tmp/sd/bin/wsrep_sst_rsync
-- Installing: /tmp/sd/bin/wsrep_sst_mariabackup
-- Installing: /tmp/sd/bin/wsrep_sst_backup
-- Installing: /tmp/sd/bin/wsrep_sst_common
-- Installing: /tmp/sd/support-files/wsrep.cnf
-- Installing: /tmp/sd/support-files/mariadb.service.d/galera.conf
-- Installing: /tmp/sd/support-files/systemd/use_galera_new_cluster.conf
(base) 
~/repos/build-mariadb-server-12.3 
$ ls -la  /tmp/sd/bin/
total 172
drwxr-xr-x. 2 dan dan   160 Apr 10 11:21 .
drwxr-xr-x. 5 dan dan   100 Apr 10 11:21 ..
-rwxr-xr-x. 1 dan dan  2451 Mar 27 15:24 wsrep_sst_backup
-rw-r--r--. 1 dan dan 69888 Mar 27 15:24 wsrep_sst_common
-rwxr-xr-x. 1 dan dan 53228 Mar 27 15:24 wsrep_sst_mariabackup
-rwxr-xr-x. 1 dan dan  9035 Mar 27 15:24 wsrep_sst_mysqldump
-rwxr-xr-x. 1 dan dan 30564 Mar 27 15:24 wsrep_sst_rsync
lrwxrwxrwx. 1 dan dan    15 Apr 10 11:21 wsrep_sst_rsync_wan -> wsrep_sst_rsync
```