### PR TITLE
MDEV-39245-Check that plugin name is pure ASCII

### DIFF
--- a/debian/mariadb-test.install
+++ b/debian/mariadb-test.install
@@ -22,6 +22,8 @@ usr/lib/mysql/plugin/ha_example.so
 usr/lib/mysql/plugin/ha_test_sql_discovery.so
 usr/lib/mysql/plugin/libdaemon_example.so
 usr/lib/mysql/plugin/mypluglib.so
+usr/lib/mysql/plugin/plugin_name_ascii.so
+usr/lib/mysql/plugin/plugin_name_non_ascii.so
 usr/lib/mysql/plugin/qa_auth_interface.so
 usr/lib/mysql/plugin/qa_auth_server.so
 usr/lib/mysql/plugin/test_sql_service.so

--- a/mysql-test/suite/plugins/r/plugin_name_ascii.result
+++ b/mysql-test/suite/plugins/r/plugin_name_ascii.result
@@ -1,0 +1,51 @@
+#
+# MDEV-39245: Check that plugin name is pure ASCII
+#
+SET NAMES utf8mb4;
+#
+# Case 1: INSTALL SONAME with non-ASCII plugin name should fail
+#
+INSTALL SONAME 'plugin_name_non_ascii';
+ERROR HY000: Plugin 'plügïn_non_ascii': name must contain only ASCII characters
+# Verify mysql.plugin table is clean
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_non_ascii';
+COUNT(*)
+0
+SET NAMES utf8mb4;
+#
+# Case 2: INSTALL PLUGIN targeting non-ASCII plugin directly should fail
+#
+INSTALL PLUGIN plügïn_non_ascii SONAME 'plugin_name_non_ascii';
+ERROR HY000: Plugin 'plügïn_non_ascii': name must contain only ASCII characters
+#
+# Case 3: INSTALL SONAME with all ASCII names should succeed
+#
+INSTALL SONAME 'plugin_name_ascii';
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME IN ('ascii_plugin_one', 'ascii_plugin_two');
+PLUGIN_NAME	PLUGIN_STATUS
+ascii_plugin_one	ACTIVE
+ascii_plugin_two	ACTIVE
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_ascii';
+COUNT(*)
+0
+UNINSTALL SONAME 'plugin_name_ascii';
+# Verify plugins are gone after uninstall
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME IN ('ascii_plugin_one', 'ascii_plugin_two');
+PLUGIN_NAME	PLUGIN_STATUS
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_ascii';
+COUNT(*)
+0
+#
+# Case 4: INSTALL PLUGIN with ASCII name should succeed
+#
+INSTALL PLUGIN ascii_plugin_one SONAME 'plugin_name_ascii';
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME = 'ascii_plugin_one';
+PLUGIN_NAME	PLUGIN_STATUS
+ascii_plugin_one	ACTIVE
+UNINSTALL PLUGIN ascii_plugin_one;

--- a/mysql-test/suite/plugins/t/plugin_name_ascii.opt
+++ b/mysql-test/suite/plugins/t/plugin_name_ascii.opt
@@ -1,0 +1,1 @@
+--plugin-maturity=stable

