### PR TITLE
MDEV-38486: Semi-sync must not await ACK for @@skip_replication events

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_skip_replication.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_skip_replication.result
@@ -1,0 +1,185 @@
+include/rpl_init.inc [topology=1->2,1->3]
+#
+# Setup: primary and two semi-sync slaves with different skip filtering:
+#   server_2: replicate_events_marked_for_skip = FILTER_ON_MASTER
+#   server_3: replicate_events_marked_for_skip = REPLICATE (default)
+#
+connection server_1;
+SET @old_master_enabled= @@global.rpl_semi_sync_master_enabled;
+SET @old_master_timeout= @@global.rpl_semi_sync_master_timeout;
+SET @old_wait_point= @@global.rpl_semi_sync_master_wait_point;
+SET GLOBAL rpl_semi_sync_master_timeout= 2000;
+SET GLOBAL rpl_semi_sync_master_enabled= 1;
+connection server_2;
+include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+include/start_slave.inc
+connection server_3;
+include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+include/start_slave.inc
+connection server_1;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
+#
+# Wait point: AFTER_SYNC
+#
+connection server_3;
+SET @skip_before= @@global.replicate_events_marked_for_skip;
+connection server_1;
+# Baseline: a normal transaction is ACKed and reaches both slaves.
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+#
+# Case 1 (mixed filtering): server_3 replicates skip_replication events,
+# so it ACKs them and semi-sync must stay in effect.
+#
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip;
+CREATE TABLE db_skip.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+# Semi-sync stayed ON and Rpl_semi_sync_master_yes_tx advanced -- PASS
+# Marker transaction, so both slaves can be synced past the skip events.
+INSERT INTO t1 VALUES (2);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+# server_3 (REPLICATE) applied the skip_replication changes.
+connection server_3;
+# server_2 (FILTER_ON_MASTER) never received them.
+connection server_2;
+#
+# Case 2 (all slaves filter): reconfigure server_3 to FILTER_ON_MASTER,
+# so that no connected slave receives skip_replication events. Such a
+# transaction can never be ACKed: the master must not await an ACK, and
+# must not count one as either granted or missed.
+#
+connection server_3;
+include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+include/start_slave.inc
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip2;
+CREATE TABLE db_skip2.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip2.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+# Semi-sync stayed ON and no ACK was requested, granted or missed -- PASS
+#
+# Cleanup
+#
+connection server_1;
+DROP DATABASE IF EXISTS db_skip;
+DROP DATABASE IF EXISTS db_skip2;
+DROP TABLE t1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+# Restore server_3 to the filtering it was called with.
+connection server_3;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= @skip_before;
+include/start_slave.inc
+connection server_1;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+#
+# Wait point: AFTER_COMMIT
+#
+connection server_3;
+SET @skip_before= @@global.replicate_events_marked_for_skip;
+connection server_1;
+# Baseline: a normal transaction is ACKed and reaches both slaves.
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+#
+# Case 1 (mixed filtering): server_3 replicates skip_replication events,
+# so it ACKs them and semi-sync must stay in effect.
+#
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip;
+CREATE TABLE db_skip.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+# Semi-sync stayed ON and Rpl_semi_sync_master_yes_tx advanced -- PASS
+# Marker transaction, so both slaves can be synced past the skip events.
+INSERT INTO t1 VALUES (2);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+# server_3 (REPLICATE) applied the skip_replication changes.
+connection server_3;
+# server_2 (FILTER_ON_MASTER) never received them.
+connection server_2;
+#
+# Case 2 (all slaves filter): reconfigure server_3 to FILTER_ON_MASTER,
+# so that no connected slave receives skip_replication events. Such a
+# transaction can never be ACKed: the master must not await an ACK, and
+# must not count one as either granted or missed.
+#
+connection server_3;
+include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+include/start_slave.inc
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip2;
+CREATE TABLE db_skip2.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip2.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+# Semi-sync stayed ON and no ACK was requested, granted or missed -- PASS
+#
+# Cleanup
+#
+connection server_1;
+DROP DATABASE IF EXISTS db_skip;
+DROP DATABASE IF EXISTS db_skip2;
+DROP TABLE t1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+# Restore server_3 to the filtering it was called with.
+connection server_3;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= @skip_before;
+include/start_slave.inc
+#
+# Cleanup
+#
+connection server_1;
+SET GLOBAL rpl_semi_sync_master_wait_point= @old_wait_point;
+SET GLOBAL rpl_semi_sync_master_enabled= @old_master_enabled;
+SET GLOBAL rpl_semi_sync_master_timeout= @old_master_timeout;
+connection server_2;
+include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+include/start_slave.inc
+connection server_3;
+include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+include/start_slave.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_skip_replication.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_skip_replication.result
@@ -1,0 +1,103 @@
+include/rpl_init.inc [topology=1->2,1->3]
+#
+# Setup: master + two semi-sync slaves with DIFFERENT skip filtering:
+#   server_2: replicate_events_marked_for_skip = FILTER_ON_MASTER
+#   server_3: replicate_events_marked_for_skip = REPLICATE (default)
+#
+connection server_1;
+call mtr.add_suppression("Timeout waiting for reply of binlog");
+SET @old_master_enabled= @@global.rpl_semi_sync_master_enabled;
+SET @old_master_timeout= @@global.rpl_semi_sync_master_timeout;
+SET GLOBAL rpl_semi_sync_master_timeout= 2000;
+SET GLOBAL rpl_semi_sync_master_enabled= 1;
+connection server_2;
+include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+include/start_slave.inc
+connection server_3;
+include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+include/start_slave.inc
+# Wait until the primary sees both semi-sync slaves.
+connection server_1;
+#
+# Baseline: a normal transaction is ACKed and replicated to both slaves.
+#
+connection server_1;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+#
+# Case 1 (mixed filtering): a @@skip_replication=1 transaction.
+# server_3 (REPLICATE) still receives and ACKs it, so semi-sync must NOT
+# be bypassed: Rpl_semi_sync_master_yes_tx must advance and the status
+# must stay ON (no timeout, no degradation to async).
+#
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip;
+CREATE TABLE db_skip.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+# Semi-sync still ON and Rpl_semi_sync_master_yes_tx advanced -- PASS
+# Marker transaction so both slaves can be synced past the skip events.
+connection server_1;
+INSERT INTO t1 VALUES (2);
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+# server_3 (REPLICATE) applied the skip_replication changes.
+connection server_3;
+# server_2 (FILTER_ON_MASTER) never received the skip_replication changes.
+connection server_2;
+#
+# Case 2 (all slaves filter): reconfigure server_3 to FILTER_ON_MASTER so
+# that NO connected slave receives skip_replication events. Now such a
+# transaction can never be ACKed, so the primary must NOT await one -- it
+# must return immediately and stay ON (the hang the fix prevents).
+#
+connection server_3;
+include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+include/start_slave.inc
+# Wait until the primary again sees both semi-sync slaves.
+connection server_1;
+connection server_1;
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip2;
+SET SESSION skip_replication= 0;
+# Semi-sync still ON with no slave able to ACK -- PASS
+#
+# Cleanup
+#
+connection server_1;
+DROP DATABASE IF EXISTS db_skip;
+DROP DATABASE IF EXISTS db_skip2;
+DROP TABLE t1;
+SET GLOBAL rpl_semi_sync_master_enabled= @old_master_enabled;
+SET GLOBAL rpl_semi_sync_master_timeout= @old_master_timeout;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+include/start_slave.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+include/start_slave.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.cnf
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.cnf
@@ -1,0 +1,12 @@
+!include include/default_mysqld.cnf
+
+[mysqld.1]
+
+[mysqld.2]
+
+[mysqld.3]
+
+[ENV]
+SERVER_MYPORT_1= @mysqld.1.port
+SERVER_MYPORT_2= @mysqld.2.port
+SERVER_MYPORT_3= @mysqld.3.port

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.inc
@@ -1,0 +1,173 @@
+#
+# Check how semi-sync accounts for transactions and events which are marked
+# with @@skip_replication, at the wait point configured by the caller.
+#
+# Whether such an event is really filtered away is decided by the slave,
+# through --replicate-events-marked-for-skip: only FILTER_ON_MASTER makes the
+# master's dump thread drop the event before sending it. A slave using the
+# default (REPLICATE) receives such events and ACKs them, and each connected
+# slave may use a different value.
+#
+#   Case 1 (mixed filtering) server_2 filters, server_3 replicates. server_3
+#           receives and ACKs the transaction, so semi-sync must behave exactly
+#           as it does for any other transaction.
+#   Case 2 (all slaves filter) both slaves filter. No connected slave can ever
+#           ACK the transaction, so the master must neither await an ACK nor
+#           account for one. Before MDEV-38486 it blocked until
+#           rpl_semi_sync_master_timeout expired and degraded to asynchronous.
+#
+# Both cases exercise the two paths which register a transaction for an ACK:
+# CREATE DATABASE takes the direct binlog write path, the InnoDB transaction
+# takes the group commit leader path.
+#
+# Parameters:
+#   $wait_point (string)  The rpl_semi_sync_master_wait_point in use. Only used
+#                         to label the test output.
+#
+# Requirements:
+#   Topology 1->2,1->3 with semi-sync enabled on all three servers, server_2
+#   running with replicate_events_marked_for_skip=FILTER_ON_MASTER and server_3
+#   with the default REPLICATE. server_3 is restored to REPLICATE on the way
+#   out, so this file can be sourced repeatedly.
+#
+
+--echo #
+--echo # Wait point: $wait_point
+--echo #
+
+--connection server_3
+SET @skip_before= @@global.replicate_events_marked_for_skip;
+
+--connection server_1
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 2
+--source include/wait_for_status_var.inc
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die Rpl_semi_sync_master_status must be ON before the test
+}
+
+--echo # Baseline: a normal transaction is ACKed and reaches both slaves.
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--connection server_3
+--source include/sync_with_master_gtid.inc
+
+--echo #
+--echo # Case 1 (mixed filtering): server_3 replicates skip_replication events,
+--echo # so it ACKs them and semi-sync must stay in effect.
+--echo #
+--connection server_1
+--let $yes_before= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip;
+CREATE TABLE db_skip.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die semi-sync degraded although a slave which replicates skip events was connected
+}
+--let $yes_after= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+if (`SELECT $yes_after <= $yes_before`)
+{
+  --die semi-sync did not await an ACK for a skip_replication txn a slave replicates
+}
+--echo # Semi-sync stayed ON and Rpl_semi_sync_master_yes_tx advanced -- PASS
+
+--echo # Marker transaction, so both slaves can be synced past the skip events.
+INSERT INTO t1 VALUES (2);
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--connection server_3
+--source include/sync_with_master_gtid.inc
+
+--echo # server_3 (REPLICATE) applied the skip_replication changes.
+--connection server_3
+if (`SELECT COUNT(*) <> 1 FROM db_skip.t1`)
+{
+  --die server_3 (REPLICATE) should have received the skip_replication changes
+}
+--echo # server_2 (FILTER_ON_MASTER) never received them.
+--connection server_2
+if (`SELECT COUNT(*) <> 0 FROM information_schema.schemata WHERE schema_name='db_skip'`)
+{
+  --die server_2 (FILTER_ON_MASTER) must not have received the filtered database
+}
+
+--echo #
+--echo # Case 2 (all slaves filter): reconfigure server_3 to FILTER_ON_MASTER,
+--echo # so that no connected slave receives skip_replication events. Such a
+--echo # transaction can never be ACKed: the master must not await an ACK, and
+--echo # must not count one as either granted or missed.
+--echo #
+--connection server_3
+--source include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+--source include/start_slave.inc
+
+--connection server_1
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 2
+--source include/wait_for_status_var.inc
+
+--let $yes_before= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+--let $no_before= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_no_tx', Value, 1)
+--let $ack_before= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_request_ack', Value, 1)
+
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip2;
+CREATE TABLE db_skip2.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip2.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die semi-sync degraded: the master awaited an ACK which no slave can send
+}
+
+--let $ack_after= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_request_ack', Value, 1)
+if (`SELECT $ack_after <> $ack_before`)
+{
+  --die an ACK was requested for a transaction which reaches no slave
+}
+--let $yes_after= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+--let $no_after= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_no_tx', Value, 1)
+if (`SELECT $yes_after <> $yes_before OR $no_after <> $no_before`)
+{
+  --die the master waited for, and accounted for, an ACK it never requested
+}
+--echo # Semi-sync stayed ON and no ACK was requested, granted or missed -- PASS
+
+--echo #
+--echo # Cleanup
+--echo #
+--connection server_1
+# IF EXISTS because the slaves which filtered the CREATE never got the
+# database, while the DROP itself is replicated to them.
+DROP DATABASE IF EXISTS db_skip;
+DROP DATABASE IF EXISTS db_skip2;
+DROP TABLE t1;
+--source include/save_master_gtid.inc
+
+--connection server_2
+--source include/sync_with_master_gtid.inc
+
+--echo # Restore server_3 to the filtering it was called with.
+--connection server_3
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= @skip_before;
+--source include/start_slave.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.test
@@ -1,0 +1,87 @@
+#
+# Purpose:
+#   Semi-sync must not await an ACK for a @@skip_replication transaction which
+# no connected slave will receive, but it must still await one when at least
+# one connected slave replicates such transactions.
+#
+# Methodology:
+#   One primary with two semi-sync replicas which use different values of
+# --replicate-events-marked-for-skip, so that both the mixed case and the
+# all-slaves-filter case are covered. The whole scenario is run once per
+# rpl_semi_sync_master_wait_point value, because the ACK is awaited in a
+# different place for each of them: the binlog group commit leader waits for
+# AFTER_SYNC, while the user thread waits after the engine commit for
+# AFTER_COMMIT.
+#
+# References:
+#   MDEV-38486: Semi-sync master hangs on @@skip_replication transactions
+#
+--source include/have_binlog_format_row.inc
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+--let $rpl_topology= 1->2,1->3
+--source include/rpl_init.inc
+
+--echo #
+--echo # Setup: primary and two semi-sync slaves with different skip filtering:
+--echo #   server_2: replicate_events_marked_for_skip = FILTER_ON_MASTER
+--echo #   server_3: replicate_events_marked_for_skip = REPLICATE (default)
+--echo #
+
+--connection server_1
+SET @old_master_enabled= @@global.rpl_semi_sync_master_enabled;
+SET @old_master_timeout= @@global.rpl_semi_sync_master_timeout;
+SET @old_wait_point= @@global.rpl_semi_sync_master_wait_point;
+# Keep the timeout short: if the primary ever awaits an ACK which cannot come,
+# it degrades to asynchronous within this many milliseconds and the test fails
+# on Rpl_semi_sync_master_status instead of hanging.
+SET GLOBAL rpl_semi_sync_master_timeout= 2000;
+SET GLOBAL rpl_semi_sync_master_enabled= 1;
+
+--connection server_2
+--source include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+--source include/start_slave.inc
+
+--connection server_3
+--source include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+--source include/start_slave.inc
+
+--connection server_1
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
+--let $wait_point= AFTER_SYNC
+--source suite/rpl/t/rpl_semi_sync_skip_replication.inc
+
+--connection server_1
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+--let $wait_point= AFTER_COMMIT
+--source suite/rpl/t/rpl_semi_sync_skip_replication.inc
+
+--echo #
+--echo # Cleanup
+--echo #
+--connection server_1
+SET GLOBAL rpl_semi_sync_master_wait_point= @old_wait_point;
+SET GLOBAL rpl_semi_sync_master_enabled= @old_master_enabled;
+SET GLOBAL rpl_semi_sync_master_timeout= @old_master_timeout;
+
+--connection server_2
+--source include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+--source include/start_slave.inc
+
+--connection server_3
+--source include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_skip_replication.test
@@ -1,0 +1,182 @@
+#
+# MDEV-38486: Semi-sync must not await an ACK for a @@skip_replication=1
+# transaction that no connected slave will receive, but it MUST still await an
+# ACK when at least one connected slave replicates such transactions.
+#
+# Whether a skip_replication event is actually filtered is decided by the
+# slave, via --replicate-events-marked-for-skip: only FILTER_ON_MASTER makes
+# the master's dump thread drop the event before it is sent. A slave using the
+# default (REPLICATE) still receives skip_replication events and ACKs them, so
+# semi-sync must keep working for it. It is also possible to have several slaves
+# connected, each with a different value.
+#
+# This test uses two slaves with different values to cover both the mixed case
+# (one FILTER_ON_MASTER slave and one REPLICATE slave) and the all-filter case
+# (every slave FILTER_ON_MASTER), which is the case that used to hang the
+# primary until rpl_semi_sync_master_timeout and degrade it to async.
+#
+--source include/have_binlog_format_row.inc
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+--let $rpl_topology= 1->2,1->3
+--source include/rpl_init.inc
+
+--echo #
+--echo # Setup: master + two semi-sync slaves with DIFFERENT skip filtering:
+--echo #   server_2: replicate_events_marked_for_skip = FILTER_ON_MASTER
+--echo #   server_3: replicate_events_marked_for_skip = REPLICATE (default)
+--echo #
+
+--connection server_1
+call mtr.add_suppression("Timeout waiting for reply of binlog");
+SET @old_master_enabled= @@global.rpl_semi_sync_master_enabled;
+SET @old_master_timeout= @@global.rpl_semi_sync_master_timeout;
+SET GLOBAL rpl_semi_sync_master_timeout= 2000;
+SET GLOBAL rpl_semi_sync_master_enabled= 1;
+
+--connection server_2
+--source include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+--source include/start_slave.inc
+
+--connection server_3
+--source include/stop_slave.inc
+SET @old_slave_enabled= @@global.rpl_semi_sync_slave_enabled;
+SET @old_skip= @@global.replicate_events_marked_for_skip;
+SET GLOBAL rpl_semi_sync_slave_enabled= 1;
+--source include/start_slave.inc
+
+--echo # Wait until the primary sees both semi-sync slaves.
+--connection server_1
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 2
+--source include/wait_for_status_var.inc
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die Rpl_semi_sync_master_status must be ON before the test
+}
+
+--echo #
+--echo # Baseline: a normal transaction is ACKed and replicated to both slaves.
+--echo #
+--connection server_1
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--connection server_3
+--source include/sync_with_master_gtid.inc
+
+--echo #
+--echo # Case 1 (mixed filtering): a @@skip_replication=1 transaction.
+--echo # server_3 (REPLICATE) still receives and ACKs it, so semi-sync must NOT
+--echo # be bypassed: Rpl_semi_sync_master_yes_tx must advance and the status
+--echo # must stay ON (no timeout, no degradation to async).
+--echo #
+--connection server_1
+--let $yes_before= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip;
+CREATE TABLE db_skip.t1 (a INT) ENGINE=InnoDB;
+INSERT INTO db_skip.t1 VALUES (1);
+SET SESSION skip_replication= 0;
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die semi-sync degraded: primary timed out although a REPLICATE slave was connected
+}
+--let $yes_after= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+if (`SELECT $yes_after <= $yes_before`)
+{
+  --die semi-sync ACK was not awaited for a skip_replication txn a slave replicates
+}
+--echo # Semi-sync still ON and Rpl_semi_sync_master_yes_tx advanced -- PASS
+
+--echo # Marker transaction so both slaves can be synced past the skip events.
+--connection server_1
+INSERT INTO t1 VALUES (2);
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--connection server_3
+--source include/sync_with_master_gtid.inc
+
+--echo # server_3 (REPLICATE) applied the skip_replication changes.
+--connection server_3
+if (`SELECT COUNT(*) <> 1 FROM db_skip.t1`)
+{
+  --die server_3 (REPLICATE) should have received the skip_replication changes
+}
+--echo # server_2 (FILTER_ON_MASTER) never received the skip_replication changes.
+--connection server_2
+if (`SELECT COUNT(*) <> 0 FROM information_schema.schemata WHERE schema_name='db_skip'`)
+{
+  --die server_2 (FILTER_ON_MASTER) must not have received the filtered database
+}
+
+--echo #
+--echo # Case 2 (all slaves filter): reconfigure server_3 to FILTER_ON_MASTER so
+--echo # that NO connected slave receives skip_replication events. Now such a
+--echo # transaction can never be ACKed, so the primary must NOT await one -- it
+--echo # must return immediately and stay ON (the hang the fix prevents).
+--echo #
+--connection server_3
+--source include/stop_slave.inc
+SET GLOBAL replicate_events_marked_for_skip= FILTER_ON_MASTER;
+--source include/start_slave.inc
+
+--echo # Wait until the primary again sees both semi-sync slaves.
+--connection server_1
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 2
+--source include/wait_for_status_var.inc
+
+--connection server_1
+SET SESSION skip_replication= 1;
+CREATE DATABASE db_skip2;
+SET SESSION skip_replication= 0;
+
+--let $ss= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_status', Value, 1)
+if (`SELECT strcmp("$ss","ON") != 0`)
+{
+  SHOW STATUS LIKE 'Rpl_semi_sync_master_status';
+  --die semi-sync degraded: primary awaited an ACK that no slave can ever send
+}
+--echo # Semi-sync still ON with no slave able to ACK -- PASS
+
+--echo #
+--echo # Cleanup
+--echo #
+--connection server_1
+DROP DATABASE IF EXISTS db_skip;
+DROP DATABASE IF EXISTS db_skip2;
+DROP TABLE t1;
+SET GLOBAL rpl_semi_sync_master_enabled= @old_master_enabled;
+SET GLOBAL rpl_semi_sync_master_timeout= @old_master_timeout;
+--source include/save_master_gtid.inc
+
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+--source include/start_slave.inc
+
+--connection server_3
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+SET GLOBAL rpl_semi_sync_slave_enabled= @old_slave_enabled;
+SET GLOBAL replicate_events_marked_for_skip= @old_skip;
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7217,7 +7217,19 @@ err:
           mysql_mutex_assert_not_owner(&LOCK_after_binlog_sync);
           mysql_mutex_assert_not_owner(&LOCK_commit_ordered);
 #ifdef HAVE_REPLICATION
