### PR TITLE
MDEV-39287 (10.6 part) Fix compilation problems with glibc 2.43/gcc 1…

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -513,7 +513,7 @@ static int run_tool(char *tool_path, DYNAMIC_STRING *ds_res, ...)
 static void find_tool(char *tool_executable_name, const char *tool_name, 
                       const char *self_name)
 {
-  char *last_fn_libchar;
+  const char *last_fn_libchar;
   DYNAMIC_STRING ds_tmp;
   DBUG_ENTER("find_tool");
   DBUG_PRINT("enter", ("progname: %s", my_progname));

--- a/dbug/dbug.c
+++ b/dbug/dbug.c
@@ -221,6 +221,7 @@ static BOOLEAN init_done= FALSE; /* Set to TRUE when initialization done */
 static struct settings init_settings;
 static const char *db_process= 0;/* Pointer to process name; argv[0] */
 my_bool _dbug_on_= TRUE;	 /* FALSE if no debugging at all */
+static char * command_line= 0; /* copy of controls */
 
 typedef struct _db_code_state_ {
   const char *process;          /* Pointer to process name; usually argv[0] */
@@ -899,10 +900,17 @@ int _db_is_pushed_()
 void _db_set_init_(const char *control)
 {
   CODE_STATE tmp_cs;
+  /* see Writable() */
+  command_line= strdup(control);
+  if (unlikely(!command_line))
+  {
+    /* We can not return error so just return */
+    return;
+  }
   bzero((uchar*) &tmp_cs, sizeof(tmp_cs));
   tmp_cs.stack= &init_settings;
   tmp_cs.process= db_process ? db_process : "dbug";
-  DbugParse(&tmp_cs, control);
+  DbugParse(&tmp_cs, command_line);
 }
 
 /*
@@ -1688,6 +1696,12 @@ void _db_end_()
   pthread_mutex_destroy(&THR_LOCK_dbug);
   init_done= 0;
   _dbug_on_= 0;
+  /* see Writable() */
+  if (command_line)
+  {
+    free(command_line);
+    command_line= 0;
+  }
 }
 
 
@@ -2158,7 +2172,11 @@ static BOOLEAN Writable(const char *pathname)
   }
   else
   {
-    lastslash= strrchr(pathname, '/');
+    /*
+      It is safe because we made duplicate of the string
+      in _db_set_init_() and freed in _db_end_()
+    */
+    lastslash= (char *)strrchr(pathname, '/');
     if (lastslash != NULL)
       *lastslash= '\0';
     else

--- a/extra/readline/display.c
+++ b/extra/readline/display.c
@@ -2285,7 +2285,7 @@ redraw_prompt (t)
 void
 _rl_redisplay_after_sigwinch ()
 {
-  char *t;
+  const char *t;
 
   /* Clear the current line and put the cursor at column 0.  Make sure
      the right thing happens if we have wrapped to a new screen line. */

--- a/sql-common/my_user.c
+++ b/sql-common/my_user.c
@@ -41,7 +41,7 @@ int parse_user(const char *user_id_str, size_t user_id_len,
                char *user_name_str, size_t *user_name_len,
                char *host_name_str, size_t *host_name_len)
 {
-  char *p= strrchr(user_id_str, '@');
+  const char *p= strrchr(user_id_str, '@');
 
   if (!p)
   {

--- a/storage/maria/ma_create.c
+++ b/storage/maria/ma_create.c
@@ -860,13 +860,16 @@ int maria_create(const char *name, enum data_file_type datafile_type,
   */
   if (ci->index_file_name)
   {
-    char *iext= strrchr(ci->index_file_name, '.');
+    const char *iext= strrchr(ci->index_file_name, '.');
     int have_iext= iext && !strcmp(iext, MARIA_NAME_IEXT);
     if (tmp_table)
     {
       char *path;
-      /* chop off the table name, tempory tables use generated name */
-      if ((path= strrchr(ci->index_file_name, FN_LIBCHAR)))
+      /*
+        chop off the table name, temporary tables use generated name
+        TODO: Following is safe but should be done other way if possible
+      */
+      if ((path= strrchr((char *)ci->index_file_name, FN_LIBCHAR)))
         *path= '\0';
       fn_format(kfilename, name, ci->index_file_name, MARIA_NAME_IEXT,
                 MY_REPLACE_DIR | MY_UNPACK_FILENAME |
@@ -892,7 +895,7 @@ int maria_create(const char *name, enum data_file_type datafile_type,
   }
   else
   {
-    char *iext= strrchr(name, '.');
+    const char *iext= strrchr(name, '.');
     int have_iext= iext && !strcmp(iext, MARIA_NAME_IEXT);
     fn_format(kfilename, name, "", MARIA_NAME_IEXT, MY_UNPACK_FILENAME |
               (internal_table ? 0 : MY_RETURN_REAL_PATH) |
@@ -1183,14 +1186,17 @@ int maria_create(const char *name, enum data_file_type datafile_type,
   {
     if (ci->data_file_name)
     {
-      char *dext= strrchr(ci->data_file_name, '.');
+      const char *dext= strrchr(ci->data_file_name, '.');
       int have_dext= dext && !strcmp(dext, MARIA_NAME_DEXT);
 
       if (tmp_table)
       {
         char *path;
-        /* chop off the table name, tempory tables use generated name */
-        if ((path= strrchr(ci->data_file_name, FN_LIBCHAR)))
+        /*
+           chop off the table name, temporary tables use generated name
+          TODO: Following is safe but should be done other way if possible
+        */
+        if ((path= strrchr((char *)ci->data_file_name, FN_LIBCHAR)))
           *path= '\0';
         fn_format(dfilename, name, ci->data_file_name, MARIA_NAME_DEXT,
                   MY_REPLACE_DIR | MY_UNPACK_FILENAME | MY_APPEND_EXT);

--- a/storage/myisam/mi_create.c
+++ b/storage/myisam/mi_create.c
@@ -589,13 +589,16 @@ int mi_create(const char *name,uint keys,MI_KEYDEF *keydefs,
   */
   if (ci->index_file_name)
   {
-    char *iext= strrchr(ci->index_file_name, '.');
+    const char *iext= strrchr(ci->index_file_name, '.');
     int have_iext= iext && !strcmp(iext, MI_NAME_IEXT);
     if (options & HA_OPTION_TMP_TABLE)
     {
       char *path;
-      /* chop off the table name, tempory tables use generated name */
-      if ((path= strrchr(ci->index_file_name, FN_LIBCHAR)))
+      /*
+        chop off the table name, tempory tables use generated name
+        TODO: Following is safe but should be done other way if possible
+      */
+      if ((path= strrchr((char *)ci->index_file_name, FN_LIBCHAR)))
         *path= '\0';
       fn_format(kfilename, name, ci->index_file_name, MI_NAME_IEXT,
                 MY_REPLACE_DIR | MY_UNPACK_FILENAME |
@@ -618,7 +621,7 @@ int mi_create(const char *name,uint keys,MI_KEYDEF *keydefs,
   }
   else
   {
-    char *iext= strrchr(name, '.');
+    const char *iext= strrchr(name, '.');
     int have_iext= iext && !strcmp(iext, MI_NAME_IEXT);
     fn_format(kfilename, name, "", MI_NAME_IEXT, MY_UNPACK_FILENAME |
               (internal_table ? 0 : MY_RETURN_REAL_PATH) |
@@ -659,14 +662,17 @@ int mi_create(const char *name,uint keys,MI_KEYDEF *keydefs,
     {
       if (ci->data_file_name)
       {
-        char *dext= strrchr(ci->data_file_name, '.');
+        const char *dext= strrchr(ci->data_file_name, '.');
         int have_dext= dext && !strcmp(dext, MI_NAME_DEXT);
 
         if (options & HA_OPTION_TMP_TABLE)
         {
           char *path;
-          /* chop off the table name, tempory tables use generated name */
-          if ((path= strrchr(ci->data_file_name, FN_LIBCHAR)))
+          /*
+            chop off the table name, tempory tables use generated name
+            TODO: Following is safe but should be done other way if possible
+          */
+          if ((path= strrchr((char *)ci->data_file_name, FN_LIBCHAR)))
             *path= '\0';
           fn_format(dfilename, name, ci->data_file_name, MI_NAME_DEXT,
                     MY_REPLACE_DIR | MY_UNPACK_FILENAME | MY_APPEND_EXT);


### PR DESCRIPTION
…6/fedora 44

Use 'const' where possible.
Use string copy to make dbug usage safe
Check safetiness of myisam/aria usage (made by Monty)