### PR TITLE
[12.3] Fix 'occured' -> 'occurred' typos in sql headers and test

### DIFF
--- a/mysql-test/main/func_str.test
+++ b/mysql-test/main/func_str.test
@@ -490,7 +490,7 @@ select SUBSTR('abcdefg',1,-1) FROM DUAL;
 
 #
 # Test that fix_fields doesn't follow to upper level (to comparison)
-# when an error on a lower level (in concat) has occured:
+# when an error on a lower level (in concat) has occurred:
 #
 create table t7 (s1 char);
 --error 1267

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -123,7 +123,7 @@ ulong total_ha_2pc= 0;
 /*
   Number of non-mandatory 2pc handlertons whose initialization failed
   to estimate total_ha_2pc value under supposition of the failures
-  have not occured.
+  have not occurred.
 */
 ulong failed_ha_2pc= 0;
 #endif

--- a/sql/sql_path.h
+++ b/sql/sql_path.h
@@ -94,7 +94,7 @@ private:
   Lex_ident_db resolve_current_schema(THD *thd, sp_head *caller, size_t i) const;
   /*
     Helper function to try resolving a routine in a specific schema.
-    Returns true if error occured.
+    Returns true if error occurred.
   */
   bool try_resolve_in_schema(THD *thd, const Lex_ident_db_normalized &schema,
                              sp_name *name, const Sp_handler **sph,


### PR DESCRIPTION
Fix 3 instances of `occured` → `occurred`:

- `sql/sql_path.h` line 97: Doc comment on return value
- `sql/handler.cc` line 126: Inline comment
- `mysql-test/main/func_str.test` line 493: Test description comment

Comment-only change.