### PR TITLE
MDEV-39318 MTR: fix test failures when running with --ssl

### DIFF
--- a/mysql-test/main/information_schema.test
+++ b/mysql-test/main/information_schema.test
@@ -1339,7 +1339,7 @@ where state='User sleep' and
 info='select * from information_schema.tables where 1=sleep(100000)';
 --source include/wait_condition.inc
 connection conn1;
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 connection default;
 disconnect conn1;
@@ -1363,7 +1363,7 @@ where state='User sleep' and
 info='select * from information_schema.columns where 1=sleep(100000)';
 --source include/wait_condition.inc
 connection conn1;
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 connection default;
 disconnect conn1;

--- a/mysql-test/main/kill_debug.test
+++ b/mysql-test/main/kill_debug.test
@@ -52,7 +52,7 @@ SET DEBUG_SYNC= 'now WAIT_FOR con1_end';
 SET DEBUG_SYNC = 'RESET';
 
 connection con1;
---error 1053,2006,2013,5014
+--error 1053,2006,2013,2026,5014
 SELECT 1;
 
 --enable_reconnect
@@ -91,7 +91,7 @@ SET DEBUG_SYNC= 'now WAIT_FOR con1_end';
 SET DEBUG_SYNC = 'RESET';
 
 connection con1;
---error 1053,2006,2013,5014
+--error 1053,2006,2013,2026,5014
 SELECT 1;
 enable_reconnect;
 SELECT 1;
@@ -138,7 +138,7 @@ KILL @id;
 SET DEBUG_SYNC= 'now WAIT_FOR con1_end';
 
 connection con1;
---error 1317,1053,2006,2013,5014
+--error 1317,1053,2006,2013,2026,5014
 reap;
 SELECT 1;
 
@@ -283,7 +283,7 @@ SET DEBUG_SYNC= 'now WAIT_FOR con1_end';
 connection con1;
 --echo # ER_SERVER_SHUTDOWN, CR_SERVER_GONE_ERROR, CR_SERVER_LOST,
 --echo # depending on the timing of close of the connection socket
---error 1053,2006,2013,5014
+--error 1053,2006,2013,2026,5014
 SELECT 1;
 --enable_reconnect
 SELECT 1;

--- a/mysql-test/main/loadxml.test
+++ b/mysql-test/main/loadxml.test
@@ -83,7 +83,7 @@ connection default;
 connection addconroot;
 # Read response from connection to avoid packets out-of-order when disconnecting
 # Note, that connection can already be dead due to previously issued kill
---error 0,2013
+--error 0,2013,2026
 --reap
 disconnect addconroot;
 connection default;

--- a/mysql-test/main/lock_kill.test
+++ b/mysql-test/main/lock_kill.test
@@ -18,7 +18,7 @@ eval KILL $conid;
 --enable_query_log
 --connection con1
 --disable_warnings
---error 0,2006,2013,ER_CONNECTION_KILLED
+--error 0,2006,2013,2026,ER_CONNECTION_KILLED
 reap;
 --enable_warnings
 --connection default
@@ -38,7 +38,7 @@ eval KILL $conid;
 --enable_query_log
 --connection con1
 --disable_warnings
---error 0,2006,2013,ER_CONNECTION_KILLED
+--error 0,2006,2013,2026,ER_CONNECTION_KILLED
 reap;
 --enable_warnings
 --connection default

--- a/mysql-test/main/mdev375.result
+++ b/mysql-test/main/mdev375.result
@@ -17,7 +17,7 @@ connect  con2,localhost,root,,;
 SELECT 2;
 2
 2
-ERROR HY000: Too many connections
+Got one of the listed errors
 connection default;
 SELECT 0;
 0

--- a/mysql-test/main/mdev375.test
+++ b/mysql-test/main/mdev375.test
@@ -24,7 +24,7 @@ SELECT 1;
 --connect (con2,localhost,root,,)
 SELECT 2;
 --disable_query_log