--- a/mysql-test/suite/plugins/t/plugin_name_ascii.test
+++ b/mysql-test/suite/plugins/t/plugin_name_ascii.test
@@ -1,0 +1,63 @@
+--echo #
+--echo # MDEV-39245: Check that plugin name is pure ASCII
+--echo #
+
+--source include/have_utf8mb4.inc
+
+if (!$PLUGIN_NAME_ASCII_SO)
+{
+  skip plugin_name_ascii plugin not available;
+}
+if (!$PLUGIN_NAME_NON_ASCII_SO)
+{
+  skip plugin_name_non_ascii plugin not available;
+}
+
+SET NAMES utf8mb4;
+
+--echo #
+--echo # Case 1: INSTALL SONAME with non-ASCII plugin name should fail
+--echo #
+--error ER_PLUGIN_IS_NOT_LOADED
+INSTALL SONAME 'plugin_name_non_ascii';
+
+--echo # Verify mysql.plugin table is clean
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_non_ascii';
+
+SET NAMES utf8mb4;
+--echo #
+--echo # Case 2: INSTALL PLUGIN targeting non-ASCII plugin directly should fail
+--echo #
+--error ER_PLUGIN_IS_NOT_LOADED
+INSTALL PLUGIN plügïn_non_ascii SONAME 'plugin_name_non_ascii';
+
+--echo #
+--echo # Case 3: INSTALL SONAME with all ASCII names should succeed
+--echo #
+INSTALL SONAME 'plugin_name_ascii';
+
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME IN ('ascii_plugin_one', 'ascii_plugin_two');
+
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_ascii';
+
+UNINSTALL SONAME 'plugin_name_ascii';
+
+--echo # Verify plugins are gone after uninstall
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME IN ('ascii_plugin_one', 'ascii_plugin_two');
+
+SELECT COUNT(*) FROM mysql.plugin WHERE dl='plugin_name_ascii';
+
+--echo #
+--echo # Case 4: INSTALL PLUGIN with ASCII name should succeed
+--echo #
+INSTALL PLUGIN ascii_plugin_one SONAME 'plugin_name_ascii';
+
+SELECT PLUGIN_NAME, PLUGIN_STATUS
+FROM information_schema.PLUGINS
+WHERE PLUGIN_NAME = 'ascii_plugin_one';
+
+UNINSTALL PLUGIN ascii_plugin_one;

--- a/plugin/plugin_name_ascii_check/CMakeLists.txt
+++ b/plugin/plugin_name_ascii_check/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+MYSQL_ADD_PLUGIN(plugin_name_ascii plugin_name_ascii.cc
+        MODULE_ONLY
+        NOT_EMBEDDED
+        COMPONENT Test)
+
+MYSQL_ADD_PLUGIN(plugin_name_non_ascii plugin_name_non_ascii.cc
+        MODULE_ONLY
+        NOT_EMBEDDED
+        COMPONENT Test)

--- a/plugin/plugin_name_ascii_check/plugin_name_ascii.cc
+++ b/plugin/plugin_name_ascii_check/plugin_name_ascii.cc
@@ -1,0 +1,66 @@
+/* Copyright (c) 2024, MariaDB Corporation.
+
+This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335 USA */
+
+/*
+  Test plugin: two plugins with pure ASCII names.
+  Used by mysql-test/suite/plugins/t/plugin_name_ascii.test
+*/
+
+#include <mysql/plugin.h>
+
+#if !defined(__attribute__) && (defined(__cplusplus) || !defined(__GNUC__)  || __GNUC__ == 2 && __GNUC_MINOR__ < 8)
+#define __attribute__(A)
+#endif
+
+static struct st_mysql_daemon plugin1_descriptor = { MYSQL_DAEMON_INTERFACE_VERSION };
+static struct st_mysql_daemon plugin2_descriptor = { MYSQL_DAEMON_INTERFACE_VERSION };
+
+static int plugin1_init(void *p __attribute__((unused))) { return 0; }
+static int plugin1_deinit(void *p __attribute__((unused))) { return 0; }
+static int plugin2_init(void *p __attribute__((unused))) { return 0; }
+static int plugin2_deinit(void *p __attribute__((unused))) { return 0; }
+
+maria_declare_plugin(plugin_name_ascii)
+{
+  MYSQL_DAEMON_PLUGIN,
+  &plugin1_descriptor,
+  "ascii_plugin_one",
+  "MariaDB",
+  "Plugin with ASCII name - one",
+  PLUGIN_LICENSE_GPL,
+  plugin1_init,
+  plugin1_deinit,
+  0x0100,
+  NULL,
+  NULL,
+  "1.0",
+  MariaDB_PLUGIN_MATURITY_STABLE
+},
+{
+  MYSQL_DAEMON_PLUGIN,
+  &plugin2_descriptor,
+  "ascii_plugin_two",
+  "MariaDB",
+  "Plugin with ASCII name - two",
+  PLUGIN_LICENSE_GPL,
+  plugin2_init,
+  plugin2_deinit,
+  0x0100,
+  NULL,
+  NULL,
+  "1.0",
+  MariaDB_PLUGIN_MATURITY_STABLE
+}
+maria_declare_plugin_end;

