### PR TITLE
Fix `$target_temp_format` in `rpl.rpl_typeconv`

### DIFF
--- a/mysql-test/suite/rpl/include/check_type.inc
+++ b/mysql-test/suite/rpl/include/check_type.inc
@@ -35,7 +35,7 @@ eval CREATE TABLE t1(
 sync_slave_with_master;
 if ($target_temp_format)
 {
-  --eval SET @@global.mysql56_temporal_format= $source_temp_format
+  --eval SET @@global.mysql56_temporal_format= $target_temp_format
 }
 eval ALTER TABLE t1 MODIFY a $target_type;
 


### PR DESCRIPTION
The MTR snippet `suite/rpl/include/check_type.inc` was setting `@@GLOBAL.mysql56_temporal_format` with the wrong variable.