### PR TITLE
MDEV-39351:  too narrow decimal precision for expression cache

### DIFF
--- a/mysql-test/main/win.result
+++ b/mysql-test/main/win.result
@@ -4793,5 +4793,28 @@ c1	c2
 2	2
 DROP TABLE t1;
 #
+# MDEV-39351: ROUND(AVG()) produces different results via window
+#             function path vs scalar subquery path
+#
+CREATE TABLE t1 (id INT PRIMARY KEY, p INT, v INT);
+INSERT INTO t1 VALUES
+(1,1,-99),(2,1,-93),(3,1,43),(4,1,-30),(5,1,46),
+(6,1,-23),(7,1,87),(8,1,-55),(9,1,-1),(10,1,8),
+(11,1,30),(12,1,32),(13,1,6),
+(14,2,-29),(15,2,-35),(16,2,96),(17,2,42),(18,2,17),
+(19,2,-46),(20,2,88),(21,2,41),(22,2,-33),(23,2,77),(24,2,1);
+# Should return Empty set (both AVG computations are identical)
+SELECT id, p, wf_avg, scalar_avg
+FROM (
+SELECT id, p, v,
+ROUND(AVG(v) OVER (PARTITION BY p), 6) AS wf_avg,
+ROUND((SELECT AVG(t2.v) FROM t1 t2
+WHERE t2.p <=> t1.p), 6) AS scalar_avg
+FROM t1
+) sub
+WHERE wf_avg <> scalar_avg;
+id	p	wf_avg	scalar_avg
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #

--- a/mysql-test/main/win.test
+++ b/mysql-test/main/win.test
@@ -3109,5 +3109,30 @@ from t1;
 DROP TABLE t1;
 
 --echo #
+--echo # MDEV-39351: ROUND(AVG()) produces different results via window
+--echo #             function path vs scalar subquery path
+--echo #
+CREATE TABLE t1 (id INT PRIMARY KEY, p INT, v INT);
+INSERT INTO t1 VALUES
+  (1,1,-99),(2,1,-93),(3,1,43),(4,1,-30),(5,1,46),
+  (6,1,-23),(7,1,87),(8,1,-55),(9,1,-1),(10,1,8),
+  (11,1,30),(12,1,32),(13,1,6),
+  (14,2,-29),(15,2,-35),(16,2,96),(17,2,42),(18,2,17),
+  (19,2,-46),(20,2,88),(21,2,41),(22,2,-33),(23,2,77),(24,2,1);
+
+--echo # Should return Empty set (both AVG computations are identical)
+SELECT id, p, wf_avg, scalar_avg
+FROM (
+  SELECT id, p, v,
+    ROUND(AVG(v) OVER (PARTITION BY p), 6) AS wf_avg,
+    ROUND((SELECT AVG(t2.v) FROM t1 t2
+           WHERE t2.p <=> t1.p), 6) AS scalar_avg
+  FROM t1
+) sub
+WHERE wf_avg <> scalar_avg;
+
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.11 tests
 --echo #

--- a/mysql-test/suite/encryption/r/tempfiles_encrypted.result
+++ b/mysql-test/suite/encryption/r/tempfiles_encrypted.result
@@ -4799,6 +4799,29 @@ c1	c2
 2	2
 DROP TABLE t1;
 #
+# MDEV-39351: ROUND(AVG()) produces different results via window
+#             function path vs scalar subquery path
+#
+CREATE TABLE t1 (id INT PRIMARY KEY, p INT, v INT);
+INSERT INTO t1 VALUES
+(1,1,-99),(2,1,-93),(3,1,43),(4,1,-30),(5,1,46),
+(6,1,-23),(7,1,87),(8,1,-55),(9,1,-1),(10,1,8),
+(11,1,30),(12,1,32),(13,1,6),
+(14,2,-29),(15,2,-35),(16,2,96),(17,2,42),(18,2,17),
+(19,2,-46),(20,2,88),(21,2,41),(22,2,-33),(23,2,77),(24,2,1);
+# Should return Empty set (both AVG computations are identical)
+SELECT id, p, wf_avg, scalar_avg
+FROM (
+SELECT id, p, v,
+ROUND(AVG(v) OVER (PARTITION BY p), 6) AS wf_avg,
+ROUND((SELECT AVG(t2.v) FROM t1 t2
+WHERE t2.p <=> t1.p), 6) AS scalar_avg
+FROM t1
+) sub
+WHERE wf_avg <> scalar_avg;
+id	p	wf_avg	scalar_avg
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #
 #

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -9396,11 +9396,45 @@ my_decimal *Item_cache_wrapper::val_decimal(my_decimal* decimal_value)
 {
   Item *cached_value;
   DBUG_ENTER("Item_cache_wrapper::val_decimal");
+
+  /*
+    The cache is not in use, typically because of reasons given in
+    Item_subselect::expr_cache_is_needed.
+
+    expr_cache_is_needed is a virtual method whose default is to
+    indicate that the cache is not needed, Item_subselect implements
+    an override.
+   */
   if (!expr_cache)
   {
     my_decimal *tmp= orig_item->val_decimal(decimal_value);
     null_value= orig_item->null_value;
     DBUG_RETURN(tmp);
+  }
+
+  /*
+    (At this point in time, the only concrete implementation of the
+    Expression_cache interface is Expression_cache_tmptable).
+
+    Expression_cache_tmptable::init() creates its temporary table's
+    result field from the metadata provided by the
+    Type_numeric_attributes parent class (which is where
+    expr_value->decimals lives, the precision of the decimal result),
+    so we must ensure that expr_value->decimals has the correct width
+    before we initialize the cache.  If we don't do this, then the
+    temporary table's result field in the cache may have a narrower
+    width than what is needed which computes a wrong result.  Evaluate
+    orig_item once here so expr_value->decimals reflects the actual
+    width of the first value that will be cached.
+  */
+  DBUG_ASSERT(expr_cache);  // We only make it here if the cache is in use.
+  DBUG_ASSERT(expr_value);  // Presumed to exist.
+  if (!expr_cache->is_inited() &&
+      expr_value->result_type() == DECIMAL_RESULT)
+  {
+    my_decimal *tmp= orig_item->val_decimal(decimal_value);
+    if (!(null_value= orig_item->null_value))
+      expr_value->decimals= tmp->frac;
   }
 
   if ((cached_value= check_cache()))


### PR DESCRIPTION
The expression cache had a narrower precision than the decimal value that it cached, leading to a wrong result as truncation errors compounded over the query's lifetime.  Fix this by taking the actual precision of the decimal value before initializing the expression cache (rather than the default value found in the Type_numeric_attributes parent class) and using it to initialize the expression cache's temporary table result field.