### PR TITLE
MDEV-39176 Allow parenthesized SELECT INTO in stored procedures

### DIFF
--- a/mysql-test/main/select_into_parens.result
+++ b/mysql-test/main/select_into_parens.result
@@ -1,0 +1,133 @@
+#
+# MDEV-39176: Allow parenthesized SELECT INTO in stored procedures
+#
+CREATE TABLE t1 (a INT, b VARCHAR(32));
+INSERT INTO t1 VALUES (1, 'one'), (2, 'two'), (3, 'three');
+#
+# Test 1: Basic parenthesized SELECT INTO in stored procedure
+#
+CREATE PROCEDURE p1(IN p INT)
+BEGIN
+DECLARE v INT;
+(SELECT a INTO v FROM t1 WHERE a = p LIMIT 1);
+SELECT v AS result;
+END//
+CALL p1(2);
+result
+2
+#
+# Test 2: Parenthesized SELECT INTO with multiple variables
+#
+CREATE PROCEDURE p2(IN p INT)
+BEGIN
+DECLARE va INT;
+DECLARE vb VARCHAR(32);
+(SELECT a, b INTO va, vb FROM t1 WHERE a = p LIMIT 1);
+SELECT va, vb;
+END//
+CALL p2(1);
+va	vb
+1	one
+#
+# Test 3: Parenthesized SELECT INTO inside IF block (original bug report)
+#
+CREATE PROCEDURE p3(IN in_var INT)
+BEGIN
+DECLARE ivar INT;
+IF in_var IS NOT NULL THEN
+(SELECT a INTO ivar FROM t1 WHERE a = in_var LIMIT 1);
+END IF;
+SELECT ivar AS result;
+END//
+CALL p3(3);
+result
+3
+CALL p3(NULL);
+result
+NULL
+#
+# Test 4: Double parentheses
+#
+CREATE PROCEDURE p4(IN p INT)
+BEGIN
+DECLARE v INT;
+((SELECT a INTO v FROM t1 WHERE a = p LIMIT 1));
+SELECT v AS result;
+END//
+CALL p4(1);
+result
+1
+#
+# Test 5: Non-parenthesized SELECT INTO still works
+#
+CREATE PROCEDURE p5(IN p INT)
+BEGIN
+DECLARE v INT;
+SELECT a INTO v FROM t1 WHERE a = p LIMIT 1;
+SELECT v AS result;
+END//
+CALL p5(3);
+result
+3
+#
+# Test 6: Parenthesized SELECT INTO with UNION should error
+#
+(SELECT 1 INTO @var) UNION (SELECT 1);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'UNION (SELECT 1)' at line 1
+(SELECT 1) UNION (SELECT 1 INTO @var);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'INTO @var)' at line 1
+#
+# Test 7: Parenthesized SELECT INTO with WITH clause in stored procedure
+#
+CREATE PROCEDURE p6(IN p INT)
+BEGIN
+DECLARE v INT;
+(WITH cte AS (SELECT a FROM t1 WHERE a = p) SELECT a INTO v FROM cte LIMIT 1);
+SELECT v AS result;
+END//
+CALL p6(2);
+result
+2
+#
+# Test 8: Parenthesized SELECT INTO with ORDER BY and LIMIT
+#
+CREATE PROCEDURE p7(IN p INT)
+BEGIN
+DECLARE v INT;
+(SELECT a INTO v FROM t1 WHERE a <= p ORDER BY a DESC LIMIT 1);
+SELECT v AS result;
+END//
+CALL p7(3);
+result
+3
+#
+# Test 9: SET var = (SELECT INTO) should error (subquery context)
+#
+CREATE PROCEDURE p_bad()
+BEGIN
+DECLARE var1 VARCHAR(10);
+DECLARE var2 VARCHAR(10);
+SET var1 = (SELECT 'val' INTO var2);
+SELECT var1, var2;
+END//
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'INTO var2);
+SELECT var1, var2;
+END' at line 5
+#
+# Test 10: Top-level parenthesized SELECT INTO (outside stored procedure)
+#
+(SELECT 1 INTO @var);
+SELECT @var;
+@var
+1
+#
+# Cleanup
+#
+DROP PROCEDURE p1;
+DROP PROCEDURE p2;
+DROP PROCEDURE p3;
+DROP PROCEDURE p4;
+DROP PROCEDURE p5;
+DROP PROCEDURE p6;
+DROP PROCEDURE p7;
+DROP TABLE t1;

