### PR TITLE
MDEV-36792: UBSAN load of null pointer and Assertion `b == &type_handler_row || b == &type_handler_null` in `Arg_comparator::set_cmp_func when using ROW()`

### DIFF
--- a/mysql-test/main/func_equal.result
+++ b/mysql-test/main/func_equal.result
@@ -54,3 +54,13 @@ c1
 0
 DROP TABLE t0;
 # End of 10.5 tests
+#
+# MDEV-36792: UBSAN load of null pointer and Assertion `b == &type_handler_row || b == &type_handler_null` in `Arg_comparator::set_cmp_func when using ROW()`
+#
+CREATE FUNCTION f() RETURNS ROW TYPE OF t RETURN 1;
+CREATE TABLE t (a INT);
+SELECT ROW(f(),1)=ROW(1,1) AS eq;
+ERROR HY000: Illegal parameter data types row and int for operation '='
+DROP FUNCTION f;
+DROP TABLE t;
+# End of 11.8 tests

--- a/mysql-test/main/func_equal.test
+++ b/mysql-test/main/func_equal.test
@@ -59,3 +59,16 @@ DROP TABLE t0;
 
 
 --echo # End of 10.5 tests
+
+--echo #
+--echo # MDEV-36792: UBSAN load of null pointer and Assertion `b == &type_handler_row || b == &type_handler_null` in `Arg_comparator::set_cmp_func when using ROW()`
+--echo #
+
+CREATE FUNCTION f() RETURNS ROW TYPE OF t RETURN 1;
+CREATE TABLE t (a INT);
+--error ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+SELECT ROW(f(),1)=ROW(1,1) AS eq;
+DROP FUNCTION f;
+DROP TABLE t;
+
+--echo # End of 11.8 tests

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -232,9 +232,15 @@ public:
                                                const Type_handler *b)
                                                const override
   {
-    DBUG_ASSERT(a == &type_handler_row);
-    DBUG_ASSERT(b == &type_handler_row);
-    return &type_handler_row;
+    /*
+      The 11.8 changes for MDEV-36792 not to be merged to 12.3,
+      as MDEV-36792 is already fixed in 12.3. See sql_type_row.cc.
+    */
+    if ((a == &type_handler_row || a == &type_handler_null) &&
+        (b == &type_handler_row || b == &type_handler_null) &&
+        (a == &type_handler_row || b == &type_handler_row))
+      return &type_handler_row;
+    return NULL;
   }
   const Type_handler *aggregate_for_min_max(const Type_handler *a,
                                             const Type_handler *b)


### PR DESCRIPTION
fixes [MDEV-36792](https://jira.mariadb.org/browse/MDEV-36792)

### Problem:
When a stored function returning `ROW` type is used as a `ROW` field and comapred against a non-ROW field, server crashes trying to aggregate types for comparison in- `Type_collection_row::aggregate_for_comparison`.
for example:
```sql  
CREATE FUNCTION f() RETURNS ROW TYPE OF t RETURN 1;
CREATE TABLE t (a INT);
SELECT ROW(f(),1)=ROW(1,1) AS eq;
```

### Fix:
Convert assertions in `Type_collection_row::aggregate_for_comparison` into a condition and return `NULL` if an invalid type combination is detected.