### PR TITLE
MDEV-34817: Performance schema is not cleared of removed package routines

### DIFF
--- a/mysql-test/suite/compat/oracle/r/perfschema.result
+++ b/mysql-test/suite/compat/oracle/r/perfschema.result
@@ -1,0 +1,64 @@
+#
+# MDEV-34817 Performance schema does not clear package routines
+#
+SET sql_mode=ORACLE;
+CREATE DATABASE mdev34817_db;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+PROCEDURE p1() AS
+BEGIN
+NULL;
+END;
+END;
+$$
+CALL mdev34817_db.pkg1.p1();
+DROP DATABASE mdev34817_db;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+object_type	object_schema	object_name
+# Testing DROP PACKAGE BODY directly
+CREATE DATABASE mdev34817_db;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+PROCEDURE p1() AS
+BEGIN
+NULL;
+END;
+END;
+$$
+CALL mdev34817_db.pkg1.p1();
+DROP PACKAGE BODY mdev34817_db.pkg1;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+object_type	object_schema	object_name
+PACKAGE	mdev34817_db	pkg1
+DROP DATABASE mdev34817_db;
+# Testing DROP PACKAGE directly
+CREATE DATABASE mdev34817_db;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+PROCEDURE p1() AS
+BEGIN
+NULL;
+END;
+END;
+$$
+CALL mdev34817_db.pkg1.p1();
+DROP PACKAGE mdev34817_db.pkg1;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+object_type	object_schema	object_name
+DROP DATABASE mdev34817_db;
+# End of 10.11 tests

--- a/mysql-test/suite/compat/oracle/t/perfschema.test
+++ b/mysql-test/suite/compat/oracle/t/perfschema.test
@@ -1,0 +1,76 @@
+--echo #
+--echo # MDEV-34817 Performance schema does not clear package routines
+--echo #
+
+SET sql_mode=ORACLE;
+CREATE DATABASE mdev34817_db;
+
+DELIMITER $$;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+  PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+  PROCEDURE p1() AS
+  BEGIN
+    NULL;
+  END;
+END;
+$$
+DELIMITER ;$$
+
+CALL mdev34817_db.pkg1.p1();
+DROP DATABASE mdev34817_db;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+
+--echo # Testing DROP PACKAGE BODY directly
+CREATE DATABASE mdev34817_db;
+
+DELIMITER $$;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+  PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+  PROCEDURE p1() AS
+  BEGIN
+    NULL;
+  END;
+END;
+$$
+DELIMITER ;$$
+
+CALL mdev34817_db.pkg1.p1();
+DROP PACKAGE BODY mdev34817_db.pkg1;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+DROP DATABASE mdev34817_db;
+
+--echo # Testing DROP PACKAGE directly
+CREATE DATABASE mdev34817_db;
+
+DELIMITER $$;
+CREATE PACKAGE mdev34817_db.pkg1 AS
+  PROCEDURE p1();
+END;
+$$
+CREATE PACKAGE BODY mdev34817_db.pkg1 AS
+  PROCEDURE p1() AS
+  BEGIN
+    NULL;
+  END;
+END;
+$$
+DELIMITER ;$$
+
+CALL mdev34817_db.pkg1.p1();
+DROP PACKAGE mdev34817_db.pkg1;
+SELECT object_type, object_schema, object_name
+FROM performance_schema.events_statements_summary_by_program
+WHERE LOWER(object_schema)='mdev34817_db';
+DROP DATABASE mdev34817_db;
+
+--echo # End of 10.11 tests

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -1104,6 +1104,35 @@ sp_returns_type(THD *thd, String &result, const sp_head *sp)
   used to indicate about errors.
 */
 
+#ifdef HAVE_PSI_SP_INTERFACE
+static void
+sp_psi_drop_package_routines(THD *thd, const char *db, size_t db_length,
+                             const LEX_CSTRING &name, sp_head *ph= NULL)
+{
+  if (!ph)
+  {
+    LEX_CSTRING ldb= {db, db_length};
+    sp_name spn(&ldb, &name, true);
+    ph= sp_cache_lookup(&thd->sp_package_body_cache, &spn);
+  }
+  if (ph)
+  {
+    sp_package *pkg= ph->get_package();
+    if (pkg)
+    {
+      List_iterator<LEX> it(pkg->m_routine_implementations);
+      for (LEX *lex; (lex= it++); )
+      {
+        sp_head *sub= lex->sphead;
+        MYSQL_DROP_SP(sub->m_handler->type(), db, static_cast<uint>(db_length),
+                      sub->m_name.str, static_cast<uint>(sub->m_name.length));
+      }
+    }
+  }
+}
+#endif
+
+
 int
 Sp_handler::sp_drop_routine_internal(THD *thd,
                                      const Database_qualified_name *name,
@@ -1127,7 +1156,14 @@ Sp_handler::sp_drop_routine_internal(THD *thd,
   sp_cache **spc= get_cache(thd);
   DBUG_ASSERT(spc);
   if ((sp= sp_cache_lookup(spc, name)))
+  {
+#ifdef HAVE_PSI_SP_INTERFACE
+    if (type() == SP_TYPE_PACKAGE_BODY)
+      sp_psi_drop_package_routines(thd, name->m_db.str, name->m_db.length,
+                                   name->m_name, sp);
+#endif
     sp_cache_remove(spc, &sp);
+  }
   /* Drop statistics for this stored program from performance schema. */
   MYSQL_DROP_SP(type(), name->m_db.str, static_cast<uint>(name->m_db.length),
                         name->m_name.str, static_cast<uint>(name->m_name.length));
@@ -1875,6 +1911,11 @@ sp_drop_db_routines(THD *thd, const char *db)
         enum_sp_type sp_type= (enum_sp_type) table->field[MYSQL_PROC_MYSQL_TYPE]->ptr[0];
         /* Drop statistics for this stored program from performance schema. */
         MYSQL_DROP_SP(sp_type, db, static_cast<uint>(db_length), name->ptr(), name->length());
+        if (sp_type == SP_TYPE_PACKAGE_BODY)
+        {
+          LEX_CSTRING l_name= {name->ptr(), name->length()};
+          sp_psi_drop_package_routines(thd, db, db_length, l_name);
+        }
 #endif
       }
       else


### PR DESCRIPTION
## Problem
When DROP DATABASE or DROP PACKAGE BODY is executed, sp_drop_db_routines() was not calling MYSQL_DROP_SP for Oracle-style package body sub-routines. This caused stale ghost rows to remain in events_statements_summary_by_program, making the MTR test perfschema.lowercase_fs_off fail non-deterministically when run after compat/oracle.sp-package.

## Fix
1. In sp_drop_routine_internal: iterate sub-routines and call MYSQL_DROP_SP before removing the package from cache.
2. In sp_drop_db_routines: use the thread's package body cache to identify and clear sub-routines when a package body is dropped during DROP DATABASE.

## Testing
- Added regression test: perfschema.mdev34817
- Verified with: ./mtr --no-reorder compat/oracle.sp-package perfschema.lowercase_fs_off --repeat=5
- Full perfschema suite passes

## References
Closes MDEV-34817
Closes MDEV-35282