### PR TITLE
MDEV-39441: Add dbug_print() helpers for join-related types

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -11210,6 +11210,443 @@ const char *dbug_print(Item *x)            { return dbug_print_item(x);   }
 const char *dbug_print(SELECT_LEX *x)      { return dbug_print_select(x); }
 const char *dbug_print(SELECT_LEX_UNIT *x) { return dbug_print_unit(x);   }
 
+
+/*
+  Debugger helper functions for visualizing TABLE_LIST join structures.
+
+  All functions return const char* into a static buffer, following the same
+  pattern as dbug_print_item() above.
+
+    (gdb) p dbug_print(join_list)
+    (gdb) p dbug_print(table)
+    (gdb) p dbug_print(table->nested_join)
+
+
+  NOTE: for nice formatting in gdb:
+    (gdb) printf "%s", dbug_print(join_tab)
+
+  NOTE: for nice formatting in lldb:
+    (lldb) p printf("%s", dbug_print(table))
+*/
+
+static char dbug_join_print_buf[16384];
+
+static void dbug_join_indent(String *out, int depth)
+{
+  for (int i= 0; i < depth; i++)
+    out->append("  ", 2);
+}
+
+static const char *dbug_join_type_str(uint outer_join)
+{
+  if (!outer_join)
+    return "INNER";
+  if (outer_join & JOIN_TYPE_RIGHT)
+    return "RIGHT";
+  if (outer_join & JOIN_TYPE_LEFT)
+    return "LEFT";
+  if (outer_join & JOIN_TYPE_OUTER)
+    return "OUTER(marker)";
+  return "???";
+}
+
+static const char *dbug_safe_alias(const TABLE_LIST *tbl)
+{
+  if (tbl->alias.str && tbl->alias.length)
+    return tbl->alias.str;
+  if (tbl->table_name.str && tbl->table_name.length)
+    return tbl->table_name.str;
+  return "<unnamed>";
+}
+
+static void dbug_str_append(String *out, const char *s)
+{
+  out->append(s, strlen(s));
+}
+
+static void dbug_str_append_ptr(String *out, const void *p)
+{
+  char tmp[32];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "%p", p);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_uint(String *out, uint val)
+{
+  char tmp[16];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "%u", val);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_hex(String *out, ulonglong val)
+{
+  char tmp[32];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "0x%llx", val);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_item(String *out, Item *item)
+{
+  if (!item)
+    out->append("NULL", 4);
+  else
+    item->print(out, QT_ORDINARY);
+}
+
+static void dbug_dump_table_to_str(String *out, const TABLE_LIST *tbl,
+                                   int depth)
+{
+  if (!tbl)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null TABLE_LIST*)\n", 19);
+    return;
+  }
+
+  dbug_join_indent(out, depth);
+
+  out->append('[');
+  dbug_str_append_ptr(out, tbl);
+  out->append("] \"", 3);
+  dbug_str_append(out, dbug_safe_alias(tbl));
+  out->append('"');
+
+  out->append("  join=", 7);
+  dbug_str_append(out, dbug_join_type_str(tbl->outer_join));
+  out->append(" (outer_join=", 13);
+  dbug_str_append_uint(out, tbl->outer_join);
+  out->append(')');
+
+  if (tbl->table)
+  {
+    out->append("  map=", 6);
+    dbug_str_append_hex(out, (ulonglong) tbl->table->map);
+  }
+
+  if (tbl->nested_join)
+  {
+    out->append("  nested_join=", 14);
+    dbug_str_append_ptr(out, tbl->nested_join);
+    out->append(" (elements=", 11);
+    dbug_str_append_uint(out, tbl->nested_join->join_list.elements);
+    out->append(')');
+  }
+
+  if (tbl->sj_on_expr)
+    out->append("  SJ_NEST", 9);
+
+  out->append('\n');
+
+  if (tbl->on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("ON: ", 4);
+    dbug_str_append_item(out, tbl->on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->sj_on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("SJ_ON: ", 7);
+    dbug_str_append_item(out, tbl->sj_on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->prep_on_expr && tbl->prep_on_expr != tbl->on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("PREP_ON: ", 9);
+    dbug_str_append_item(out, tbl->prep_on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->dep_tables)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("dep_tables: ", 12);
+    dbug_str_append_hex(out, (ulonglong) tbl->dep_tables);
+    out->append('\n');
+  }
+
+  if (tbl->on_expr_dep_tables)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("on_expr_dep_tables: ", 20);
+    dbug_str_append_hex(out, (ulonglong) tbl->on_expr_dep_tables);
+    out->append('\n');
+  }
+}
+
+static void dbug_dump_join_list_to_str(String *out, List<TABLE_LIST> *jl,
+                                       int depth, bool recurse);
+
+static void dbug_dump_nested_join_to_str(String *out, const NESTED_JOIN *nj,
+                                         int depth)
+{
+  if (!nj)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null NESTED_JOIN*)\n", 20);
+    return;
+  }
+  dbug_join_indent(out, depth);
+  out->append("NESTED_JOIN [", 13);
+  dbug_str_append_ptr(out, nj);
+  out->append("]\n", 2);
+  dbug_join_indent(out, depth + 1);
+  out->append("used_tables:     ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->used_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("not_null_tables: ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->not_null_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("n_tables:        ", 17);
+  dbug_str_append_uint(out, nj->n_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("counter:         ", 17);
+  dbug_str_append_uint(out, nj->counter);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("nest_type:       ", 17);
+  dbug_str_append_uint(out, nj->nest_type);
+  if (nj->nest_type & JOIN_OP_NEST)
+    out->append(" (JOIN_OP_NEST)", 15);
+  if (nj->nest_type & REBALANCED_NEST)
+    out->append(" (REBALANCED_NEST)", 18);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("nj_map:          ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->nj_map);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("join_list:\n", 11);
+  dbug_dump_join_list_to_str(out,
+                             &const_cast<NESTED_JOIN*>(nj)->join_list,
+                             depth + 2, true);
+}
+
+static void dbug_dump_join_list_to_str(String *out, List<TABLE_LIST> *jl,
+                                       int depth, bool recurse)
+{
+  if (!jl)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null join_list)\n", 17);
+    return;
+  }
+
+  dbug_join_indent(out, depth);
+  out->append("join_list ", 10);
+  dbug_str_append_ptr(out, jl);
+  out->append(" [", 2);
+  dbug_str_append_uint(out, jl->elements);
+  out->append(" element(s)]:\n", 14);
+
+  List_iterator<TABLE_LIST> it(*jl);
+  TABLE_LIST *tbl;
+  uint idx= 0;
+  while ((tbl= it++))
+  {
+    dbug_join_indent(out, depth);
+    out->append("--- #", 5);
+    dbug_str_append_uint(out, idx++);
+    out->append(" ---\n", 5);
+    dbug_dump_table_to_str(out, tbl, depth + 1);
+
+    if (recurse && tbl->nested_join)
+    {
+      dbug_dump_nested_join_to_str(out, tbl->nested_join, depth + 2);
+    }
+  }
+}
+
+static const char *dbug_return_join_buf(String *str, char *buf)
+{
+  if (str->c_ptr_safe() == buf)
+    return buf;
+  else
+    return "Couldn't fit into buffer";
+}
+
+const char *dbug_print_table(const TABLE_LIST *tbl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!tbl)
+    return "(TABLE_LIST*)NULL";
+  dbug_dump_table_to_str(&str, tbl, 0);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join_list(List<TABLE_LIST> *jl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!jl)
+    return "(List<TABLE_LIST>*)NULL";
+  dbug_dump_join_list_to_str(&str, jl, 0, false);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join_tree(List<TABLE_LIST> *jl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!jl)
+    return "(List<TABLE_LIST>*)NULL";
+  dbug_dump_join_list_to_str(&str, jl, 0, true);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_embedding(const TABLE_LIST *tbl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!tbl)
+    return "(TABLE_LIST*)NULL";
+
+  int depth= 0;
+  for (const TABLE_LIST *cur= tbl; cur; cur= cur->embedding)
+  {
+    dbug_join_indent(&str, depth);
+    str.append('[');
+    dbug_str_append_ptr(&str, cur);
+    str.append("] \"", 3);
+    dbug_str_append(&str, dbug_safe_alias(cur));
+    str.append("\"  join=", 8);
+    dbug_str_append(&str, dbug_join_type_str(cur->outer_join));
+    str.append("  nested_join=", 14);
+    dbug_str_append_ptr(&str, cur->nested_join);
+    if (cur->on_expr)
+    {
+      str.append("  ON=<", 6);
+      dbug_str_append_item(&str, cur->on_expr);
+      str.append('>');
+    }
+    str.append('\n');
+    depth++;
+  }
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_nested_join(const NESTED_JOIN *nj)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!nj)
+    return "(NESTED_JOIN*)NULL";
+  dbug_dump_nested_join_to_str(&str, nj, 0);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join(JOIN *j)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!j)
+    return "(JOIN*)NULL";
+  if (!j->join_list)
+  {
+    str.append("JOIN [", 6);
+    dbug_str_append_ptr(&str, j);
+    str.append("]: join_list is NULL\n", 21);
+    return dbug_return_join_buf(&str, buf);
+  }
+  str.append("JOIN [", 6);
+  dbug_str_append_ptr(&str, j);
+  str.append("]  table_count=", 15);
+  dbug_str_append_uint(&str, j->table_count);
+  str.append("  const_tables=", 15);
+  dbug_str_append_uint(&str, j->const_tables);
+  str.append('\n');
+  if (j->conds)
+  {
+    str.append("  WHERE: ", 9);
+    dbug_str_append_item(&str, j->conds);
+    str.append('\n');
+  }
+  dbug_dump_join_list_to_str(&str, j->join_list, 0, true);
+  return dbug_return_join_buf(&str, buf);
+}
+
+/*
+  Debugger helper function for visualizing a result set row.
+
+  Prints the name and current value of each Item in the row list,
+  as they would be sent to the client by Protocol::send_result_set_row().
+  The output format matches dbug_print_table_row():
+
+    result_set_row(name1, name2, ...)=(val1, val2, ...)
+
+    (gdb)  p dbug_print_result_set_row(&items)
+    (lldb) p dbug_print_result_set_row(&items)
+*/
+
+const char *dbug_print_result_set_row(List<Item> *row_items)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!row_items)
+    return "(List<Item>*)NULL";
+
+  str.append(STRING_WITH_LEN("("));
+
+  List_iterator_fast<Item> name_it(*row_items);
+  bool first= true;
+  for (Item *item= name_it++; item; item= name_it++)
+  {
+    if (first)
+      first= false;
+    else
+      str.append(STRING_WITH_LEN(", "));
+
+    if (item->name.str)
+      str.append(item->name.str, item->name.length);
+    else
+      str.append(STRING_WITH_LEN("(no name)"));
+  }
+
+  str.append(STRING_WITH_LEN(")=("));
+
+  List_iterator_fast<Item> val_it(*row_items);
+  String val_tmp;
+  first= true;
+  for (Item *item= val_it++; item; item= val_it++)
+  {
+    if (first)
+      first= false;
+    else
+      str.append(STRING_WITH_LEN(", "));
+
+    String *val= item->val_str(&val_tmp);
+    if (val)
+      str.append(val->ptr(), val->length());
+    else
+      str.append(&NULL_clex_str);
+  }
+
+  str.append(')');
+
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print(const TABLE_LIST *x)  { return dbug_print_table(x); }
+const char *dbug_print(List<TABLE_LIST> *x)  { return dbug_print_join_tree(x); }
+const char *dbug_print(const NESTED_JOIN *x) { return dbug_print_nested_join(x); }
+const char *dbug_print(JOIN *x)              { return dbug_print_join(x); }
+const char *dbug_print(List<Item> *x)        { return dbug_print_result_set_row(x); }
+
 #endif /*DBUG_OFF*/
 
 void Item::register_in(THD *thd)

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -11454,6 +11454,443 @@ const char *dbug_print(Item *x)            { return dbug_print_item(x);   }
 const char *dbug_print(SELECT_LEX *x)      { return dbug_print_select(x); }
 const char *dbug_print(SELECT_LEX_UNIT *x) { return dbug_print_unit(x);   }
 
