### PR TITLE
MDEV-39414: cleanup optimizer context tests and docs

### DIFF
--- a/mysql-test/include/get_rec_idx_ranges_from_opt_ctx.inc
+++ b/mysql-test/include/get_rec_idx_ranges_from_opt_ctx.inc
@@ -7,6 +7,10 @@ set @records=
     (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.num_of_records')));
 select *from json_table(@records,
                         '$[*]' columns(num_of_records text path '$')) as jt;
+set @file_stat_records=
+    (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+                        '$[*]' columns(file_stat_records text path '$')) as jt;
 set @indexes=
     (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(

--- a/mysql-test/include/opt_context_replay_innodb.inc
+++ b/mysql-test/include/opt_context_replay_innodb.inc
@@ -1,5 +1,4 @@
 set optimizer_record_context=OFF;
-set optimizer_trace=1;
 
 create database db1;
 use db1;

--- a/mysql-test/include/opt_context_schema.inc
+++ b/mysql-test/include/opt_context_schema.inc
@@ -17,6 +17,9 @@ let $opt_context_schema=
           "num_of_records": {
             "type": "number"
           },
+          "file_stat_records": {
+            "type": "number"
+          },
           "read_cost_io": {
             "type": "number"
           },
@@ -190,6 +193,7 @@ let $opt_context_schema=
           "name",
           "ddl",
           "num_of_records",
+          "file_stat_records",
           "read_cost_io",
           "read_cost_cpu"
         ]

--- a/mysql-test/main/opt_context_load_stats_basic.result
+++ b/mysql-test/main/opt_context_load_stats_basic.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set @saved_opt_context_var_name_1= 'saved_opt_context_1';
 set @saved_opt_context_var_name_2= 'saved_opt_context_2';
 set @opt_context_var_name= 'opt_context';
@@ -37,6 +36,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
@@ -196,30 +201,10 @@ select @opt_context;
 @opt_context
 NULL
 #
-# with optimizer_trace OFF,
-# nothing gets printed to the trace
-#
-set optimizer_trace=0;
-select * from t1 where a < 3 and b > 6;
-a	b
-0	7
-0	7
-2	7
-2	7
-set @opt_context=
-(select REGEXP_SUBSTR(
-context,
-'(?<=set @opt_context=\')([\n\r].*)*(?=\'\;#opt_context_ends)')
-from information_schema.optimizer_context);
-select @opt_context;
-@opt_context
-NULL
-#
-# Now, after re-enabling optimizer_trace, and optimizer_record_context,
+# Now, after re-enabling optimizer_record_context,
 # Loaded stats should be picked by the planner instead of the analyzed table stats,
 # as the optimizer_replay_context is still set to a valid json containing other stats
 #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 select * from t1 where a < 3 and b > 6;
 a	b
@@ -370,6 +355,11 @@ select * from t1 where a > 10;
 a	b
 Warnings:
 Warning	4253	Failed to parse saved optimizer context: "num_of_records" element not present at offset 1405.
+set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].file_stat_records');
+select * from t1 where a > 10;
+a	b
+Warnings:
+Warning	4253	Failed to parse saved optimizer context: "file_stat_records" element not present at offset 1402.
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0].index_name');
 select * from t1 where a > 10;
 a	b

--- a/mysql-test/main/opt_context_load_stats_basic.test
+++ b/mysql-test/main/opt_context_load_stats_basic.test
@@ -1,8 +1,7 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set @saved_opt_context_var_name_1= 'saved_opt_context_1';
 set @saved_opt_context_var_name_2= 'saved_opt_context_2';
 set @opt_context_var_name= 'opt_context';
@@ -126,23 +125,10 @@ select * from t1 where a < 3 and b > 6;
 select @opt_context;
 
 --echo #
