### PR TITLE
MDEV-21735: Wrong result with prefix indexes using rocksdb

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9171,10 +9171,10 @@ void Field_blob::sort_string(uchar *to,uint length)
 #ifdef DBUG_ASSERT_EXISTS
     size_t rc=
 #endif
-    field_charset()->strnxfrm(to, length, length,
-                              (const uchar *) buf.ptr(), buf.length(),
-                              MY_STRXFRM_PAD_WITH_SPACE |
-                              MY_STRXFRM_PAD_TO_MAXLEN);
+        field_charset()->strnxfrm(to, length, length / mbmaxlen(),
+                                  (const uchar *) buf.ptr(), buf.length(),
+                                  MY_STRXFRM_PAD_WITH_SPACE |
+                                      MY_STRXFRM_PAD_TO_MAXLEN);
     DBUG_ASSERT(rc == length);
   }
 }

--- a/storage/rocksdb/mysql-test/rocksdb/r/rocksdb.result
+++ b/storage/rocksdb/mysql-test/rocksdb/r/rocksdb.result
@@ -2642,4 +2642,20 @@ DROP TABLE t1, t2;
 CREATE TABLE t1 (a INET6 NOT NULL, KEY (a)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES ('41::1'),('61::1');
 DROP TABLE t1;
+#
+# MDEV-21735: text prefix indexes return wrong results
+#
+create table t1 (txt text COLLATE utf8mb4_swedish_ci) engine=rocksdb;
+insert into t1 values ('long text');
+create index i1 on t1(txt(3));
+select * from t1 where txt='long text';
+txt
+long text
+select * from t1 where txt like 'long text';
+txt
+long text
+select * from t1 where txt like 'long%';
+txt
+long text
+drop table t1;
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK = @ORIG_PAUSE_BACKGROUND_WORK;

--- a/storage/rocksdb/mysql-test/rocksdb/t/rocksdb.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/rocksdb.test
@@ -1971,4 +1971,17 @@ CREATE TABLE t1 (a INET6 NOT NULL, KEY (a)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES ('41::1'),('61::1');
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-21735: text prefix indexes return wrong results
+--echo #
+create table t1 (txt text COLLATE utf8mb4_swedish_ci) engine=rocksdb;
+insert into t1 values ('long text');
+create index i1 on t1(txt(3));
+
+select * from t1 where txt='long text';
+select * from t1 where txt like 'long text';
+select * from t1 where txt like 'long%';
+
+drop table t1;
+
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK = @ORIG_PAUSE_BACKGROUND_WORK;


### PR DESCRIPTION
    Rows are missing from the output when searching by indexed text column
    when the value is longer than the index's prefix length.
    Using "like 'prefix%'" only works when the prefix is shorter than the
    index's length (or equal, if value=prefix).
    The issue seems to only happen when using utf8/utf8mb4/utf16/utf32 collations.
    However, latin1/ascii/ucs2 collations work correctly.
    
    For non-working collations, the mem-comparable buffer created for values
    put into the index and the one read from the index are different.
    
    When buffer is being filled with binary form data, the length, and
    weights arguments are set to the same value for strnxfrm() when invoked
    from Field_blob::sort_string(). Since weights are set to a larger value, we
    fill space with unnecessary data in the buffer, and hence
    the buffer comparison fail.
    
    Solution
    --------
    Set the weights argument to length/charset::mbmaxlen() value, which is
    what was being done in other types such as Field_varstring, as well as
    other methods in Field_blob.