--- a/mysql-test/main/select_into_parens.test
+++ b/mysql-test/main/select_into_parens.test
@@ -1,0 +1,151 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-39176: Allow parenthesized SELECT INTO in stored procedures
+--echo #
+
+CREATE TABLE t1 (a INT, b VARCHAR(32));
+INSERT INTO t1 VALUES (1, 'one'), (2, 'two'), (3, 'three');
+
+--echo #
+--echo # Test 1: Basic parenthesized SELECT INTO in stored procedure
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p1(IN p INT)
+BEGIN
+  DECLARE v INT;
+  (SELECT a INTO v FROM t1 WHERE a = p LIMIT 1);
+  SELECT v AS result;
+END//
+DELIMITER ;//
+
+CALL p1(2);
+
+--echo #
+--echo # Test 2: Parenthesized SELECT INTO with multiple variables
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p2(IN p INT)
+BEGIN
+  DECLARE va INT;
+  DECLARE vb VARCHAR(32);
+  (SELECT a, b INTO va, vb FROM t1 WHERE a = p LIMIT 1);
+  SELECT va, vb;
+END//
+DELIMITER ;//
+
+CALL p2(1);
+
+--echo #
+--echo # Test 3: Parenthesized SELECT INTO inside IF block (original bug report)
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p3(IN in_var INT)
+BEGIN
+  DECLARE ivar INT;
+  IF in_var IS NOT NULL THEN
+    (SELECT a INTO ivar FROM t1 WHERE a = in_var LIMIT 1);
+  END IF;
+  SELECT ivar AS result;
+END//
+DELIMITER ;//
+
+CALL p3(3);
+CALL p3(NULL);
+
+--echo #
+--echo # Test 4: Double parentheses
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p4(IN p INT)
+BEGIN
+  DECLARE v INT;
+  ((SELECT a INTO v FROM t1 WHERE a = p LIMIT 1));
+  SELECT v AS result;
+END//
+DELIMITER ;//
+
+CALL p4(1);
+
+--echo #
+--echo # Test 5: Non-parenthesized SELECT INTO still works
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p5(IN p INT)
+BEGIN
+  DECLARE v INT;
+  SELECT a INTO v FROM t1 WHERE a = p LIMIT 1;
+  SELECT v AS result;
+END//
+DELIMITER ;//
+
+CALL p5(3);
+
+--echo #
+--echo # Test 6: Parenthesized SELECT INTO with UNION should error
+--echo #
+--error ER_PARSE_ERROR
+(SELECT 1 INTO @var) UNION (SELECT 1);
+
+--error ER_PARSE_ERROR
+(SELECT 1) UNION (SELECT 1 INTO @var);
+
+--echo #
+--echo # Test 7: Parenthesized SELECT INTO with WITH clause in stored procedure
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p6(IN p INT)
+BEGIN
+  DECLARE v INT;
+  (WITH cte AS (SELECT a FROM t1 WHERE a = p) SELECT a INTO v FROM cte LIMIT 1);
+  SELECT v AS result;
+END//
+DELIMITER ;//
+
+CALL p6(2);
+
+--echo #
+--echo # Test 8: Parenthesized SELECT INTO with ORDER BY and LIMIT
+--echo #
+DELIMITER //;
+CREATE PROCEDURE p7(IN p INT)
+BEGIN
+  DECLARE v INT;
+  (SELECT a INTO v FROM t1 WHERE a <= p ORDER BY a DESC LIMIT 1);
+  SELECT v AS result;
+END//
+DELIMITER ;//
+
+CALL p7(3);
+
+--echo #
+--echo # Test 9: SET var = (SELECT INTO) should error (subquery context)
+--echo #
+DELIMITER //;
+--error ER_PARSE_ERROR
+CREATE PROCEDURE p_bad()
+BEGIN
+  DECLARE var1 VARCHAR(10);
+  DECLARE var2 VARCHAR(10);
+  SET var1 = (SELECT 'val' INTO var2);
+  SELECT var1, var2;
+END//
+DELIMITER ;//
+
+--echo #
+--echo # Test 10: Top-level parenthesized SELECT INTO (outside stored procedure)
+--echo #
+(SELECT 1 INTO @var);
+SELECT @var;
+
+--echo #
+--echo # Cleanup
+--echo #
+DROP PROCEDURE p1;
+DROP PROCEDURE p2;
+DROP PROCEDURE p3;
+DROP PROCEDURE p4;
+DROP PROCEDURE p5;
+DROP PROCEDURE p6;
+DROP PROCEDURE p7;
+DROP TABLE t1;

