### PR TITLE
MDEV-39382: Trace replay produces "Impossible WHERE noticed after rea…

### DIFF
--- a/mysql-test/include/get_rec_idx_ranges_from_opt_ctx.inc
+++ b/mysql-test/include/get_rec_idx_ranges_from_opt_ctx.inc
@@ -7,6 +7,10 @@ set @records=
     (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.num_of_records')));
 select *from json_table(@records,
                         '$[*]' columns(num_of_records text path '$')) as jt;
+set @file_stat_records=
+    (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+                        '$[*]' columns(file_stat_records text path '$')) as jt;
 set @indexes=
     (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(

--- a/mysql-test/include/opt_context_schema.inc
+++ b/mysql-test/include/opt_context_schema.inc
@@ -17,6 +17,9 @@ let $opt_context_schema=
           "num_of_records": {
             "type": "number"
           },
+          "file_stat_records": {
+            "type": "number"
+          },
           "read_cost_io": {
             "type": "number"
           },
@@ -190,6 +193,7 @@ let $opt_context_schema=
           "name",
           "ddl",
           "num_of_records",
+          "file_stat_records",
           "read_cost_io",
           "read_cost_cpu"
         ]

--- a/mysql-test/main/opt_context_load_stats_basic.result
+++ b/mysql-test/main/opt_context_load_stats_basic.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set @saved_opt_context_var_name_1= 'saved_opt_context_1';
 set @saved_opt_context_var_name_2= 'saved_opt_context_2';
 set @opt_context_var_name= 'opt_context';
@@ -37,6 +36,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
@@ -196,30 +201,10 @@ select @opt_context;
 @opt_context
 NULL
 #
-# with optimizer_trace OFF,
-# nothing gets printed to the trace
-#
-set optimizer_trace=0;
-select * from t1 where a < 3 and b > 6;
-a	b
-0	7
-0	7
-2	7
-2	7
-set @opt_context=
-(select REGEXP_SUBSTR(
-context,
-'(?<=set @opt_context=\')([\n\r].*)*(?=\'\;#opt_context_ends)')
-from information_schema.optimizer_context);
-select @opt_context;
-@opt_context
-NULL
-#
-# Now, after re-enabling optimizer_trace, and optimizer_record_context,
+# Now, after re-enabling optimizer_record_context,
 # Loaded stats should be picked by the planner instead of the analyzed table stats,
 # as the optimizer_replay_context is still set to a valid json containing other stats
 #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 select * from t1 where a < 3 and b > 6;
 a	b
@@ -358,7 +343,7 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].name');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "name" element not present at offset 1384.
+Warning	4253	Failed to parse saved optimizer context: "name" element not present at offset 1409.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].ddl');
 select * from t1 where a > 10;
 a	b
@@ -369,47 +354,52 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].num_of_re
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "num_of_records" element not present at offset 1380.
+Warning	4253	Failed to parse saved optimizer context: "num_of_records" element not present at offset 1405.
+set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].file_stat_records');
+select * from t1 where a > 10;
+a	b
+Warnings:
+Warning	4253	Failed to parse saved optimizer context: "file_stat_records" element not present at offset 1402.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0].index_name');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "index_name" element not present at offset 141.
+Warning	4253	Failed to parse saved optimizer context: "index_name" element not present at offset 166.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0].rec_per_key');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "rec_per_key" element not present at offset 145.
+Warning	4253	Failed to parse saved optimizer context: "rec_per_key" element not present at offset 170.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].index_name');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "index_name" element not present at offset 618.
+Warning	4253	Failed to parse saved optimizer context: "index_name" element not present at offset 643.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].ranges');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "ranges" element not present at offset 610.
+Warning	4253	Failed to parse saved optimizer context: "ranges" element not present at offset 635.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].num_rows');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "num_rows" element not present at offset 628.
+Warning	4253	Failed to parse saved optimizer context: "num_rows" element not present at offset 653.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].cost');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "cost" element not present at offset 412.
+Warning	4253	Failed to parse saved optimizer context: "cost" element not present at offset 437.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].max_index_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 621.
+Warning	4253	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 646.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_ranges[0].max_row_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 623.
+Warning	4253	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 648.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0]');
 select * from t1 where a > 10;
 a	b
