### PR TITLE
MDEV-39453: mtr: make main.group_by MDEV-6129 UNION query deterministic

### DIFF
--- a/mysql-test/main/group_by.test
+++ b/mysql-test/main/group_by.test
@@ -1796,6 +1796,7 @@ DROP TABLE t1;
 --echo #
 
 SET sql_mode='ONLY_FULL_GROUP_BY';
+--sorted_result
 SELECT 1 AS test UNION SELECT 2 AS test ORDER BY test IS NULL ASC;
 SET sql_mode='';
 


### PR DESCRIPTION
## Problem

`main.group_by` is flaky in the mtr suite. The failing case is the regression test for MDEV-6129 (server crash on UNION with `ORDER BY <expr> IS NULL`):

```sql
SET sql_mode='ONLY_FULL_GROUP_BY';
SELECT 1 AS test UNION SELECT 2 AS test ORDER BY test IS NULL ASC;
```

Both rows have `test IS NULL = 0`, so the ORDER BY key is constant and the row order is unspecified. Under parallel test load (`mtr --parallel=auto`) the server sometimes returns `2,1` instead of the `1,2` baked into `group_by.result`:

```
--- mysql-test/main/group_by.result
+++ mysql-test/main/group_by.reject
@@ -2636,8 +2636,8 @@
 SET sql_mode='ONLY_FULL_GROUP_BY';
 SELECT 1 AS test UNION SELECT 2 AS test ORDER BY test IS NULL ASC;
 test
-1
 2
+1
 SET sql_mode='';
```

Repro seen recently on the `mariadb-connector-c` CI (parallel build, clean 11.4 tree): https://github.com/mariadb-corporation/mariadb-connector-c/actions/runs/24903791217/job/72927889893 — and on the scheduled 3.4 run of 2026-04-19 against the same 11.4 server (https://github.com/mariadb-corporation/mariadb-connector-c/actions/runs/24619796993/job/71988293365), which had no libmariadb changes at all.

## Fix

MDEV-6129 was a crash fix; the regression test exists to prove the query parses, executes, and returns without crashing — the inter-row order of `1` vs `2` is incidental. So keep the exact query unchanged and add `--sorted_result`, which tells mtr to sort the client-visible output before diffing:

```diff
 SET sql_mode='ONLY_FULL_GROUP_BY';
+--sorted_result
 SELECT 1 AS test UNION SELECT 2 AS test ORDER BY test IS NULL ASC;
 SET sql_mode='';
```

No `.result` file change needed — `1\n2` is already in sorted order, and the variant seen in the wild (`2\n1`) sorts to the same thing.

## Branch coverage

The same line appears unchanged on `10.6`, `10.11`, `11.0`, `11.2`, `11.4`, `11.8`, `12.0`, `12.1`, `12.2`. Targeting `11.4` per MariaDB's merge-up convention; maintainers may want to cherry-pick to older branches (10.6/10.11) as well.

## Scope

Single line added in `mysql-test/main/group_by.test`. No server code, no other tests, no `.result` files changed.