--- a/mysql-test/main/union.result
+++ b/mysql-test/main/union.result
@@ -1538,7 +1538,7 @@ SELECT a FROM (SELECT a FROM t1 UNION SELECT a FROM t1 ORDER BY c) AS test;
 ERROR 42S22: Unknown column 'c' in 'ORDER BY'
 DROP TABLE t1;
 (select 1 into @var) union (select 1);
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'into @var) union (select 1)' at line 1
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'union (select 1)' at line 1
 (select 1) union (select 1 into @var);
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'into @var)' at line 1
 select @var;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -9152,6 +9152,7 @@ select_into:
             if (Lex->select_finalize(unit))
               MYSQL_YYABORT;
           }
+        | '(' select_into ')' {}
         ;
 
 simple_table:


### PR DESCRIPTION
## Description

Allow parenthesized SELECT ... INTO statements inside stored procedures to improve MySQL compatibility. Currently, MariaDB's parser rejects the parenthesized form, causing syntax errors (Error 1064).

## Release Notes

N/A

## How can this PR be tested?

* [x] All MTR tests pass.
* [x] New test `main.select_into_parens` added with 10 test cases:
  1. Basic parenthesized SELECT INTO — `(SELECT a INTO v FROM t1 WHERE a = p LIMIT 1)` with single variable assignment
  2. Multiple variables — `(SELECT a, b INTO va, vb ...)` with two variables assigned at once
  3. Inside IF block — the original bug report scenario, `IF ... THEN (SELECT INTO ...) END IF`
  4. Double parentheses — `((SELECT a INTO v ...))` to verify recursive nesting
  5. Regression check — non-parenthesized `SELECT INTO` to confirm existing syntax is not broken
  6. UNION with parenthesized SELECT INTO — confirms `(SELECT INTO) UNION (SELECT)` correctly errors
  7. WITH clause — `(WITH cte AS (...) SELECT INTO ...)` works in stored procedure
  8. ORDER BY and LIMIT — `(SELECT INTO ... ORDER BY ... LIMIT 1)` works in stored procedure
  9. SET var = (SELECT INTO) — confirms subquery context correctly errors
  10. Top-level parenthesized SELECT INTO — `(SELECT 1 INTO @var)` works outside stored procedure
* [x] Verify that parenthesized SELECT INTO works inside stored procedures:

### Before the fix

```
MariaDB [test]> DELIMITER //
MariaDB [test]> CREATE PROCEDURE test_proc(IN in_var INT)
    -> BEGIN
    ->   DECLARE ivar INT;
    ->   IF in_var IS NOT NULL THEN
    ->     (SELECT a INTO ivar FROM t1 WHERE a = in_var LIMIT 1);
    ->   END IF;
    ->   SELECT ivar AS result;
    -> END//
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'INTO ivar FROM t1 WHERE a = in_var LIMIT 1);
  END IF;
  SELECT ivar AS resul...' at line 5
```

### After the fix

```
MariaDB [test]> CREATE TABLE t1 (a INT);
Query OK, 0 rows affected (0.014 sec)

MariaDB [test]> INSERT INTO t1 VALUES (1), (2), (3);
Query OK, 3 rows affected (0.002 sec)
Records: 3  Duplicates: 0  Warnings: 0

MariaDB [test]> DELIMITER //
MariaDB [test]> CREATE PROCEDURE test_proc(IN in_var INT)
    -> BEGIN
    ->   DECLARE ivar INT;
    ->   IF in_var IS NOT NULL THEN
    ->     (SELECT a INTO ivar FROM t1 WHERE a = in_var LIMIT 1);
    ->   END IF;
    ->   SELECT ivar AS result;
    -> END//
Query OK, 0 rows affected (0.005 sec)

MariaDB [test]> DELIMITER ;
MariaDB [test]> CALL test_proc(1);
+--------+
| result |
+--------+
|      1 |
+--------+
1 row in set (0.000 sec)

Query OK, 1 row affected (0.001 sec)
```

## **Basing the PR against the correct MariaDB version**

* [x] _This is a parser compatibility improvement, and the PR is based against the latest MariaDB development branch._

## **Copyright**

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.