### PR TITLE
MDEV-39303: innodb_force_recovery=6 startup fails: innodb_read_only=ON prevents an upgrade of the change buffer

### DIFF
--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -1025,6 +1025,9 @@ ATTRIBUTE_COLD dberr_t ibuf_upgrade()
 
 dberr_t ibuf_upgrade_needed()
 {
+  if (srv_force_recovery == SRV_FORCE_NO_LOG_REDO)
+    return DB_SUCCESS;
+
   mtr_t mtr{nullptr};
   mtr.start();
   mtr.x_lock_space(fil_system.sys_space);
@@ -1035,8 +1038,6 @@ dberr_t ibuf_upgrade_needed()
   {
   err_exit:
     sql_print_error("InnoDB: The change buffer is corrupted");
-    if (srv_force_recovery == SRV_FORCE_NO_LOG_REDO)
-      err= DB_SUCCESS;
   func_exit:
     mtr.commit();
     return err;
@@ -1067,7 +1068,7 @@ dberr_t ibuf_upgrade_needed()
                     " of the change buffer");
     err= DB_READ_ONLY;
   }
-  else if (srv_force_recovery != SRV_FORCE_NO_LOG_REDO)
+  else
     err= DB_FAIL;
 
   goto func_exit;

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1250,7 +1250,9 @@ void log_t::clear_mmap() noexcept
   {
     ut_d(latch.wr_lock());
     ut_ad(!resize_in_progress());
-    ut_ad(get_lsn() == get_flushed_lsn(std::memory_order_relaxed));
+    ut_d(extern bool ibuf_upgrade_was_needed;)
+    ut_ad(get_lsn() == get_flushed_lsn(std::memory_order_relaxed) ||
+          ibuf_upgrade_was_needed);
     ut_d(latch.wr_unlock());
     return;
   }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1217,8 +1217,8 @@ static dberr_t srv_load_tables(bool must_upgrade_ibuf) noexcept
   dberr_t err = dict_load_indexes(&mtr, dict_sys.sys_tables, false, heap,
                                   DICT_ERR_IGNORE_NONE);
   mem_heap_empty(heap);
-  if ((err == DB_SUCCESS || srv_force_recovery >= SRV_FORCE_NO_DDL_UNDO) &&
-      UNIV_UNLIKELY(must_upgrade_ibuf))
+  if (UNIV_UNLIKELY(must_upgrade_ibuf) &&
+      (err == DB_SUCCESS || srv_force_recovery >= SRV_FORCE_NO_DDL_UNDO))
   {
     dict_sys.unlock();
     dict_load_tablespaces(nullptr, true);
@@ -1412,10 +1412,7 @@ dberr_t srv_start(bool create_new_db)
 		      || srv_operation == SRV_OPERATION_RESTORE_EXPORT);
 		ut_ad(!recv_sys.recovery_on);
 
-		if (srv_force_recovery >= SRV_FORCE_NO_LOG_REDO) {
-			sql_print_information("InnoDB: innodb_force_recovery=6"
-					      " skips redo log apply");
-		} else {
+		if (srv_force_recovery < SRV_FORCE_NO_LOG_REDO) {
 			log_sys.latch.wr_lock();
 			err = recv_sys.find_checkpoint();
 			log_sys.latch.wr_unlock();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-39303](https://jira.mariadb.org/browse/MDEV-39303), [MDEV-37058](https://jira.mariadb.org/browse/MDEV-37058)*
## Description
InnoDB would fail to upgrade from MariaDB Server 10.x if `innodb_force_recovery=6` is set, claiming in a rather confusing way that `innodb_read_only=ON` is set. Internally, setting `innodb_force_recovery=6` will imply that setting.

`ibuf_upgrade_needed()`: Pretend that no upgrade is needed when `innodb_force_recovery=6`.

`srv_load_tables()`: Test the least likely condition first.

`srv_start()`: Remove a message that is duplicating one at the start of `recv_recovery_from_checkpoint_start()`.

`log_t::clear_mmap()`: Relax a debug assertion that was verified to fail when upgrading from MariaDB Server 10.6.
## Release Notes
InnoDB would fail to upgrade from MariaDB Server 10.x if `innodb_force_recovery=6` is set, claiming in a rather confusing way that `innodb_read_only=ON` is set.
## How can this PR be tested?
First, start up MariaDB Server 10.6:
```sh    
mysql-test/mtr main.1st
```
Then, on this data directory, attempt to start up MariaDB Server 11.4 or later:
```
sql/mariadbd --innodb-force-recovery=6 --datadir "$(pwd)"/mysql-test/var/mysqld.1/data
sql/mariadbd --datadir "$(pwd)"/mysql-test/var/mysqld.1/data
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*