### PR TITLE
MDEV-39207: Fix plugin name passed to find_bookmark in test_plugin_op…

### DIFF
--- a/mysql-test/suite/sys_vars/r/session_track_system_variables_basic.result
+++ b/mysql-test/suite/sys_vars/r/session_track_system_variables_basic.result
@@ -151,7 +151,7 @@ SELECT @@session.session_track_system_variables;
 SET SESSION session_track_system_variables="sql_slave_skip_counter", sql_slave_skip_counter= 0;
 # Restoring the original values.
 SET @@global.session_track_system_variables = @global_saved_tmp;
-# End of tests.
+# End of 10.2 tests.
 #
 # MDEV-39207 plugin variables disappear from session_track_system_variables list
 #

--- a/mysql-test/suite/sys_vars/t/session_track_system_variables_basic.test
+++ b/mysql-test/suite/sys_vars/t/session_track_system_variables_basic.test
@@ -125,7 +125,7 @@ SET SESSION session_track_system_variables="sql_slave_skip_counter", sql_slave_s
 --echo # Restoring the original values.
 SET @@global.session_track_system_variables = @global_saved_tmp;
 
---echo # End of tests.
+--echo # End of 10.2 tests.
 
 --echo #
 --echo # MDEV-39207 plugin variables disappear from session_track_system_variables list
@@ -151,8 +151,12 @@ set session example_int_var = -1;
 disable_session_track_info;
 
 connection default;
+--disable_ps_protocol
+--disable_cursor_protocol
 disconnect foo;
 uninstall soname 'ha_example.so';
+--enable_cursor_protocol
+--enable_ps_protocol
 SET @@global.session_track_system_variables = @global_saved_tmp;
 
 --echo # End of 10.11 tests


### PR DESCRIPTION
…tions (test postfix)

Under cursor/ps-protocl the UNINSTALL SONAME in the cleanup could generate a warning during shutdown.

disable the service connection for the test cleanup.