### PR TITLE
MDEV-39333 fix main.group_by test to be ordered predictably

### DIFF
--- a/mysql-test/main/group_by.test
+++ b/mysql-test/main/group_by.test
@@ -1786,6 +1786,7 @@ DROP TABLE t1;
 --echo #
 
 SET sql_mode='ONLY_FULL_GROUP_BY';
+--sorted_result
 SELECT 1 AS test UNION SELECT 2 AS test ORDER BY test IS NULL ASC;
 SET sql_mode='';
 


### PR DESCRIPTION
Since commit 80ea16c6209, 'order by column is null' may produce an
indeterminate column order of rows where 'column is null' is
satisfied.  This commit fixes an existing test in main.group_by
for MDEV-6129.