@@ -448,51 +438,51 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_inde
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "key_number" element not present at offset 510.
+Warning	4253	Failed to parse saved optimizer context: "key_number" element not present at offset 535.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].num_records');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "num_records" element not present at offset 509.
+Warning	4253	Failed to parse saved optimizer context: "num_records" element not present at offset 534.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].eq_ref');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "eq_ref" element not present at offset 514.
+Warning	4253	Failed to parse saved optimizer context: "eq_ref" element not present at offset 539.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].index_cost_io');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "index_cost_io" element not present at offset 507.
+Warning	4253	Failed to parse saved optimizer context: "index_cost_io" element not present at offset 532.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].index_cost_cpu');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "index_cost_cpu" element not present at offset 496.
+Warning	4253	Failed to parse saved optimizer context: "index_cost_cpu" element not present at offset 521.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].row_cost_io');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "row_cost_io" element not present at offset 509.
+Warning	4253	Failed to parse saved optimizer context: "row_cost_io" element not present at offset 534.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].row_cost_cpu');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "row_cost_cpu" element not present at offset 498.
+Warning	4253	Failed to parse saved optimizer context: "row_cost_cpu" element not present at offset 523.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].max_index_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 504.
+Warning	4253	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 529.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].max_row_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 506.
+Warning	4253	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 531.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].list_index_read_costs[0].copy_cost');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4253	Failed to parse saved optimizer context: "copy_cost" element not present at offset 511.
+Warning	4253	Failed to parse saved optimizer context: "copy_cost" element not present at offset 536.
 drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_load_stats_basic.test
+++ b/mysql-test/main/opt_context_load_stats_basic.test
@@ -1,8 +1,7 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set @saved_opt_context_var_name_1= 'saved_opt_context_1';
 set @saved_opt_context_var_name_2= 'saved_opt_context_2';
 set @opt_context_var_name= 'opt_context';
@@ -126,23 +125,10 @@ select * from t1 where a < 3 and b > 6;
 select @opt_context;
 
 --echo #
---echo # with optimizer_trace OFF,
---echo # nothing gets printed to the trace
---echo #
-set optimizer_trace=0;
-
-select * from t1 where a < 3 and b > 6;
-
---source include/get_opt_context.inc
-
-select @opt_context;
-
---echo #
---echo # Now, after re-enabling optimizer_trace, and optimizer_record_context,
+--echo # Now, after re-enabling optimizer_record_context,
 --echo # Loaded stats should be picked by the planner instead of the analyzed table stats,
 --echo # as the optimizer_replay_context is still set to a valid json containing other stats
 --echo #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 
 select * from t1 where a < 3 and b > 6;
@@ -235,6 +221,9 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].ddl');
 select * from t1 where a > 10;
 
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].num_of_records');
+select * from t1 where a > 10;
+
+set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].file_stat_records');
 select * from t1 where a > 10;
 
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0].index_name');

--- a/mysql-test/main/opt_context_replay_basic.result
+++ b/mysql-test/main/opt_context_replay_basic.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create table t1
@@ -69,7 +68,7 @@ SET optimizer_selectivity_sampling_limit=100;
 
 SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
 
-SET optimizer_trace='enabled=on';
+SET optimizer_trace='enabled=off';
 
 SET optimizer_trace_max_mem_size=1048576;
 
@@ -114,7 +113,7 @@ SET optimizer_scan_setup_cost=10.000000;
 SET optimizer_search_depth=62;
 SET optimizer_selectivity_sampling_limit=100;
 SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
-SET optimizer_trace='enabled=on';
+SET optimizer_trace='enabled=off';
 SET optimizer_trace_max_mem_size=1048576;
 SET optimizer_use_condition_selectivity=4;
 SET optimizer_where_cost=0.032000;
