### PR TITLE
MDEV-39349 NO_INDEX hint using QB_NAME doesn't work inside VIEWs

### DIFF
--- a/mysql-test/main/opt_hint_rowid_filter.test
+++ b/mysql-test/main/opt_hint_rowid_filter.test
@@ -1,5 +1,4 @@
 --enable_prepare_warnings
---disable_view_protocol # Since optimizer hints are not supported inside views
 
 CREATE TABLE t1 (a INT, b VARCHAR(10), c VARCHAR(100), d VARCHAR(200),
   KEY key_a(a), KEY key_b(b), KEY key_c(c), KEY key_d(d));

--- a/mysql-test/main/opt_hints.result
+++ b/mysql-test/main/opt_hints.result
@@ -1848,9 +1848,9 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 3	DERIVED	ten	ALL	NULL	NULL	NULL	NULL	10	Using where; Using join buffer (flat, BNL join)
 SHOW CREATE VIEW v2;
 View	Create View	character_set_client	collation_connection
-v2	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2` AS select /*+ JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`	utf8mb3	utf8mb3_uca1400_ai_ci
+v2	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2` AS select `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`	utf8mb3	utf8mb3_uca1400_ai_ci
 # This next CREATE VIEW statement should match the output of SHOW CREATE VIEW v2.  The following EXPLAIN output should match EXPLAIN SELECT * FROM v2 as a way to demonstrate that the output of SHOW CREATE VIEW is correct.
-CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3` AS select /*+ JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`;
+CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3` AS select `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`;
 EXPLAIN SELECT * FROM v3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	200	
@@ -1928,7 +1928,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 3	DERIVED	t7	ALL	NULL	NULL	NULL	NULL	256	Using where
 SHOW CREATE VIEW v7;
 View	Create View	character_set_client	collation_connection
-v7	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v7` AS select /*+ NO_INDEX(`t7`@`qb`) NO_MERGE(`dt`) */ `dt`.`a` AS `a` from (select /*+ QB_NAME(`qb`) */ `t7`.`a` AS `a` from `t7` where `t7`.`a` > 1 and `t7`.`a` < 3) `dt` where `dt`.`a` = 2	utf8mb3	utf8mb3_uca1400_ai_ci
+v7	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v7` AS select /*+ NO_MERGE(`dt`) */ `dt`.`a` AS `a` from (select /*+ QB_NAME(`qb`) NO_INDEX(`t7`@`qb`) */ `t7`.`a` AS `a` from `t7` where `t7`.`a` > 1 and `t7`.`a` < 3) `dt` where `dt`.`a` = 2	utf8mb3	utf8mb3_uca1400_ai_ci
 # End INDEX/JOIN_INDEX example
 # Example of many nested derived tables are not merged.
 EXPLAIN SELECT /*+ NO_MERGE(da) */ * FROM (SELECT /*+ NO_MERGE(db) */ * FROM (SELECT /*+ NO_MERGE(dc) */ * FROM (SELECT /*+ NO_MERGE(dd) */ * FROM (SELECT /*+ NO_MERGE(de) */ * FROM (SELECT /*+ NO_MERGE(df) */ * FROM (SELECT /*+ NO_MERGE(dg) */ * FROM (SELECT /*+ NO_MERGE(dh) */ * FROM (SELECT /*+ NO_MERGE(di) */ * FROM (SELECT /*+ NO_MERGE(dj) */ * FROM (SELECT /*+ NO_MERGE(dk) */ * FROM (SELECT /*+ NO_MERGE(dl) */ * FROM (SELECT * FROM ten) dl) dk) dj) di) dh) dg) df) de) dd) dc) db) da;
@@ -2108,3 +2108,74 @@ DROP TABLE t1;
 DROP VIEW v1;
 # End Examples from QA
 # End of 12.2 tests
+#
+# MDEV-39349 NO_INDEX hint using QB_NAME doesn't work inside VIEWs
+#
+CREATE TABLE t1 (
+a INT,
+b INT,
+INDEX(a),
+INDEX(b)
+);
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_1000;
+CREATE VIEW v1 AS SELECT /*+ QB_NAME(foo) NO_INDEX(t1@foo) */ a, b FROM t1 WHERE a<3 LIMIT 10;
+SHOW CREATE VIEW v1;
+View	Create View	character_set_client	collation_connection
+v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select /*+ QB_NAME(`foo`) NO_INDEX(`t1`@`foo`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b` from `t1` where `t1`.`a` < 3 limit 10	utf8mb3	utf8mb3_uca1400_ai_ci
+# Should use full scan of t1 (`ALL`)
+EXPLAIN EXTENDED SELECT * FROM v1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	10	100.00	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	1000	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `v1`.`a` AS `a`,`v1`.`b` AS `b` from `test`.`v1`
+CREATE VIEW v2 AS
+SELECT * FROM (SELECT /*+ QB_NAME(foo) NO_INDEX(t1@foo) */ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+WHERE a+b < 1000 ;
+SHOW CREATE VIEW v2;
+View	Create View	character_set_client	collation_connection
+v2	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2` AS select `dt`.`a` AS `a`,`dt`.`b` AS `b` from (select /*+ QB_NAME(`foo`) NO_INDEX(`t1`@`foo`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b` from `t1` where `t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000	utf8mb3	utf8mb3_uca1400_ai_ci
+# Should use full scan of t1 (`ALL`)
+EXPLAIN EXTENDED SELECT * FROM v2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+3	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	1000	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `dt`.`a` AS `a`,`dt`.`b` AS `b` from (/* select#3 */ select /*+ QB_NAME(`foo`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where `test`.`t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000
+CREATE VIEW v3 AS
+SELECT * FROM
+(SELECT a+b AS sumab, COUNT(*) AS cnt
+FROM  (SELECT /*+ NO_INDEX(t1) */ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+WHERE a+b < 1000
+GROUP BY a+b) aggr
+WHERE sumab < cnt;
+SHOW CREATE VIEW v3;
+View	Create View	character_set_client	collation_connection
+v3	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3` AS select `aggr`.`sumab` AS `sumab`,`aggr`.`cnt` AS `cnt` from (select `dt`.`a` + `dt`.`b` AS `sumab`,count(0) AS `cnt` from (select /*+ NO_INDEX(`t1`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b` from `t1` where `t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000 group by `dt`.`a` + `dt`.`b`) `aggr` where `aggr`.`sumab` < `aggr`.`cnt`	utf8mb3	utf8mb3_uca1400_ai_ci
+EXPLAIN EXTENDED SELECT * FROM v3 WHERE sumab < 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+3	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where; Using temporary; Using filesort
+4	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	1000	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `aggr`.`sumab` AS `sumab`,`aggr`.`cnt` AS `cnt` from (/* select#3 */ select `dt`.`a` + `dt`.`b` AS `sumab`,count(0) AS `cnt` from (/* select#4 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where `test`.`t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000 and `dt`.`a` + `dt`.`b` < 2 group by `dt`.`a` + `dt`.`b`) `aggr` where `aggr`.`sumab` < 2 and `aggr`.`sumab` < `aggr`.`cnt`
+CREATE VIEW v4 AS
+SELECT * FROM
+(SELECT /*+ NO_INDEX(t1@inner_qb)*/ a+b AS sumab, COUNT(*) AS cnt
+FROM  (SELECT /*+ QB_NAME(inner_qb)*/ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+WHERE a+b < 1000
+GROUP BY a+b) aggr
+WHERE sumab < cnt;
+SHOW CREATE VIEW v4;
+View	Create View	character_set_client	collation_connection
+v4	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v4` AS select `aggr`.`sumab` AS `sumab`,`aggr`.`cnt` AS `cnt` from (select `dt`.`a` + `dt`.`b` AS `sumab`,count(0) AS `cnt` from (select /*+ QB_NAME(`inner_qb`) NO_INDEX(`t1`@`inner_qb`) */ `t1`.`a` AS `a`,`t1`.`b` AS `b` from `t1` where `t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000 group by `dt`.`a` + `dt`.`b`) `aggr` where `aggr`.`sumab` < `aggr`.`cnt`	utf8mb3	utf8mb3_uca1400_ai_ci
+EXPLAIN EXTENDED SELECT * FROM v4 WHERE sumab < 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+3	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where; Using temporary; Using filesort
+4	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	1000	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `aggr`.`sumab` AS `sumab`,`aggr`.`cnt` AS `cnt` from (/* select#3 */ select `dt`.`a` + `dt`.`b` AS `sumab`,count(0) AS `cnt` from (/* select#4 */ select /*+ QB_NAME(`inner_qb`) */ `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where `test`.`t1`.`a` < 3 limit 10) `dt` where `dt`.`a` + `dt`.`b` < 1000 and `dt`.`a` + `dt`.`b` < 2 group by `dt`.`a` + `dt`.`b`) `aggr` where `aggr`.`sumab` < 2 and `aggr`.`sumab` < `aggr`.`cnt`
+DROP VIEW v1, v2, v3, v4;
+DROP TABLE t1;
+# End of 12.3 tests

--- a/mysql-test/main/opt_hints.test
+++ b/mysql-test/main/opt_hints.test
@@ -1,6 +1,5 @@
 --source include/have_sequence.inc
 --enable_prepare_warnings
---disable_view_protocol # Since optimizer hints are not supported inside views
 SET NAMES utf8mb4;
 
 --echo # Testing that index names in hints are accent sensitive case insensitive
@@ -12,9 +11,15 @@ SELECT /*+ NO_MRR(t1 idx_A) */ a FROM t1;
 # Warnings "Unresolved table/index name..." are generated during both prepare
 # and execution stages. So disable PS protocol to avoid duplication
 --disable_ps_protocol
+
+# Warnings during views creation have different format: query block names are stripped.
+# So disable view protocol here
+--disable_view_protocol
+
 SELECT /*+ NO_MRR(t1 idx_å) */ a FROM t1;
 SELECT /*+ NO_MRR(t1 idx_a, idx_å, idx_A) */ a FROM t1;
 --enable_ps_protocol
+--enable_view_protocol
 DROP TABLE t1;
 
 --echo # Testing that query block names are accent sensitive case insensitive
@@ -555,9 +560,15 @@ SELECT /*+ BKA(a b) */   1 FROM t1 a, t1 b;
 # Warnings "Unresolved table/index name..." are generated during both prepare
 # and execution stages. So disable PS protocol to avoid duplication
 --disable_ps_protocol
+
+# Warnings during views creation have different format: query block names are stripped.
+# So disable view protocol here
+--disable_view_protocol
+
 SELECT /*+ NO_ICP(i1) */ 1 FROM t1;
 SELECT /*+ NO_ICP(i1 i2) */ 1 FROM t1;
 --enable_ps_protocol
+--enable_view_protocol
 SELECT /*+ NO_ICP(@qb ident) */ 1 FROM t1;
 
 --echo
@@ -586,6 +597,11 @@ CREATE INDEX 3rd_index ON t1(i, j);
 # Warnings "Unresolved table/index name..." are generated during both prepare
 # and execution stages. So disable PS protocol to avoid duplication
 --disable_ps_protocol
+
+# Warnings during views creation have different format: query block names are stripped.
+# So disable view protocol here
+--disable_view_protocol
+
 SELECT /*+ NO_ICP(3rd_index) */ 1 FROM t1;
 
 CREATE INDEX $index ON t1(j, i);
@@ -614,6 +630,7 @@ SELECT /*+ BKA(" quoted name test") */ 1 FROM t1;
 DROP TABLE ` quoted name test`;
 DROP TABLE `test1``test2```;
 --enable_ps_protocol
+--enable_view_protocol
 
 --echo # Valid hints, no warning:
 EXPLAIN EXTENDED SELECT /*+ QB_NAME(`*`) */ 1;
@@ -640,6 +657,11 @@ CREATE TABLE tableТ (i INT);
 # Warnings "Unresolved table/index name..." are generated during both prepare
 # and execution stages. So disable PS protocol to avoid duplication
 --disable_ps_protocol
+
+# Warnings during views creation have different format: query block names are stripped.
+# So disable view protocol here
+--disable_view_protocol
+
 SELECT /*+ BKA(tableТ) */ 1 FROM t1;
 SELECT /*+ BKA(test@tableТ) */ 1 FROM t1;
 DROP TABLE tableТ;
@@ -654,6 +676,7 @@ SELECT /*+ NO_ICP(`\D1`) */ 1 FROM t1;
 
 DROP TABLE таблица;
 --enable_ps_protocol
+--enable_view_protocol
 
 --echo
 --echo # derived tables and other subqueries:
@@ -938,7 +961,7 @@ CREATE VIEW v2 AS SELECT /*+ JOIN_ORDER(@qb2 twenty,ten) */ * FROM (SELECT /*+ Q
 EXPLAIN SELECT * FROM v2;
 SHOW CREATE VIEW v2;
 --echo # This next CREATE VIEW statement should match the output of SHOW CREATE VIEW v2.  The following EXPLAIN output should match EXPLAIN SELECT * FROM v2 as a way to demonstrate that the output of SHOW CREATE VIEW is correct.
-CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3` AS select /*+ JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`;
+CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v3` AS select `t`.`a` AS `a` from (select /*+ QB_NAME(`qb2`) JOIN_ORDER(@`qb2` `twenty`,`ten`) */ `ten`.`a` AS `a` from (`ten` join `twenty`) where `ten`.`a` = `twenty`.`a` limit 1000) `t`;
 EXPLAIN SELECT * FROM v3;
 
 --echo # Named hint example.
@@ -1054,3 +1077,59 @@ DROP VIEW v1;
 --echo # End Examples from QA
 
 --echo # End of 12.2 tests
+
+--echo #
+--echo # MDEV-39349 NO_INDEX hint using QB_NAME doesn't work inside VIEWs
+--echo #
+CREATE TABLE t1 (
+  a INT,
+  b INT,
+  INDEX(a),
+  INDEX(b)
+);
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_1000;
+
+CREATE VIEW v1 AS SELECT /*+ QB_NAME(foo) NO_INDEX(t1@foo) */ a, b FROM t1 WHERE a<3 LIMIT 10;
+
+SHOW CREATE VIEW v1;
+
+--echo # Should use full scan of t1 (`ALL`)
+EXPLAIN EXTENDED SELECT * FROM v1;
+
+CREATE VIEW v2 AS
+SELECT * FROM (SELECT /*+ QB_NAME(foo) NO_INDEX(t1@foo) */ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+   WHERE a+b < 1000 ;
+
+SHOW CREATE VIEW v2;
+
+--echo # Should use full scan of t1 (`ALL`)
+EXPLAIN EXTENDED SELECT * FROM v2;
+
+CREATE VIEW v3 AS
+  SELECT * FROM
+  (SELECT a+b AS sumab, COUNT(*) AS cnt
+   FROM  (SELECT /*+ NO_INDEX(t1) */ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+   WHERE a+b < 1000
+   GROUP BY a+b) aggr
+  WHERE sumab < cnt;
+
+SHOW CREATE VIEW v3;
+
+EXPLAIN EXTENDED SELECT * FROM v3 WHERE sumab < 2;
+
+CREATE VIEW v4 AS
+  SELECT * FROM
+  (SELECT /*+ NO_INDEX(t1@inner_qb)*/ a+b AS sumab, COUNT(*) AS cnt
+   FROM  (SELECT /*+ QB_NAME(inner_qb)*/ a,b FROM t1 WHERE a<3 LIMIT 10) dt
+   WHERE a+b < 1000
+   GROUP BY a+b) aggr
+  WHERE sumab < cnt;
+
+SHOW CREATE VIEW v4;
+
+EXPLAIN EXTENDED SELECT * FROM v4 WHERE sumab < 2;
+
+DROP VIEW v1, v2, v3, v4;
+DROP TABLE t1;
+
+--echo # End of 12.3 tests

--- a/mysql-test/main/opt_hints_join_order.result
+++ b/mysql-test/main/opt_hints_join_order.result
@@ -131,19 +131,15 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using join buffer (incremental, BNL join)
 Warnings:
 Note	1003	select /*+ QB_NAME(`q1`) JOIN_ORDER(@`q1` `t2`@`q1`,`t1`) JOIN_ORDER(@`q1` `t3`,`t2`@`q1`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t2` join `test`.`t3`
-# Invalid mix of notations
 EXPLAIN EXTENDED
 SELECT /*+ QB_NAME(q1) JOIN_PREFIX(@q1 t2, t1@q1)*/ count(*)
 FROM t1, t2, t3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	
-1	SIMPLE	t3	ALL	NULL	NULL	NULL	NULL	5	100.00	Using join buffer (flat, BNL join)
-1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	20	100.00	Using join buffer (incremental, BNL join)
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	20	100.00	
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using join buffer (flat, BNL join)
+1	SIMPLE	t3	ALL	NULL	NULL	NULL	NULL	5	100.00	Using join buffer (incremental, BNL join)
 Warnings:
-Warning	1064	Optimizer hint syntax error near '@q1)*/ count(*)
-FROM t1, t2, t3' at line 2
-Note	1003	select count(0) AS `count(*)` from `test`.`t1` join `test`.`t2` join `test`.`t3`
-# Hint is correct
+Note	1003	select /*+ QB_NAME(`q1`) JOIN_PREFIX(@`q1` `t2`,`t1`@`q1`) */ count(0) AS `count(*)` from `test`.`t1` join `test`.`t2` join `test`.`t3`
 EXPLAIN EXTENDED
 SELECT /*+ QB_NAME(qb1) JOIN_SUFFIX(t1@qb1, t2)*/ count(*) FROM t1, t2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
@@ -296,6 +292,24 @@ t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
 count(*)
 300
 explain extended SELECT /*+ QB_NAME(q1) JOIN_PREFIX(t3, t2, t2@subq2) */ count(*) FROM t1 JOIN t2 JOIN t3
+WHERE t1.f1 IN (SELECT /*+ QB_NAME(subq1) */ f1 FROM t2) AND
+t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	5	100.00	
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	20	100.00	Using join buffer (flat, BNL join)
+1	PRIMARY	t2	hash_ALL	NULL	#hash#$hj	4	test.t2.f1	20	5.00	Using where; FirstMatch(t2); Using join buffer (incremental, BNLH join)
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using join buffer (incremental, BNL join)
+1	PRIMARY	<subquery2>	eq_ref	distinct_key	distinct_key	4	func	1	100.00	
+2	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	20	100.00	
+Warnings:
+Note	1003	select /*+ QB_NAME(`q1`) JOIN_PREFIX(@`q1` `t3`,`t2`,`t2`@`subq2`) */ count(0) AS `count(*)` from `test`.`t1` semi join (`test`.`t2`) semi join (`test`.`t2`) join `test`.`t2` join `test`.`t3` where `test`.`t2`.`f1` = `test`.`t2`.`f1`
+# Variation of above (JOIN_PREFIX hint includes QB name here)
+SELECT /*+ QB_NAME(q1) JOIN_PREFIX(@q1 t3, t2, t2@subq2) */ count(*) FROM t1 JOIN t2 JOIN t3
+WHERE t1.f1 IN (SELECT /*+ QB_NAME(subq1) */ f1 FROM t2) AND
+t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
+count(*)
+300
+explain extended SELECT /*+ QB_NAME(q1) JOIN_PREFIX(@q1 t3, t2, t2@subq2) */ count(*) FROM t1 JOIN t2 JOIN t3
 WHERE t1.f1 IN (SELECT /*+ QB_NAME(subq1) */ f1 FROM t2) AND
 t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra

--- a/mysql-test/main/opt_hints_join_order.test
+++ b/mysql-test/main/opt_hints_join_order.test
@@ -73,12 +73,10 @@ EXPLAIN EXTENDED
   SELECT /*+ QB_NAME(q1) JOIN_ORDER(t2@q1, t1) JOIN_ORDER(t3, t2@q1)*/ count(*)
   FROM t1, t2, t3;
   
---echo # Invalid mix of notations
 EXPLAIN EXTENDED
   SELECT /*+ QB_NAME(q1) JOIN_PREFIX(@q1 t2, t1@q1)*/ count(*)
   FROM t1, t2, t3;
 
---echo # Hint is correct
 EXPLAIN EXTENDED
   SELECT /*+ QB_NAME(qb1) JOIN_SUFFIX(t1@qb1, t2)*/ count(*) FROM t1, t2;
 
@@ -145,6 +143,13 @@ eval explain extended $query;
 
 --echo # Check name resolving
 let $query= SELECT /*+ QB_NAME(q1) JOIN_PREFIX(t3, t2, t2@subq2) */ count(*) FROM t1 JOIN t2 JOIN t3
+              WHERE t1.f1 IN (SELECT /*+ QB_NAME(subq1) */ f1 FROM t2) AND
+                    t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
+eval $query;
+eval explain extended $query;
+
+--echo # Variation of above (JOIN_PREFIX hint includes QB name here)
+let $query= SELECT /*+ QB_NAME(q1) JOIN_PREFIX(@q1 t3, t2, t2@subq2) */ count(*) FROM t1 JOIN t2 JOIN t3
               WHERE t1.f1 IN (SELECT /*+ QB_NAME(subq1) */ f1 FROM t2) AND
                     t2.f1 IN (SELECT /*+ QB_NAME(subq2) */ f1 FROM t2);
 eval $query;

--- a/mysql-test/main/opt_hints_merge.test
+++ b/mysql-test/main/opt_hints_merge.test
@@ -1,5 +1,4 @@
 --source include/have_sequence.inc
---disable_view_protocol
 create table t1 select seq as i, 10*seq as j from seq_1_to_10;
 create view v1 as select * from t1 where i % 2 = 0;
 
@@ -62,6 +61,10 @@ WHERE dt.a = dt2.a and dt.b = dt2.b AND dt.a < 3 AND dt.b > 8;
 set optimizer_switch=@save_optimizer_switch;
 
 # Test warnings
+# Warnings during views creation have different format: query block names are stripped.
+# So disable view protocol here
+--disable_view_protocol
+
 explain extended select /*+ NO_MERGE(t) */ * from (select * from t1) t;
 explain extended select /*+ MERGE(t) */ * from (select * from t1) t;
 create table t2 select seq as i, 10*seq as j from seq_1_to_10;

--- a/sql/opt_hints_parser.cc
+++ b/sql/opt_hints_parser.cc
@@ -307,6 +307,17 @@ Parser::Table_name_list_container::add(Optimizer_hint_parser *p,
 }
 
 
+bool Parser::Table_name_ext_container::add(Optimizer_hint_parser *p,
+                                           Table_name_ext &&elem)
+{
+  Table_name_ext *pe= (Table_name_ext*) p->m_thd->alloc(sizeof(*pe));
+  if (!pe)
+    return true;
+  *pe= std::move(elem);
+  return push_back(pe, p->m_thd->mem_root);
+}
+
+
 bool Parser::Hint_param_table_list_container::add(Optimizer_hint_parser *p,
                                                   Hint_param_table &&elem)
 {
@@ -1144,17 +1155,20 @@ bool Parser::Join_order_hint::resolve(Parse_context *pc)
 
   Opt_hints_qb *qb= nullptr;
   Lex_ident_sys qb_name;
-  if (const At_query_block_name_opt_table_name_list &at_qb_tab_list= *this)
+  const Table_level_hint_body_extended_container &body= *this;
+  if (body.m_qb_name)
   {
-    // this is @ query_block_name opt_table_name_list
-    qb_name= Query_block_name::to_ident_sys(pc->thd);
+    /*
+      This is @ query_block_name opt_table_name_ext_list,
+      for example JOIN_PREFIX(@q1 t3, t2, t2@subq2)
+    */
+    qb_name= static_cast<const Query_block_name&>(body.m_qb_name).to_ident_sys(pc->thd);
     qb= find_qb_hints(pc, qb_name, hint_type, true);
-    // Compose `tables_names` list for warnings and final hints resolving
-    const Opt_table_name_list &opt_table_name_list= at_qb_tab_list;
-    for (const Table_name &table : opt_table_name_list)
+    for (const Table_name_ext &table : body.m_tables)
     {
       Parser::Table_name_and_Qb *tbl_qb= new (pc->mem_root)
-        Parser::Table_name_and_Qb(table.to_ident_sys(pc->thd), Lex_ident_sys());
+        Parser::Table_name_and_Qb(table.Table_name::to_ident_sys(pc->thd),
+                                  table.Query_block_name::to_ident_sys(pc->thd));
       if (!tbl_qb)
         return true;
       table_names.push_back(tbl_qb, pc->mem_root);
@@ -1162,10 +1176,9 @@ bool Parser::Join_order_hint::resolve(Parse_context *pc)
   }
   else
   {
-    // this is opt_hint_param_table_list, query block name is not specified
+    // global QB name is not specified, for example JOIN_ORDER(t3, t2, t2@subq2)
     qb= find_qb_hints(pc, Lex_ident_sys(), hint_type, true);
-    const Opt_hint_param_table_list &opt_hint_param_table_list= *this;
-    for (const Hint_param_table &table : opt_hint_param_table_list)
+    for (const Table_name_ext &table : body.m_tables)
     {
       // e.g. JOIN_ORDER(t1@qb1, t2@qb2, t3)
       Parser::Table_name_and_Qb *tbl_qb=

--- a/sql/opt_hints_parser.h
+++ b/sql/opt_hints_parser.h
@@ -579,7 +579,6 @@ private:
     using OR2C::OR2C;
   };
 
-
   /*
     at_query_block_name_opt_table_name_list ::=
       @ query_block_name opt_table_name_list
@@ -592,7 +591,6 @@ private:
   public:
     using AND2::AND2;
   };
-
 
   /*
     table_level_hint_body:   @ query_block_name opt_table_name_list
@@ -619,8 +617,7 @@ private:
 
     bool resolve(Parse_context *pc) const;
   };
-
-
+  
   // index_level_hint_body ::= hint_param_table_ext opt_hint_param_index_list
   class Index_level_hint_body: public AND2<Parser,
                                            Hint_param_table_ext,
@@ -898,6 +895,93 @@ public:
              id == TokenID::keyword_JOIN_SUFFIX;
     }
   };
+
+  //
+  // Structures required for join order hints
+  //
+  //  table_name_ext ::= table_name opt_qb_name
+  class Table_name_ext: public AND2<Parser, Table_name, Opt_qb_name>
+  {
+  public:
+    using AND2::AND2;
+  };
+
+  class Table_name_ext_container: public List<Table_name_ext>
+  {
+  public:
+    Table_name_ext_container()
+    { }
+    bool add(Optimizer_hint_parser *p, Table_name_ext &&table);
+    size_t count() const { return elements; }
+  };
+
+  /*
+    table_name_ext_list ::= table_name_ext [ {, table_name_ext}... ]
+  */
+  class Table_name_ext_list: public LIST<Parser,
+                                         Table_name_ext_container,
+                                         Table_name_ext,
+                                         TokenID::tCOMMA, 0>
+  {
+    using LIST::LIST;
+  };
+
+  /*
+    at_query_block_name_table_name_ext_list ::= @ query_block_name table_name_ext_list
+  */
+  class At_query_block_name_table_name_ext_list: public AND2<
+                                                    Parser,
+                                                    At_query_block_name,
+                                                    Table_name_ext_list>
+  {
+  public:
+    using AND2::AND2;
+  };
+
+  class Table_level_hint_body_extended_container
+  {
+  public:
+    At_query_block_name m_qb_name;
+    Table_name_ext_list m_tables;
+
+    Table_level_hint_body_extended_container() = default;
+    Table_level_hint_body_extended_container(
+      At_query_block_name_table_name_ext_list &&src) :
+      m_qb_name(std::move(static_cast<At_query_block_name&>(src))),
+      m_tables(std::move(static_cast<Table_name_ext_list&>(src)))
+    {}
+    Table_level_hint_body_extended_container(Table_name_ext_list &&tables) :
+      m_tables(std::move(tables))
+    {}
+    Table_level_hint_body_extended_container &operator=(
+      At_query_block_name_table_name_ext_list &&src)
+    {
+      m_qb_name= std::move(static_cast<At_query_block_name&>(src));
+      m_tables= std::move(static_cast<Table_name_ext_list&>(src));
+      return *this;
+    }
+    Table_level_hint_body_extended_container &operator=(
+      Table_name_ext_list &&tables)
+    {
+      m_tables= std::move(tables);
+      return *this;
+    }
+    operator bool() const
+    {
+      return (bool) m_qb_name || (bool) m_tables;
+    }
+  };
+
+  class Table_level_hint_body_extended: public OR2C<
+                                        Parser,
+                                        Table_level_hint_body_extended_container,
+                                        At_query_block_name_table_name_ext_list,
+                                        Table_name_ext_list>
+  {
+  public:
+    using OR2C::OR2C;
+  };
+
   class Join_order_hint_type: public TokenChoice<Parser,
                                                  Join_order_hint_type_cond>
   {
@@ -930,7 +1014,7 @@ public:
   class Join_order_hint: public AND4<Parser,
                                    Join_order_hint_type,
                                    LParen,
-                                   Table_level_hint_body,
+                                   Table_level_hint_body_extended,
                                    RParen>,
                          public Printable_parser_rule
   {
@@ -949,7 +1033,9 @@ public:
     */
     List<Table_name_and_Qb> table_names;
   };
-
+  //
+  // End of structures required for join order hints
+  //
 
   /*
     hint ::=   index_level_hint

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -32596,29 +32596,32 @@ void st_select_lex::print(THD *thd, String *str, enum_query_type query_type)
   // PROCEDURE unsupported here
 }
 
-
-void st_select_lex::print_hints(THD *thd,
-                                String *str)
+void st_select_lex::print_hints(THD *thd, String *str)
 {
+  if (!parent_lex->opt_hints_global)
+    return;
+
+  const bool is_view= parent_lex->sql_command == SQLCOM_CREATE_VIEW ||
+                      parent_lex->sql_command == SQLCOM_SHOW_CREATE;
   constexpr LEX_CSTRING header={STRING_WITH_LEN("/*+ ")};
   str->append(header);
   const uint32 len_before_hints= str->length();
 
   if (opt_hints_qb)
     opt_hints_qb->append_qb_hint(thd, str);
-
-  if (thd->lex->sql_command == SQLCOM_CREATE_VIEW ||
-      thd->lex->sql_command == SQLCOM_SHOW_CREATE)
+  if (this == parent_lex->unit.first_select() && !is_view)
   {
-    if (str->length() <= len_before_hints &&
-        opt_hints_qb && opt_hints_qb->get_parent())
-      opt_hints_qb->get_parent()->print(thd, str);
+    /*
+      For normal queries (not views creation/show) opt_hints_global will
+      print itself and all children recursively into the first select.
+      Global hints are not supported inside views, so it is safe to skip them
+    */
+    parent_lex->opt_hints_global->print(thd, str);
   }
-  else
+  if (is_view && opt_hints_qb)
   {
-    if (thd->lex->opt_hints_global &&
-        select_number == 1)  // toplevel SELECT
-      thd->lex->opt_hints_global->print(thd, str);
+    // For views print hints related to a QB right into the QB they target
+    opt_hints_qb->print(thd, str);
   }
 
   // If no hints were added, then rollback the previouly added header.


### PR DESCRIPTION
Refine the logic of storing hints inside view definitions.

The same procedures are used for printing hints in both
EXPLAIN EXTENDED of regular statements and when storing view
definitions. For regular statements all hints (except QB_NAME)
are printed into the topmost SELECT with attachment of target
query block names. If some query blocks do not have explicit
names set with QB_NAME hints, implicit names `select#1`, `select#2`
are attached.

 This approach does not work views, because view definitions do not
 have such implicit numbering of query blocks. The solution is
 to print hints related to a particular query block right
 into this query block instead of printing them into
 the topmost SELECT.