+
+/*
+  Debugger helper functions for visualizing TABLE_LIST join structures.
+
+  All functions return const char* into a static buffer, following the same
+  pattern as dbug_print_item() above.
+
+    (gdb) p dbug_print(join_list)
+    (gdb) p dbug_print(table)
+    (gdb) p dbug_print(table->nested_join)
+
+
+  NOTE: for nice formatting in gdb:
+    (gdb) printf "%s", dbug_print(join_tab)
+
+  NOTE: for nice formatting in lldb:
+    (lldb) p printf("%s", dbug_print(table))
+*/
+
+static char dbug_join_print_buf[16384];
+
+static void dbug_join_indent(String *out, int depth)
+{
+  for (int i= 0; i < depth; i++)
+    out->append("  ", 2);
+}
+
+static const char *dbug_join_type_str(uint outer_join)
+{
+  if (!outer_join)
+    return "INNER";
+  if (outer_join & JOIN_TYPE_RIGHT)
+    return "RIGHT";
+  if (outer_join & JOIN_TYPE_LEFT)
+    return "LEFT";
+  if (outer_join & JOIN_TYPE_OUTER)
+    return "OUTER(marker)";
+  return "???";
+}
+
+static const char *dbug_safe_alias(const TABLE_LIST *tbl)
+{
+  if (tbl->alias.str && tbl->alias.length)
+    return tbl->alias.str;
+  if (tbl->table_name.str && tbl->table_name.length)
+    return tbl->table_name.str;
+  return "<unnamed>";
+}
+
+static void dbug_str_append(String *out, const char *s)
+{
+  out->append(s, strlen(s));
+}
+
+static void dbug_str_append_ptr(String *out, const void *p)
+{
+  char tmp[32];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "%p", p);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_uint(String *out, uint val)
+{
+  char tmp[16];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "%u", val);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_hex(String *out, ulonglong val)
+{
+  char tmp[32];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "0x%llx", val);
+  out->append(tmp, len);
+}
+
+static void dbug_str_append_item(String *out, Item *item)
+{
+  if (!item)
+    out->append("NULL", 4);
+  else
+    item->print(out, QT_ORDINARY);
+}
+
+static void dbug_dump_table_to_str(String *out, const TABLE_LIST *tbl,
+                                   int depth)
+{
+  if (!tbl)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null TABLE_LIST*)\n", 19);
+    return;
+  }
+
+  dbug_join_indent(out, depth);
+
+  out->append('[');
+  dbug_str_append_ptr(out, tbl);
+  out->append("] \"", 3);
+  dbug_str_append(out, dbug_safe_alias(tbl));
+  out->append('"');
+
+  out->append("  join=", 7);
+  dbug_str_append(out, dbug_join_type_str(tbl->outer_join));
+  out->append(" (outer_join=", 13);
+  dbug_str_append_uint(out, tbl->outer_join);
+  out->append(')');
+
+  if (tbl->table)
+  {
+    out->append("  map=", 6);
+    dbug_str_append_hex(out, (ulonglong) tbl->table->map);
+  }
+
+  if (tbl->nested_join)
+  {
+    out->append("  nested_join=", 14);
+    dbug_str_append_ptr(out, tbl->nested_join);
+    out->append(" (elements=", 11);
+    dbug_str_append_uint(out, tbl->nested_join->join_list.elements);
+    out->append(')');
+  }
+
+  if (tbl->sj_on_expr)
+    out->append("  SJ_NEST", 9);
+
+  out->append('\n');
+
+  if (tbl->on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("ON: ", 4);
+    dbug_str_append_item(out, tbl->on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->sj_on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("SJ_ON: ", 7);
+    dbug_str_append_item(out, tbl->sj_on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->prep_on_expr && tbl->prep_on_expr != tbl->on_expr)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("PREP_ON: ", 9);
+    dbug_str_append_item(out, tbl->prep_on_expr);
+    out->append('\n');
+  }
+
+  if (tbl->dep_tables)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("dep_tables: ", 12);
+    dbug_str_append_hex(out, (ulonglong) tbl->dep_tables);
+    out->append('\n');
+  }
+
+  if (tbl->on_expr_dep_tables)
+  {
+    dbug_join_indent(out, depth + 1);
+    out->append("on_expr_dep_tables: ", 20);
+    dbug_str_append_hex(out, (ulonglong) tbl->on_expr_dep_tables);
+    out->append('\n');
+  }
+}
+
+static void dbug_dump_join_list_to_str(String *out, List<TABLE_LIST> *jl,
+                                       int depth, bool recurse);
+
+static void dbug_dump_nested_join_to_str(String *out, const NESTED_JOIN *nj,
+                                         int depth)
+{
+  if (!nj)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null NESTED_JOIN*)\n", 20);
+    return;
+  }
+  dbug_join_indent(out, depth);
+  out->append("NESTED_JOIN [", 13);
+  dbug_str_append_ptr(out, nj);
+  out->append("]\n", 2);
+  dbug_join_indent(out, depth + 1);
+  out->append("used_tables:     ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->used_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("not_null_tables: ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->not_null_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("n_tables:        ", 17);
+  dbug_str_append_uint(out, nj->n_tables);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("counter:         ", 17);
+  dbug_str_append_uint(out, nj->counter);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("nest_type:       ", 17);
+  dbug_str_append_uint(out, nj->nest_type);
+  if (nj->nest_type & JOIN_OP_NEST)
+    out->append(" (JOIN_OP_NEST)", 15);
+  if (nj->nest_type & REBALANCED_NEST)
+    out->append(" (REBALANCED_NEST)", 18);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("nj_map:          ", 17);
+  dbug_str_append_hex(out, (ulonglong) nj->nj_map);
+  out->append('\n');
+  dbug_join_indent(out, depth + 1);
+  out->append("join_list:\n", 11);
+  dbug_dump_join_list_to_str(out,
+                             &const_cast<NESTED_JOIN*>(nj)->join_list,
+                             depth + 2, true);
+}
+
+static void dbug_dump_join_list_to_str(String *out, List<TABLE_LIST> *jl,
+                                       int depth, bool recurse)
+{
+  if (!jl)
+  {
+    dbug_join_indent(out, depth);
+    out->append("(null join_list)\n", 17);
+    return;
+  }
+
+  dbug_join_indent(out, depth);
+  out->append("join_list ", 10);
+  dbug_str_append_ptr(out, jl);
+  out->append(" [", 2);
+  dbug_str_append_uint(out, jl->elements);
+  out->append(" element(s)]:\n", 14);
+
+  List_iterator<TABLE_LIST> it(*jl);
+  TABLE_LIST *tbl;
+  uint idx= 0;
+  while ((tbl= it++))
+  {
+    dbug_join_indent(out, depth);
+    out->append("--- #", 5);
+    dbug_str_append_uint(out, idx++);
+    out->append(" ---\n", 5);
+    dbug_dump_table_to_str(out, tbl, depth + 1);
+
+    if (recurse && tbl->nested_join)
+    {
+      dbug_dump_nested_join_to_str(out, tbl->nested_join, depth + 2);
+    }
+  }
+}
+
+static const char *dbug_return_join_buf(String *str, char *buf)
+{
+  if (str->c_ptr_safe() == buf)
+    return buf;
+  else
+    return "Couldn't fit into buffer";
+}
+
+const char *dbug_print_table(const TABLE_LIST *tbl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!tbl)
+    return "(TABLE_LIST*)NULL";
+  dbug_dump_table_to_str(&str, tbl, 0);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join_list(List<TABLE_LIST> *jl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!jl)
+    return "(List<TABLE_LIST>*)NULL";
+  dbug_dump_join_list_to_str(&str, jl, 0, false);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join_tree(List<TABLE_LIST> *jl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!jl)
+    return "(List<TABLE_LIST>*)NULL";
+  dbug_dump_join_list_to_str(&str, jl, 0, true);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_embedding(const TABLE_LIST *tbl)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!tbl)
+    return "(TABLE_LIST*)NULL";
+
+  int depth= 0;
+  for (const TABLE_LIST *cur= tbl; cur; cur= cur->embedding)
+  {
+    dbug_join_indent(&str, depth);
+    str.append('[');
+    dbug_str_append_ptr(&str, cur);
+    str.append("] \"", 3);
+    dbug_str_append(&str, dbug_safe_alias(cur));
+    str.append("\"  join=", 8);
+    dbug_str_append(&str, dbug_join_type_str(cur->outer_join));
+    str.append("  nested_join=", 14);
+    dbug_str_append_ptr(&str, cur->nested_join);
+    if (cur->on_expr)
+    {
+      str.append("  ON=<", 6);
+      dbug_str_append_item(&str, cur->on_expr);
+      str.append('>');
+    }
+    str.append('\n');
+    depth++;
+  }
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_nested_join(const NESTED_JOIN *nj)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!nj)
+    return "(NESTED_JOIN*)NULL";
+  dbug_dump_nested_join_to_str(&str, nj, 0);
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print_join(JOIN *j)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!j)
+    return "(JOIN*)NULL";
+  if (!j->join_list)
+  {
+    str.append("JOIN [", 6);
+    dbug_str_append_ptr(&str, j);
+    str.append("]: join_list is NULL\n", 21);
+    return dbug_return_join_buf(&str, buf);
+  }
+  str.append("JOIN [", 6);
+  dbug_str_append_ptr(&str, j);
+  str.append("]  table_count=", 15);
+  dbug_str_append_uint(&str, j->table_count);
+  str.append("  const_tables=", 15);
+  dbug_str_append_uint(&str, j->const_tables);
+  str.append('\n');
+  if (j->conds)
+  {
+    str.append("  WHERE: ", 9);
+    dbug_str_append_item(&str, j->conds);
+    str.append('\n');
+  }
+  dbug_dump_join_list_to_str(&str, j->join_list, 0, true);
+  return dbug_return_join_buf(&str, buf);
+}
+
+/*
+  Debugger helper function for visualizing a result set row.
+
+  Prints the name and current value of each Item in the row list,
+  as they would be sent to the client by Protocol::send_result_set_row().
+  The output format matches dbug_print_table_row():
+
+    result_set_row(name1, name2, ...)=(val1, val2, ...)
+
+    (gdb)  p dbug_print_result_set_row(&items)
+    (lldb) p dbug_print_result_set_row(&items)
+*/
+
+const char *dbug_print_result_set_row(List<Item> *row_items)
+{
+  char *buf= dbug_join_print_buf;
+  String str(buf, sizeof(dbug_join_print_buf), &my_charset_bin);
+  str.length(0);
+  if (!row_items)
+    return "(List<Item>*)NULL";
+
+  str.append(STRING_WITH_LEN("("));
+
+  List_iterator_fast<Item> name_it(*row_items);
+  bool first= true;
+  for (Item *item= name_it++; item; item= name_it++)
+  {
+    if (first)
+      first= false;
+    else
+      str.append(STRING_WITH_LEN(", "));
+
+    if (item->name.str)
+      str.append(item->name.str, item->name.length);
+    else
+      str.append(STRING_WITH_LEN("(no name)"));
+  }
+
+  str.append(STRING_WITH_LEN(")=("));
+
+  List_iterator_fast<Item> val_it(*row_items);
+  String val_tmp;
+  first= true;
+  for (Item *item= val_it++; item; item= val_it++)
+  {
+    if (first)
+      first= false;
+    else
+      str.append(STRING_WITH_LEN(", "));
+
+    String *val= item->val_str(&val_tmp);
+    if (val)
+      str.append(val->ptr(), val->length());
+    else
+      str.append(&NULL_clex_str);
+  }
+
+  str.append(')');
+
+  return dbug_return_join_buf(&str, buf);
+}
+
+const char *dbug_print(const TABLE_LIST *x)  { return dbug_print_table(x); }
+const char *dbug_print(List<TABLE_LIST> *x)  { return dbug_print_join_tree(x); }
+const char *dbug_print(const NESTED_JOIN *x) { return dbug_print_nested_join(x); }
+const char *dbug_print(JOIN *x)              { return dbug_print_join(x); }
+const char *dbug_print(List<Item> *x)        { return dbug_print_result_set_row(x); }
+
 #endif /*DBUG_OFF*/
 
 void Item::register_in(THD *thd)

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -8045,6 +8045,221 @@ const char* dbug_print_join_prefix(const POSITION *join_positions,
   else
     return "Couldn't fit into buffer";
 }