---error ER_CON_COUNT_ERROR
+--error ER_CON_COUNT_ERROR,2002
 --connect (con3,localhost,root,,)
 --enable_query_log
 

--- a/mysql-test/main/processlist.test
+++ b/mysql-test/main/processlist.test
@@ -102,7 +102,7 @@ let $wait_condition=select count(*)=0 from information_schema.processlist
 where state='User sleep' and info='SELECT SLEEP(1000)';
 --source include/wait_condition.inc
 connection conn1;
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 connection default;
 disconnect conn1;

--- a/mysql-test/main/quick_select_4161.test
+++ b/mysql-test/main/quick_select_4161.test
@@ -43,7 +43,7 @@ eval kill $id;
 set debug_sync='now signal done';
 
 connection killee;
---error 1053,1927,2006,2013
+--error 1053,1927,2006,2013,2026
 reap;
 
 connection default;

--- a/mysql-test/suite/innodb/r/innodb-blob.result
+++ b/mysql-test/suite/innodb/r/innodb-blob.result
@@ -45,7 +45,7 @@ INSERT INTO t2 VALUES (42);
 disconnect con1;
 disconnect con2;
 connection default;
-ERROR HY000: Lost connection to server during query
+Got one of the listed errors
 CHECK TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
@@ -103,7 +103,7 @@ connection con2;
 # restart
 disconnect con2;
 connection default;
-ERROR HY000: Lost connection to server during query
+Got one of the listed errors
 CHECK TABLE t1,t2,t3;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
@@ -133,7 +133,7 @@ UPDATE t3 SET c=REPEAT('j',3000) WHERE a=2
 # restart
 disconnect con2;
 connection default;
-ERROR HY000: Lost connection to server during query
+Got one of the listed errors
 CHECK TABLE t1,t2,t3;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK

--- a/mysql-test/suite/innodb/t/innodb-blob.test
+++ b/mysql-test/suite/innodb/t/innodb-blob.test
@@ -77,7 +77,7 @@ disconnect con1;
 disconnect con2;
 connection default;
 # This connection should notice the crash as well.
---error 2013
+--error 2013,2026
 reap;
 
 --enable_reconnect
@@ -153,7 +153,7 @@ connection con2;
 disconnect con2;
 connection default;
 # This connection should notice the crash as well.
---error 2013
+--error 2013,2026
 reap;
 
 --enable_reconnect
@@ -193,7 +193,7 @@ WHERE state = 'debug sync point: after_row_upd_extern';
 disconnect con2;
 connection default;
 # This connection should notice the crash as well.
---error 2013
+--error 2013,2026
 reap;
 
 --enable_reconnect

--- a/mysql-test/suite/perfschema/include/show_aggregate.inc
+++ b/mysql-test/suite/perfschema/include/show_aggregate.inc
@@ -8,10 +8,19 @@
 --echo # Global results
 --echo #=================
 USE test;
+# Under --ssl, Ssl_cipher_list exceeds VARCHAR(1024) in PFS tables, causing
+# ER_DATA_TOO_LONG during multi-table UPDATE scans.  Temporarily relax
+# STRICT_TRANS_TABLES so the truncation is a warning, not an error.
+--disable_query_log
+SET @save_sql_mode= @@sql_mode;
+SET sql_mode= REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '');
+--enable_query_log
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.global_status sg
   SET sr.stop = sg.variable_value
   WHERE sr.variable_name = sg.variable_name
     AND sg.variable_name IN ('handler_delete', 'handler_rollback');
+--enable_warnings
 --echo #
 --echo # Global deltas: END - START.
 UPDATE test.status_results sr
@@ -25,25 +34,31 @@ UPDATE test.status_results sr
 --echo # Status by thread
 --echo #=================
 --echo # Thread results from CON1.
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_thread sbt
   SET sr.t1 = sbt.variable_value
   WHERE sr.variable_name = sbt.variable_name
     AND sbt.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbt.thread_id = @con1_id;
