### PR TITLE
MDEV-39390 videx: fix libcurl leak in ask_from_videx_http()

### DIFF
--- a/storage/videx/ha_videx.cc
+++ b/storage/videx/ha_videx.cc
@@ -209,6 +209,8 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
   CURL *curl;
   CURLcode res_code;
   std::string readBuffer;
+  struct curl_slist *headers= nullptr;
+  int rc= 1;
 
   curl= curl_easy_init();
   if (curl)
@@ -221,7 +223,6 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request_str.c_str());
 
     // Set the headers
-    struct curl_slist *headers= NULL;
     headers= curl_slist_append(headers, "Content-Type: application/json");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
@@ -243,7 +244,7 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
       sql_print_warning(
           "VIDEX: access videx_server failed res_code != curle_ok: %s",
           host_ip);
-      return 1;
+      goto cleanup;
     }
     else
     {
@@ -254,21 +255,22 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
       if (error)
       {
         sql_print_warning("VIDEX: JSON parse error: %s", message.c_str());
-        return 1;
+        goto cleanup;
       }
       else
       {
         if (message == "OK")
         {
           DBUG_PRINT("info", ("access videx_server success: %s", host_ip));
-          return 0;
+          rc= 0;
+          goto cleanup;
         }
         else
         {
           sql_print_warning(
               "VIDEX: access videx_server success but msg != OK: %s",
               readBuffer.c_str());
-          return 1;
+          goto cleanup;
         }
       }
     }
@@ -276,6 +278,11 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
   sql_print_warning("VIDEX: access videx_server failed curl = false: %s",
                     host_ip);
   return 1;
+
+cleanup:
+  curl_slist_free_all(headers);
+  curl_easy_cleanup(curl);
+  return rc;
 }
 
 /**
@@ -934,9 +941,9 @@ maria_declare_plugin(videx){
     PLUGIN_LICENSE_GPL,
     videx_init,                          /* Plugin Init */
     NULL,                                /* Plugin Deinit */
-    0x0001,                              /* version number (0.1) */
+    0x0002,                              /* version number (0.2) */
     NULL,                   /* status variables */
     videx_system_variables,              /* system variables */
-    "0.1",                               /* string version */
+    "0.2",                               /* string version */
     MariaDB_PLUGIN_MATURITY_EXPERIMENTAL /* maturity */
 } maria_declare_plugin_end;

