### PR TITLE
MDEV-38213 Remove leftover CXX11_FLAGS reference in build_rocksdb.cmake

### DIFF
--- a/storage/rocksdb/build_rocksdb.cmake
+++ b/storage/rocksdb/build_rocksdb.cmake
@@ -511,7 +511,7 @@ else()
     PROPERTIES COMPILE_FLAGS "-Wframe-larger-than=40960")
   set_source_files_properties(${ROCKSDB_SOURCE_DIR}/options/cf_options.cc
     PROPERTIES COMPILE_FLAGS "-Wframe-larger-than=32768")
-  set(CMAKE_REQUIRED_FLAGS "-msse4.2 -mpclmul ${CXX11_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "-msse4.2 -mpclmul")
 
   CHECK_CXX_SOURCE_COMPILES("
 #include <cstdint>


### PR DESCRIPTION
## Description

MDEV-38855 removed the C++11 compiler checks from `CMakeLists.txt` but left a `${CXX11_FLAGS}` reference in the SSE4.2 compile check. Remove it, as the C++ standard is now inherited from the parent project.

## How can this PR be tested?

Run a full CMake configure and build with the RocksDB storage engine enabled (`-DPLUGIN_ROCKSDB=YES`). The build should succeed without any C++ standard-related errors.

## Basing the PR against the correct MariaDB version

* [x] _This is a cleanup task and the PR is based against the latest MariaDB development branch_

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.