+--enable_warnings
 --echo #
 --echo # Thread results from CON2.
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_thread sbt
   SET sr.t2 = sbt.variable_value
   WHERE sr.variable_name = sbt.variable_name
     AND sbt.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbt.thread_id = @con2_id;
+--enable_warnings
 --echo #
 --echo # Thread results from CON3.
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_thread sbt
   SET sr.t3 = sbt.variable_value
   WHERE sr.variable_name = sbt.variable_name
     AND sbt.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbt.thread_id = @con3_id;
+--enable_warnings
 --echo #
 --echo # Thread totals for 3 connections.
 UPDATE test.status_results sr
@@ -53,25 +68,31 @@ UPDATE test.status_results sr
 --echo # Status by user
 --echo #=================
 --echo # User1
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_user sbu
   SET sr.u1 = sbu.variable_value
   WHERE sr.variable_name = sbu.variable_name
     AND sbu.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbu.user IN ('user1');
+--enable_warnings
 --echo #
 --echo # User2
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_user sbu
   SET sr.u2 = sbu.variable_value
   WHERE sr.variable_name = sbu.variable_name
     AND sbu.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbu.user IN ('user2');
+--enable_warnings
 --echo #
 --echo # User3
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_user sbu
   SET sr.u3 = sbu.variable_value
   WHERE sr.variable_name = sbu.variable_name
     AND sbu.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbu.user IN ('user3');
+--enable_warnings
 --echo #
 --echo # Status totals for 3 users.
 UPDATE test.status_results sr
@@ -82,11 +103,13 @@ UPDATE test.status_results sr
 --echo #===========================
 --echo #
 --echo # host1 = localhost
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_host sbh
   SET sr.h1 = sbh.variable_value
   WHERE sr.variable_name = sbh.variable_name
     AND sbh.variable_name IN ('handler_delete', 'handler_rollback')
     AND sbh.host IN ('localhost');
+--enable_warnings
 --echo #
 --echo # Status totals for 'localhost' only.
 UPDATE test.status_results sr
@@ -96,30 +119,40 @@ UPDATE test.status_results sr
 --echo # Status by account
 --echo #==================
 --echo # User1@localhost
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_account sba
   SET sr.a1 = sba.variable_value
   WHERE sr.variable_name = sba.variable_name
     AND sba.variable_name IN ('handler_delete', 'handler_rollback')
     AND sba.user IN ('user1');
+--enable_warnings
 --echo #
 --echo # User2@localhost
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_account sba
   SET sr.a2 = sba.variable_value
   WHERE sr.variable_name = sba.variable_name
     AND sba.variable_name IN ('handler_delete', 'handler_rollback')
     AND sba.user IN ('user2');
+--enable_warnings
 --echo #
 --echo # User3@localhost
+--disable_warnings
 UPDATE test.status_results sr, performance_schema.status_by_account sba
   SET sr.a3 = sba.variable_value
   WHERE sr.variable_name = sba.variable_name
     AND sba.variable_name IN ('handler_delete', 'handler_rollback')
     AND sba.user IN ('user3');
+--enable_warnings
 --echo #
 --echo #
 --echo # Status totals for 3 accounts.
 UPDATE test.status_results sr
   SET sr.acct = sr.a1 + sr.a2 + sr.a3;
+
+--disable_query_log
+SET sql_mode= @save_sql_mode;
+--enable_query_log
 
 #--echo DEBUG
 #SELECT * FROM test.status_results;

--- a/mysql-test/suite/perfschema/t/nesting.test
+++ b/mysql-test/suite/perfschema/t/nesting.test
@@ -13,6 +13,14 @@
 --source include/have_wsrep.inc
 --source ../include/wait_for_pfs_thread_count.inc
 
+# SSL/TLS bypasses PFS socket I/O instrumentation
+# (SSL_read/SSL_write instead of recv/send)
+--let $have_ssl= `SELECT VARIABLE_VALUE != '' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME='Ssl_cipher'`
+if ($have_ssl)
+{
+  --skip Socket I/O not available over SSL/TLS
+}
+
 --disable_query_log
 
 create user user1@localhost;