---echo # with optimizer_trace OFF,
---echo # nothing gets printed to the trace
---echo #
-set optimizer_trace=0;
-
-select * from t1 where a < 3 and b > 6;
-
---source include/get_opt_context.inc
-
-select @opt_context;
-
---echo #
---echo # Now, after re-enabling optimizer_trace, and optimizer_record_context,
+--echo # Now, after re-enabling optimizer_record_context,
 --echo # Loaded stats should be picked by the planner instead of the analyzed table stats,
 --echo # as the optimizer_replay_context is still set to a valid json containing other stats
 --echo #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 
 select * from t1 where a < 3 and b > 6;
@@ -235,6 +221,9 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].ddl');
 select * from t1 where a > 10;
 
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].num_of_records');
+select * from t1 where a > 10;
+
+set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].file_stat_records');
 select * from t1 where a > 10;
 
 set @opt_context=json_remove(@saved_opt_context_1, '$.list_contexts[0].indexes[0].index_name');

--- a/mysql-test/main/opt_context_load_stats_innodb.result
+++ b/mysql-test/main/opt_context_load_stats_innodb.result
@@ -5,7 +5,6 @@ set @opt_context_schema='$opt_context_schema';
 #
 set session use_stat_tables='PREFERABLY_FOR_QUERIES';
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set optimizer_replay_context="";
 create database db1;
 use db1;

--- a/mysql-test/main/opt_context_load_stats_innodb.test
+++ b/mysql-test/main/opt_context_load_stats_innodb.test
@@ -9,7 +9,6 @@
 --echo #
 set session use_stat_tables='PREFERABLY_FOR_QUERIES';
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 set optimizer_replay_context="";
 
 create database db1;

--- a/mysql-test/main/opt_context_replay_basic.result
+++ b/mysql-test/main/opt_context_replay_basic.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create table t1
@@ -69,7 +68,7 @@ SET optimizer_selectivity_sampling_limit=100;
 
 SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
 
-SET optimizer_trace='enabled=on';
+SET optimizer_trace='enabled=off';
 
 SET optimizer_trace_max_mem_size=1048576;
 
@@ -114,7 +113,7 @@ SET optimizer_scan_setup_cost=10.000000;
 SET optimizer_search_depth=62;
 SET optimizer_selectivity_sampling_limit=100;
 SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
-SET optimizer_trace='enabled=on';
+SET optimizer_trace='enabled=off';
 SET optimizer_trace_max_mem_size=1048576;
 SET optimizer_use_condition_selectivity=4;
 SET optimizer_where_cost=0.032000;

--- a/mysql-test/main/opt_context_replay_basic.test
+++ b/mysql-test/main/opt_context_replay_basic.test
@@ -1,9 +1,8 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
 --source include/no_view_protocol.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 
 create database db1;
 use db1;

--- a/mysql-test/main/opt_context_replay_innodb_comp.result
+++ b/mysql-test/main/opt_context_replay_innodb_comp.result
@@ -1,7 +1,6 @@
 set @opt_context_schema='$opt_context_schema';
-set session use_stat_tables='PREFERABLY';
+set session use_stat_tables='COMPLEMENTARY';
 set optimizer_record_context=OFF;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create function round_cost(explain_output text)

--- a/mysql-test/main/opt_context_replay_innodb_comp.test
+++ b/mysql-test/main/opt_context_replay_innodb_comp.test
@@ -4,4 +4,4 @@
 --source include/opt_context_schema.inc
 
 set session use_stat_tables='COMPLEMENTARY';
---source include/opt_ctx_replay_innodb.inc
+--source include/opt_context_replay_innodb.inc

--- a/mysql-test/main/opt_context_replay_innodb_pref.result
+++ b/mysql-test/main/opt_context_replay_innodb_pref.result
@@ -1,7 +1,6 @@
 set @opt_context_schema='$opt_context_schema';
-set session use_stat_tables='COMPLEMENTARY';
+set session use_stat_tables='PREFERABLY';
 set optimizer_record_context=OFF;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create function round_cost(explain_output text)

