### PR TITLE
MDEV-37534: Assertion `a == &type_handler_row || a == &type_handler_null` failed on `CREATE TABLE ... ROW()`

### DIFF
--- a/mysql-test/main/case.result
+++ b/mysql-test/main/case.result
@@ -676,3 +676,15 @@ ERROR 21000: Operand should contain 1 column(s)
 SELECT NULLIF(ROW(1,2), NULL);
 ERROR HY000: Illegal parameter data type row for operation 'nullif'
 # End of 12.0 tests
+#
+# MDEV-37534: Assertion `a == &type_handler_row || a == &type_handler_null` failed on `CREATE TABLE ... ROW()`
+#
+CREATE TABLE t (c INT CHECK(c=CASE c WHEN ROW(1, 1) THEN c=0 END IN (c)=1));
+ERROR HY000: Illegal parameter data types int and row for operation 'case..when'
+select CASE 1 WHEN ROW(1, 2) THEN 0 END from dual;
+ERROR HY000: Illegal parameter data types int and row for operation 'case..when'
+select CASE WHEN NULLIF(1, ROW(1,1)) THEN 0 ELSE 1 END from dual;
+ERROR HY000: Illegal parameter data types int and row for operation 'nullif'
+select NULLIF(1, ROW(1,2));
+ERROR HY000: Illegal parameter data types int and row for operation 'nullif'
+# End of 12.3 tests

--- a/mysql-test/main/case.test
+++ b/mysql-test/main/case.test
@@ -524,3 +524,21 @@ SELECT NULLIF(NULL, ROW(1,2));
 SELECT NULLIF(ROW(1,2), NULL);
 
 --echo # End of 12.0 tests
+
+--echo #
+--echo # MDEV-37534: Assertion `a == &type_handler_row || a == &type_handler_null` failed on `CREATE TABLE ... ROW()`
+--echo #
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+CREATE TABLE t (c INT CHECK(c=CASE c WHEN ROW(1, 1) THEN c=0 END IN (c)=1));
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+select CASE 1 WHEN ROW(1, 2) THEN 0 END from dual;
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+select CASE WHEN NULLIF(1, ROW(1,1)) THEN 0 ELSE 1 END from dual;
+
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+select NULLIF(1, ROW(1,2));
+
+--echo # End of 12.3 tests

--- a/sql/sql_type_row.cc
+++ b/sql/sql_type_row.cc
@@ -46,10 +46,11 @@ public:
       Allowed combinations:
         ROW+ROW, NULL+ROW, ROW+NULL
     */
-    DBUG_ASSERT(a == &type_handler_row || a == &type_handler_null);
-    DBUG_ASSERT(b == &type_handler_row || b == &type_handler_null);
-    DBUG_ASSERT(a == &type_handler_row || b == &type_handler_row);
-    return &type_handler_row;
+    if ((a == &type_handler_row || a == &type_handler_null) &&
+        (b == &type_handler_row || b == &type_handler_null) &&
+        (a == &type_handler_row || b == &type_handler_row))
+      return &type_handler_row;
+    return NULL;
   }
   const Type_handler *aggregate_for_min_max(const Type_handler *a,
                                             const Type_handler *b)


### PR DESCRIPTION
fixes [MDEV-37534]()

### Problem:
The function `Type_collection_row::aggregate_for_comparison()` uses debug assert to check if types involved in comparison are either `ROW` or `NULL`. When hybrid functions like `CASE-WHEN-THEN` and `NULLIF` tries to compare `ROW` type with other types, assertion fails.

### Fix:
Convert assertions in `Type_collection_row::aggregate_for_comparison` into a condition and return `NULL` if an invalid type combination is detected.