--- a/plugin/plugin_name_ascii_check/plugin_name_non_ascii.cc
+++ b/plugin/plugin_name_ascii_check/plugin_name_non_ascii.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2024, MariaDB Corporation.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335 USA */
+
+/*
+  Test plugin: two plugins with ASCII names and one with a non-ASCII name.
+  Used by mysql-test/suite/plugins/t/plugin_name_ascii.test
+  The non-ASCII plugin name "plügïn_non_ascii" is represented as raw UTF-8 literal.
+*/
+
+#include <mysql/plugin.h>
+
+#if !defined(__attribute__) && (defined(__cplusplus) || !defined(__GNUC__)  || __GNUC__ == 2 && __GNUC_MINOR__ < 8)
+#define __attribute__(A)
+#endif
+
+static struct st_mysql_daemon plugin1_descriptor = { MYSQL_DAEMON_INTERFACE_VERSION };
+static struct st_mysql_daemon plugin2_descriptor = { MYSQL_DAEMON_INTERFACE_VERSION };
+static struct st_mysql_daemon plugin3_descriptor = { MYSQL_DAEMON_INTERFACE_VERSION };
+
+static int plugin1_init(void *p __attribute__((unused))) { return 0; }
+static int plugin1_deinit(void *p __attribute__((unused))) { return 0; }
+static int plugin2_init(void *p __attribute__((unused))) { return 0; }
+static int plugin2_deinit(void *p __attribute__((unused))) { return 0; }
+static int plugin3_init(void *p __attribute__((unused))) { return 0; }
+static int plugin3_deinit(void *p __attribute__((unused))) { return 0; }
+
+maria_declare_plugin(plugin_name_non_ascii)
+{
+    MYSQL_DAEMON_PLUGIN,
+    &plugin1_descriptor,
+    "plugin_one",
+    "MariaDB",
+    "Plugin with ASCII name - one",
+    PLUGIN_LICENSE_GPL,
+    plugin1_init,
+    plugin1_deinit,
+    0x0100,
+    NULL,
+    NULL,
+    "1.0",
+    MariaDB_PLUGIN_MATURITY_STABLE
+},
+{
+    MYSQL_DAEMON_PLUGIN,
+    &plugin2_descriptor,
+    "plugin_two",
+    "MariaDB",
+    "Plugin with ASCII name - two",
+    PLUGIN_LICENSE_GPL,
+    plugin2_init,
+    plugin2_deinit,
+    0x0100,
+    NULL,
+    NULL,
+    "1.0",
+    MariaDB_PLUGIN_MATURITY_STABLE
+},
+{
+    MYSQL_DAEMON_PLUGIN,
+    &plugin3_descriptor,
+    "plügïn_non_ascii",  /* "plügïn_non_ascii" in raw UTF-8 literal */
+    "MariaDB",
+    "Plugin with non-ASCII name",
+    PLUGIN_LICENSE_GPL,
+    plugin3_init,
+    plugin3_deinit,
+    0x0100,
+    NULL,
+    NULL,
+    "1.0",
+    MariaDB_PLUGIN_MATURITY_STABLE
+}
+maria_declare_plugin_end;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1107,6 +1107,21 @@ static st_plugin_int *plugin_insert_or_reuse(struct st_plugin_int *plugin)
   DBUG_RETURN(tmp);
 }
 
