### PR TITLE
MDEV-37491: Assertion `(mem_root->flags & 4) == 0` failed in `void *alloc_root(MEM_ROOT *, size_t)`

### DIFF
--- a/mysql-test/main/ps_mem_leaks.result
+++ b/mysql-test/main/ps_mem_leaks.result
@@ -465,4 +465,35 @@ va
 # Clean up
 DROP PROCEDURE p1;
 DROP TABLE t1;
+#
+# MDEV-37491: Assertion `(mem_root->flags & 4) == 0` failed in `void *alloc_root(MEM_ROOT *, size_t)`
+#
+CREATE PROCEDURE p(x INT DEFAULT (SELECT 1))
+BEGIN
+SELECT x FROM DUAL;
+END;
+//
+CALL p(1);
+x
+1
+CALL p();
+x
+1
+# Verify the there are no repeated allocations on statement mem_root
+SET @saved_dbug = @@SESSION.debug_dbug;
+SET SESSION debug_dbug="+d,assert_no_alloc_ref_array,assert_no_alloc_pre_fix";
+CALL p();
+x
+1
+CALL p();
+x
+1
+CALL p(1);
+x
+1
+CALL p();
+x
+1
+SET SESSION debug_dbug= @saved_dbug;
+DROP PROCEDURE p;
 # End of 11.8 tests

--- a/mysql-test/main/ps_mem_leaks.test
+++ b/mysql-test/main/ps_mem_leaks.test
@@ -500,4 +500,31 @@ CALL p1;
 DROP PROCEDURE p1;
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-37491: Assertion `(mem_root->flags & 4) == 0` failed in `void *alloc_root(MEM_ROOT *, size_t)`
+--echo #
+
+--DELIMITER //
+CREATE PROCEDURE p(x INT DEFAULT (SELECT 1))
+BEGIN
+  SELECT x FROM DUAL;
+END;
+//
+--DELIMITER ;
+CALL p(1);
+CALL p();
+
+--echo # Verify the there are no repeated allocations on statement mem_root
+SET @saved_dbug = @@SESSION.debug_dbug;
+SET SESSION debug_dbug="+d,assert_no_alloc_ref_array,assert_no_alloc_pre_fix";
+
+CALL p();
+CALL p();
+CALL p(1);
+CALL p();
+
+SET SESSION debug_dbug= @saved_dbug;
+
+DROP PROCEDURE p;
+
 --echo # End of 11.8 tests

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8212,7 +8212,24 @@ bool setup_fields(THD *thd, Ref_ptr_array ref_pointer_array,
   while ((item= it++))
   {
     if (make_pre_fix)
-      pre_fix->push_back(item, thd->active_stmt_arena_to_use()->mem_root);
+    {
+      DBUG_EXECUTE_IF("assert_no_alloc_pre_fix", { DBUG_ASSERT(0); });
+      Query_arena *arena= thd->active_stmt_arena_to_use();
+
+#ifdef PROTECT_STATEMENT_MEMROOT
+      const bool read_only_mem_root= !arena->is_conventional() &&
+                                (arena->mem_root->flags & ROOT_FLAG_READ_ONLY);
+      if (read_only_mem_root)
+        arena->mem_root->flags&= ~ROOT_FLAG_READ_ONLY;
+#endif
+
+      pre_fix->push_back(item, arena->mem_root);
+
+#ifdef PROTECT_STATEMENT_MEMROOT
+      if (read_only_mem_root)
+        arena->mem_root->flags|= ROOT_FLAG_READ_ONLY;
+#endif
+    }
 
     if (item->fix_fields_if_needed_for_scalar(thd, it.ref()))
     {

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -3733,7 +3733,23 @@ bool st_select_lex::setup_ref_array(THD *thd, uint order_group_num)
   if (!ref_pointer_array.is_null())
     return false;
 
-  Item **array= thd->active_stmt_arena_to_use()->calloc<Item*>(n_elems);
+  DBUG_EXECUTE_IF("assert_no_alloc_ref_array", { DBUG_ASSERT(0); });
+  Query_arena *arena= thd->active_stmt_arena_to_use();
+
+#ifdef PROTECT_STATEMENT_MEMROOT
+  const bool read_only_mem_root= !arena->is_conventional() &&
+                                 (arena->mem_root->flags & ROOT_FLAG_READ_ONLY);
+  if (read_only_mem_root)
+    arena->mem_root->flags&= ~ROOT_FLAG_READ_ONLY;
+#endif
+
+  Item **array= arena->calloc<Item*>(n_elems);
+
+#ifdef PROTECT_STATEMENT_MEMROOT
+  if (read_only_mem_root)
+    arena->mem_root->flags|= ROOT_FLAG_READ_ONLY;
+#endif
+
   if (likely(array != NULL))
     ref_pointer_array= Ref_ptr_array(array, n_elems);
   return array == NULL;


### PR DESCRIPTION
fixes [MDEV-37491](https://jira.mariadb.org/browse/MDEV-37491)

### Problem:
Server crashes when a procedure with default parameter is executed and default value for the parameter is evaluated after the procedure's first execution.
```sql
  CREATE PROCEDURE p(x INT DEFAULT (SELECT 1)) ...
  CALL p(1); -- first exec, marks mem_root read-only
  CALL p(); -- tries to allocate on locked when executing DEFAULT
```

### Fix:
Temporarily clear the read-only flag on the statement memory root to allow the allocation. Also adds a debug hook to verify allocation happens not more than once per prepared statement and per internal table added to the list.