### PR TITLE
MDEV-29803: Change mariadb-binlog --gtid-strict-mode default to OFF

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -127,7 +127,7 @@ static my_bool print_row_count_used= 0, print_row_event_positions_used= 0;
 static my_bool debug_info_flag, debug_check_flag;
 static my_bool force_if_open_opt= 1;
 static my_bool opt_raw_mode= 0, opt_stop_never= 0;
-my_bool opt_gtid_strict_mode= true;
+my_bool opt_gtid_strict_mode= false;
 static ulong opt_stop_never_slave_server_id= 0;
 static my_bool opt_verify_binlog_checksum= 1;
 static ulonglong offset = 0;
@@ -1885,7 +1885,7 @@ static struct my_option my_options[] =
    "start < stop comparison condition. Sequence numbers of any gtid domain "
    "must comprise monotically growing sequence",
    &opt_gtid_strict_mode, &opt_gtid_strict_mode, 0,
-   GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
+   GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"stop-datetime", OPT_STOP_DATETIME,
    "Stop reading the binlog at first event having a datetime equal or "
    "posterior to the argument; the argument must be a date and time "

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -127,7 +127,7 @@ static my_bool print_row_count_used= 0, print_row_event_positions_used= 0;
 static my_bool debug_info_flag, debug_check_flag;
 static my_bool force_if_open_opt= 1;
 static my_bool opt_raw_mode= 0, opt_stop_never= 0;
-my_bool opt_gtid_strict_mode= true;
+my_bool opt_gtid_strict_mode= false;
 static ulong opt_stop_never_slave_server_id= 0;
 static my_bool opt_verify_binlog_checksum= 1;
 static ulonglong offset = 0;
@@ -1887,7 +1887,7 @@ static struct my_option my_options[] =
    "start < stop comparison condition. Sequence numbers of any gtid domain "
    "must comprise monotically growing sequence",
    &opt_gtid_strict_mode, &opt_gtid_strict_mode, 0,
-   GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
+   GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"stop-datetime", OPT_STOP_DATETIME,
    "Stop reading the binlog at first event having a datetime equal or "
    "posterior to the argument; the argument must be a date and time "

--- a/mysql-test/suite/binlog/include/mysqlbinlog_gtid_window_test_cases.inc
+++ b/mysql-test/suite/binlog/include/mysqlbinlog_gtid_window_test_cases.inc
@@ -577,9 +577,9 @@ if ($is_remote == 0)
 --echo #   Error Case 3:
 --echo #   A GTID --start-position with any sequence numbers that are not
 --echo # eventually processed results in error
---echo # MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 > tmp_out_ 2> err_out_
+--echo # MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 --gtid-strict-mode > tmp_out_ 2> err_out_
 --error 1
---exec $MYSQL_BINLOG $BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 > $tmp_out_ 2> $err_out_
+--exec $MYSQL_BINLOG $BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 --gtid-strict-mode > $tmp_out_ 2> $err_out_
 if ($is_remote == 1)
 {
     --let SEARCH_PATTERN=ERROR: Got error reading packet from server

--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_gtid_window.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_gtid_window.result
@@ -208,7 +208,7 @@ FOUND 1 /ERROR: Binary logs are missing data for domain 0/ in err.out
 #   Error Case 3:
 #   A GTID --start-position with any sequence numbers that are not
 # eventually processed results in error
-# MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 > tmp_out_ 2> err_out_
+# MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 --gtid-strict-mode > tmp_out_ 2> err_out_
 FOUND 2 /ERROR: Binary logs never reached expected GTID state/ in err.out
 ######################################
 #      Test Group 2
@@ -440,7 +440,7 @@ FOUND 1 /ERROR: Got error reading packet from server/ in err.out
 #   Error Case 3:
 #   A GTID --start-position with any sequence numbers that are not
 # eventually processed results in error
-# MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 > tmp_out_ 2> err_out_
+# MYSQL_BINLOG BINLOG_FILE_PARAM2 --start-position=0-1-8,1-2-6 --gtid-strict-mode > tmp_out_ 2> err_out_
 FOUND 1 /ERROR: Got error reading packet from server/ in err.out
 #
 # Remote-only cleanup from error cases

--- a/mysql-test/suite/binlog/r/mdev_29803.result
+++ b/mysql-test/suite/binlog/r/mdev_29803.result
@@ -1,0 +1,9 @@
+reset master;
+create table t1 (a int);
+create table t2 (a int);
+drop table t1, t2;
+flush binary logs;
+drop table if exists t1, t2;
+Warnings:
+Note	1051	Unknown table 'test.t1,test.t2'
+flush binary logs;

--- a/mysql-test/suite/binlog/t/mdev_29803.test
+++ b/mysql-test/suite/binlog/t/mdev_29803.test
@@ -1,0 +1,36 @@
+--source include/have_log_bin.inc
+
+#
+# MDEV-29803: Unexpected ERROR: Found out of order GTID after replaying
+# binlog read from remote server, then reading the resulting local binlog.
+#
+# When mysqlbinlog replays a remote binlog into a server, and we then
+# read back the local binlog files, the replayed events reset the GTID
+# sequence, which causes a "Found out of order GTID" error if
+# --gtid-strict-mode is enabled.
+#
+# The fix is to change the default of --gtid-strict-mode to OFF so that
+# mysqlbinlog does not refuse to display events by default.
+#
+
+reset master;
+create table t1 (a int);
+create table t2 (a int);
+drop table t1, t2;
+flush binary logs;
+
+# Replay remote binlog into this server
+--exec $MYSQL_BINLOG --read-from-remote-server -uroot --protocol=tcp --port=$MASTER_MYPORT master-bin.000001 | $MYSQL test 2>&1
+
+drop table if exists t1, t2;
+flush binary logs;
+
+--let $datadir= `select @@datadir`
+
+# With the fix, the default --gtid-strict-mode=OFF allows reading both binlog
+# files without error, even though replayed events create out-of-order GTIDs.
+--exec $MYSQL_BINLOG $datadir/master-bin.000001 $datadir/master-bin.000002 > /dev/null 2>&1
+
+# Explicitly enabling --gtid-strict-mode should still produce an error
+--error 1
+--exec $MYSQL_BINLOG --gtid-strict-mode $datadir/master-bin.000001 $datadir/master-bin.000002 > /dev/null 2>&1


### PR DESCRIPTION
# Problem

When replaying a remote binlog into a server via `mariadb-binlog | mariadb` and then reading back both local binlog files, `mariadb-binlog` errors with "Found out of order GTID" and exits. This happens because the replayed events create duplicate GTID sequences in the local binlog, which the default `--gtid-strict-mode=ON` rejects.

Since `mariadb-binlog` is primarily a diagnostic/display tool, refusing to show events by default is counterproductive — users cannot even inspect the situation.

## Fix

Change the default of `--gtid-strict-mode` from ON to OFF in `mariadb-binlog`.
Users who want strict validation can still explicitly pass `--gtid-strict-mode`.

This was suggested by Kristian Nielsen in the Jira issue comments.

## Changes

- `client/mysqlbinlog.cc`: Changed `opt_gtid_strict_mode` default from
  `true` to `false`, and the option definition default from `1` to `0`
- Added regression test `binlog.mdev_29803`

## Test Results

- `binlog.mdev_29803` — PASS (mix, row, stmt)
- `binlog.binlog_mysqlbinlog_gtid_strict_mode` — PASS (no regression)
- `rpl.rpl_gtid_slave_filtering` — PASS
- `rpl.rpl_mysqlbinlog_slave_consistency` — PASS