### PR TITLE
MDEV-39418: Merge 11.4 into 11.8 - null-merge MDEV-39240

### DIFF
--- a/sql/sp_instr.cc
+++ b/sql/sp_instr.cc
@@ -534,7 +534,19 @@ int sp_lex_keeper::validate_lex_and_exec_core(THD *thd, uint *nextp,
     m_first_execution= false;
 
     if (!rc)
+    {
+      /*
+       sp_lex_instr is re-parsed after the metadata change, which sets up a new
+       mem_root for reparsing. Once the sp_lex_instr is reparsed and re-executed
+       (via reset_lex_and_exec_core) it should be marked as read-only to enforce
+       sp memory root protection.
+       */
+#ifdef PROTECT_STATEMENT_MEMROOT
+      if (rerun_the_same_instr && instr->mem_root)
+        instr->mem_root->flags |= ROOT_FLAG_READ_ONLY;
+#endif
       break;
+    }
 
     /*
       Raise the error upper level in case:


### PR DESCRIPTION
Merge branch 11.4 into 11.8 as part of the Q2 2026 release.

[MDEV-39240](https://jira.mariadb.org/browse/MDEV-39240) is null-merged (excluded) as if removed by [MDEV-32188](https://jira.mariadb.org/browse/MDEV-32188).

MDEV-39240 fixed a replication issue where pre-11.5 replicas accepted
timestamps beyond Year 2038 via row-based replication, introduced as a
side effect of MDEV-32188 being a preview feature in 11.4. In 11.8,
MDEV-32188 is fully released and the extended timestamp range is stable,
so MDEV-39240 does not apply and must not be merged.

This was requested by Jimmy Hú in the Q2 2026 release task ([MDEV-39403](https://jira.mariadb.org/browse/MDEV-39403)).

I confirm this contribution is provided under the BSD New 3-Clause License.