--- a/mysql-test/suite/perfschema/t/socket_summary_by_event_name_func.test
+++ b/mysql-test/suite/perfschema/t/socket_summary_by_event_name_func.test
@@ -22,6 +22,14 @@
 # Wait for any clients from previous tests to disconnect
 --source ../include/wait_for_pfs_thread_count.inc
 
+# SSL/TLS bypasses PFS socket I/O instrumentation
+# (SSL_read/SSL_write instead of recv/send)
+--let $have_ssl= `SELECT VARIABLE_VALUE != '' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME='Ssl_cipher'`
+if ($have_ssl)
+{
+  --skip Socket I/O not available over SSL/TLS
+}
+
 # The values in the performance_schema tables depend on how much communication
 # happens per SQL statement within our MTR tests. And there is a significant
 # difference between standard statement execution and execution via

--- a/mysql-test/suite/perfschema/t/socket_summary_by_instance_func.test
+++ b/mysql-test/suite/perfschema/t/socket_summary_by_instance_func.test
@@ -33,6 +33,14 @@
 --source include/no_valgrind_without_big.inc
 --source include/have_perfschema.inc
 
+# SSL/TLS bypasses PFS socket I/O instrumentation
+# (SSL_read/SSL_write instead of recv/send)
+--let $have_ssl= `SELECT VARIABLE_VALUE != '' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME='Ssl_cipher'`
+if ($have_ssl)
+{
+  --skip Socket I/O not available over SSL/TLS
+}
+
 # The values in the performance_schema tables depend on how much communication
 # happens per SQL statement within our MTR tests. And there is a significant
 # difference between standard statement execution and execution via

--- a/mysql-test/suite/perfschema/t/threads_mysql.test
+++ b/mysql-test/suite/perfschema/t/threads_mysql.test
@@ -31,6 +31,8 @@ SET GLOBAL event_scheduler = OFF;
 #    find a correcet row for our current thread but the content will differ.
 #    Therefore we have to disable this protocol for the next statement.
 --disable_ps_protocol
+# Normalize connection_type: SSL/TLS -> Socket (--ssl compatibility)
+--replace_result SSL/TLS Socket
 SELECT name, type, processlist_user, processlist_host, processlist_db,
        processlist_command, processlist_info, connection_type,
        IF(parent_thread_id IS NULL, parent_thread_id, 'unified parent_thread_id')

--- a/mysql-test/suite/plugins/t/feedback_plugin_load.test
+++ b/mysql-test/suite/plugins/t/feedback_plugin_load.test
@@ -18,20 +18,28 @@ select plugin_status from information_schema.plugins where plugin_name='feedback
 # so lets get back to it if it ever happens.
 
 # Lets say the plugin was used X times before this SELECT
+# Under --ssl, Ssl_cipher_list exceeds VARCHAR(1024) in the feedback table,
+# producing truncation warnings on every SELECT.  Suppress them.
+--disable_warnings
 --disable_cursor_protocol
 SELECT variable_value INTO @feedback_used FROM information_schema.feedback where variable_name = 'FEEDBACK used';
 --enable_cursor_protocol
+--enable_warnings
 
 # Now $feedback_used == X+1, and 'FEEDBACK used' is also X+1. And variable_value is increased again when we run the next SELECT
+--disable_warnings
 SELECT variable_value = @feedback_used + 1 as 'MUST BE 1' FROM information_schema.feedback where variable_name = 'FEEDBACK used';
+--enable_warnings
 
 # Now when we are happy with 'FEEDBACK used', we can check everything else
 
 --replace_result https http
 --sorted_result
+--disable_warnings
 select * from information_schema.feedback where variable_name like 'feed%'
        and variable_name not like '%_uid' and variable_name not like 'FEEDBACK used'
        and variable_name not like '%debug%';
