### PR TITLE
MDEV-38561: ASAN heap-use-after-free in Query_arena::free_items/sp_le…

### DIFF
--- a/mysql-test/main/sp_validation.result
+++ b/mysql-test/main/sp_validation.result
@@ -2085,4 +2085,43 @@ DROP PROCEDURE p2;
 DROP PROCEDURE p3;
 DROP PROCEDURE p4;
 DROP TABLE t1;
-SET sql_mode = default;
+#
+# MDEV-38561: ASAN heap-use-after-free in Query_arena::free_items/sp_lex_cursor::~sp_lex_cursor
+#
+SET @save_sql_mode=@@sql_mode;
+SET sql_mode='oracle';
+CREATE OR REPLACE PACKAGE pkg1 AS
+PROCEDURE p1 ();
+PROCEDURE p2 ();
+END pkg1;
+$
+CREATE OR REPLACE PACKAGE BODY pkg1 AS
+PROCEDURE p1() IS
+CURSOR c1 IS SELECT a FROM t1;
+va c1%ROWTYPE;
+BEGIN
+SELECT 1;
+END p1;
+PROCEDURE p2() is
+BEGIN
+FOR i IN 1..2
+LOOP
+SELECT i;
+CREATE OR REPLACE temporary TABLE t1 (a INT);
+CALL pkg1.p1;
+END loop;
+END p2;
+END pkg1
+$
+CALL pkg1.p2();
+i
+1
+1
+1
+i
+2
+1
+1
+DROP PACKAGE BODY pkg1;
+DROP PACKAGE pkg1;
+SET sql_mode=@save_sql_mode;

--- a/mysql-test/main/sp_validation.test
+++ b/mysql-test/main/sp_validation.test
@@ -2886,5 +2886,46 @@ DROP PROCEDURE p3;
 DROP PROCEDURE p4;
 DROP TABLE t1;
 
-SET sql_mode = default;
+--echo #
+--echo # MDEV-38561: ASAN heap-use-after-free in Query_arena::free_items/sp_lex_cursor::~sp_lex_cursor
+--echo #
+SET @save_sql_mode=@@sql_mode;
+SET sql_mode='oracle';
+
+--delimiter $
+
+CREATE OR REPLACE PACKAGE pkg1 AS
+PROCEDURE p1 ();
+PROCEDURE p2 ();
+END pkg1;
+$
+
+CREATE OR REPLACE PACKAGE BODY pkg1 AS
+PROCEDURE p1() IS
+  CURSOR c1 IS SELECT a FROM t1;
+  va c1%ROWTYPE;
+BEGIN
+  SELECT 1;
+END p1;
+
+PROCEDURE p2() is
+BEGIN
+  FOR i IN 1..2
+  LOOP
+    SELECT i;
+    CREATE OR REPLACE temporary TABLE t1 (a INT);
+    CALL pkg1.p1;
+  END loop;
+END p2;
+END pkg1
+$
+
+--delimiter ;
+CALL pkg1.p2();
+
+DROP PACKAGE BODY pkg1;
+DROP PACKAGE pkg1;
+
+SET sql_mode=@save_sql_mode;
+
 --enable_ps2_protocol

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -904,6 +904,8 @@ sp_head::~sp_head()
   delete m_pcont;
   free_items();
 
+  deallocate_sp_instrs_mem_roots();
+
   /*
     If we have non-empty LEX stack then we just came out of parser with
     error. Now we should delete all auxilary LEXes and restore original
@@ -918,6 +920,44 @@ sp_head::~sp_head()
   sp_head::destroy(m_next_cached_sp);
 
   DBUG_VOID_RETURN;
+}
+
+
+/**
+  Iterate along a list of mem_roots created for reparsing of failed
+  SP instructions. There are as many mem_roots in this list as a number of
+  failed sp instructions.
+*/
+
+void sp_head::deallocate_sp_instrs_mem_roots()
+{
+  List_iterator_fast<MEM_ROOT> it(m_mem_roots_to_release);
+  MEM_ROOT *sp_instr_mem_root;
+
+  while ((sp_instr_mem_root= it++))
+  {
+    free_root(sp_instr_mem_root, MYF(0));
+  }
+  m_mem_roots_to_release.empty();
+}
+
+
+/**
+  Register the memory root for later deallocation
+
+  @param mem_root  the pointer to an instance of MEM_ROOT
+
+  @return false on success, true on error
+*/
+
+bool sp_head::register_instr_mem_root_for_deallocation(MEM_ROOT *mem_root)
+{
+  DBUG_ASSERT(mem_root != nullptr);
+
+  if (unlikely(mem_root == nullptr))
+    return false;
+
+  return m_mem_roots_to_release.push_back(mem_root);
 }
 
 

--- a/sql/sp_head.h
+++ b/sql/sp_head.h
@@ -333,6 +333,12 @@ private:
   */
   const char *m_cpp_body_begin;
 
+  /**
+    List of pointers to MEM_ROOT objects created when re-parsing failing
+    SP instructions.
+  */
+  List<MEM_ROOT> m_mem_roots_to_release;
+
 public:
   /*
     Security context for stored routine which should be run under
@@ -345,6 +351,11 @@ protected:
           enum_sp_aggregate_type agg_type);
   virtual ~sp_head();
 public:
+
+  void deallocate_sp_instrs_mem_roots();
+
+  bool register_instr_mem_root_for_deallocation(MEM_ROOT *mem_root);
+
   static void destroy(sp_head *sp);
   static sp_head *create(sp_package *parent, const Sp_handler *handler,
                          enum_sp_aggregate_type agg_type,

--- a/sql/sp_instr.h
+++ b/sql/sp_instr.h
@@ -400,7 +400,8 @@ public:
   sp_lex_instr(uint ip, sp_pcontext *ctx, LEX *lex, bool is_lex_owner)
   : sp_instr(ip, ctx),
     m_lex_keeper(lex, is_lex_owner),
-    m_mem_root_for_reparsing(nullptr)
+    m_mem_root_for_reparsing(nullptr),
+    m_sp{lex->sphead}
   {}
 
   ~sp_lex_instr() override
@@ -418,7 +419,13 @@ public:
       */
       free_items();
       m_lex_keeper.~sp_lex_keeper();
-      free_root(m_mem_root_for_reparsing, MYF(0));
+
+      /*
+        Ignore the OOM error explicitly since we are inside destructor
+      */
+      (void)m_sp->register_instr_mem_root_for_deallocation(
+        m_mem_root_for_reparsing);
+
       m_mem_root_for_reparsing= nullptr;
     }
   }
@@ -507,6 +514,7 @@ private:
   */
   List<Item_param> cleanup_before_parsing(enum_sp_type sp_type);
 
+  sp_head *m_sp;
 
   /**
     Set up field object for every NEW/OLD item of the trigger and


### PR DESCRIPTION
…x_cursor::~sp_lex_cursor

On re-parsing of a failed cursor statement inside the stored routine, the free_list of sp_lex_cursor could point to items placed on a dedicated memory root that is created during re-parsing of the failed statement.

In result, when sp_head object is destroyed the mem_root created for re-parsing the cursor's statement is de-allocated but the free_list pointer of sp_lex_cursor still point to objects previously allocated on this memory root.

To fix the issue, delay deallocation of mem_roots created for re-parsing of SP instructions till the moment the sp_head be destroyed.