+static inline bool plugin_should_be_skipped(const struct st_maria_plugin *p,
+                                      const struct st_plugin_dl *plugin_dl,
+                                      const LEX_CSTRING *name)
+{
+  if (p->type < 0 || p->type >= MYSQL_MAX_PLUGIN_TYPE_NUM)
+    return true;
+  if (p->type == MYSQL_UDF_PLUGIN ||
+      (p->type == MariaDB_PASSWORD_VALIDATION_PLUGIN &&
+       plugin_dl->mariaversion == 0))
+    return true;
+  if (name->str && system_charset_info->strnncoll(name->str, name->length,
+                                                  p->name, strlen(p->name)))
+    return true;
+  return false;
+}
 
 /*
   NOTE
@@ -1133,23 +1148,34 @@ static enum install_status plugin_add(MEM_ROOT *tmp_root, bool if_not_exists,
   fix_dl_name(tmp_root, dl);
   if (! (tmp.plugin_dl= plugin_dl_add(dl, MyFlags)))
     DBUG_RETURN(INSTALL_FAIL_NOT_OK);
+
+  /* Pre-validation: ensure plugin name of all plugins or the plugin to be installed are in pure ASCII */
+  for (plugin= tmp.plugin_dl->plugins; plugin->info; plugin++)
+  {
+    if (plugin_should_be_skipped(plugin, tmp.plugin_dl, name))
+      continue;
+
+    if (MY_REPERTOIRE_ASCII !=
+        my_string_repertoire(&my_charset_latin1,
+                             plugin->name, strlen(plugin->name)))
+    {
+      my_printf_error(ER_PLUGIN_IS_NOT_LOADED,
+                "Plugin '%s': name must contain only ASCII characters",
+                MyFlags, plugin->name);
+      plugin_dl_del(tmp.plugin_dl);
+      DBUG_RETURN(INSTALL_FAIL_NOT_OK);
+    }
+  }
+
   /* Find plugin by name */
   for (plugin= tmp.plugin_dl->plugins; plugin->info; plugin++)
   {
+
+    if (plugin_should_be_skipped(plugin, tmp.plugin_dl, name))
+      continue;
+
     tmp.name.str= (char *)plugin->name;
     tmp.name.length= strlen(plugin->name);
-
-    if (plugin->type < 0 || plugin->type >= MYSQL_MAX_PLUGIN_TYPE_NUM)
-      continue; // invalid plugin type
-
-    if (plugin->type == MYSQL_UDF_PLUGIN ||
-        (plugin->type == MariaDB_PASSWORD_VALIDATION_PLUGIN &&
-         tmp.plugin_dl->mariaversion == 0))
-      continue; // unsupported plugin type
-
-    if (name->str && system_charset_info->strnncoll(name->str, name->length,
-                                                    tmp.name.str, tmp.name.length))
-      continue; // plugin name doesn't match
 
     if (!name->str &&
         (maybe_dupe= plugin_find_internal(&tmp.name, MYSQL_ANY_PLUGIN)))
@@ -1678,6 +1704,13 @@ int plugin_init(int *argc, char **argv, int flags)
       tmp.plugin= plugin;
       tmp.name.str= (char *)plugin->name;
       tmp.name.length= strlen(plugin->name);
+      if (MY_REPERTOIRE_ASCII !=
+        my_string_repertoire(&my_charset_latin1, tmp.name.str,
+                         tmp.name.length))
+      {
+        print_init_failed_error(&tmp);
+        goto err_unlock;
+      }
       tmp.state= 0;
       tmp.load_option= mandatory ? PLUGIN_FORCE : PLUGIN_ON;
       DBUG_ASSERT(!mandatory ||


### PR DESCRIPTION
fixes [MDEV-39245](https://jira.mariadb.org/browse/MDEV-39245)
### Problem:
It is assumed plugin names are pure ASCII (e.g., uses my_casedn_str with latin1 charset) but never validates this at plugin registration time, allowing plugins with non-ASCII names to be installed, causing undefined behavior.

### Fix
Added ASCII validation at two points using my_string_repertoire():

1. Built-in plugins (plugin_init):
   A non-ASCII builtin name is a developer error. Added a check
   using my_string_repertoire() that prints an error via
   print_init_failed_error() and returns 1 to abort server startup.

2. Dynamically loaded plugins (plugin_add):
   Added a pre-validation loop before the registration loop. If any
   plugin name in the .so is non-ASCII, the entire .so is rejected
   before any plugin is registered, preventing partial state where
   valid plugins from the same .so get left INACTIVE in the hash.

Added test plugins and MTR tests to verify both rejection of
non-ASCII named plugins and successful loading of ASCII named plugins.