-          if (repl_semisync_master.report_binlog_update(thd, thd,
+          /*
+            MDEV-38486: Do not await a semi-sync ACK for an event marked with
+            LOG_EVENT_SKIP_REPLICATION_F when every connected semi-sync slave
+            requested master-side filtering (FILTER_ON_MASTER). Such an event
+            is sent to no slave and can never be ACKed, so awaiting it would
+            hang the primary until rpl_semi_sync_master_timeout. When at least
+            one slave does not filter, that slave still receives and ACKs the
+            event, so the normal semi-sync wait must apply.
+          */
+          if (!((event_info->flags & LOG_EVENT_SKIP_REPLICATION_F) &&
+                repl_semisync_master.
+                  all_semi_sync_slaves_filter_skip_replication()) &&
+              repl_semisync_master.report_binlog_update(thd, thd,
                                                         log_file_name, offset))
           {
             sql_print_error("Failed to run 'after_flush' hooks");
@@ -8833,7 +8845,19 @@ MYSQL_BIN_LOG::trx_group_commit_leader(group_commit_entry *leader)
                           SEMI_SYNC_MASTER_WAIT_POINT_AFTER_STORAGE_COMMIT)
                              ? current->thd
                              : leader->thd;
+        /*
+          MDEV-38486: Do not await a semi-sync ACK for a transaction committed
+          with @@skip_replication=1 when every connected semi-sync slave
+          requested master-side filtering (FILTER_ON_MASTER). Such a
+          transaction is sent to no slave and can never be ACKed, so awaiting
+          it would hang the primary until rpl_semi_sync_master_timeout. When at
+          least one slave does not filter, that slave still receives and ACKs
+          the transaction, so the normal semi-sync wait must apply.
+        */
         if (likely(!current->error) &&
+            !((current->thd->variables.option_bits & OPTION_SKIP_REPLICATION) &&
+              repl_semisync_master.
+                all_semi_sync_slaves_filter_skip_replication()) &&
             unlikely(repl_semisync_master.
                      report_binlog_update(current->thd, waiter_thd,
                                           current->cache_mngr->

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7202,6 +7202,28 @@ err:
       my_off_t offset= my_b_tell(file);
       bool check_purge= false;
       DBUG_ASSERT(!is_relay_log);
+#ifdef HAVE_REPLICATION
+      /*
+        An event flagged LOG_EVENT_SKIP_REPLICATION_F is dropped by the dump
+        thread of every slave which connected with
+        --replicate-events-marked-for-skip=FILTER_ON_MASTER. If no connected
+        semi-sync slave replicates such events, this one reaches nobody and can
+        never be ACKed; awaiting an ACK would block the commit until
+        rpl_semi_sync_master_timeout expires and degrade semi-sync to
+        asynchronous. So neither register the event for an ACK below nor wait
+        for one further down.
+
+        The decision is taken once and reused by the wait, so that a slave
+        connecting or disconnecting in between cannot make us wait for an ACK
+        which was never requested, which would leave the semi-sync counters
+        inconsistent.
+      */
+      const bool semisync_skip_ack=
+        (event_info->flags & LOG_EVENT_SKIP_REPLICATION_F) &&
+        repl_semisync_master.no_slave_receives_skip_replication_events();
+      if (semisync_skip_ack)
+        repl_semisync_master.skip_ack_wait(thd);
+#endif
 
       if (likely(!error))
       {
@@ -7217,7 +7239,8 @@ err:
           mysql_mutex_assert_not_owner(&LOCK_after_binlog_sync);
           mysql_mutex_assert_not_owner(&LOCK_commit_ordered);
 #ifdef HAVE_REPLICATION
-          if (repl_semisync_master.report_binlog_update(thd, thd,
+          if (!semisync_skip_ack &&
+              repl_semisync_master.report_binlog_update(thd, thd,
                                                         log_file_name, offset))
           {
             sql_print_error("Failed to run 'after_flush' hooks");
@@ -7252,7 +7275,8 @@ err:
       mysql_mutex_assert_owner(&LOCK_after_binlog_sync);
       mysql_mutex_assert_not_owner(&LOCK_commit_ordered);
 #ifdef HAVE_REPLICATION
-      if (repl_semisync_master.wait_after_sync(log_file_name, offset))
+      if (!semisync_skip_ack &&
+          repl_semisync_master.wait_after_sync(log_file_name, offset))
       {
         error=1;
         /* error is already printed inside hook */
@@ -8131,6 +8155,7 @@ MYSQL_BIN_LOG::write_transaction_to_binlog(THD *thd,
   entry.cache_mngr= cache_mngr;
   entry.error= 0;
   entry.all= all;
+  entry.semisync_skip_ack= false;
   entry.using_stmt_cache= using_stmt_cache;
   entry.using_trx_cache= using_trx_cache;
   entry.need_unlog= is_preparing_xa(thd);
@@ -8833,13 +8858,31 @@ MYSQL_BIN_LOG::trx_group_commit_leader(group_commit_entry *leader)
                           SEMI_SYNC_MASTER_WAIT_POINT_AFTER_STORAGE_COMMIT)
                              ? current->thd
                              : leader->thd;
-        if (likely(!current->error) &&
-            unlikely(repl_semisync_master.
-                     report_binlog_update(current->thd, waiter_thd,
-                                          current->cache_mngr->
-                                          last_commit_pos_file,
-                                          current->cache_mngr->
-                                          last_commit_pos_offset)))
+        /*
+          A transaction committed with @@skip_replication=1 is dropped by the
+          dump thread of every slave which connected with
+          --replicate-events-marked-for-skip=FILTER_ON_MASTER. If no connected
+          semi-sync slave replicates such transactions, this one reaches nobody
+          and can never be ACKed; awaiting an ACK would block the commit until
+          rpl_semi_sync_master_timeout expires and degrade semi-sync to
+          asynchronous. So do not register it for an ACK, and remember that in
+          the entry so that the wait further down is skipped as well -- waiting
+          for an ACK which was never requested would leave the semi-sync
+          counters inconsistent.
+        */
+        current->semisync_skip_ack=
+          (current->thd->variables.option_bits & OPTION_SKIP_REPLICATION) &&
+          repl_semisync_master.no_slave_receives_skip_replication_events();
+
+        if (current->semisync_skip_ack)
+          repl_semisync_master.skip_ack_wait(current->thd);
+        else if (likely(!current->error) &&
+                 unlikely(repl_semisync_master.
+                          report_binlog_update(current->thd, waiter_thd,
+                                               current->cache_mngr->
+                                               last_commit_pos_file,
+                                               current->cache_mngr->
+                                               last_commit_pos_offset)))
         {
           current->error= ER_ERROR_ON_WRITE;
           current->commit_errno= -1;
@@ -8922,7 +8965,7 @@ MYSQL_BIN_LOG::trx_group_commit_leader(group_commit_entry *leader)
     {
       last= current->next == NULL;
 #ifdef HAVE_REPLICATION
-      if (likely(!current->error))
+      if (likely(!current->error) && !current->semisync_skip_ack)
         current->error=
           repl_semisync_master.wait_after_sync(current->cache_mngr->
                                                last_commit_pos_file,

--- a/sql/log.h
+++ b/sql/log.h
@@ -486,6 +486,12 @@ class MYSQL_BIN_LOG: public TC_LOG, private MYSQL_LOG
     bool check_purge;
     /* Flag used to optimise around wait_for_prior_commit. */
     bool queued_by_other;
+    /*
+      Set during group commit if this transaction was deliberately not
+      registered for a semi-sync ACK, so that the wait for that ACK is skipped
+      as well.
+    */
+    bool semisync_skip_ack;
     ulong binlog_id;
     bool ro_1pc;  // passes the binlog_cache_mngr::ro_1pc value to Gtid ctor
   };

--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -417,6 +417,7 @@ Active_tranx::is_thd_waiter(THD *thd_to_check, const char *log_file_name,
 Repl_semi_sync_master::Repl_semi_sync_master()
   : m_active_tranxs(NULL),
     m_init_done(false),
+    m_slaves_with_master_filtering(0),
     m_reply_file_name_inited(false),
     m_reply_file_pos(0L),
     m_wait_file_name_inited(false),
@@ -565,17 +566,24 @@ void Repl_semi_sync_master::unlock()
   mysql_mutex_unlock(&LOCK_binlog);
 }
 
-void Repl_semi_sync_master::add_slave()
+void Repl_semi_sync_master::add_slave(bool filter_skip_on_master)
 {
   lock();
   rpl_semi_sync_master_clients++;
+  if (filter_skip_on_master)
+    m_slaves_with_master_filtering++;
   unlock();
 }
 
-void Repl_semi_sync_master::remove_slave()
+void Repl_semi_sync_master::remove_slave(bool filter_skip_on_master)
 {
   lock();
   DBUG_ASSERT(rpl_semi_sync_master_clients > 0);
+  if (filter_skip_on_master)
+  {
+    DBUG_ASSERT(m_slaves_with_master_filtering > 0);
+    m_slaves_with_master_filtering--;
+  }
   if (!(--rpl_semi_sync_master_clients) && !rpl_semi_sync_master_wait_no_slave
       && get_master_enabled())
   {
@@ -588,6 +596,17 @@ void Repl_semi_sync_master::remove_slave()
                                               signal_waiting_transaction);
   }
   unlock();
+}
+
+
+bool Repl_semi_sync_master::all_semi_sync_slaves_filter_skip_replication()
+{
+  bool res;
+  lock();
+  DBUG_ASSERT(m_slaves_with_master_filtering <= rpl_semi_sync_master_clients);
+  res= (rpl_semi_sync_master_clients == m_slaves_with_master_filtering);
+  unlock();
+  return res;
 }
 
 
@@ -841,7 +860,15 @@ int Repl_semi_sync_master::dump_start(THD* thd,
     return 1;
   }
 
-  add_slave();
+  /*
+    MDEV-38486: A slave running with --replicate-events-marked-for-skip=
+    FILTER_ON_MASTER asks the master to filter @@skip_replication events by
+    issuing "SET skip_replication=1" on the dump connection, which sets
+    OPTION_SKIP_REPLICATION on this dump thread. Remember that here so the
+    commit path can tell whether any connected slave would actually receive
+    (and thus ACK) a skip_replication transaction.
+  */
+  add_slave((thd->variables.option_bits & OPTION_SKIP_REPLICATION) != 0);
   report_reply_binlog(thd->variables.server_id,
                       log_file + dirname_length(log_file), log_pos);
   sql_print_information("Start semi-sync binlog_dump to slave "
@@ -862,7 +889,7 @@ void Repl_semi_sync_master::dump_end(THD* thd)
   sql_print_information("Stop semi-sync binlog_dump to slave (server_id: %ld)",
                         (long) thd->variables.server_id);
 
-  remove_slave();
+  remove_slave((thd->variables.option_bits & OPTION_SKIP_REPLICATION) != 0);
   ack_receiver.remove_slave(thd);
 }
 

--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -417,6 +417,7 @@ Active_tranx::is_thd_waiter(THD *thd_to_check, const char *log_file_name,
 Repl_semi_sync_master::Repl_semi_sync_master()
   : m_active_tranxs(NULL),
     m_init_done(false),
+    m_slaves_replicating_skip_events(0),
     m_reply_file_name_inited(false),
     m_reply_file_pos(0L),
     m_wait_file_name_inited(false),
@@ -565,14 +566,23 @@ void Repl_semi_sync_master::unlock()
   mysql_mutex_unlock(&LOCK_binlog);
 }
 
-void Repl_semi_sync_master::add_slave()
+void Repl_semi_sync_master::add_slave(bool filters_skip_events)
 {
+  /*
+    Count the slave as a receiver of skip_replication events before it is
+    counted as a client, and stop counting it as a receiver only after it has
+    stopped being a client (see remove_slave()). This way
+    no_slave_receives_skip_replication_events() never claims that nobody
+    receives such events while a slave which does is still connected.
+  */
+  if (!filters_skip_events)
+    m_slaves_replicating_skip_events++;
   lock();
   rpl_semi_sync_master_clients++;
   unlock();
 }
 
-void Repl_semi_sync_master::remove_slave()
+void Repl_semi_sync_master::remove_slave(bool filters_skip_events)
 {
   lock();
   DBUG_ASSERT(rpl_semi_sync_master_clients > 0);
@@ -588,6 +598,29 @@ void Repl_semi_sync_master::remove_slave()
                                               signal_waiting_transaction);
   }
   unlock();
+
+  if (!filters_skip_events)
+  {
+    DBUG_ASSERT(m_slaves_replicating_skip_events > 0);
+    m_slaves_replicating_skip_events--;
+  }
+}
+
+
+bool Repl_semi_sync_master::no_slave_receives_skip_replication_events()
+{
+  return rpl_semi_sync_master_clients > 0 &&
+         m_slaves_replicating_skip_events == 0;
+}
+
+
+void Repl_semi_sync_master::skip_ack_wait(THD *trans_thd)
+{
+  if (Trans_binlog_info *log_info= trans_thd->semisync_info)
+  {
+    log_info->log_file[0]= 0;
+    log_info->log_pos= 0;
+  }
 }
 
 
@@ -841,7 +874,15 @@ int Repl_semi_sync_master::dump_start(THD* thd,
     return 1;
   }
 
-  add_slave();
+  /*
+    A slave running with --replicate-events-marked-for-skip=FILTER_ON_MASTER
+    asks the master to filter away @@skip_replication events by issuing
+    "SET skip_replication=1" on the dump connection, which sets
+    OPTION_SKIP_REPLICATION on this dump thread. Remember that here, so the
+    commit path can tell whether any connected slave would actually receive
+    (and thus ACK) a skip_replication transaction.
+  */
+  add_slave((thd->variables.option_bits & OPTION_SKIP_REPLICATION) != 0);
   report_reply_binlog(thd->variables.server_id,
                       log_file + dirname_length(log_file), log_pos);
   sql_print_information("Start semi-sync binlog_dump to slave "
@@ -862,7 +903,7 @@ void Repl_semi_sync_master::dump_end(THD* thd)
   sql_print_information("Stop semi-sync binlog_dump to slave (server_id: %ld)",
                         (long) thd->variables.server_id);
 
-  remove_slave();
+  remove_slave((thd->variables.option_bits & OPTION_SKIP_REPLICATION) != 0);
   ack_receiver.remove_slave(thd);
 }
 

--- a/sql/semisync_master.h
+++ b/sql/semisync_master.h
@@ -19,6 +19,7 @@
 #ifndef SEMISYNC_MASTER_H
 #define SEMISYNC_MASTER_H
 
+#include "my_counter.h"
 #include "semisync.h"
 #include "semisync_master_ack_receiver.h"
 
@@ -430,6 +431,13 @@ class Repl_semi_sync_master
    */
   mysql_mutex_t LOCK_binlog;
 
+  /* Number of connected semi-sync slaves that did *not* ask the master to
+   * filter away @@skip_replication events, i.e. that connected with a
+   * --replicate-events-marked-for-skip other than FILTER_ON_MASTER. Those are
+   * the only slaves which can ever ACK a skip_replication event.
+   */
+  Atomic_counter<uint32> m_slaves_replicating_skip_events;
+
   /* This is set to true when m_reply_file_name contains meaningful data. */
   bool            m_reply_file_name_inited;
 
@@ -556,11 +564,36 @@ class Repl_semi_sync_master
   /* Disable the object to disable semi-sync replication inside the master. */
   void disable_master();
 
-  /* Add a semi-sync replication slave */
-  void add_slave();
-    
-  /* Remove a semi-sync replication slave */
-  void remove_slave();
+  /* Add a semi-sync replication slave. filters_skip_events is true when the
+     slave asked the master to filter away @@skip_replication events
+     (--replicate-events-marked-for-skip=FILTER_ON_MASTER). */
+  void add_slave(bool filters_skip_events);
+
+  /* Remove a semi-sync replication slave. filters_skip_events must match the
+     value passed to the corresponding add_slave() call. */
+  void remove_slave(bool filters_skip_events);
+
+  /*
+    Returns true if at least one semi-sync slave is connected and none of them
+    replicates @@skip_replication events. In that state such an event is sent
+    to nobody and can therefore never be ACKed, so the commit path must
+    neither register it for an ACK nor wait for one.
+
+    Read without LOCK_binlog, so the answer may be stale if a slave connects or
+    disconnects concurrently. That is harmless: a slave which connects after
+    the event was binlogged still receives (and ACKs) it, and a commit which
+    stops waiting for a slave that just disconnected would not have been ACKed
+    by it anyway.
+  */
+  bool no_slave_receives_skip_replication_events();
+
+  /*
+    Called instead of report_binlog_update() for a transaction whose ACK is
+    deliberately not awaited. It drops the binlog coordinates cached on the
+    transaction thread, so that a later wait at the AFTER_COMMIT wait point
+    does not wait for, and account for, an ACK which was never requested.
+  */
+  void skip_ack_wait(THD *trans_thd);
 
   /* It parses a reply packet and call report_reply_binlog to handle it. */
   int report_reply_packet(uint32 server_id, const uchar *packet,

--- a/sql/semisync_master.h
+++ b/sql/semisync_master.h
@@ -430,6 +430,15 @@ class Repl_semi_sync_master
    */
   mysql_mutex_t LOCK_binlog;
 
+  /* Number of connected semi-sync slaves (a subset of
+   * rpl_semi_sync_master_clients) that requested master-side filtering of
+   * @@skip_replication events, i.e. connected with
+   * --replicate-events-marked-for-skip=FILTER_ON_MASTER. Such slaves never
+   * receive skip_replication events and therefore never ACK them.
+   * Protected by LOCK_binlog.
+   */
+  ulong           m_slaves_with_master_filtering;
+
   /* This is set to true when m_reply_file_name contains meaningful data. */
   bool            m_reply_file_name_inited;
 
@@ -556,11 +565,26 @@ class Repl_semi_sync_master
   /* Disable the object to disable semi-sync replication inside the master. */
   void disable_master();
 
-  /* Add a semi-sync replication slave */
-  void add_slave();
-    
-  /* Remove a semi-sync replication slave */
-  void remove_slave();
+  /* Add a semi-sync replication slave. filter_skip_on_master is true when the
+     slave requested master-side filtering of @@skip_replication events
+     (--replicate-events-marked-for-skip=FILTER_ON_MASTER). */
+  void add_slave(bool filter_skip_on_master);
+
+  /* Remove a semi-sync replication slave. filter_skip_on_master must match the
+     value passed to the corresponding add_slave() call. */
+  void remove_slave(bool filter_skip_on_master);
+
+  /*
+    MDEV-38486: Returns true if every connected semi-sync slave requested
+    master-side filtering of @@skip_replication events (or if there are no
+    semi-sync slaves at all). In that case a skip_replication transaction is
+    sent to no slave and can never be ACKed, so the commit path must not
+    register it for a semi-sync wait -- otherwise the primary would hang until
+    rpl_semi_sync_master_timeout and degrade to async. When at least one
+    connected slave does not filter, that slave will receive and ACK the event,
+    so the normal semi-sync wait must still apply.
+  */
+  bool all_semi_sync_slaves_filter_skip_replication();
 
   /* It parses a reply packet and call report_reply_binlog to handle it. */
   int report_reply_packet(uint32 server_id, const uchar *packet,


### PR DESCRIPTION
## Description

### Root Cause

Semi-sync replication works by registering every committed transaction with the semi-sync plugin before the commit returns to the client. The plugin then blocks the thread until a replica ACKs receipt of that transaction's binlog position.

The `@@skip_replication` session variable (combined with `replicate_events_marked_for_skip=FILTER_ON_MASTER` on the slave) is a mechanism to prevent specific transactions from being replicated — the events are written to the binlog with the `LOG_EVENT_SKIP_REPLICATION_F` flag, and the dump thread uses that flag to silently skip sending them to the replica.

The bug is that the semi-sync layer has no awareness of this flag. It registers every committed transaction as needing an ACK, regardless of whether the replica will ever receive it. When a transaction is skipped, the replica never receives it, never sends an ACK, and the primary hangs until `rpl_semi_sync_master_timeout` expires — at which point semi-sync degrades to async mode.

## The Fix

Two places in `log.cc` call `repl_semisync_master.report_binlog_update()`, which is what registers a transaction as needing an ACK:

* **Direct write path — `MYSQL_BIN_LOG::write()`:** Used when a single event is written directly (e.g., DDL statements like `CREATE DATABASE`). Guard the call with a check on `event_info->flags & LOG_EVENT_SKIP_REPLICATION_F`.
* **Group commit leader path — `MYSQL_BIN_LOG::trx_group_commit_leader()`:** Used for the common transactional case where multiple threads' commits are batched. For each entry in the commit queue, guard the call with a check on `current->thd->variables.option_bits & OPTION_SKIP_REPLICATION`.

In both cases, if the transaction is marked for skip, we simply do not call `report_binlog_update()`, so the semi-sync plugin never registers it as needing an ACK.

## How to Test

The test performs the following sequence:
```./mtr --suite=rpl rpl_semi_sync_skip_replication```
1.  Starts master and slave with semi-sync enabled and `rpl_semi_sync_master_timeout=2000`.
2.  Sets `replicate_events_marked_for_skip=FILTER_ON_MASTER` on the slave (so the dump thread will filter skip_replication events).
3.  Commits a normal transaction — confirmed to be ACKed.
4.  Commits a `CREATE DATABASE` with `@@skip_replication=1`.
5.  Asserts `Rpl_semi_sync_master_status` is still ON — without the fix, it becomes OFF because the 2s timeout fires.