--- a/mysql-test/main/opt_context_replay_innodb_pref.test
+++ b/mysql-test/main/opt_context_replay_innodb_pref.test
@@ -4,4 +4,4 @@
 --source include/opt_context_schema.inc
 
 set session use_stat_tables='PREFERABLY';
---source include/opt_ctx_replay_innodb.inc
+--source include/opt_context_replay_innodb.inc

--- a/mysql-test/main/opt_context_store_ddls.result
+++ b/mysql-test/main/opt_context_store_ddls.result
@@ -14,10 +14,9 @@ create table t2 (a int);
 insert into t2 values (1),(2);
 create view view1 as (select t1.a as a, t1.b as b, t2.a as c from (t1 join t2) where t1.a = t2.a);
 #
-# disable both optimizer_trace and optimizer_record_context
-# there should be no trace
+# disable optimizer_record_context
+# there should be no context
 #
-set optimizer_trace=0;
 set optimizer_record_context=OFF;
 select * from t1 where t1.a = 3;
 a	b
@@ -38,7 +37,7 @@ select @ddls;
 @ddls
 NULL
 #
-# disable optimizer_trace, but enable optimizer_record_context
+# enable optimizer_record_context
 # The context will be recorded.
 #
 set optimizer_record_context=ON;
@@ -67,10 +66,9 @@ CREATE TABLE `t1` (
 
 
 #
-# enable optimizer_trace, but disable optimizer_record_context
-# trace result should be empty
+# disable again optimizer_record_context
+# context result should be empty
 #
-set optimizer_trace=1;
 set optimizer_record_context=OFF;
 select * from t1 where t1.a = 3;
 a	b
@@ -91,10 +89,9 @@ select @ddls;
 @ddls
 NULL
 #
-# enable both optimizer_trace and optimizer_record_context
-# trace result should have 1 ddl statement for table t1
+# enable optimizer_record_context
+# context result should have 1 ddl statement for table t1
 #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 select * from t1 where t1.a = 3;
 a	b
@@ -121,9 +118,8 @@ CREATE TABLE `t1` (
 
 
 #
-# enable both optimizer_trace and optimizer_record_context
 # test for view
-# trace result should have 3 ddl statements
+# context result should have 3 ddl statements
 #
 set optimizer_record_context=ON;
 select * from view1 where view1.a = 3;
@@ -158,9 +154,8 @@ CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW 
 
 
 #
-# enable both optimizer_trace and optimizer_record_context
 # test for temp table
-# trace result should have 1 ddl statement for table t1
+# context result should have 1 ddl statement for table t1
 #
 create temporary table temp1(col1 int);
 insert into temp1 select * from t2;
@@ -256,7 +251,7 @@ CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW 
 
 #
 # test for insert
-# there should be no trace for insert with values
+# there should be no context for insert with values
 #
 insert into t1 values ((select max(t2.a) from t2), (select min(t2.a) from t2));
 set @opt_context=
@@ -277,7 +272,7 @@ select @ddls;
 NULL
 #
 # test for delete
-# trace result should have 1 ddl statement for table t1
+# context result should have 1 ddl statement for table t1
 #
 delete from t1 where t1.a=3;
 set @opt_context=
@@ -304,7 +299,7 @@ CREATE TABLE `t1` (
 
 #
 # test for update
-# trace result should have 1 ddl statement for table t1
+# context result should have 1 ddl statement for table t1
 #
 update t1 set t1.b = t1.a;
 set @opt_context=
@@ -331,7 +326,7 @@ CREATE TABLE `t1` (
 
 #
 # test for insert as select
-# trace result should have 2 ddl statements for tables t1, t2
+# context result should have 2 ddl statements for tables t1, t2
 #
 insert into t1 (select t2.a as a, t2.a as b from t2);
 set @opt_context=
@@ -368,7 +363,7 @@ insert into t1 values (1),(2),(3);
 #
 # use database db1
 # test to select 2 tables with same name from 2 databases
-# trace result should have 2 ddl statements for tables db1.t1, db2.t1
+# context result should have 2 ddl statements for tables db1.t1, db2.t1
 #
 use db1;
 select db1_t1.b
@@ -405,7 +400,7 @@ CREATE TABLE `t1` (
 #
 # use database db2
 # test to select 2 tables with same name but from 2 databases
-# trace result should have 2 ddl statements for tables db1.t1, db2.t1
+# context result should have 2 ddl statements for tables db1.t1, db2.t1
 #
 use db2;
 select db1_t1.b
@@ -445,7 +440,7 @@ CREATE TABLE `db1`.`t1` (
 # use database db2
 # test to select from 2 tables from 2 different databases,
 # of which one is a mysql table, and other is a db1 table
-# trace result should have only 1 ddl
+# context result should have only 1 ddl
 #
 select t1.b
 FROM db1.t1 AS t1, mysql.db AS t2
@@ -524,7 +519,7 @@ drop table t1;
 drop table t2;
 #
 # query failure test
-# trace should not contain the failed query result
+# context should not contain the failed query result
 # no table definitions for t10, and t11 should be present
 #
 create table t10 (a int, b int);
@@ -553,7 +548,7 @@ drop table t10;
 drop table t11;
 #
 # partitioned table test
-# trace result should have 1 ddl
+# context result should have 1 ddl
 #
 create table t1 (
 pk int primary key,
@@ -602,7 +597,7 @@ drop table t1;
 #
 # test with insert delayed
 # test shouldn't fail
-# Also, trace result shouldn't have any ddls
+# Also, context result shouldn't have any ddls
 #
 CREATE TABLE t1 (
 a int(11) DEFAULT 1,
@@ -634,7 +629,7 @@ NULL
 drop table t1;
 #
 # test primary, and foreign key tables
-# trace result should have the ddls in correct order
+# context result should have the ddls in correct order
 #
 CREATE TABLE t1 (
 id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -686,7 +681,7 @@ drop table t1;
 drop table t2;
 #
 # MDEV-37207: test multi delete of 2 tables
-# trace result should have the ddls for both the tables
+# context result should have the ddls for both the tables
 #
 create table t1(id1 int not null auto_increment primary key);
 create table t2(id2 int not null);
@@ -721,7 +716,7 @@ CREATE TABLE `t1` (
 
 
 # rerun the same delete query
-# Now, trace result should have the ddls for all 2 tables,
+# Now, context result should have the ddls for all 2 tables,
 # even though no data is deleted
 delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
 set @opt_context=

--- a/mysql-test/main/opt_context_store_ddls.test
+++ b/mysql-test/main/opt_context_store_ddls.test
@@ -20,17 +20,16 @@ insert into t2 values (1),(2);
 create view view1 as (select t1.a as a, t1.b as b, t2.a as c from (t1 join t2) where t1.a = t2.a);
 
 --echo #
---echo # disable both optimizer_trace and optimizer_record_context
---echo # there should be no trace
+--echo # disable optimizer_record_context
+--echo # there should be no context
 --echo #
-set optimizer_trace=0;
 set optimizer_record_context=OFF;
 
 select * from t1 where t1.a = 3;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo #
---echo # disable optimizer_trace, but enable optimizer_record_context
+--echo # enable optimizer_record_context
 --echo # The context will be recorded.
 --echo #
 
@@ -41,10 +40,9 @@ select * from t1 where t1.a = 3;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo #
---echo # enable optimizer_trace, but disable optimizer_record_context
---echo # trace result should be empty
+--echo # disable again optimizer_record_context
+--echo # context result should be empty
 --echo #
-set optimizer_trace=1;
 set optimizer_record_context=OFF;
 
 select * from t1 where t1.a = 3;
@@ -52,10 +50,9 @@ select * from t1 where t1.a = 3;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo #
---echo # enable both optimizer_trace and optimizer_record_context
---echo # trace result should have 1 ddl statement for table t1
+--echo # enable optimizer_record_context
+--echo # context result should have 1 ddl statement for table t1
 --echo #
-set optimizer_trace=1;
 set optimizer_record_context=ON;
 
 select * from t1 where t1.a = 3;
@@ -63,9 +60,8 @@ select * from t1 where t1.a = 3;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo #
---echo # enable both optimizer_trace and optimizer_record_context
 --echo # test for view
---echo # trace result should have 3 ddl statements
+--echo # context result should have 3 ddl statements
 --echo #
 set optimizer_record_context=ON;
 
@@ -74,9 +70,8 @@ select * from view1 where view1.a = 3;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo #
---echo # enable both optimizer_trace and optimizer_record_context
 --echo # test for temp table
---echo # trace result should have 1 ddl statement for table t1
+--echo # context result should have 1 ddl statement for table t1
 --echo #
 create temporary table temp1(col1 int);
 insert into temp1 select * from t2;
@@ -101,7 +96,7 @@ select * from view1 where view1.a = 3 union select * from view1 where view1.a = 
 
 --echo #
 --echo # test for insert
---echo # there should be no trace for insert with values
+--echo # there should be no context for insert with values
 --echo #
 insert into t1 values ((select max(t2.a) from t2), (select min(t2.a) from t2));
 
@@ -109,7 +104,7 @@ insert into t1 values ((select max(t2.a) from t2), (select min(t2.a) from t2));
 
 --echo #
 --echo # test for delete
---echo # trace result should have 1 ddl statement for table t1
+--echo # context result should have 1 ddl statement for table t1
 --echo #
 delete from t1 where t1.a=3;
 
@@ -117,7 +112,7 @@ delete from t1 where t1.a=3;
 
 --echo #
 --echo # test for update
---echo # trace result should have 1 ddl statement for table t1
+--echo # context result should have 1 ddl statement for table t1
 --echo #
 update t1 set t1.b = t1.a;
 
@@ -125,7 +120,7 @@ update t1 set t1.b = t1.a;
 
 --echo #
 --echo # test for insert as select
---echo # trace result should have 2 ddl statements for tables t1, t2
+--echo # context result should have 2 ddl statements for tables t1, t2
 --echo #
 insert into t1 (select t2.a as a, t2.a as b from t2);
 
@@ -139,7 +134,7 @@ insert into t1 values (1),(2),(3);
 --echo #
 --echo # use database db1
 --echo # test to select 2 tables with same name from 2 databases
---echo # trace result should have 2 ddl statements for tables db1.t1, db2.t1
+--echo # context result should have 2 ddl statements for tables db1.t1, db2.t1
 --echo #
 use db1;
 select db1_t1.b
@@ -152,7 +147,7 @@ WHERE db1_t1.a = db2_t1.a AND db1_t1.a >= 3;
 --echo #
 --echo # use database db2
 --echo # test to select 2 tables with same name but from 2 databases
---echo # trace result should have 2 ddl statements for tables db1.t1, db2.t1
+--echo # context result should have 2 ddl statements for tables db1.t1, db2.t1
 --echo #
 use db2;
 
@@ -167,7 +162,7 @@ WHERE db1_t1.a = db2_t1.a AND db1_t1.a >= 3;
 --echo # use database db2
 --echo # test to select from 2 tables from 2 different databases,
 --echo # of which one is a mysql table, and other is a db1 table
---echo # trace result should have only 1 ddl
+--echo # context result should have only 1 ddl
 --echo #
 select t1.b
 FROM db1.t1 AS t1, mysql.db AS t2
@@ -198,7 +193,7 @@ drop table t2;
 
 --echo #
 --echo # query failure test
---echo # trace should not contain the failed query result
+--echo # context should not contain the failed query result
 --echo # no table definitions for t10, and t11 should be present
 --echo #
 create table t10 (a int, b int);
@@ -216,7 +211,7 @@ drop table t11;
 
 --echo #
 --echo # partitioned table test
---echo # trace result should have 1 ddl
+--echo # context result should have 1 ddl
 --echo #
 create table t1 (
     pk int primary key,
@@ -241,7 +236,7 @@ drop table t1;
 --echo #
 --echo # test with insert delayed
 --echo # test shouldn't fail
---echo # Also, trace result shouldn't have any ddls
+--echo # Also, context result shouldn't have any ddls
 --echo #
 
 CREATE TABLE t1 (
@@ -263,7 +258,7 @@ drop table t1;
 
 --echo #
 --echo # test primary, and foreign key tables
---echo # trace result should have the ddls in correct order
+--echo # context result should have the ddls in correct order
 --echo #
 
 CREATE TABLE t1 (
@@ -290,7 +285,7 @@ drop table t2;
 
 --echo #
 --echo # MDEV-37207: test multi delete of 2 tables
---echo # trace result should have the ddls for both the tables
+--echo # context result should have the ddls for both the tables
 --echo #
 
 create table t1(id1 int not null auto_increment primary key);
@@ -304,7 +299,7 @@ delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
 --source include/get_names_ddls_from_opt_ctx.inc
 
 --echo # rerun the same delete query
---echo # Now, trace result should have the ddls for all 2 tables,
+--echo # Now, context result should have the ddls for all 2 tables,
 --echo # even though no data is deleted
 delete t1.*, t2.* from t1, t2 where t1.id1 = t2.id2;
 

--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -1,6 +1,5 @@
-#enable both optimizer_trace, and optimizer_record_context
+#enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 create database db1;
 use db1;
 create table t1
@@ -46,6 +45,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 0
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -84,6 +89,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -128,6 +140,11 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -160,6 +177,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -206,6 +230,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+20
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -242,6 +272,13 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+30
+20
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 30
 20
 set @indexes=
@@ -291,6 +328,12 @@ select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
 50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -332,6 +375,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
@@ -380,6 +429,11 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
 select *from json_table(
@@ -414,6 +468,12 @@ set @records=
 select *from json_table(@records,
 '$[*]' columns(num_of_records text path '$')) as jt;
 num_of_records
+50
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
 50
 set @indexes=
 (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));

--- a/mysql-test/main/opt_context_store_stats.test
+++ b/mysql-test/main/opt_context_store_stats.test
@@ -1,8 +1,7 @@
 --source include/not_embedded.inc
 --source include/have_sequence.inc
---echo #enable both optimizer_trace, and optimizer_record_context
+--echo #enable optimizer_record_context
 set optimizer_record_context=ON;
-set optimizer_trace=1;
 
 create database db1;
 use db1;

--- a/sql/opt_context_store_replay.cc
+++ b/sql/opt_context_store_replay.cc
@@ -56,6 +56,7 @@ using namespace json_reader;
         {
           "name": "table_name",
           "num_of_records": n,
+          "file_stat_records": n,
           "read_cost_io": n,
           "read_cost_cpu": n,
           "indexes": [ //optional
@@ -1875,6 +1876,8 @@ void Optimizer_context_replay::dbug_print_read_stats()
     DBUG_PRINT("info", ("-----------------"));
     DBUG_PRINT("info", ("name: %s", tbl_ctx->name));
     DBUG_PRINT("info", ("num_of_records: %llx", tbl_ctx->total_rows));
+    DBUG_PRINT("info",
+               ("file_stat_records: %llx", tbl_ctx->file_stat_records));
 
     List_iterator<index_context_for_replay> index_itr(tbl_ctx->index_list);
 


### PR DESCRIPTION
1. included file_stat_records in the schema, and dbug_print_read_stats()
2. Removed "optimizer_trace=ON" from the tests, as it has no impact on the tests.
3. Added a test to check the presence of file_stat_records, and produce an error if not present.