@@ -135,6 +134,7 @@ set @opt_context='
     {
       "name": "db1.t1",
       "num_of_records": 0,
+      "file_stat_records": 20,
       "read_cost_io": 0,
       "read_cost_cpu": 0.0100356,
       "indexes": [
@@ -166,4 +166,70 @@ create table t2( a int);
 #
 insert into t2 select seq from seq_1_to_10;
 drop table t1, t2;
+#
+# MDEV-39382: Trace replay produces "Impossible WHERE noticed after reading const tables"
+#
+CREATE TABLE t1 (a INT, b INT, KEY(a)) engine=myisam;
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+db1.t1	analyze	status	Engine-independent statistics collected
+db1.t1	analyze	status	OK
+set optimizer_record_context=1;
+EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE a = 1;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "cost": 0.002024411,
+    "nested_loop": [
+      {
+        "table": {
+          "table_name": "t1",
+          "access_type": "ref",
+          "possible_keys": ["a"],
+          "key": "a",
+          "key_length": "5",
+          "used_key_parts": ["a"],
+          "ref": ["const"],
+          "loops": 1,
+          "rows": 1,
+          "cost": 0.002024411,
+          "filtered": 100
+        }
+      }
+    ]
+  }
+}
+select context into dumpfile "../../tmp/dump1.sql" 
+from information_schema.optimizer_context;
+drop table t1;
+set optimizer_replay_context='opt_context';
+# Same query as above, must have same explain:
+EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE a = 1;
+EXPLAIN
+{
+  "query_block": {
+    "select_id": 1,
+    "cost": 0.002024411,
+    "nested_loop": [
+      {
+        "table": {
+          "table_name": "t1",
+          "access_type": "ref",
+          "possible_keys": ["a"],
+          "key": "a",
+          "key_length": "5",
+          "used_key_parts": ["a"],
+          "ref": ["const"],
+          "loops": 1,
+          "rows": 1,
+          "cost": 0.002024411,
+          "filtered": 100
+        }
+      }
+    ]
+  }
+}
+drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_replay_basic.test
+++ b/mysql-test/main/opt_context_replay_basic.test
@@ -1,9 +1,8 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
 --source include/no_view_protocol.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 
 create database db1;
 use db1;
@@ -44,4 +43,28 @@ insert into t2 select seq from seq_1_to_10;
 --remove_file "$MYSQLTEST_VARDIR/tmp/dump1.sql"
 
 drop table t1, t2;
+
+--echo #
+--echo # MDEV-39382: Trace replay produces "Impossible WHERE noticed after reading const tables"
+--echo #
+CREATE TABLE t1 (a INT, b INT, KEY(a)) engine=myisam;
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+analyze table t1;
+set optimizer_record_context=1;
+EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE a = 1;
+
+select context into dumpfile "../../tmp/dump1.sql" 
+from information_schema.optimizer_context;
+drop table t1;
+
+--disable_query_log
+--disable_result_log
+--source "$MYSQLTEST_VARDIR/tmp/dump1.sql"
+--enable_query_log
+--enable_result_log
+set optimizer_replay_context='opt_context';
+--echo # Same query as above, must have same explain:
+EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE a = 1;
+
+drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create table t1
@@ -46,6 +45,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 0
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -84,6 +89,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -128,6 +140,11 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -160,6 +177,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -206,6 +230,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -242,6 +272,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -291,6 +328,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -332,6 +375,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
@@ -380,6 +429,11 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -414,6 +468,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));

--- a/mysql-test/main/opt_context_store_stats.test
+++ b/mysql-test/main/opt_context_store_stats.test
@@ -1,8 +1,7 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 
 create database db1;
 use db1;

