### PR TITLE
MDEV-36763: Assertion failed in `Type_handler_json_common::json_type_handler_from_generic`

### DIFF
--- a/mysql-test/main/func_if.result
+++ b/mysql-test/main/func_if.result
@@ -238,3 +238,37 @@ First	Second	Third
 2.0	1	2
 NULL	1	2
 drop table t1;
+#
+# MDEV-36763: Assertion failed in `Type_handler_json_common::json_type_handler_from_generic`
+#
+# Test for NULLIF()
+SELECT NULLIF(CASE WHEN 1 THEN NULL ELSE JSON_ARRAY() END, 1);
+NULLIF(CASE WHEN 1 THEN NULL ELSE JSON_ARRAY() END, 1)
+NULL
+SELECT NULLIF(JSON_OBJECT(), 1);
+NULLIF(JSON_OBJECT(), 1)
+{}
+Warnings:
+Warning	1292	Truncated incorrect DECIMAL value: '{}'
+SELECT NULLIF(JSON_ARRAY(), NULL);
+NULLIF(JSON_ARRAY(), NULL)
+[]
+# Tests for IF()
+DO IF(JSON_DEPTH(0), JSON_OBJECT(), NULL);
+SELECT IF(1, JSON_ARRAY(), NULL);
+IF(1, JSON_ARRAY(), NULL)
+[]
+SELECT IF(1, NULL, JSON_ARRAY());
+IF(1, NULL, JSON_ARRAY())
+NULL
+# Tests for NVL2 (ORACLE mode)
+SET @save_sql_mode=@@sql_mode;
+SET sql_mode=ORACLE;
+SELECT NVL2(1, JSON_ARRAY(), NULL);
+NVL2(1, JSON_ARRAY(), NULL)
+[]
+SELECT NVL2(1, NULL, JSON_ARRAY());
+NVL2(1, NULL, JSON_ARRAY())
+NULL
+SET sql_mode=@save_sql_mode;
+# End of 12.3 tests

--- a/mysql-test/main/func_if.test
+++ b/mysql-test/main/func_if.test
@@ -223,3 +223,28 @@ drop table t1;
 # Restore timezone to default
 set time_zone= @@global.time_zone;
 --enable_query_log
+
+--echo #
+--echo # MDEV-36763: Assertion failed in `Type_handler_json_common::json_type_handler_from_generic`
+--echo #
+
+--echo # Test for NULLIF()
+SELECT NULLIF(CASE WHEN 1 THEN NULL ELSE JSON_ARRAY() END, 1);
+SELECT NULLIF(JSON_OBJECT(), 1);
+SELECT NULLIF(JSON_ARRAY(), NULL);
+
+--echo # Tests for IF()
+DO IF(JSON_DEPTH(0), JSON_OBJECT(), NULL);
+SELECT IF(1, JSON_ARRAY(), NULL);
+SELECT IF(1, NULL, JSON_ARRAY());
+
+--echo # Tests for NVL2 (ORACLE mode)
+SET @save_sql_mode=@@sql_mode;
+SET sql_mode=ORACLE;
+
+SELECT NVL2(1, JSON_ARRAY(), NULL);
+SELECT NVL2(1, NULL, JSON_ARRAY());
+
+SET sql_mode=@save_sql_mode;
+
+--echo # End of 12.3 tests

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -2724,7 +2724,9 @@ Item_func_nullif::fix_length_and_dec(THD *thd)
     Check it here to be a valid returned type for a hybrid function.
     args[1] will be checked below, to be comparable to args[0],
     its data type does not affect the returned data type.
+    Set type handler for the hybrid function before calling fix_attributes.
   */
+  set_handler(args[0]->type_handler());
   if (args[0]->type_handler()->
          Item_hybrid_func_fix_attributes(current_thd, func_name_cstring(),
                                          this, this, &args[0], 1))

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -1308,12 +1308,12 @@ protected:
 
   bool cache_type_info(THD *thd, Item *source, bool maybe_null_arg)
   {
+    set_handler(source->type_handler());
     if (source->type_handler()->
           Item_hybrid_func_fix_attributes(thd, func_name_cstring(),
                                           this, this, &source, 1))
       return true;
     Type_std_attributes::set(source);
-    set_handler(source->type_handler());
     set_maybe_null(maybe_null_arg);
     return false;
   }


### PR DESCRIPTION
fixes [MDEV-36763](https://jira.mariadb.org/browse/MDEV-36763)

### Problem:
Queries returning JSON from hybrid functions (`NULLIF`, `IF`, `NVL2`) crash. This is a regression from MDEV-36716, which added early calls to `Item_hybrid_func_fix_attributes()` inside
  - `Item_func_nullif::fix_length_and_dec()` and
  - `Item_func_case_abbreviation2::cache_type_info()` to block `ROW` arguments.

Standard hybrid functions populate their `m_type_handler` by calling `aggregate_for_result()` prior to fixing attributes. However, since `NULLIF` and `IF` deduce their return type from a single argument, they optimize away the `aggregate_for_result()` step.

This caused `Item_hybrid_func_fix_attributes()` to execute while `m_type_handler` was still in its uninitialized default state, triggering a debug assertion failure in the JSON handler.

### Fix:
Explicitly set the type handler from the source argument before calling `Item_hybrid_func_fix_attributes()`.