### PR TITLE
MDEV-39118: `test_if_hard_path` crashes on recursively resolving `$HOME`

### DIFF
--- a/mysql-test/main/mdev_39118-win.cnf
+++ b/mysql-test/main/mdev_39118-win.cnf
@@ -1,0 +1,4 @@
+!include include/default_my.cnf
+
+[ENV]
+HOME=~\

--- a/mysql-test/main/mdev_39118-win.result
+++ b/mysql-test/main/mdev_39118-win.result
@@ -1,0 +1,6 @@
+#
+# MDEV-39118: test_if_hard_path() crashes on recursively resolving $HOME
+#
+create table t (c int) engine=MyISAM data directory="~\\foo\\bar";
+ERROR 42000: Incorrect table name '~\foo\bar'
+# End of 10.11 tests

--- a/mysql-test/main/mdev_39118-win.test
+++ b/mysql-test/main/mdev_39118-win.test
@@ -1,0 +1,9 @@
+--source include/windows.inc
+--echo #
+--echo # MDEV-39118: test_if_hard_path() crashes on recursively resolving \$HOME
+--echo #
+
+--error ER_WRONG_TABLE_NAME
+create table t (c int) engine=MyISAM data directory="~\\foo\\bar";
+
+--echo # End of 10.11 tests

--- a/mysql-test/main/mdev_39118.cnf
+++ b/mysql-test/main/mdev_39118.cnf
@@ -1,0 +1,4 @@
+!include include/default_my.cnf
+
+[ENV]
+HOME=~/

--- a/mysql-test/main/mdev_39118.result
+++ b/mysql-test/main/mdev_39118.result
@@ -1,0 +1,6 @@
+#
+# MDEV-39118: test_if_hard_path() crashes on recursively resolving $HOME
+#
+create table t (c int) engine=MyISAM data directory="~/foo/bar";
+ERROR 42000: Incorrect table name '~/foo/bar'
+# End of 10.11 tests

--- a/mysql-test/main/mdev_39118.test
+++ b/mysql-test/main/mdev_39118.test
@@ -1,0 +1,9 @@
+--source include/not_windows.inc
+--echo #
+--echo # MDEV-39118: test_if_hard_path() crashes on recursively resolving \$HOME
+--echo #
+
+--error ER_WRONG_TABLE_NAME
+create table t (c int) engine=MyISAM data directory="~/foo/bar";
+
+--echo # End of 10.11 tests

--- a/mysys/my_getwd.c
+++ b/mysys/my_getwd.c
@@ -132,7 +132,7 @@ int my_setwd(const char *dir, myf MyFlags)
 int test_if_hard_path(register const char *dir_name)
 {
   if (dir_name[0] == FN_HOMELIB && dir_name[1] == FN_LIBCHAR)
-    return (home_dir != NullS && test_if_hard_path(home_dir));
+    return (home_dir != NullS && home_dir != dir_name && test_if_hard_path(home_dir));
   if (dir_name[0] == FN_LIBCHAR)
     return (TRUE);
 #ifdef FN_DEVCHAR


### PR DESCRIPTION
fixes [MDEV-39118](https://jira.mariadb.org/browse/MDEV-39118)
### Problem:
When `$HOME` is set to `~/` (or any string starting with `~/`), the `home_dir` is initialized to that value. When `test_if_hard_path` is called on a path starting with `~/`, it replaces the `~/` prefix by recursively calling `test_if_hard_path(home_dir)` leading to infinite recursion and a crash.

### Fix:
Add a check in `test_if_hard_path` to see if `home_dir` itself begins with `~/`. If it does, skip the recursive call to prevent the infinite loop.