--- a/sql/opt_context_store_replay.cc
+++ b/sql/opt_context_store_replay.cc
@@ -332,6 +332,7 @@ static void dump_table_stats(THD *thd, TABLE_LIST *tbl, uchar *tbl_name,
   IO_AND_CPU_COST cost= table->file->ha_scan_time(records);
   ctx_wrapper.add("name", (char *) tbl_name, tbl_name_len);
   ctx_wrapper.add("num_of_records", records);
+  ctx_wrapper.add("file_stat_records", table->file->stats.records);
   ctx_wrapper.add("read_cost_io", cost.io);
   ctx_wrapper.add("read_cost_cpu", cost.cpu);
   if (!table->key_info)
@@ -857,6 +858,7 @@ public:
   */
   char *name;
   ha_rows total_rows;
+  ha_rows file_stat_records;
   double read_cost_io;
   double read_cost_cpu;
   List<index_context_for_replay> index_list;
@@ -891,7 +893,9 @@ class Saved_Table_stats : public Sql_alloc
 {
 public:
   TABLE *table;
-  ha_rows original_rows;
+  ha_rows original_rows; // this is table->used_stat_records
+  /* saved table->file->stats.records */ 
+  ha_rows original_file_stats_records;
   List<Saved_Index_stats> saved_indexstats_list;
 };
 
@@ -1129,6 +1133,9 @@ static int parse_table_context(THD *thd, json_engine_t *je, String *err_buf,
       {"name", Read_string(thd, &table_ctx->name), false},
       {"num_of_records",
        Read_non_neg_integer<ha_rows, ULONGLONG_MAX>(&table_ctx->total_rows),
+       false},
+      {"file_stat_records",
+       Read_non_neg_integer<ha_rows, ULONGLONG_MAX>(&table_ctx->file_stat_records),
        false},
       {"read_cost_io", Read_double(&table_ctx->read_cost_io), false},
       {"read_cost_cpu", Read_double(&table_ctx->read_cost_cpu), false},
@@ -1572,15 +1579,13 @@ void Optimizer_context_replay::infuse_table_stats(TABLE *table)
 
   saved_ts->table= table;
   saved_ts->original_rows= table->used_stat_records;
+  saved_ts->original_file_stats_records= table->file->stats.records;
 
   if (saved_table_stats.push_back(saved_ts))
     return;
 
-  ha_rows temp_rows;
-  if (!infuse_table_rows(table, &temp_rows))
+  if (!infuse_table_rows(table))
   {
-    table->used_stat_records= temp_rows;
-
     KEY *key_info, *key_info_end;
     for (key_info= table->key_info, key_info_end= key_info + table->s->keys;
          key_info < key_info_end; key_info++)
@@ -1692,6 +1697,8 @@ void Optimizer_context_replay::restore_modified_table_stats()
   while (Saved_Table_stats *saved_ts= table_li++)
   {
     saved_ts->table->used_stat_records= saved_ts->original_rows;
+    saved_ts->table->file->stats.records= saved_ts->original_file_stats_records;
+
     List_iterator<Saved_Index_stats> index_li(saved_ts->saved_indexstats_list);
     while (Saved_Index_stats *saved_is= index_li++)
     {
@@ -1800,6 +1807,8 @@ void Optimizer_context_replay::dbug_print_read_stats()
     DBUG_PRINT("info", ("-----------------"));
     DBUG_PRINT("info", ("name: %s", tbl_ctx->name));
     DBUG_PRINT("info", ("num_of_records: %llx", tbl_ctx->total_rows));
+    DBUG_PRINT("info",
+               ("file_stat_records: %llx", tbl_ctx->file_stat_records));
 
     List_iterator<index_context_for_replay> index_itr(tbl_ctx->index_list);
 
@@ -1890,8 +1899,7 @@ void Optimizer_context_replay::dbug_print_read_stats()
     false  OK
     true  Error
 */
-bool Optimizer_context_replay::infuse_table_rows(const TABLE *tbl,
-                                                 ha_rows *rows)
+bool Optimizer_context_replay::infuse_table_rows(TABLE *tbl)
 {
   if (!has_records() || !is_base_table(tbl->pos_in_table_list))
     return true;
@@ -1902,7 +1910,8 @@ bool Optimizer_context_replay::infuse_table_rows(const TABLE *tbl,
   if (table_context_for_replay *tbl_ctx=
           find_table_context(tbl_name.c_ptr_safe()))
   {
-    *rows= tbl_ctx->total_rows;
+    tbl->used_stat_records= tbl_ctx->total_rows;
+    tbl->file->stats.records= tbl_ctx->file_stat_records;
     return false;
   }
 

--- a/sql/opt_context_store_replay.h
+++ b/sql/opt_context_store_replay.h
@@ -149,7 +149,7 @@ private:
                                             const char *idx_name);
   void store_range_contexts(const TABLE *tbl, const char *idx_name,
                             List<Multi_range_read_const_call_record> *list);
-  bool infuse_table_rows(const TABLE *tbl, ha_rows *rows);
+  bool infuse_table_rows(TABLE *tbl);
   table_context_for_replay *find_table_context(const char *name);
 };
 


### PR DESCRIPTION
…ding const tables"

Constant table check in make_join_statistics() checks the value of "table->file->stats.records", not table->used_stat_records. These two values can be different.

So, make the Optimizer Context save and restore both values. (used_stat_records was saved already, this patch also saves table->file->stats.records).