### PR TITLE
MDEV-38822 Lock wait timeout during CREATE TABLE AS SELECT FROM mysql.innodb_table_stats

### DIFF
--- a/mysql-test/suite/innodb/r/alter_copy_stats.result
+++ b/mysql-test/suite/innodb/r/alter_copy_stats.result
@@ -106,12 +106,7 @@ DROP TABLE t2;
 #
 # MDEV-38667 Assertion in diagnostics area on DDL stats timeout
 #
-set @lock_wait_timeout= @@global.innodb_lock_wait_timeout;
-SET innodb_lock_wait_timeout = 1;
 CREATE TABLE t ENGINE=InnoDB AS SELECT * FROM mysql.innodb_table_stats;
-Warnings:
-Warning	1088	Error updating stats for table after table rebuild: Lock wait timeout
-SET innodb_lock_wait_timeout = @lock_wait_timeout;
 DROP TABLE t;
 #
 #  MDEV-38882 Assertion in diagnostics area on DDL stats

--- a/mysql-test/suite/innodb/t/alter_copy_stats.test
+++ b/mysql-test/suite/innodb/t/alter_copy_stats.test
@@ -92,10 +92,7 @@ DROP TABLE t2;
 --echo #
 --echo # MDEV-38667 Assertion in diagnostics area on DDL stats timeout
 --echo #
-set @lock_wait_timeout= @@global.innodb_lock_wait_timeout;
-SET innodb_lock_wait_timeout = 1;
 CREATE TABLE t ENGINE=InnoDB AS SELECT * FROM mysql.innodb_table_stats;
-SET innodb_lock_wait_timeout = @lock_wait_timeout;
 DROP TABLE t;
 
 --echo #

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15875,7 +15875,7 @@ ha_innobase::extra(
 			handler::extra(HA_EXTRA_BEGIN_ALTER_COPY). */
 			log_buffer_flush_to_disk();
 		}
-		alter_stats_rebuild(m_prebuilt->table, thd);
+		alter_stats_rebuild(m_prebuilt->table, thd, true);
 		break;
 	default:/* Do nothing */
 		;
@@ -21292,11 +21292,13 @@ ulint buf_pool_size_align(ulint size) noexcept
 Remove statistics for dropped indexes, add statistics for created indexes
 and rename statistics for renamed indexes.
 @param table InnoDB table that was rebuilt by ALTER TABLE
-@param thd   alter table thread */
-void alter_stats_rebuild(dict_table_t *table, THD *thd)
+@param thd   alter table thread
+@param copy  Caller is from COPY alter algorithm*/
+void alter_stats_rebuild(dict_table_t *table, THD *thd, bool copy)
 {
   DBUG_ENTER("alter_stats_rebuild");
-  if (!table->space || !dict_stats_is_persistent_enabled(table))
+  if (!table->space || !dict_stats_is_persistent_enabled(table) ||
+      (copy && !table->name.is_temporary()))
     DBUG_VOID_RETURN;
 
   dberr_t ret= dict_stats_update(table, DICT_STATS_RECALC_PERSISTENT);

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -947,5 +947,6 @@ bool too_big_key_part_length(size_t max_field_len, const KEY& key);
 Remove statistics for dropped indexes, add statistics for created indexes
 and rename statistics for renamed indexes.
 @param table_name Table name in MySQL
-@param thd        alter table thread */
-void alter_stats_rebuild(dict_table_t *table, THD *thd);
+@param thd        alter table thread
+@param copy       caller is from COPY algorithm */
+void alter_stats_rebuild(dict_table_t *table, THD *thd, bool copy=false);


### PR DESCRIPTION
Analysis:
=========
1) Starts the CREATE TABLE ... SELECT and acquires an Intent Shared lock on mysql.innodb_table_stats to read the rows. (Transaction: T1)

2) The table t1 is populated. As part of the post-copy phase (introduced by MDEV-35163), InnoDB triggers the statistics update.

3) InnoDB opens a new internal transaction to update the statistics. This transaction(T2) attempts to acquire an LOCK_X on the same table in mysql.innodb_table_stats. T2 (x-lock) must wait for T1 to commit or rollback because X-locks are incompatible with IS locks from other trasnaction.

Solution:
========
Currently, Intermediate tables don't trigger dict_stats_update_if_needed(), so they require explicit stats update via alter_stats_rebuild(). For CREATE...SELECT stats are updated automatically through the normal DML path via dict_stats_update_if_needed()

Skip calling dict_stats_update() in alter_stats_rebuild() for non-intermediate tables when using copy algorithm, since their statistics will be updated automatically via dict_stats_update_if_needed().