### PR TITLE
MDEV-33843: Server crashes by stack-overflow with UPDATEXML

### DIFF
--- a/mysql-test/main/xml.result
+++ b/mysql-test/main/xml.result
@@ -1320,7 +1320,7 @@ f
 foo
 <b></b>
 #
-# Start of 10.5 tests
+# End of 10.5 tests
 #
 #
 # ExtractValue/UpdateXML crash
@@ -1414,3 +1414,9 @@ Warning	1525	Incorrect XML value: 'parse error at line 10 pos 27: unexpected END
 #
 # Start of 10.6 tests
 #
+#
+# MDEV-33843: Server crashes by stack-overflow with UPDATEXML
+#
+SELECT UPDATEXML(NULL, REPEAT('(', 100000), 1);
+ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
+# End of 10.6 test

--- a/mysql-test/main/xml.test
+++ b/mysql-test/main/xml.test
@@ -822,7 +822,7 @@ DROP TABLE t1;
 SELECT 'foo' AS f UNION SELECT BINARY( UpdateXML('<a></a>', '/a', '<b></b>')) AS f;
 
 --echo #
---echo # Start of 10.5 tests
+--echo # End of 10.5 tests
 --echo #
 
 --echo #
@@ -894,6 +894,17 @@ set @xml= '<?xml version="1.0"?>
 <?employee ABSDEV !@#$ ?>';
 
 SELECT ExtractValue(@xml, '/employee/dt3');
+
 --echo #
 --echo # Start of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-33843: Server crashes by stack-overflow with UPDATEXML
+--echo #
+
+--replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
+--error ER_STACK_OVERRUN_NEED_MORE
+SELECT UPDATEXML(NULL, REPEAT('(', 100000), 1);
+
+--echo # End of 10.6 test

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -26,6 +26,7 @@
 #include "my_xml.h"
 #include "sp_pcontext.h"
 #include "sql_class.h"                          // THD
+#include "sql_parse.h"                          // for check_stack_overrun
 
 /*
   TODO: future development directions:
@@ -2210,6 +2211,9 @@ static int my_xpath_parse_FilterExpr(MY_XPATH *xpath)
 */
 static int my_xpath_parse_OrExpr(MY_XPATH *xpath)
 {
+  if (check_stack_overrun(current_thd, STACK_MIN_SIZE , NULL))
+    return 1;
+
   if (!my_xpath_parse_AndExpr(xpath))
     return 0;
 


### PR DESCRIPTION
Analysis:
The stack size if insufficient and there is no stack overrun check.

Fix:
Add stack overrun check.