+--enable_warnings
 
 # Embedded server does not use the table mysqld.user and thus
 # does not automatically use utf8mb4 on startup. Use it manually.
@@ -41,13 +49,17 @@ if (`SELECT VERSION() LIKE '%embedded%'`)
   create temporary table t1 (a json);
 }
 --enable_query_log
+--disable_warnings
 SELECT VARIABLE_VALUE>0, VARIABLE_NAME FROM INFORMATION_SCHEMA.FEEDBACK
 WHERE VARIABLE_NAME LIKE 'Collation used %'
 ORDER BY VARIABLE_NAME;
+--enable_warnings
 
+--disable_warnings
 prepare stmt from "SELECT VARIABLE_VALUE>0, VARIABLE_NAME FROM INFORMATION_SCHEMA.FEEDBACK WHERE VARIABLE_NAME LIKE 'Collation used %' ORDER BY VARIABLE_NAME";
 
 execute stmt;
 execute stmt;
+--enable_warnings
 
 deallocate prepare stmt;

--- a/mysql-test/suite/plugins/t/server_audit.test
+++ b/mysql-test/suite/plugins/t/server_audit.test
@@ -283,7 +283,7 @@ show variables like 'server_audit%';
 uninstall plugin server_audit;
 
 # replace the timestamp and the hostname with constant values
---replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,/TIME,HOSTNAME,/ /\,[1-9][0-9]*\,/,1,/ /\,[1-9][0-9]*/,ID/
+--replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,/TIME,HOSTNAME,/ /\,[1-9][0-9]*\,/,1,/ /\,[1-9][0-9]*/,ID/ /,TLSv[0-9.]+,/,,/
 cat_file $MYSQLD_DATADIR/server_audit.log;
 remove_file $MYSQLD_DATADIR/server_audit.log;
 --enable_ps2_protocol

--- a/mysql-test/suite/plugins/t/thread_pool_server_audit.test
+++ b/mysql-test/suite/plugins/t/thread_pool_server_audit.test
@@ -145,7 +145,7 @@ uninstall plugin server_audit;
 
 let $MYSQLD_DATADIR= `SELECT @@datadir`;
 # replace the timestamp and the hostname with constant values
---replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,/TIME,HOSTNAME,/ /\,[1-9][0-9]*\,/,1,/ /\,[1-9][0-9]*/,ID/
+--replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,/TIME,HOSTNAME,/ /\,[1-9][0-9]*\,/,1,/ /\,[1-9][0-9]*/,ID/ /,TLSv[0-9.]+,/,,/
 cat_file $MYSQLD_DATADIR/server_audit.log;
 remove_file $MYSQLD_DATADIR/server_audit.log;
 

--- a/mysql-test/suite/rpl/t/rpl_err_ignoredtable.test
+++ b/mysql-test/suite/rpl/t/rpl_err_ignoredtable.test
@@ -53,7 +53,7 @@ insert into t4 values (3),(4);
 connection master;
 # The get_lock function causes warning for unsafe statement.
 --disable_warnings
---error 0,1317,2013
+--error 0,1317,2013,2026
 reap;
 --enable_warnings
 connection master1;

--- a/mysql-test/suite/rpl/t/rpl_gtid_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_basic.test
@@ -373,7 +373,7 @@ reap;
 eval KILL CONNECTION $kill2_id;
 
 --connection s6
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 
 --connection server_1

--- a/mysql-test/suite/rpl/t/rpl_mysql_manager_race_condition.test
+++ b/mysql-test/suite/rpl/t/rpl_mysql_manager_race_condition.test
@@ -91,7 +91,7 @@ set @@session.debug_dbug="+d,crash_before_writing_xid";
 --source include/wait_until_disconnected.inc
 
 --connection slave1
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 --reap
 
 --echo # Restart mariadbd in recovery mode. Note --tc-heuristic-recover

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_wait_point.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_wait_point.test
@@ -67,7 +67,7 @@ KILL @other_connection_id;
 
 --echo # Collect the error from the INSERT thread; it should be disconnected.
 connection other;
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 
 connection default;