--- a/storage/videx/mysql-test/videx/create-table-and-index.result
+++ b/storage/videx/mysql-test/videx/create-table-and-index.result
@@ -1,3 +1,4 @@
+CALL mtr.add_suppression("VIDEX: access videx_server failed res_code != curle_ok");
 CREATE TABLE `orders` (
 `O_ORDERKEY` int NOT NULL,
 `O_CUSTKEY` int NOT NULL,
@@ -11,7 +12,6 @@ CREATE TABLE `orders` (
 PRIMARY KEY (`O_ORDERKEY`),
 KEY `ORDERS_FK1` (`O_CUSTKEY`)
 ) ENGINE=VIDEX;
-SET SESSION videx_server_ip=NULL;
 SHOW CREATE TABLE orders;
 Table	Create Table
 orders	CREATE TABLE `orders` (
@@ -45,4 +45,3 @@ orders	CREATE TABLE `orders` (
   KEY `idx_orders_status_date` (`O_ORDERSTATUS`,`O_ORDERDATE`)
 ) ENGINE=VIDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 DROP TABLE orders;
-SET SESSION videx_server_ip=DEFAULT;

--- a/storage/videx/mysql-test/videx/create-table-and-index.test
+++ b/storage/videx/mysql-test/videx/create-table-and-index.test
@@ -1,5 +1,7 @@
 --source include/have_videx.inc
 
+CALL mtr.add_suppression("VIDEX: access videx_server failed res_code != curle_ok");
+
 CREATE TABLE `orders` (
   `O_ORDERKEY` int NOT NULL,
   `O_CUSTKEY` int NOT NULL,
@@ -14,8 +16,6 @@ CREATE TABLE `orders` (
   KEY `ORDERS_FK1` (`O_CUSTKEY`)
 ) ENGINE=VIDEX;
 
-SET SESSION videx_server_ip=NULL;
-
 SHOW CREATE TABLE orders;
 
 CREATE INDEX idx_orders_status_date ON orders (O_ORDERSTATUS, O_ORDERDATE);
@@ -23,5 +23,3 @@ CREATE INDEX idx_orders_status_date ON orders (O_ORDERSTATUS, O_ORDERDATE);
 SHOW CREATE TABLE orders;
 
 DROP TABLE orders;
-
-SET SESSION videx_server_ip=DEFAULT;


### PR DESCRIPTION

## Jira
[MDEV-39390](https://jira.mariadb.org/browse/MDEV-39390)

## Summary

This patch fixes a libcurl resource leak in `ask_from_videx_http()`.

The issue is that several return paths after `curl_easy_init()` bypass
cleanup, so the curl handle and HTTP header list are not released.
The fix keeps the change minimal by replacing those returns with
`goto cleanup` and releasing the resources in one shared cleanup block:

- `curl_slist_free_all(headers)`
- `curl_easy_cleanup(curl)`

No functional change is intended beyond fixing the leak.

## Environment

Reproduced on Debian with clang/LSan available:

```sh
/usr/bin/clang --version
/usr/bin/clang++ --version
dpkg -s libclang-rt-19-dev | grep '^Version'
grep -E '^(PRETTY_NAME|NAME|VERSION=)' /etc/os-release
```

Observed environment:

```text
Debian clang version 19.1.7 (20+b2)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-19/bin

Debian clang version 19.1.7 (20+b2)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-19/bin

Version: 1:19.1.7-20+b2

PRETTY_NAME="Debian GNU/Linux forky/sid"
NAME="Debian GNU/Linux"
```

## Build / reproduction

Build MariaDB with ASAN enabled (WITH_ASAN, WITH_UBSAN):

```sh
/usr/bin/cmake \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_COMPILER=/usr/bin/clang \
  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
  -G Ninja --fresh \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
  -DCMAKE_INSTALL_PREFIX=. \
  -DMYSQL_DATADIR=./data \
  -DSYSCONFDIR=./etc \
  -DPLUGIN_COLUMNSTORE=NO \
  -DPLUGIN_ROCKSDB=NO \
  -DPLUGIN_S3=NO \
  -DPLUGIN_MROONGA=NO \
  -DPLUGIN_CONNECT=NO \
  -DPLUGIN_TOKUDB=NO \
  -DPLUGIN_PERFSCHEMA=NO \
  -DWITH_WSREP=OFF \
  -DPLUGIN_VIDEX=YES \
  -DWITH_ASAN=ON \
  -DWITH_ASAN_SCOPE=ON \
  -DWITH_UBSAN=ON \
  -S /root/mariadb_server \
  -B /root/mariadb_server/mysql_build_output/build
```

Then start `mariadbd` and run:

```sql
install soname 'ha_videx';
create table t (a int primary key) engine=videx;
show create table t;
drop table t;
uninstall soname 'ha_videx';
shutdown
```

## Before fix

On shutdown, LeakSanitizer reports a leak with libcurl-related allocations, e.g.:

```text
2026-04-23  5:26:31 0 [Note] ./sql/mariadbd: Shutdown complete
==961614==WARNING: invalid path to external symbolizer!
==961614==WARNING: Failed to use and restart external symbolizer!

=================================================================
==961614==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 5480 byte(s) in 1 object(s) allocated from:
    #0 0x5568021d4f4d  (/root/mariadb_server/mysql_build_output/build/sql/mariadbd+0x1c35f4d)
    #1 0x7f6dab8aa8c5  (/usr/lib/x86_64-linux-gnu/libcurl.so.4+0x8e8c5)
    #2 0x44dc957b402fe3ff  (<unknown module>)
    #3 0x7f6d7d9d1a3f  (<unknown module>)

Indirect leak of 5480 byte(s) in 1 object(s) allocated from:
    #0 0x5568021d4f4d  (/root/mariadb_server/mysql_build_output/build/sql/mariadbd+0x1c35f4d)
    #1 0x7f6dab8aa8c5  (/usr/lib/x86_64-linux-gnu/libcurl.so.4+0x8e8c5)
    #2 0x44dc957b402fe3ff  (<unknown module>)
...
```

## After fix

After this patch, the same reproduction no longer reports the leak.
The server shuts down cleanly:

```text
2026-04-23  5:15:53 0 [Note] InnoDB: Shutdown completed; log sequence number 3984330858; transaction id 927
2026-04-23  5:15:53 0 [Note] ./sql/mariadbd: Shutdown complete
```
