### PR TITLE
MDEV-39284 LPAD/RPAD corrupts cached string buffer

### DIFF
--- a/mysql-test/main/func_str.result
+++ b/mysql-test/main/func_str.result
@@ -5681,3 +5681,16 @@ Warnings:
 Warning	1292	Truncated incorrect DOUBLE value: 'foo'
 drop table t0;
 # End of 10.11 tests
+#
+# MDEV-39284 SELECT and DELETE/UPDATE return inconsistent row counts with identical WHERE clause
+#
+CREATE TABLE t (id INT);
+INSERT INTO t VALUES (1),(2),(3),(4),(5);
+SELECT COUNT(*) FROM t WHERE LPAD(LTRIM('v0px'), id) < LEFT('tutl', id);
+COUNT(*)
+1
+SELECT COUNT(*) FROM t WHERE RPAD(RTRIM('v0px'), id, 'x') = LEFT('v0px', id);
+COUNT(*)
+4
+DROP TABLE t;
+# End of MDEV-39284 tests

--- a/mysql-test/main/func_str.test
+++ b/mysql-test/main/func_str.test
@@ -2625,3 +2625,25 @@ select c0 from t0 where lpad('123', 2-c0, c0);
 drop table t0;
 
 --echo # End of 10.11 tests
+
+--echo #
+--echo # MDEV-39284 SELECT and DELETE/UPDATE return inconsistent row counts with identical WHERE clause
+--echo #
+
+CREATE TABLE t (id INT);
+INSERT INTO t VALUES (1),(2),(3),(4),(5);
+
+# bug: mutating cache, checked for lpad
+# Row 1 (id=1): truncates 'v0px' to 'v', poisons cache
+# Rows 2-5: without fix get ' v', '  v' etc due to corrupted str_length
+# Correct: 1, Buggy: 4
+SELECT COUNT(*) FROM t WHERE LPAD(LTRIM('v0px'), id) < LEFT('tutl', id);
+
+# bug: mutating cache, checked for rpad
+# RPAD('v0px', id) = LEFT('v0px', id) should match 4 rows (id=1..4)
+# Correct: 4, Buggy: 1
+SELECT COUNT(*) FROM t WHERE RPAD(RTRIM('v0px'), id, 'x') = LEFT('v0px', id);
+
+DROP TABLE t;
+
+--echo # End of MDEV-39284 tests

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3297,22 +3297,18 @@ String *Item_func_chr::val_str(String *str)
 inline String* alloc_buffer(String *res,String *str,String *tmp_value,
 			    ulong length)
 {
-  if (res->alloced_length() < length)
+  if (str->alloced_length() < length)
   {
-    if (str->alloced_length() >= length)
-    {
-      (void) str->copy(*res);
-      str->length(length);
-      return str;
-    }
     if (tmp_value->alloc(length))
       return 0;
     (void) tmp_value->copy(*res);
     tmp_value->length(length);
     return tmp_value;
   }
-  res->length(length);
-  return res;
+
+  (void) str->copy(*res);
+  str->length(length);
+  return str;
 }
 
 
@@ -3611,8 +3607,10 @@ String *Item_func_rpad::val_str(String *str)
 
   if (count <= (res_char_length= res->numchars()))
   {						// String to pad is big enough
-    res->length(res->charpos((int) count));	// Shorten result if longer
-    return (res);
+    if (str->copy(*res))
+      goto err;
+    str->length(str->charpos((int) count));
+    return str;
   }
 
   byte_count= count * collation.collation->mbmaxlen;
@@ -3706,10 +3704,10 @@ String *Item_func_lpad::val_str(String *str)
 
   if (count <= res_char_length)
   {
-    int len= res->charpos((int) count);
-    res= copy_if_not_alloced(str, res, len);
-    res->length(len);
-    return res;
+    if (str->copy(*res))
+      goto err;
+    str->length(str->charpos((int) count));
+    return str;
   }
   
   byte_count= count * collation.collation->mbmaxlen;


### PR DESCRIPTION
When LPAD or RPAD is called with a constant first argument in a SELECT expression e.x. LPAD(LTRIM('v0px'), id), the constant item e.x. LTRIM('v0px') is cached for reuse across rows. In the val_str implementations of LPAD/RPAD, certain code mutated the cache in place. So, all subsequent row computations recieved a corrupted cache leading to wrong results.

Since SELECT uses the const-item cache optimization but DELETE/UPDATE doesn't, there was a difference in the number of rows returned despite similar WHERE conditions.

Fixed it by copying cache contents to a non-cache buffer, mutating and returning it.