@@ -175,7 +175,7 @@ KILL @other_connection_id;
 
 --echo # Collect the error from the INSERT thread; it should be disconnected.
 connection other;
---error 2013,ER_CONNECTION_KILLED
+--error 2013,2026,ER_CONNECTION_KILLED
 reap;
 
 connection default;

--- a/mysql-test/suite/rpl/t/rpl_stm_000001.test
+++ b/mysql-test/suite/rpl/t/rpl_stm_000001.test
@@ -100,7 +100,7 @@ connection master;
 # The get_lock function causes warning for unsafe statement.
 --disable_warnings
 # 2013 = CR_SERVER_LOST
---error ER_QUERY_INTERRUPTED,ER_CONNECTION_KILLED,2013
+--error ER_QUERY_INTERRUPTED,ER_CONNECTION_KILLED,2013,2026
 reap;
 --enable_warnings
 connection slave;


### PR DESCRIPTION
When MTR runs with `--ssl` (as Fedora's `%check` does), all client connections use TLS.  This causes four categories of test failure.  All fixes are test-side, backward-compatible, and produce identical results without `--ssl`.

Upstream CI doesn't use `--ssl`, so these failures go unnoticed.

## 1. TLS error codes replace MySQL protocol error codes

The connector's TLS layer intercepts server-side errors before the MySQL protocol can report them.  For example, error 2026 (`CR_SSL_CONNECTION_ERROR`) replaces 2013 (`CR_SERVER_LOST`) on killed/crashed connections, and error 2002 (`CR_CONNECTION_ERROR`) replaces 1040 (`ER_CON_COUNT_ERROR`) when max_connections is exceeded.

This was partially addressed in two earlier commits (CONC-603 in 2022, MDEV-30452 in 2023), but only for tests actively failing upstream at the time.  Thirteen tests remained unfixed.

This is arguably a connector bug — the connector should propagate the server's error code through the TLS layer rather than replacing it with a generic TLS error.  The test-side fix (adding the TLS error codes to `--error` directives) is needed until the connector is fixed, and becomes a harmless no-op afterward.

## 2. Value differences in test output

`connection_type` in `performance_schema.threads` shows `SSL/TLS` instead of `Socket`.  The server_audit plugin logs the TLS version (e.g. `TLSv1.3`) in CONNECT/DISCONNECT events.

Fix: `--replace_result` and `--replace_regex` to normalize the output.  Without `--ssl` the replacements are no-ops.

## 3. Missing PFS socket instrumentation

Under TLS, data flows through SSL_read/SSL_write instead of direct recv/send syscalls, completely bypassing the performance_schema socket I/O instrumentation hooks.  Tests that verify socket wait events or byte counters get zero values.

Fix: detect active TLS session via `Ssl_cipher` status variable and skip the affected tests.  The existing `not_ssl.inc` checks `@@have_ssl` (server capability), which is always `YES` on OpenSSL builds and would skip too aggressively.

## 4. Ssl_cipher_list truncation

`Ssl_cipher_list` contains the full list of supported ciphers (~2047 chars on Fedora's OpenSSL 3.x), exceeding the VARCHAR(1024) VARIABLE_VALUE column in PFS and information_schema tables.  This causes ER_DATA_TOO_LONG in multi-table UPDATEs with STRICT_TRANS_TABLES, and Warning 1265 in information_schema SELECTs.

Fix: temporarily relax sql_mode for PFS-joining UPDATEs; wrap information_schema SELECTs with `--disable_warnings`.

---

Each test was verified in the upstream BuildBot Fedora 42 container (both RelWithDebInfo and Debug builds):
- without `--ssl`, before patch: pass (baseline)
- with `--ssl`, before patch: fail
- without `--ssl`, after patch: pass (no regression)
- with `--ssl`, after patch: pass (fix works)