### PR TITLE
MDEV-39240: Fix mixed-sign comparison on 32-bit

### DIFF
--- a/sql/rpl_record.cc
+++ b/sql/rpl_record.cc
@@ -355,7 +355,11 @@ unpack_row(rpl_group_info *rgi,
             {
               if (likely(seconds >= 0 && seconds <= TIMESTAMP_MAX_VALUE))
                 break;
-              else if (likely(seconds == UINT_MAX32)) // They are both signed.
+              /*
+                `my_time_t` is signed, whereas `UINT_MAX32` is
+                unsigned if `long` is 32-bit and signed otherwise.
+              */
+              else if (likely(seconds == static_cast<my_time_t>(UINT_MAX32)))
               {
                 // Normalize MariaDB 11.5.1+ Epochalypse
                 f->store_timestamp(TIMESTAMP_MAX_VALUE, microseconds);


### PR DESCRIPTION
Until MDEV-32188 on 11.5, both `my_time_t` and the literal behind the `UINT_MAX32` macro are `signed long`.
But on platforms whose `long` is 32-bit, the value of `UINT_MAX32` exceeds the range of `signed long`, and so the macro instead has the next best data type, [`unsigned long`](https://jira.mariadb.org/issues/?jql=labels+%3D+ulong).