+
+/*
+  Debugger helper function for visualizing a JOIN_TAB and its context.
+
+  Shows the tab's identity, neighbors in the join_tab array, the
+  JOIN::return_tab pointer, the writing_null_complements flag, and
+  the logical execution call chain from do_select() down to this tab.
+
+    (gdb)  p dbug_print(join_tab)
+
+
+  NOTE: for nice formatting in gdb:
+    (gdb) printf "%s", dbug_print(join_tab-1)
+
+  NOTE: for nice formatting in lldb:
+    (lldb) p printf("%s", dbug_print(join_tab))
+*/
+
+static const char *dbug_next_select_func_name(Next_select_func func)
+{
+  if (!func)                              return "(null)";
+  if (func == sub_select)                 return "sub_select";
+  if (func == sub_select_cache)           return "sub_select_cache";
+  if (func == sub_select_postjoin_aggr)   return "sub_select_postjoin_aggr";
+  if (func == end_send)                   return "end_send";
+  if (func == end_send_group)             return "end_send_group";
+  if (func == end_write)                  return "end_write";
+  if (func == end_write_group)            return "end_write_group";
+  if (func == end_update)                 return "end_update";
+  if (func == end_unique_update)          return "end_unique_update";
+  return "(unknown)";
+}
+
+static void dbug_str_append_tab_brief(String *out, const JOIN_TAB *t)
+{
+  char tmp[64];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", t);
+  out->append(tmp, len);
+  if (t && t->table)
+  {
+    out->append(" \"", 2);
+    out->append(t->table->alias);
+    out->append('"');
+  }
+}
+
+static char dbug_join_tab_print_buf[16384];
+
+const char *dbug_print_join_tab(const JOIN_TAB *tab)
+{
+  char *buf= dbug_join_tab_print_buf;
+  String str(buf, sizeof(dbug_join_tab_print_buf), &my_charset_bin);
+  str.length(0);
+  char tmp[64];
+  size_t len;
+
+  if (!tab)
+    return "(JOIN_TAB*)NULL";
+
+  JOIN *join= tab->join;
+
+  /* Compute position in the join_tab array */
+  int tab_idx= -1;
+  int total_tabs= 0;
+  if (join && join->join_tab)
+  {
+    tab_idx= (int)(tab - join->join_tab);
+    total_tabs= join->top_join_tab_count + join->aggr_tables;
+  }
+
+  /* Header */
+  str.append("JOIN_TAB ", 9);
+  dbug_str_append_tab_brief(&str, tab);
+  str.append('\n');
+
+  /* Position in array */
+  if (tab_idx >= 0)
+  {
+    str.append("  position: #", 13);
+    len= (size_t)snprintf(tmp, sizeof(tmp), "%d of %u", tab_idx+1, total_tabs);
+    str.append(tmp, len);
+    str.append(" (join_tab array ", 17);
+    len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", join->join_tab);
+    str.append(tmp, len);
+    str.append(")\n", 2);
+  }
+
+  /* Access type */
+  str.append("  type: ", 8);
+  str.append(join_type_str[tab->type], strlen(join_type_str[tab->type]));
+  str.append('\n');
+
+  /* Neighbors */
+  if (tab_idx > 0)
+  {
+    str.append("  prev: ", 8);
+    dbug_str_append_tab_brief(&str, tab - 1);
+    str.append(" (", 2);
+    str.append(join_type_str[(tab - 1)->type], strlen(join_type_str[(tab - 1)->type]));
+    str.append(")\n", 2);
+  }
+  else
+    str.append("  prev: (none)\n", 15);
+
+  if (tab_idx >= 0 && (tab_idx + 1) < total_tabs)
+  {
+    str.append("  next: ", 8);
+    dbug_str_append_tab_brief(&str, tab + 1);
+    str.append(" (", 2);
+    str.append(join_type_str[(tab + 1)->type], strlen(join_type_str[(tab + 1)->type]));
+    str.append(")\n", 2);
+  }
+  else
+    str.append("  next: (none)\n", 15);
+
+  /* return_tab */
+  str.append("  return_tab: ", 14);
+  if (join && join->return_tab)
+  {
+    dbug_str_append_tab_brief(&str, join->return_tab);
+    if (join->join_tab)
+    {
+      int ret_idx= (int)(join->return_tab - join->join_tab);
+      len= (size_t)snprintf(tmp, sizeof(tmp), " (#%d)", ret_idx+1);
+      str.append(tmp, len);
+    }
+    str.append('\n');
+  }
+  else
+    str.append("(null)\n", 7);
+
+  /* next_select function pointer */
+  str.append("  next_select: ", 15);
+  str.append(dbug_next_select_func_name(tab->next_select), strlen(dbug_next_select_func_name(tab->next_select)));
+  str.append('\n');
+
+  /* Outer join pointers */
+  if (tab->first_inner)
+  {
+    str.append("  first_inner: ", 15);
+    dbug_str_append_tab_brief(&str, tab->first_inner);
+    str.append('\n');
+  }
+  if (tab->last_inner)
+  {
+    str.append("  last_inner: ", 14);
+    dbug_str_append_tab_brief(&str, tab->last_inner);
+    str.append('\n');
+  }
+  if (tab->first_upper)
+  {
+    str.append("  first_upper: ", 15);
+    dbug_str_append_tab_brief(&str, tab->first_upper);
+    str.append('\n');
+  }
+
+  /* select_cond */
+  str.append("  select_cond: ", 15);
+  if (tab->select_cond)
+  {
+    len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", tab->select_cond);
+    str.append(tmp, len);
+    str.append("  ", 2);
+    const char* item_buf= nullptr;
+    item_buf= dbug_print_item(tab->select_cond);
+    str.append(item_buf, strlen(item_buf));
+    str.append('\n');
+  }
+  else
+  {
+    str.append("(none)", 6);
+    str.append('\n');
+  }
+
+  /*
+    Logical call chain from do_select() to this tab.
+
+    do_select() calls join->first_select(join, join_tab[const_tables], ...),
+    which is typically sub_select.  Each tab's next_select is then used to
+    advance to the next tab in the nested loop.
+  */
+  if (join && join->join_tab && tab_idx >= 0)
+  {
+    int start= (int)join->const_tables;
+
+    for (int i= start; i < total_tabs; i++)
+    {
+      const JOIN_TAB *t= &join->join_tab[i];
+      str.append("    #", 5);
+      len= (size_t)snprintf(tmp, sizeof(tmp), "%d ", i+1);
+      str.append(tmp, len);
+      dbug_str_append_tab_brief(&str, t);
+      str.append(" (", 2);
+      str.append(join_type_str[t->type], strlen(join_type_str[t->type]));
+      str.append(')');
+
+      str.append("  next_select=", 14);
+      str.append(dbug_next_select_func_name(t->next_select), strlen(dbug_next_select_func_name(t->next_select)));
+
+      if (i == tab_idx)
+        str.append("  <-- current", 13);
+
+      str.append('\n');
+    }
+  }
+
+  if (str.c_ptr_safe() == buf)
+    return buf;
+  else
+    return "Couldn't fit into buffer";
+}
+
+
+const char *dbug_print(const JOIN_TAB *x)    { return dbug_print_join_tab(x); }
+
 #endif
 
 /**

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -8238,6 +8238,221 @@ const char* dbug_print_join_prefix(const POSITION *join_positions,
   else
     return "Couldn't fit into buffer";
 }
+
+/*
+  Debugger helper function for visualizing a JOIN_TAB and its context.
+
+  Shows the tab's identity, neighbors in the join_tab array, the
+  JOIN::return_tab pointer, the writing_null_complements flag, and
+  the logical execution call chain from do_select() down to this tab.
+
+    (gdb)  p dbug_print(join_tab)
+
+
+  NOTE: for nice formatting in gdb:
+    (gdb) printf "%s", dbug_print(join_tab-1)
+
+  NOTE: for nice formatting in lldb:
+    (lldb) p printf("%s", dbug_print(join_tab))
+*/
+
+static const char *dbug_next_select_func_name(Next_select_func func)
+{
+  if (!func)                              return "(null)";
+  if (func == sub_select)                 return "sub_select";
+  if (func == sub_select_cache)           return "sub_select_cache";
+  if (func == sub_select_postjoin_aggr)   return "sub_select_postjoin_aggr";
+  if (func == end_send)                   return "end_send";
+  if (func == end_send_group)             return "end_send_group";
+  if (func == end_write)                  return "end_write";
+  if (func == end_write_group)            return "end_write_group";
+  if (func == end_update)                 return "end_update";
+  if (func == end_unique_update)          return "end_unique_update";
+  return "(unknown)";
+}
+
+static void dbug_str_append_tab_brief(String *out, const JOIN_TAB *t)
+{
+  char tmp[64];
+  size_t len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", t);
+  out->append(tmp, len);
+  if (t && t->table)
+  {
+    out->append(" \"", 2);
+    out->append(t->table->alias);
+    out->append('"');
+  }
+}
+
+static char dbug_join_tab_print_buf[16384];
+
+const char *dbug_print_join_tab(const JOIN_TAB *tab)
+{
+  char *buf= dbug_join_tab_print_buf;
+  String str(buf, sizeof(dbug_join_tab_print_buf), &my_charset_bin);
+  str.length(0);
+  char tmp[64];
+  size_t len;
+
+  if (!tab)
+    return "(JOIN_TAB*)NULL";
+
+  JOIN *join= tab->join;
+
+  /* Compute position in the join_tab array */
+  int tab_idx= -1;
+  int total_tabs= 0;
+  if (join && join->join_tab)
+  {
+    tab_idx= (int)(tab - join->join_tab);
+    total_tabs= join->top_join_tab_count + join->aggr_tables;
+  }
+
+  /* Header */
+  str.append("JOIN_TAB ", 9);
+  dbug_str_append_tab_brief(&str, tab);
+  str.append('\n');
+
+  /* Position in array */
+  if (tab_idx >= 0)
+  {
+    str.append("  position: #", 13);
+    len= (size_t)snprintf(tmp, sizeof(tmp), "%d of %u", tab_idx+1, total_tabs);
+    str.append(tmp, len);
+    str.append(" (join_tab array ", 17);
+    len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", join->join_tab);
+    str.append(tmp, len);
+    str.append(")\n", 2);
+  }
+
+  /* Access type */
+  str.append("  type: ", 8);
+  str.append(join_type_str[tab->type], strlen(join_type_str[tab->type]));
+  str.append('\n');
+
+  /* Neighbors */
+  if (tab_idx > 0)
+  {
+    str.append("  prev: ", 8);
+    dbug_str_append_tab_brief(&str, tab - 1);
+    str.append(" (", 2);
+    str.append(join_type_str[(tab - 1)->type], strlen(join_type_str[(tab - 1)->type]));
+    str.append(")\n", 2);
+  }
+  else
+    str.append("  prev: (none)\n", 15);
+
+  if (tab_idx >= 0 && (tab_idx + 1) < total_tabs)
+  {
+    str.append("  next: ", 8);
+    dbug_str_append_tab_brief(&str, tab + 1);
+    str.append(" (", 2);
+    str.append(join_type_str[(tab + 1)->type], strlen(join_type_str[(tab + 1)->type]));
+    str.append(")\n", 2);
+  }
+  else
+    str.append("  next: (none)\n", 15);
+
+  /* return_tab */
+  str.append("  return_tab: ", 14);
+  if (join && join->return_tab)
+  {
+    dbug_str_append_tab_brief(&str, join->return_tab);
+    if (join->join_tab)
+    {
+      int ret_idx= (int)(join->return_tab - join->join_tab);
+      len= (size_t)snprintf(tmp, sizeof(tmp), " (#%d)", ret_idx+1);
+      str.append(tmp, len);
+    }
+    str.append('\n');
+  }
+  else
+    str.append("(null)\n", 7);
+
+  /* next_select function pointer */
+  str.append("  next_select: ", 15);
+  str.append(dbug_next_select_func_name(tab->next_select), strlen(dbug_next_select_func_name(tab->next_select)));
+  str.append('\n');
+
+  /* Outer join pointers */
+  if (tab->first_inner)
+  {
+    str.append("  first_inner: ", 15);
+    dbug_str_append_tab_brief(&str, tab->first_inner);
+    str.append('\n');
+  }
+  if (tab->last_inner)
+  {
+    str.append("  last_inner: ", 14);
+    dbug_str_append_tab_brief(&str, tab->last_inner);
+    str.append('\n');
+  }
+  if (tab->first_upper)
+  {
+    str.append("  first_upper: ", 15);
+    dbug_str_append_tab_brief(&str, tab->first_upper);
+    str.append('\n');
+  }
+
+  /* select_cond */
+  str.append("  select_cond: ", 15);
+  if (tab->select_cond)
+  {
+    len= (size_t)snprintf(tmp, sizeof(tmp), "[%p]", tab->select_cond);
+    str.append(tmp, len);
+    str.append("  ", 2);
+    const char* item_buf= nullptr;
+    item_buf= dbug_print_item(tab->select_cond);
+    str.append(item_buf, strlen(item_buf));
+    str.append('\n');
+  }
+  else
+  {
+    str.append("(none)", 6);
+    str.append('\n');
+  }
+
+  /*
+    Logical call chain from do_select() to this tab.
+
+    do_select() calls join->first_select(join, join_tab[const_tables], ...),
+    which is typically sub_select.  Each tab's next_select is then used to
+    advance to the next tab in the nested loop.
+  */
+  if (join && join->join_tab && tab_idx >= 0)
+  {
+    int start= (int)join->const_tables;
+
+    for (int i= start; i < total_tabs; i++)
+    {
+      const JOIN_TAB *t= &join->join_tab[i];
+      str.append("    #", 5);
+      len= (size_t)snprintf(tmp, sizeof(tmp), "%d ", i+1);
+      str.append(tmp, len);
+      dbug_str_append_tab_brief(&str, t);
+      str.append(" (", 2);
+      str.append(join_type_str[t->type], strlen(join_type_str[t->type]));
+      str.append(')');
+
+      str.append("  next_select=", 14);
+      str.append(dbug_next_select_func_name(t->next_select), strlen(dbug_next_select_func_name(t->next_select)));
+
+      if (i == tab_idx)
+        str.append("  <-- current", 13);
+
+      str.append('\n');
+    }
+  }
+
+  if (str.c_ptr_safe() == buf)
+    return buf;
+  else
+    return "Couldn't fit into buffer";
+}
+
+
+const char *dbug_print(const JOIN_TAB *x)    { return dbug_print_join_tab(x); }
+
 #endif
 
 /**


### PR DESCRIPTION
Introduces new dbug_print() functions for the following types:
```
  dbug_print(NESTED_JOIN)
  dbug_print(JOIN)
  dbug_print(TABLE_LIST)
  dbug_print(JOIN_TAB)
  dbug_print(List<Item>)
```

Typically pointers to instances of the given types are passed. The dbug_print(List<Item>) is intended to show result row before sending to client (e.g., invoke in debugger while tracing end_send) but may work in other contexts.

These functions produce nicely formatted output, please use them in conjunction with the formatted printfs available in GDB or LLDB:
```
   (gdb) printf "%s", dbug_print(join_tab)
```
```
  (lldb) p printf("%s", dbug_print(table))
```

Example output from dbug_print(JOIN) in LLDB.  The last line with value 1302 is the number of characters produced by the printf command.
```
(lldb) p printf("%s",dbug_print(join))
JOIN [0x15801bfe8]  table_count=3  const_tables=0
join_list 0x158018340 [1 element(s)]:
--- #0 ---
  [0x15801af10] "(nest_last_join)"  join=INNER (outer_join=0)  nested_join=0x15801b618 (elements=2)
    NESTED_JOIN [0x15801b618]
      used_tables:     0x0
      not_null_tables: 0x0
      n_tables:        0
      counter:         0
      nest_type:       1 (JOIN_OP_NEST)
      nj_map:          0x0
      join_list:
        join_list 0x15801b618 [2 element(s)]:
        --- #0 ---
          [0x15801a308] "t3"  join=LEFT (outer_join=1)  map=0x4
            ON: `test`.`t2`.`a` = `test`.`t3`.`a`
        --- #1 ---
          [0x158019b30] "(nest_last_join)"  join=INNER (outer_join=0)  nested_join=0x15801a238 (elements=2)
            NESTED_JOIN [0x15801a238]
              used_tables:     0x0
              not_null_tables: 0x0
              n_tables:        0
              counter:         0
              nest_type:       0
              nj_map:          0x0
              join_list:
                join_list 0x15801a238 [2 element(s)]:
                --- #0 ---
                  [0x1580187c0] "t1"  join=RIGHT (outer_join=2)  map=0x1
                    ON: `test`.`t1`.`a` = `test`.`t2`.`a`
                --- #1 ---
                  [0x158018f08] "t2"  join=INNER (outer_join=0)  map=0x2
(int) 1302
```