### PR TITLE
MDEV-39466 proxy_protocol: fix off-by-one stack buffer overflow in PROXY v1 header parsing

### DIFF
--- a/include/my_time.h
+++ b/include/my_time.h
@@ -285,7 +285,7 @@ typedef struct my_timespec
   ulong usec;
 } my_timespec_t;
 
-inline
+static inline
 int cmp(my_timespec_t a, my_timespec_t b)
 {
   return ((a.sec > b.sec || (a.sec == b.sec && a.usec > b.usec)) ? 1 :

--- a/include/my_time.h
+++ b/include/my_time.h
@@ -279,6 +279,41 @@ enum interval_type
   INTERVAL_MINUTE_MICROSECOND, INTERVAL_SECOND_MICROSECOND, INTERVAL_LAST
 };
 
+typedef struct my_timespec
+{
+  my_time_t sec;
+  ulong usec;
+} my_timespec_t;
+
+inline
+int cmp(my_timespec_t a, my_timespec_t b)
+{
+  return ((a.sec > b.sec || (a.sec == b.sec && a.usec > b.usec)) ? 1 :
+         ((a.sec < b.sec || (a.sec == b.sec && a.usec < b.usec)) ? -1 : 0));
+}
+
 C_MODE_END
 
+#ifdef __cplusplus
+constexpr my_timespec_t MY_TIMESPEC_MIN= {MY_TIME_T_MIN, 0};
+constexpr my_timespec_t MY_TIMESPEC_MAX= {TIMESTAMP_MAX_VALUE, TIME_MAX_SECOND_PART};
+
+inline
+bool operator< (my_timespec_t a, my_timespec_t b)
+{
+  return cmp(a, b) < 0;
+}
+
+inline
+bool operator> (my_timespec_t a, my_timespec_t b)
+{
+  return cmp(a, b) > 0;
+}
+
+inline
+bool operator== (my_timespec_t a, my_timespec_t b)
+{
+  return (a.sec == b.sec) && (a.usec == b.usec);
+}
+#endif
 #endif /* _my_time_h_ */

--- a/mysql-test/main/partition.result
+++ b/mysql-test/main/partition.result
@@ -2921,3 +2921,18 @@ DROP TABLE mdev20498;
 #
 # End of 10.6 tests
 #
+#
+# MDEV-25529 ALTER TABLE FORCE syntax improved
+#
+create table t1 (id int primary key);
+alter table t1 force partition by hash(id) partitions 2;
+alter table t1 force remove partitioning;
+alter table t1 partition by hash(id) partitions 2 force;
+alter table t1 remove partitioning force;
+alter table t1 force partition by hash(id) partitions 2 force;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'force' at line 1
+alter table t1 force remove partitioning force;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'force' at line 1
+alter table t1 add column x int partition by hash(id) partitions 2;
+alter table t1 remove partitioning add column y int;
+drop table t1;

--- a/mysql-test/main/partition.test
+++ b/mysql-test/main/partition.test
@@ -3144,3 +3144,20 @@ DROP TABLE mdev20498;
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-25529 ALTER TABLE FORCE syntax improved
+--echo #
+create table t1 (id int primary key);
+alter table t1 force partition by hash(id) partitions 2;
+alter table t1 force remove partitioning;
+alter table t1 partition by hash(id) partitions 2 force;
+alter table t1 remove partitioning force;
+--error ER_PARSE_ERROR
+alter table t1 force partition by hash(id) partitions 2 force;
+--error ER_PARSE_ERROR
+alter table t1 force remove partitioning force;
+# Strange syntax, but it exists since 2005 (cd483c55)
+alter table t1 add column x int partition by hash(id) partitions 2;
+alter table t1 remove partitioning add column y int;
+drop table t1;

--- a/mysql-test/main/proxy_protocol_v1_malformed.result
+++ b/mysql-test/main/proxy_protocol_v1_malformed.result
@@ -1,0 +1,11 @@
+#
+# Test A: V1 header longer than MAX_PROXY_HEADER_LEN (256 bytes) without newline
+#
+Test A: server did not crash after long V1 header
+#
+# Test B: V1 header with excessively long fields
+#
+Test B: server did not crash after excessively long fields in V1 header
+server_alive
+1
+# End of proxy_protocol_v1_malformed tests

--- a/mysql-test/main/proxy_protocol_v1_malformed.test
+++ b/mysql-test/main/proxy_protocol_v1_malformed.test
@@ -1,0 +1,74 @@
+#
+# Test: Malformed PROXY protocol V1 headers must be rejected without crashing.
+#
+# This test sends crafted proxy protocol V1 headers over raw TCP
+# to verify that the server correctly rejects:
+#   A) Headers longer than MAX_PROXY_HEADER_LEN without a newline
+#   B) Fields longer than MAX_PROXY_HEADER_LEN
+#
+# The server must close the connection gracefully in all cases (no crash).
+#
+
+--source include/not_embedded.inc
+--source include/not_windows.inc
+
+# Need proxy_protocol_networks enabled for the server to enter the
+# proxy protocol parsing path.
+SET @save_proxy= @@global.proxy_protocol_networks;
+SET GLOBAL proxy_protocol_networks='*';
+
+# Use a short connect_timeout so tests don't hang
+SET @save_timeout= @@global.connect_timeout;
+SET GLOBAL connect_timeout=5;
+
+--echo #
+--echo # Test A: V1 header longer than MAX_PROXY_HEADER_LEN (256 bytes) without newline
+--echo #
+--perl
+use Socket;
+
+# Build a V1 header that exceeds the 256 byte buffer limit
+my $v1_sig = "PROXY";
+my $long_hdr = $v1_sig . ("A" x 260); 
+
+socket(SOCK, PF_INET, SOCK_STREAM, getprotobyname("tcp"))
+  or die "socket: $!\n";
+connect(SOCK, pack_sockaddr_in($ENV{MASTER_MYPORT}, inet_aton("127.0.0.1")))
+  or die "connect: $!\n";
+# Send long header and immediately close
+syswrite(SOCK, $long_hdr);
+select(undef, undef, undef, 0.5);
+close(SOCK);
+print "Test A: server did not crash after long V1 header\n";
+EOF
+
+--echo #
+--echo # Test B: V1 header with excessively long fields
+--echo #
+--perl
+use Socket;
+
+my $v1_sig = "PROXY";
+my $long_field = "A" x 300;
+my $hdr = "$v1_sig $long_field $long_field $long_field 123 456\n";
+
+socket(SOCK, PF_INET, SOCK_STREAM, getprotobyname("tcp"))
+  or die "socket: $!\n";
+connect(SOCK, pack_sockaddr_in($ENV{MASTER_MYPORT}, inet_aton("127.0.0.1")))
+  or die "connect: $!\n";
+syswrite(SOCK, $hdr);
+select(undef, undef, undef, 0.5);
+close(SOCK);
+print "Test B: server did not crash after excessively long fields in V1 header\n";
+EOF
+
+# Allow time for the server to clean up aborted connections
+--sleep 1
+
+# Verify the server is still alive and accepting connections
+SELECT 1 AS server_alive;
+
+SET GLOBAL connect_timeout= @save_timeout;
+SET GLOBAL proxy_protocol_networks= @save_proxy;
+
+--echo # End of proxy_protocol_v1_malformed tests

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -484,7 +484,7 @@ PARTITIONS 2
 create or replace table t1 (i int) with system versioning
 partition by system_time interval 1 day starts '2000-01-01 00:00:01';
 Warnings:
-Warning	4164	`t1`: STARTS is later than query time, first history partition may exceed INTERVAL value
+Warning	4164	`t1`: STARTS timestamp 2000-01-01 00:00:01 is later than query timestamp 2000-01-01 00:00:00, first history partition may exceed INTERVAL value
 # Test default STARTS rounding
 set timestamp= unix_timestamp('1999-12-15 13:33:33');
 create or replace table t1 (i int) with system versioning
@@ -556,7 +556,7 @@ set time_zone="+03:00";
 create or replace table t1 (i int) with system versioning
 partition by system_time interval 1 day starts '2000-01-01 00:00:00';
 Warnings:
-Warning	4164	`t1`: STARTS is later than query time, first history partition may exceed INTERVAL value
+Warning	4164	`t1`: STARTS timestamp 2000-01-01 00:00:00 is later than query timestamp 1999-12-15 16:33:33, first history partition may exceed INTERVAL value
 set timestamp= unix_timestamp('2000-01-01 00:00:00');
 create or replace table t2 (i int) with system versioning
 partition by system_time interval 1 day;
@@ -616,7 +616,7 @@ create or replace table t1 (i int) with system versioning
 partition by system_time interval 1 day starts '2000-01-03 00:00:00'
 partitions 3;
 Warnings:
-Warning	4164	`t1`: STARTS is later than query time, first history partition may exceed INTERVAL value
+Warning	4164	`t1`: STARTS timestamp 2000-01-03 00:00:00 is later than query timestamp 2000-01-01 00:00:00, first history partition may exceed INTERVAL value
 insert into t1 values (0);
 set timestamp= unix_timestamp('2000-01-01 00:00:01');
 update t1 set i= i + 1;

--- a/mysql-test/suite/versioning/r/partition2.result
+++ b/mysql-test/suite/versioning/r/partition2.result
@@ -15,7 +15,7 @@ index (row_end, row_start),
 index (row_start),
 index (row_end, x),
 index (x, row_end),
-index (row_end)) with system versioning
+index (row_end desc)) with system versioning
 partition by system_time limit 1000 partitions 6;
 show create table t1;
 Table	Create Table
@@ -27,7 +27,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME LIMIT 1000
@@ -118,7 +118,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -146,7 +146,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -176,7 +176,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -209,7 +209,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 20 MINUTE STARTS TIMESTAMP'2000-01-01 00:10:00' AUTO
@@ -246,7 +246,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -266,7 +266,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -286,7 +286,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2005-01-01 00:00:00' AUTO
@@ -307,7 +307,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 7 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -327,7 +327,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 8 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
@@ -346,7 +346,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 8 HOUR STARTS TIMESTAMP'2000-01-03 00:00:00' AUTO
@@ -365,7 +365,7 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY HASH (`x`)
@@ -386,11 +386,104 @@ t1	CREATE TABLE `t1` (
   KEY `row_start` (`row_start`),
   KEY `row_end_2` (`row_end`,`x`),
   KEY `x` (`x`,`row_end`),
-  KEY `row_end_3` (`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
   PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
  PARTITION BY SYSTEM_TIME INTERVAL 9 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
 PARTITIONS 7
+# Year/month interval
+delete history from t1;
+alter table t1 remove partitioning;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+alter table t1 partition by system_time interval 1 month auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 MONTH STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 2
+set timestamp= unix_timestamp('2003-10-01 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 11 month auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 11 MONTH STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 6
+alter table t1 partition by system_time interval 1 year auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 YEAR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 5
+# No history
+delete history from t1;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+alter table t1 partition by system_time interval 1 hour auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 5
+insert t1 values (99);
+alter table t1 partition by system_time interval 1 hour auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end` DESC),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 5
 # Slow scan warning
 create or replace table t1 (x int,
 row_start timestamp(6) as row start invisible,

--- a/mysql-test/suite/versioning/r/partition2.result
+++ b/mysql-test/suite/versioning/r/partition2.result
@@ -1,0 +1,440 @@
+set @@session.time_zone='+00:00';
+#
+# MDEV-25529 Auto-create: Pre-existing historical data is not partitioned as specified by ALTER
+#
+set @old_dbug= @@debug_dbug;
+set debug_dbug= '+d,test_mdev-25529';
+create or replace table t1 (x int) with system versioning
+partition by system_time limit 1;
+alter table t1 partition by system_time limit 1 auto;
+create or replace table t1 (x int,
+row_start timestamp(6) as row start invisible,
+row_end timestamp(6) as row end invisible,
+period for system_time (row_start, row_end),
+index (row_end, row_start),
+index (row_start),
+index (row_end, x),
+index (x, row_end),
+index (row_end)) with system versioning
+partition by system_time limit 1000 partitions 6;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME LIMIT 1000
+PARTITIONS 6
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (0);
+set timestamp= unix_timestamp('2000-01-01 00:10:00.22');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 01:00:00');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 01:30:00');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 02:00:00');
+update t1 set x= x + 1;
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (p2);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (p3);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (p4);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+set timestamp= default;
+ALTER table t1 partition by system_time
+interval 1 hour starts '2000-01-01 00:00:00';
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+select *, row_start, row_end from t1 partition (p2);
+x	row_start	row_end
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (p3);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (p4);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+alter TABLE t1 partition by system_time
+interval 1 hour;
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+select *, row_start, row_end from t1 partition (p2);
+x	row_start	row_end
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (p3);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (p4);
+x	row_start	row_end
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+set @@system_versioning_alter_history= keep;
+alter table t1 remove partitioning;
+select *, row_start, row_end from t1 for system_time all;
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+alter table t1 PARTITION by system_time interval 1 hour auto;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 3
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+alter table t1 remove partitioning;
+alter table t1 partition by SYSTEM_TIME interval 1 hour starts '2000-01-01 00:00:00' auto;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 3
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2038-01-19 03:14:07.999999
+set timestamp= unix_timestamp('2000-01-02 03:01:23.456');
+delete from t1;
+alter table t1 remove partitioning;
+alter table t1 partition by SYSTEM_TIME interval 1 hour auto;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 29
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p1);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+2	2000-01-01 01:00:00.000000	2000-01-01 01:30:00.000000
+select *, row_start, row_end from t1 partition (p2);
+x	row_start	row_end
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (p27);
+x	row_start	row_end
+4	2000-01-01 02:00:00.000000	2000-01-02 03:01:23.456000
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+set timestamp= unix_timestamp('2000-01-02 03:01:23.456');
+delete from t1;
+alter table t1 partition by system_time INTERVAL 20 minute auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 20 MINUTE STARTS TIMESTAMP'2000-01-01 00:10:00' AUTO
+PARTITIONS 82
+select *, row_start, row_end from t1 partition (p0);
+x	row_start	row_end
+0	2000-01-01 00:00:00.000000	2000-01-01 00:10:00.220000
+select *, row_start, row_end from t1 partition (p2);
+x	row_start	row_end
+1	2000-01-01 00:10:00.220000	2000-01-01 01:00:00.000000
+select *, row_start, row_end from t1 partition (p5);
+x	row_start	row_end
+3	2000-01-01 01:30:00.000000	2000-01-01 02:00:00.000000
+select *, row_start, row_end from t1 partition (pn);
+x	row_start	row_end
+alter table t1 remove partitioning;
+alter table t1 partition by system_time interval 1 hour
+starts '2002-01-01 00:00:00' auto;
+Warnings:
+Warning	4164	`t1`: STARTS timestamp 2002-01-01 00:00:00 is later than query timestamp 2000-01-02 03:01:23, first history partition may exceed INTERVAL value
+Warning	4193	`t1`: STARTS timestamp 2002-01-01 00:00:00 is above earliest history date 2000-01-01 00:10:00 and was set to 2000-01-01 00:00:00
+# STARTS changed and WARN_VERS_WRONG_STARTS is here
+alter table t1 force partition by system_time interval 1 hour
+starts '2003-01-01 00:00:00' auto;
+Warnings:
+Warning	4193	`t1`: STARTS timestamp 2003-01-01 00:00:00 is above earliest history date 2000-01-01 00:10:00 and was set to 2000-01-01 00:00:00
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 29
+alter table t1 partition by system_time interval 1 hour
+starts '2004-01-01 00:00:00' auto force;
+Warnings:
+Warning	4164	`t1`: STARTS timestamp 2004-01-01 00:00:00 is later than query timestamp 2000-01-02 03:01:23, first history partition may exceed INTERVAL value
+Warning	4193	`t1`: STARTS timestamp 2004-01-01 00:00:00 is above earliest history date 2000-01-01 00:10:00 and was set to 2000-01-01 00:00:00
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 29
+# STARTS doesn't change without FORCE
+alter table t1 partition by system_time interval 1 hour
+starts '2005-01-01 00:00:00' auto;
+Warnings:
+Warning	4164	`t1`: STARTS timestamp 2005-01-01 00:00:00 is later than query timestamp 2000-01-02 03:01:23, first history partition may exceed INTERVAL value
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR STARTS TIMESTAMP'2005-01-01 00:00:00' AUTO
+PARTITIONS 29
+# min_ts == max_ts case, partitions decrease
+delete history from t1;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+alter table t1 partition by system_time interval 7 hour auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 7 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 2
+# Explicit partition list ignores AUTO FORCE
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 8 hour auto force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 8 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 7
+alter table t1 partition by system_time interval 8 hour auto (
+partition p0 history,
+partition p1 history,
+partition pn current) force;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 8 HOUR STARTS TIMESTAMP'2000-01-03 00:00:00' AUTO
+(PARTITION `p0` HISTORY ENGINE = MyISAM,
+ PARTITION `p1` HISTORY ENGINE = MyISAM,
+ PARTITION `pn` CURRENT ENGINE = MyISAM)
+# Switch system_time -> hash
+alter table t1 partition by hash(x) partitions 3;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY HASH (`x`)
+PARTITIONS 3
+# Switch hash -> system_time
+alter table t1 partition by system_time interval 9 hour
+starts '2001-01-01 00:00:00' auto force;
+Warnings:
+Warning	4164	`t1`: STARTS timestamp 2001-01-01 00:00:00 is later than query timestamp 2000-01-03 00:00:00, first history partition may exceed INTERVAL value
+Warning	4193	`t1`: STARTS timestamp 2001-01-01 00:00:00 is above earliest history date 2000-01-01 00:00:00 and was set to 2000-01-01 00:00:00
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `row_end` (`row_end`,`row_start`),
+  KEY `row_start` (`row_start`),
+  KEY `row_end_2` (`row_end`,`x`),
+  KEY `x` (`x`,`row_end`),
+  KEY `row_end_3` (`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 9 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 7
+# Slow scan warning
+create or replace table t1 (x int,
+row_start timestamp(6) as row start invisible,
+row_end timestamp(6) as row end invisible,
+period for system_time (row_start, row_end),
+index (x, row_end, row_start),
+index (row_start, row_end),
+index (x, row_end)) with system versioning;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 10 hour auto;
+Warnings:
+Warning	4194	`t1`: ROW END index not found, using slow scan
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int(11) DEFAULT NULL,
+  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,
+  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,
+  KEY `x` (`x`,`row_end`,`row_start`),
+  KEY `row_start` (`row_start`,`row_end`),
+  KEY `x_2` (`x`,`row_end`),
+  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 10 HOUR STARTS TIMESTAMP'2000-01-01 00:00:00' AUTO
+PARTITIONS 6
+# TRX_ID versioning
+create or replace table t1 (x int,
+row_start bigint(20) unsigned as row start invisible,
+row_end bigint(20) unsigned as row end invisible,
+period for system_time (row_start, row_end),
+index (row_end)) with system versioning engine innodb;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+# Partitioning is not allowed for TRX_ID versioning
+alter table t1 partition by system_time interval 11 hour auto;
+ERROR HY000: `row_start` must be of type TIMESTAMP(6) for system-versioned table `t1`
+drop table t1;
+set debug_dbug= @old_dbug;

--- a/mysql-test/suite/versioning/t/partition2.test
+++ b/mysql-test/suite/versioning/t/partition2.test
@@ -1,0 +1,201 @@
+--source include/have_partition.inc
+--source include/have_innodb.inc
+--source include/maybe_debug.inc
+
+--enable_prepare_warnings
+set @@session.time_zone='+00:00';
+
+--echo #
+--echo # MDEV-25529 Auto-create: Pre-existing historical data is not partitioned as specified by ALTER
+--echo #
+
+# Test both index and scan, compare the results between them
+if ($have_debug)
+{
+  set @old_dbug= @@debug_dbug;
+  set debug_dbug= '+d,test_mdev-25529';
+}
+
+create or replace table t1 (x int) with system versioning
+partition by system_time limit 1;
+alter table t1 partition by system_time limit 1 auto;
+
+create or replace table t1 (x int,
+  row_start timestamp(6) as row start invisible,
+  row_end timestamp(6) as row end invisible,
+  period for system_time (row_start, row_end),
+  index (row_end, row_start),
+  index (row_start),
+  index (row_end, x),
+  index (x, row_end),
+  index (row_end)) with system versioning
+partition by system_time limit 1000 partitions 6;
+
+show create table t1;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (0);
+set timestamp= unix_timestamp('2000-01-01 00:10:00.22');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 01:00:00');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 01:30:00');
+update t1 set x= x + 1;
+set timestamp= unix_timestamp('2000-01-01 02:00:00');
+update t1 set x= x + 1;
+
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (p2);
+select *, row_start, row_end from t1 partition (p3);
+select *, row_start, row_end from t1 partition (p4);
+select *, row_start, row_end from t1 partition (pn);
+set timestamp= default;
+
+ALTER table t1 partition by system_time
+interval 1 hour starts '2000-01-01 00:00:00';
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (p2);
+select *, row_start, row_end from t1 partition (p3);
+select *, row_start, row_end from t1 partition (p4);
+select *, row_start, row_end from t1 partition (pn);
+
+alter TABLE t1 partition by system_time
+interval 1 hour;
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (p2);
+select *, row_start, row_end from t1 partition (p3);
+select *, row_start, row_end from t1 partition (p4);
+select *, row_start, row_end from t1 partition (pn);
+
+set @@system_versioning_alter_history= keep;
+alter table t1 remove partitioning;
+# First history:  2000-01-01 00:10:00.220000
+# Last history:   2000-01-01 02:00:00.00000021
+select *, row_start, row_end from t1 for system_time all;
+
+alter table t1 PARTITION by system_time interval 1 hour auto;
+
+show create table t1;
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (pn);
+
+alter table t1 remove partitioning;
+alter table t1 partition by SYSTEM_TIME interval 1 hour starts '2000-01-01 00:00:00' auto;
+
+show create table t1;
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (pn);
+
+set timestamp= unix_timestamp('2000-01-02 03:01:23.456');
+delete from t1;
+alter table t1 remove partitioning;
+alter table t1 partition by SYSTEM_TIME interval 1 hour auto;
+
+show create table t1;
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p1);
+select *, row_start, row_end from t1 partition (p2);
+select *, row_start, row_end from t1 partition (p27);
+select *, row_start, row_end from t1 partition (pn);
+
+set timestamp= unix_timestamp('2000-01-02 03:01:23.456');
+delete from t1;
+alter table t1 partition by system_time INTERVAL 20 minute auto force;
+show create table t1;
+select *, row_start, row_end from t1 partition (p0);
+select *, row_start, row_end from t1 partition (p2);
+select *, row_start, row_end from t1 partition (p5);
+select *, row_start, row_end from t1 partition (pn);
+
+alter table t1 remove partitioning;
+alter table t1 partition by system_time interval 1 hour
+starts '2002-01-01 00:00:00' auto;
+
+--echo # STARTS changed and WARN_VERS_WRONG_STARTS is here
+alter table t1 force partition by system_time interval 1 hour
+starts '2003-01-01 00:00:00' auto;
+show create table t1;
+
+alter table t1 partition by system_time interval 1 hour
+starts '2004-01-01 00:00:00' auto force;
+show create table t1;
+
+--echo # STARTS doesn't change without FORCE
+alter table t1 partition by system_time interval 1 hour
+starts '2005-01-01 00:00:00' auto;
+show create table t1;
+
+--echo # min_ts == max_ts case, partitions decrease
+delete history from t1;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+alter table t1 partition by system_time interval 7 hour auto force;
+show create table t1;
+
+--echo # Explicit partition list ignores AUTO FORCE
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 8 hour auto force;
+show create table t1;
+
+alter table t1 partition by system_time interval 8 hour auto (
+  partition p0 history,
+  partition p1 history,
+  partition pn current) force;
+show create table t1;
+
+--echo # Switch system_time -> hash
+alter table t1 partition by hash(x) partitions 3;
+show create table t1;
+--echo # Switch hash -> system_time
+alter table t1 partition by system_time interval 9 hour
+starts '2001-01-01 00:00:00' auto force;
+show create table t1;
+
+--echo # Slow scan warning
+create or replace table t1 (x int,
+  row_start timestamp(6) as row start invisible,
+  row_end timestamp(6) as row end invisible,
+  period for system_time (row_start, row_end),
+  index (x, row_end, row_start),
+  index (row_start, row_end),
+  index (x, row_end)) with system versioning;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 10 hour auto;
+show create table t1;
+
+--echo # TRX_ID versioning
+create or replace table t1 (x int,
+  row_start bigint(20) unsigned as row start invisible,
+  row_end bigint(20) unsigned as row end invisible,
+  period for system_time (row_start, row_end),
+  index (row_end)) with system versioning engine innodb;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+set timestamp= unix_timestamp('2000-01-03 00:00:00');
+insert t1 values (88);
+delete from t1;
+--echo # Partitioning is not allowed for TRX_ID versioning
+--error ER_VERS_FIELD_WRONG_TYPE
+alter table t1 partition by system_time interval 11 hour auto;
+
+drop table t1;
+
+if ($have_debug)
+{
+  set debug_dbug= @old_dbug;
+}
+
+--disable_prepare_warnings

--- a/mysql-test/suite/versioning/t/partition2.test
+++ b/mysql-test/suite/versioning/t/partition2.test
@@ -28,7 +28,7 @@ create or replace table t1 (x int,
   index (row_start),
   index (row_end, x),
   index (x, row_end),
-  index (row_end)) with system versioning
+  index (row_end desc)) with system versioning
 partition by system_time limit 1000 partitions 6;
 
 show create table t1;
@@ -156,6 +156,31 @@ show create table t1;
 --echo # Switch hash -> system_time
 alter table t1 partition by system_time interval 9 hour
 starts '2001-01-01 00:00:00' auto force;
+show create table t1;
+
+--echo # Year/month interval
+delete history from t1;
+alter table t1 remove partitioning;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+insert t1 values (77);
+delete from t1;
+alter table t1 partition by system_time interval 1 month auto force;
+show create table t1;
+set timestamp= unix_timestamp('2003-10-01 00:00:00');
+insert t1 values (88);
+delete from t1;
+alter table t1 partition by system_time interval 11 month auto force;
+show create table t1;
+alter table t1 partition by system_time interval 1 year auto force;
+show create table t1;
+
+--echo # No history
+delete history from t1;
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+alter table t1 partition by system_time interval 1 hour auto force;
+show create table t1;
+insert t1 values (99);
+alter table t1 partition by system_time interval 1 hour auto force;
 show create table t1;
 
 --echo # Slow scan warning

--- a/sql/event_data_objects.cc
+++ b/sql/event_data_objects.cc
@@ -689,6 +689,10 @@ add_interval(MYSQL_TIME *ltime, const Time_zone *time_zone,
 /*
   Computes the sum of a timestamp plus interval.
 
+  Computes the smallest next > time_now obtained by adding one or more
+  multiples of the given interval (i_value, i_type) to start, taking
+  into account time_zone conversions and DST ambiguities.
+
   SYNOPSIS
     get_next_time()
       time_zone     event time zone

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -2372,6 +2372,32 @@ bool Field_vers_trx_id::get_date(MYSQL_TIME *ltime, date_mode_t fuzzydate, ulong
 }
 
 
+my_time_t Field_vers_trx_id::get_timestamp(const uchar *pos, ulong *sec_part) const
+{
+  ulonglong trx_id= uint8korr(pos);
+  THD *thd= get_thd();
+  if (trx_id == ULONGLONG_MAX)
+  {
+    if (sec_part)
+    {
+      *sec_part= TIME_MAX_SECOND_PART;
+    }
+    return TIMESTAMP_MAX_VALUE;
+  }
+  TR_table trt(thd);
+  if (trt.query(trx_id))
+  {
+    return trt[TR_table::FLD_COMMIT_TS]->get_timestamp(sec_part);
+  }
+
+  push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                      ER_VERS_NO_TRX_ID, ER_THD(thd, ER_VERS_NO_TRX_ID),
+                      (longlong) trx_id);
+
+  return -1;
+}
+
+
 Field_str::Field_str(uchar *ptr_arg,uint32 len_arg, uchar *null_ptr_arg,
                      uchar null_bit_arg, utype unireg_check_arg,
                      const LEX_CSTRING *field_name_arg,

--- a/sql/field.h
+++ b/sql/field.h
@@ -2884,6 +2884,7 @@ public:
   {
     return get_date(ltime, fuzzydate, (ulonglong) val_int());
   }
+  my_time_t get_timestamp(const uchar *pos, ulong *sec_part) const override;
   bool test_if_equality_guarantees_uniqueness(const Item *item) const override;
   Data_type_compatibility can_optimize_keypart_ref(const Item_bool_func *,
                                                    const Item *)

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -2873,7 +2873,9 @@ bool partition_info::vers_set_interval(THD* thd, Item* interval,
     }
     if (!table)
     {
-      if (thd->query_start() < vers_info->interval.start) {
+      if (thd->query_start() < vers_info->interval.start &&
+          !(auto_hist && (thd->lex->alter_info.flags & ALTER_RECREATE)))
+      {
         TimestampString str_interval(thd, vers_info->interval.start);
         TimestampString str_query(thd, thd->query_start());
         push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
@@ -2897,6 +2899,7 @@ interval_starts_error:
 }
 
 
+/* Round down STARTS to units based on INTERVAL value */
 bool partition_info::vers_set_starts(THD *thd, my_time_t ts)
 {
   MYSQL_TIME ltime;

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -423,6 +423,7 @@ bool partition_info::set_up_default_partitions(THD *thd, handler *file,
   i= 0;
   do
   {
+    // FIXME (newbie): how is it freed? Explain in comment or remake via table->mem_root.
     partition_element *part_elem= new partition_element();
     if (likely(part_elem != 0 &&
                (!partitions.push_back(part_elem))))
@@ -442,7 +443,10 @@ bool partition_info::set_up_default_partitions(THD *thd, handler *file,
       }
     }
     else
+    {
+      my_error(ER_OUT_OF_RESOURCES, MYF(0));
       goto end;
+    }
   } while (++i < num_parts);
   result= FALSE;
 end:

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -2840,6 +2840,7 @@ bool partition_info::vers_set_interval(THD* thd, Item* interval,
   /* 2. assign STARTS to interval.start */
   if (starts)
   {
+    vers_info->starts_clause= true;
     if (starts->fix_fields_if_needed_for_scalar(thd, &starts))
       return true;
     switch (starts->result_type())
@@ -2880,20 +2881,7 @@ bool partition_info::vers_set_interval(THD* thd, Item* interval,
   }
   else // calculate default STARTS depending on INTERVAL
   {
-    thd->variables.time_zone->gmt_sec_to_TIME(&ltime, thd->query_start());
-    if (vers_info->interval.step.second)
-      goto interval_set_starts;
-    ltime.second= 0;
-    if (vers_info->interval.step.minute)
-      goto interval_set_starts;
-    ltime.minute= 0;
-    if (vers_info->interval.step.hour)
-      goto interval_set_starts;
-    ltime.hour= 0;
-
-interval_set_starts:
-    vers_info->interval.start= TIME_to_timestamp(thd, &ltime, &err);
-    if (err)
+    if (vers_set_starts(thd, thd->query_start()))
       goto interval_starts_error;
   }
 
@@ -2902,6 +2890,27 @@ interval_set_starts:
 interval_starts_error:
   my_error(ER_PART_WRONG_VALUE, MYF(0), table_name, "STARTS");
   return true;
+}
+
+
+bool partition_info::vers_set_starts(THD *thd, my_time_t ts)
+{
+  MYSQL_TIME ltime;
+  uint err;
+  thd->variables.time_zone->gmt_sec_to_TIME(&ltime, ts);
+  if (vers_info->interval.step.second)
+    goto interval_set_starts;
+  ltime.second= 0;
+  if (vers_info->interval.step.minute)
+    goto interval_set_starts;
+  ltime.minute= 0;
+  if (vers_info->interval.step.hour)
+    goto interval_set_starts;
+  ltime.hour= 0;
+
+interval_set_starts:
+  vers_info->interval.start= TIME_to_timestamp(thd, &ltime, &err);
+  return (bool) err;
 }
 
 

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -2869,10 +2869,12 @@ bool partition_info::vers_set_interval(THD* thd, Item* interval,
     if (!table)
     {
       if (thd->query_start() < vers_info->interval.start) {
+        TimestampString str_interval(thd, vers_info->interval.start);
+        TimestampString str_query(thd, thd->query_start());
         push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                            ER_PART_STARTS_BEYOND_INTERVAL,
-                            ER_THD(thd, ER_PART_STARTS_BEYOND_INTERVAL),
-                            table_name);
+                            WARN_VERS_STARTS_BEYOND_INTERVAL,
+                            ER_THD(thd, WARN_VERS_STARTS_BEYOND_INTERVAL),
+                            table_name, str_interval.cstr(), str_query.cstr());
       }
     }
   }

--- a/sql/partition_info.h
+++ b/sql/partition_info.h
@@ -41,6 +41,7 @@ struct Vers_part_info : public Sql_alloc
   Vers_part_info() :
     limit(0),
     auto_hist(false),
+    starts_clause(false),
     now_part(NULL),
     hist_part(NULL)
   {
@@ -50,6 +51,7 @@ struct Vers_part_info : public Sql_alloc
     interval(src.interval),
     limit(src.limit),
     auto_hist(src.auto_hist),
+    starts_clause(src.starts_clause),
     now_part(NULL),
     hist_part(NULL)
   {
@@ -59,6 +61,7 @@ struct Vers_part_info : public Sql_alloc
     interval= src.interval;
     limit= src.limit;
     auto_hist= src.auto_hist;
+    starts_clause= src.starts_clause;
     now_part= src.now_part;
     hist_part= src.hist_part;
     return *this;
@@ -91,6 +94,7 @@ struct Vers_part_info : public Sql_alloc
   } interval;
   ulonglong limit;
   bool auto_hist;
+  bool starts_clause;
   partition_element *now_part;
   partition_element *hist_part;
 };
@@ -417,6 +421,7 @@ public:
   bool vers_set_interval(THD *thd, Item *interval,
                          interval_type int_type, Item *starts,
                          bool auto_part, const char *table_name);
+  bool vers_set_starts(THD *thd, my_time_t ts);
   bool vers_set_limit(ulonglong limit, bool auto_part, const char *table_name);
   bool vers_set_hist_part(THD* thd, uint *create_count);
   bool vers_require_hist_part(THD *thd) const

--- a/sql/proxy_protocol.cc
+++ b/sql/proxy_protocol.cc
@@ -42,7 +42,7 @@ static int parse_v1_header(char *hdr, size_t len, proxy_peer_info *peer_info)
   int client_port;
   int server_port;
 
-  int ret = sscanf(hdr, "PROXY %s %s %s %d %d",
+  int ret = sscanf(hdr, "PROXY %256s %256s %256s %d %d",
     address_family, client_address, server_address,
     &client_port, &server_port);
 
@@ -174,7 +174,7 @@ bool has_proxy_protocol_header(NET *net)
 */
 int parse_proxy_protocol_header(NET *net, proxy_peer_info *peer_info)
 {
-  uchar hdr[MAX_PROXY_HEADER_LEN];
+  uchar hdr[MAX_PROXY_HEADER_LEN + 1];
   size_t pos= 0;
 
   DBUG_ASSERT(!net->compress);
@@ -195,12 +195,12 @@ int parse_proxy_protocol_header(NET *net, proxy_peer_info *peer_info)
   if (have_v1_header)
   {
     /* Read until end of header (newline character)*/
-    while(pos < sizeof(hdr))
+    while(pos < sizeof(hdr) - 1)
     {
       long len= (long)vio_read(vio, hdr + pos, 1);
-      if (len < 0)
+      if (len <= 0)
         return -1;
-      pos++;
+      pos+= len;
       if (hdr[pos-1] == '\n')
         break;
     }
@@ -525,7 +525,7 @@ bool is_proxy_protocol_allowed(const sockaddr *addr)
 
   /*
    Non-TCP addresses (unix domain socket, windows pipe and shared memory
-   gets tranlated to TCP4 localhost address.
+   gets translated to TCP4 localhost address.
 
    Note, that vio remote addresses are initialized with binary zeros
    for these protocols (which is AF_UNSPEC everywhere).

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -10758,3 +10758,11 @@ ER_CM_OPTION_MISSING_REQUIREMENT
         eng "CHANGE MASTER TO option '%s=%s' is missing requirement %s"
 ER_SLAVE_STATEMENT_TIMEOUT 70100
         eng "Slave log event execution was interrupted (slave_max_statement_time exceeded)"
+WARN_VERS_WRONG_STARTS
+        chi "%`s: STARTS 时间戳 %s 晚于最早历史日期 %s，已被设置为 %s"
+        eng "%`s: STARTS timestamp %s is above earliest history date %s and was set to %s"
+        spa "%`s: la marca de tiempo STARTS %s es posterior a la fecha histórica más temprana %s y se estableció en %s"
+WARN_VERS_SLOW_ROW_END
+        chi "%`s: 未找到 ROW END 索引，正在使用慢速扫描"
+        eng "%`s: ROW END index not found, using slow scan"
+        spa "%`s: no se encontró el índice ROW END, usando escaneo lento"

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -10676,9 +10676,9 @@ ER_UNKNOWN_OPERATOR
         spa "El operador no existe: '%-.128s'"
 ER_UNUSED_29
 	eng "You should never see it"
-ER_PART_STARTS_BEYOND_INTERVAL
-        eng "%`s: STARTS is later than query time, first history partition may exceed INTERVAL value"
-        spa "%`s: STARTS es posterior al momento de consulta (query), la primera partición de historia puede exceder el valor INTERVAL"
+WARN_VERS_STARTS_BEYOND_INTERVAL
+        eng "%`s: STARTS timestamp %s is later than query timestamp %s, first history partition may exceed INTERVAL value"
+        spa "%`s: STARTS %s es posterior al momento de consulta (query) %s, la primera partición de historia puede exceder el valor INTERVAL"
 ER_GALERA_REPLICATION_NOT_SUPPORTED
         eng "Galera replication not supported"
         spa "La replicación en Galera no está soportada"

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -8676,6 +8676,14 @@ bool THD::timestamp_to_TIME(MYSQL_TIME *ltime, my_time_t ts,
 }
 
 
+bool THD::timestamp_to_string(String *str, uint dec, my_timespec_t ts)
+{
+  Temporal_hybrid th(this, ts);
+  used|= TIME_ZONE_USED;
+  return th.to_string(str, dec) == nullptr;
+}
+
+
 void THD::my_ok_with_recreate_info(const Recreate_info &info,
                                    ulong warn_count)
 {

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3113,7 +3113,7 @@ public:
   enum { RAND_USED=1, TIME_ZONE_USED=2, QUERY_START_SEC_PART_USED=4,
          THREAD_SPECIFIC_USED=8 };
 
-  used_t used;
+  used_t used; /* used by binlog */
 
 #ifndef MYSQL_CLIENT
   binlog_cache_mngr *  binlog_setup_trx_data();

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4140,6 +4140,11 @@ public:
   const Type_handler *type_handler_for_datetime() const;
   bool timestamp_to_TIME(MYSQL_TIME *ltime, my_time_t ts,
                          ulong sec_part, date_mode_t fuzzydate);
+  bool timestamp_to_string(String *str, uint dec, my_timespec_t ts);
+  bool timestamp_to_string(String *str, uint dec, my_time_t ts)
+  {
+    return timestamp_to_string(str, dec, {ts, 0});
+  }
   inline my_time_t query_start() { return start_time; }
   inline ulong query_start_sec_part()
   { used|= QUERY_START_SEC_PART_USED; return start_time_sec_part; }
@@ -8420,6 +8425,25 @@ public:
 #ifdef WITH_WSREP
     wsrep_to_isolation= do_wsrep_iso && WSREP(m_thd);
 #endif
+  }
+};
+
+
+class TimestampString : public String
+{
+  THD *thd;
+  my_timespec_t ts;
+
+public:
+  TimestampString(THD *thd, my_timespec_t ts) : thd{thd}, ts{ts} {}
+  TimestampString(THD *thd, my_time_t sec) : thd{thd}, ts{sec, 0} {}
+
+  const char * cstr(uint dec= 0)
+  {
+    if (thd->timestamp_to_string(this, dec, ts))
+      return "ERROR";
+    else
+      return c_ptr_safe();
   }
 };
 

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -6141,6 +6141,76 @@ the generated partition syntax in a correct manner.
         }
       }
 
+      if (table->versioned() &&
+          (alter_info->partition_flags & ALTER_PARTITION_INFO) &&
+          part_info->part_type == VERSIONING_PARTITION &&
+          part_info->vers_info->auto_hist &&
+          alt_part_info->use_default_partitions &&
+          (!*fast_alter_table || (alter_info->flags & ALTER_RECREATE)))
+      {
+        if (*fast_alter_table)
+          *fast_alter_table= false;
+        my_timespec_t min_ts, max_ts;
+        Vers_part_info *vers_info= part_info->vers_info;
+        auto &interval= vers_info->interval;
+        if (table->vers_get_history_range(thd, min_ts, max_ts))
+          DBUG_RETURN(true);
+        if (max_ts.sec > MY_TIME_T_MIN) /* there is history in the table */
+        {
+          DBUG_ASSERT(max_ts.sec < TIMESTAMP_MAX_VALUE);
+          DBUG_ASSERT(min_ts.sec <= max_ts.sec);
+          if (max_ts.usec)
+          {
+            max_ts.sec++;
+            max_ts.usec= 0;
+          }
+          if (vers_info->starts_clause)
+          {
+            if (interval.start > min_ts.sec)
+            {
+              TimestampString str_interval(thd, interval.start);
+              if (part_info->vers_set_starts(thd, min_ts.sec))
+              {
+                my_error(ER_PART_WRONG_VALUE, MYF(0),
+                         table->s->table_name.str, "STARTS");
+                DBUG_RETURN(true);
+              }
+              TimestampString str_min_ts(thd, min_ts);
+              TimestampString str_interval2(thd, interval.start);
+              push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                                  WARN_VERS_WRONG_STARTS, ER_THD(thd, WARN_VERS_WRONG_STARTS),
+                                  table->s->table_name.str,
+                                  str_interval.cstr(), str_min_ts.cstr(), str_interval2.cstr());
+
+            }
+          }
+          else if (part_info->vers_set_starts(thd, min_ts.sec))
+          {
+            my_error(ER_PART_WRONG_VALUE, MYF(0),
+                     table->s->table_name.str, "STARTS");
+            DBUG_RETURN(true);
+          }
+
+          part_info->use_default_num_partitions= false;
+          part_info->use_default_partitions= true;
+          part_info->default_partitions_setup= false;
+          part_info->partitions.empty();
+
+          my_time_t range= max_ts.sec - interval.start;
+          DBUG_ASSERT(range >= 0);
+          if (!range)
+            range++;
+          const longlong i_sec= interval2sec(&interval.step);
+          DBUG_ASSERT(i_sec > 0);
+          uint hist_parts= range / i_sec;
+          if (hist_parts * i_sec != range)
+            hist_parts++;
+          part_info->num_parts= hist_parts + 1;
+        } /* if (max_ts.sec > MY_TIME_T_MIN) */
+        else
+          DBUG_ASSERT(max_ts == MY_TIMESPEC_MIN); /* no history in table */
+      } /* if (need to get history range) */
+
       /*
         Set up partition default_engine_type either from the create_info
         or from the previus table
@@ -6166,7 +6236,7 @@ the generated partition syntax in a correct manner.
         DBUG_ASSERT(create_info->db_type);
         create_info->db_type= partition_hton;
       }
-    }
+    } /* if (thd->work_part_info) */
   }
   DBUG_RETURN(FALSE);
 err:

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -100,6 +100,9 @@ static int get_partition_id_linear_key_sub(partition_info *part_info, uint32 *pa
 static uint32 get_next_partition_via_walking(PARTITION_ITERATOR*);
 static void set_up_range_analysis_info(partition_info *part_info);
 static uint32 get_next_subpartition_via_walking(PARTITION_ITERATOR*);
+static bool vers_calc_hist_parts(THD *thd, my_time_t end,
+                                 const Vers_part_info::interval_t &interval,
+                                 uint *hist_parts);
 #endif
 
 uint32 get_next_partition_id_range(PARTITION_ITERATOR* part_iter);
@@ -6196,15 +6199,9 @@ the generated partition syntax in a correct manner.
           part_info->default_partitions_setup= false;
           part_info->partitions.empty();
 
-          my_time_t range= max_ts.sec - interval.start;
-          DBUG_ASSERT(range >= 0);
-          if (!range)
-            range++;
-          const longlong i_sec= interval2sec(&interval.step);
-          DBUG_ASSERT(i_sec > 0);
-          uint hist_parts= range / i_sec;
-          if (hist_parts * i_sec != range)
-            hist_parts++;
+          uint hist_parts= 0;
+          if (vers_calc_hist_parts(thd, max_ts.sec, interval, &hist_parts))
+            DBUG_RETURN(true);
           part_info->num_parts= hist_parts + 1;
         } /* if (max_ts.sec > MY_TIME_T_MIN) */
         else
@@ -6244,6 +6241,74 @@ err:
   if (saved_part_info)
     table->part_info= saved_part_info;
   DBUG_RETURN(TRUE);
+}
+
+
+static bool vers_calc_hist_parts(THD *thd, my_time_t end,
+                                 const Vers_part_info::interval_t &interval,
+                                 uint *hist_parts)
+{
+  uint error= 0;
+  my_time_t start= interval.start;
+  DBUG_ASSERT(hist_parts != NULL);
+  *hist_parts= 0;
+
+  if (end < start)
+    return false;
+
+  if (!(interval.step.year || interval.step.month))
+  {
+    my_time_t range= end - start;
+    if (!range)
+      range++;
+
+    const longlong i_sec= interval2sec(&interval.step);
+    DBUG_ASSERT(i_sec > 0);
+
+    *hist_parts= static_cast<uint>(range / i_sec);
+    if ((*hist_parts) * i_sec != range)
+      (*hist_parts)++;
+    if (*hist_parts >= MAX_PARTITIONS)
+    {
+      my_error(ER_TOO_MANY_PARTITIONS_ERROR, MYF(0));
+      return true;
+    }
+    return false;
+  }
+
+  MYSQL_TIME boundary;
+  thd->variables.time_zone->gmt_sec_to_TIME(&boundary, start);
+
+  if (end == start)
+  {
+    *hist_parts= 1;
+    return false;
+  }
+
+  while (start < end)
+  {
+    if (date_add_interval(thd, &boundary, interval.type, interval.step))
+    {
+      my_error(ER_DATA_OUT_OF_RANGE, MYF(0), "TIMESTAMP", "INTERVAL");
+      return true;
+    }
+
+    start= thd->variables.time_zone->TIME_to_gmt_sec(&boundary, &error);
+    if (error)
+    {
+      my_error(ER_DATA_OUT_OF_RANGE, MYF(0), "TIMESTAMP", "INTERVAL");
+      return true;
+    }
+
+    (*hist_parts)++;
+    if (*hist_parts >= MAX_PARTITIONS)
+    {
+      my_error(ER_TOO_MANY_PARTITIONS_ERROR, MYF(0));
+      return true;
+    }
+  }
+
+  return false;
 }
 
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -62,6 +62,7 @@
 #include "rpl_mi.h"
 #include "rpl_rli.h"
 #include "log.h"
+#include "key.h"
 
 #ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
@@ -2394,7 +2395,7 @@ void promote_first_timestamp_column(List<Create_field> *column_definitions)
   }
 }
 
-static bool key_cmp(const Key_part_spec &a, const Key_part_spec &b)
+static bool key_eq(const Key_part_spec &a, const Key_part_spec &b)
 {
   return a.length == b.length && a.asc == b.asc &&
          !lex_string_cmp(system_charset_info, &a.field_name, &b.field_name);
@@ -2438,7 +2439,7 @@ static void check_duplicate_key(THD *thd, const Key *key, const KEY *key_info,
     }
 
     if (std::equal(key->columns.begin(), key->columns.end(), k.columns.begin(),
-                   key_cmp))
+                   key_eq))
     {
       push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_DUP_INDEX,
                           ER_THD(thd, ER_DUP_INDEX), key_info->name.str);
@@ -13285,3 +13286,151 @@ bool HA_CREATE_INFO::
   }
   return false;
 }
+
+
+#ifdef WITH_PARTITION_STORAGE_ENGINE
+bool TABLE::vers_get_history_range(THD *thd, my_timespec_t &min_ts,
+                                   my_timespec_t &max_ts)
+{
+  DBUG_ASSERT(versioned());
+  // Find best key
+  KEY *key= key_info, *best_key= NULL;
+  uint best_idx;
+  Field *end_field= vers_end_field();
+  const field_index_t end_field_idx= end_field->field_index;
+  for (uint idx= 0; idx < s->keys; idx++, key++)
+  {
+    /*
+      Note: we don't check keys_in_use_for_query as ALTER TABLE doesn't call
+      setup_tables().
+    */
+    DBUG_ASSERT(key->key_part->fieldnr > 0);
+    const ulong index_flags= file->index_flags(idx, 0, false);
+    if (key->key_part->fieldnr - 1 == end_field_idx &&
+        (index_flags & HA_READ_ORDER) &&
+        !(index_flags & HA_ONLY_WHOLE_INDEX) &&
+        !(key->key_part->key_part_flag & HA_REVERSE_SORT) &&
+        (!best_key || best_key->key_length > key->key_length))
+    {
+      best_key= key;
+      best_idx= idx;
+    }
+  }
+
+  int error;
+  my_timespec_t ts;
+  min_ts= MY_TIMESPEC_MAX;
+  max_ts= MY_TIMESPEC_MIN;
+#ifndef DBUG_OFF
+  my_timespec_t min_ts2, max_ts2;
+#endif /* DBUG_OFF */
+  MY_BITMAP *save_read_set=  read_set;
+  MY_BITMAP *save_write_set= write_set;
+  DBUG_ASSERT(save_read_set != &tmp_set);
+  bitmap_clear_all(&tmp_set);
+  column_bitmaps_set(&tmp_set, &tmp_set);
+  bitmap_set_bit(read_set, end_field->field_index);
+  file->column_bitmaps_signal();
+  DBUG_ASSERT(thd->mdl_context.is_lock_owner(MDL_key::TABLE, s->db.str,
+                                              s->table_name.str, MDL_SHARED_READ));
+  if ((error= file->ha_external_lock(thd, F_RDLCK)))
+    goto end;
+
+  if (best_key)
+  {
+    uchar search_key[MAX_KEY_LENGTH];
+    KEY *best_key_info= key_info + best_idx;
+    end_field->set_max();
+    KEY_PART_INFO *key_part= best_key_info->key_part;
+    const uint key_prefix_len= key_part[0].store_length;
+    key_copy(search_key, record[0], best_key_info, key_prefix_len);
+
+    /* Get range from index */
+    if ((error= file->ha_index_init(best_idx, true)))
+      goto end_unlock;
+
+    if (!(error= file->ha_index_first(record[0])))
+    {
+      min_ts.sec= end_field->get_timestamp(&min_ts.usec);
+      error= file->ha_index_read_map(record[0], (uchar*) search_key,
+                                     (key_part_map) 1, HA_READ_BEFORE_KEY);
+      if (!error)
+      {
+        max_ts.sec= end_field->get_timestamp(&max_ts.usec);
+      }
+    }
+
+    file->ha_index_end();
+
+    if (error == HA_ERR_END_OF_FILE || error == HA_ERR_KEY_NOT_FOUND)
+      error= 0;
+    else if (error)
+      goto end_unlock;
+
+#ifndef DBUG_OFF
+    /* Test both index and scan, compare the results between them */
+    min_ts2= min_ts;
+    max_ts2= max_ts;
+    if (DBUG_IF("test_mdev-25529"))
+      goto jump_scan;
+#endif /* DBUG_OFF */
+  }
+  else
+  {
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                        WARN_VERS_SLOW_ROW_END,
+                        ER_THD(thd, WARN_VERS_SLOW_ROW_END),
+                        s->table_name.str);
+#ifndef DBUG_OFF
+jump_scan:
+#endif /* DBUG_OFF */
+    /* Get range by scan */
+    if ((error= file->ha_rnd_init(1)))
+      goto end_unlock;
+
+    /* can_continue_handler_scan() is only for heap (record changed protection) */
+    while (!(error= file->can_continue_handler_scan()) &&
+          !(error= file->ha_rnd_next(record[0])))
+    {
+      ts.sec= end_field->get_timestamp(&ts.usec);
+      if (ts == MY_TIMESPEC_MAX)
+        continue;
+      if (ts < min_ts)
+        min_ts= ts;
+      if (ts > max_ts)
+        max_ts= ts;
+    }
+
+    file->ha_rnd_end();
+#ifndef DBUG_OFF
+    if (best_key)
+    {
+      DBUG_ASSERT(DBUG_IF("test_mdev-25529"));
+      DBUG_ASSERT(min_ts == min_ts2);
+      DBUG_ASSERT(max_ts == max_ts2);
+    }
+#endif /* DBUG_OFF */
+  }
+
+  if (error == HA_ERR_END_OF_FILE)
+    error= 0;
+
+end_unlock:
+  file->ha_external_unlock(thd);
+
+end:
+  if (error)
+  {
+    myf flags= 0;
+
+    if (file->is_fatal_error(error, HA_CHECK_ALL))
+      flags|= ME_FATAL; /* Other handler errors are fatal */
+
+    file->print_error(error, MYF(flags));
+  }
+
+  column_bitmaps_set(save_read_set, save_write_set);
+  file->column_bitmaps_signal();
+  return error;
+}
+#endif /* WITH_PARTITION_STORAGE_ENGINE */

--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -24,6 +24,7 @@
 #include <m_ctype.h>
 
 
+/* Daynumber from year 0 to 9999-12-31 */
 #define MAX_DAY_NUMBER 3652424L
 
 	/* Some functions to calculate dates */
@@ -920,11 +921,6 @@ void make_truncated_value_warning(THD *thd,
 }
 
 
-/* Daynumber from year 0 to 9999-12-31 */
-#define COMBINE(X)                                                      \
-               (((((X)->day * 24LL + (X)->hour) * 60LL +                \
-                   (X)->minute) * 60LL + (X)->second)*1000000LL +       \
-                   (X)->second_part)
 #define GET_PART(X, N) X % N ## LL; X/= N ## LL
 
 bool date_add_interval(THD *thd, MYSQL_TIME *ltime, interval_type int_type,
@@ -964,7 +960,7 @@ bool date_add_interval(THD *thd, MYSQL_TIME *ltime, interval_type int_type,
     if (time_type != MYSQL_TIMESTAMP_TIME)
       ltime->day+= calc_daynr(ltime->year, ltime->month, 1) - 1;
 
-    usec= COMBINE(ltime) + sign*COMBINE(&interval);
+    usec= interval2usec(ltime) + sign * interval2usec(&interval);
 
     if (usec < 0)
     {

--- a/sql/sql_time.h
+++ b/sql/sql_time.h
@@ -187,4 +187,15 @@ longlong pack_time(const MYSQL_TIME *my_time);
 void unpack_time(longlong packed, MYSQL_TIME *my_time,
                  enum_mysql_timestamp_type ts_type);
 
+template <typename T>
+inline longlong interval2sec(T x)
+{
+  return ((x->day * 24LL + x->hour) * 60LL + x->minute) * 60LL + x->second;
+}
+
+template <typename T>
+inline longlong interval2usec(T x)
+{
+  return interval2sec(x) * 1000000LL + x->second_part;
+}
 #endif /* SQL_TIME_INCLUDED */

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -438,6 +438,14 @@ Temporal_hybrid::Temporal_hybrid(THD *thd, Item *item, date_mode_t fuzzydate)
 }
 
 
+Temporal_hybrid::Temporal_hybrid(THD *thd, my_timespec_t time)
+{
+  thd->variables.time_zone->gmt_sec_to_TIME(this, time.sec);
+  DBUG_ASSERT(time.usec < 1000000);
+  second_part= time.usec;
+}
+
+
 uint Timestamp::binary_length_to_precision(uint length)
 {
   switch (length) {

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -1319,6 +1319,7 @@ public:
     else
       make_from_decimal(thd, warn, nr, mode);
   }
+  Temporal_hybrid(THD *thd, my_timespec_t time);
   // End of constuctors
 
   bool copy_valid_value_to_mysql_time(MYSQL_TIME *ltime) const

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -7361,8 +7361,12 @@ alter_commands:
           }
         | alter_list
           opt_partitioning
+        | partitioning
+          alter_list
         | alter_list
           remove_partitioning
+        | remove_partitioning
+          alter_list
         | remove_partitioning
         | partitioning
 /*

--- a/sql/table.h
+++ b/sql/table.h
@@ -1852,6 +1852,8 @@ public:
 #ifdef WITH_PARTITION_STORAGE_ENGINE
   bool vers_switch_partition(THD *thd, TABLE_LIST *table_list,
                              Open_table_context *ot_ctx);
+  bool vers_get_history_range(THD *thd, my_timespec_t &min_ts,
+                              my_timespec_t &max_ts);
 #endif
 
   int update_generated_fields();

--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -469,14 +469,14 @@ static void test_prepare_simple()
   strmov(query, "SHOW SLAVE STATUS");
   stmt= mysql_simple_prepare(mysql, query);
   check_stmt(stmt);
-  DIE_UNLESS(mysql_stmt_field_count(stmt) == 54);
+  DIE_UNLESS(mysql_stmt_field_count(stmt) == 56);
   mysql_stmt_close(stmt);
 
   /* show master status */
   strmov(query, "SHOW MASTER STATUS");
   stmt= mysql_simple_prepare(mysql, query);
   check_stmt(stmt);
-  DIE_UNLESS(mysql_stmt_field_count(stmt) == 4);
+  DIE_UNLESS(mysql_stmt_field_count(stmt) == 5);
   mysql_stmt_close(stmt);
 
   /* show create procedure */
@@ -1488,7 +1488,7 @@ static void test_prepare()
   /* now, execute the prepared statement to insert 10 records.. */
   for (tiny_data= 0; tiny_data < 100; tiny_data++)
   {
-    length[1]= snprintf(str_data, sizeof(str_data), "MySQL%d", int_data);
+    length[1]= sprintf(str_data, "MySQL%d", int_data);
     rc= mysql_stmt_execute(stmt);
     check_execute(stmt, rc);
     int_data += 25;
@@ -1527,7 +1527,7 @@ static void test_prepare()
   /* now, execute the prepared statement to insert 10 records.. */
   for (o_tiny_data= 0; o_tiny_data < 100; o_tiny_data++)
   {
-    len= snprintf(data, sizeof(data), "MySQL%d", o_int_data);
+    len= sprintf(data, "MySQL%d", o_int_data);
 
     rc= mysql_stmt_fetch(stmt);
     check_execute(stmt, rc);
@@ -2944,7 +2944,7 @@ static void test_simple_update()
   my_bind[0].buffer= szData;                /* string data */
   my_bind[0].buffer_length= sizeof(szData);
   my_bind[0].length= &length[0];
-  length[0]= snprintf(szData, sizeof(szData), "updated-data");
+  length[0]= sprintf(szData, "updated-data");
 
   my_bind[1].buffer= (void *) &nData;
   my_bind[1].buffer_type= MYSQL_TYPE_LONG;
@@ -3140,7 +3140,7 @@ static void test_long_data_str()
   DIE_UNLESS(rc == 1);
   mysql_free_result(result);
 
-  snprintf(data, sizeof(data), "%d", i*5);
+  sprintf(data, "%d", i*5);
   verify_col_data("test_long_data_str", "LENGTH(longstr)", data);
   data[0]= '\0';
   while (i--)
@@ -3198,7 +3198,7 @@ static void test_long_data_str1()
 
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_execute(stmt, rc);
-  length= snprintf(data, sizeof(data), "MySQL AB");
+  length= sprintf(data, "MySQL AB");
 
   /* supply data in pieces */
   for (i= 0; i < 3; i++)
@@ -3238,10 +3238,10 @@ static void test_long_data_str1()
   DIE_UNLESS(rc == 1);
   mysql_free_result(result);
 
-  snprintf(data, sizeof(data), "%ld", (long)i*length);
+  sprintf(data, "%ld", (long)i*length);
   verify_col_data("test_long_data_str", "length(longstr)", data);
 
-  snprintf(data, sizeof(data), "%d", i*2);
+  sprintf(data, "%d", i*2);
   verify_col_data("test_long_data_str", "length(blb)", data);
 
   /* Test length of field->max_length */
@@ -3513,7 +3513,7 @@ static void test_update()
   my_bind[0].buffer= szData;
   my_bind[0].buffer_length= sizeof(szData);
   my_bind[0].length= &length[0];
-  length[0]= snprintf(szData, sizeof(szData), "inserted-data");
+  length[0]= sprintf(szData, "inserted-data");
 
   my_bind[1].buffer= (void *)&nData;
   my_bind[1].buffer_type= MYSQL_TYPE_LONG;
@@ -3542,7 +3542,7 @@ static void test_update()
   my_bind[0].buffer= szData;
   my_bind[0].buffer_length= sizeof(szData);
   my_bind[0].length= &length[0];
-  length[0]= snprintf(szData, sizeof(szData), "updated-data");
+  length[0]= sprintf(szData, "updated-data");
 
   my_bind[1].buffer= (void *)&nData;
   my_bind[1].buffer_type= MYSQL_TYPE_LONG;
@@ -4111,7 +4111,7 @@ static void bind_fetch(int row_count)
     /* CHAR */
     {
       char buff[20];
-      long len= snprintf(buff, sizeof(buff), "%d", rc);
+      long len= sprintf(buff, "%d", rc);
       DIE_UNLESS(strcmp(s_data, buff) == 0);
       DIE_UNLESS(length[6] == (ulong) len);
     }
@@ -4704,7 +4704,7 @@ static void test_insert()
   /* now, execute the prepared statement to insert 10 records.. */
   for (tiny_data= 0; tiny_data < 3; tiny_data++)
   {
-    length= snprintf(str_data, sizeof(str_data), "MySQL%d", tiny_data);
+    length= sprintf(str_data, "MySQL%d", tiny_data);
     rc= mysql_stmt_execute(stmt);
     check_execute(stmt, rc);
   }
@@ -7861,7 +7861,7 @@ static void test_explain_bug()
 
   if ( mysql_get_server_version(mysql) >= 50027 )
   {
-    /*  The patch for bug#23037 changes column type of DEAULT to blob */
+    /*  The patch for bug#23037 changes column type of DEFAULT to blob */
     verify_prepare_field(result, 4, "Default", "COLUMN_DEFAULT",
                          MYSQL_TYPE_BLOB, 0, 0, "information_schema", 0, 0);
   }
@@ -8952,7 +8952,7 @@ static void test_mem_overun()
   strxmov(buffer, "create table t_mem_overun(", NullS);
   for (i= 0; i < 1000; i++)
   {
-    snprintf(field, sizeof(field), "c%u int", i);
+    sprintf(field, "c%u int", i);
     strxmov(buffer, buffer, field, ", ", NullS);
   }
   length= strlen(buffer);
@@ -9399,7 +9399,7 @@ static void test_ts()
   {
     int row_count= 0;
 
-    snprintf(query, sizeof(query), queries[field_count], name);
+    sprintf(query, queries[field_count], name);
 
     if (!opt_silent)
       fprintf(stdout, "\n  %s", query);
@@ -11713,7 +11713,7 @@ static void test_view_star()
   myquery(rc);
   bzero((char*) my_bind, sizeof(my_bind));
   for (i= 0; i < 2; i++) {
-    snprintf((char *)&parms[i], sizeof(parms[i]), "%d", i);
+    sprintf((char *)&parms[i], "%d", i);
     my_bind[i].buffer_type = MYSQL_TYPE_VAR_STRING;
     my_bind[i].buffer = (char *)&parms[i];
     my_bind[i].buffer_length = 100;
@@ -12068,7 +12068,7 @@ static void test_bug5399()
 
   for (stmt= stmt_list; stmt != stmt_list + NUM_OF_USED_STMT; ++stmt)
   {
-    snprintf(buff, sizeof(buff), "select %d", (int) (stmt - stmt_list));
+    sprintf(buff, "select %d", (int) (stmt - stmt_list));
     *stmt= mysql_stmt_init(mysql);
     rc= mysql_stmt_prepare(*stmt, buff, strlen(buff));
     check_execute(*stmt, rc);
@@ -12100,8 +12100,6 @@ static void test_bug5194()
   MYSQL_BIND *my_bind;
   char *query;
   char *param_str;
-  size_t param_str_size;
-  size_t query_size;
   int param_str_length;
   const char *stmt_text;
   int rc;
@@ -12198,11 +12196,9 @@ static void test_bug5194()
   myquery(rc);
 
   my_bind= (MYSQL_BIND*) malloc(MAX_PARAM_COUNT * sizeof(MYSQL_BIND));
-  query_size= strlen(query_template) +
-              MAX_PARAM_COUNT * CHARS_PER_PARAM + 1;
-  query= (char*) malloc(query_size);
-  param_str_size= COLUMN_COUNT * CHARS_PER_PARAM;
-  param_str= (char*) malloc(param_str_size);
+  query= (char*) malloc(strlen(query_template) +
+                        MAX_PARAM_COUNT * CHARS_PER_PARAM + 1);
+  param_str= (char*) malloc(COLUMN_COUNT * CHARS_PER_PARAM);
 
   if (my_bind == 0 || query == 0 || param_str == 0)
   {
@@ -12219,7 +12215,7 @@ static void test_bug5194()
   stmt= mysql_stmt_init(mysql);
 
   /* setup a template for one row of parameters */
-  snprintf(param_str, param_str_size, "(");
+  sprintf(param_str, "(");
   for (i= 1; i < COLUMN_COUNT; ++i)
     strcat(param_str, "?, ");
   strcat(param_str, "?)");
@@ -12243,7 +12239,7 @@ static void test_bug5194()
   {
     char *query_ptr;
     /* Create statement text for current number of rows */
-    snprintf(query, query_size, query_template, param_str);
+    sprintf(query, query_template, param_str);
     query_ptr= query + strlen(query);
     for (i= 1; i < nrows; ++i)
     {
@@ -13748,7 +13744,7 @@ static void test_bug8378()
   /* No escaping should have actually happened. */
   DIE_UNLESS(memcmp(out, TEST_BUG8378_OUT, len) == 0);
 
-  snprintf(buf, sizeof(buf), "SELECT '%s'", out);
+  sprintf(buf, "SELECT '%s'", out);
   
   rc=mysql_real_query(lmysql, buf, strlen(buf));
   myquery(rc);
@@ -13783,7 +13779,7 @@ static void test_bug8722()
   myquery(rc);
   /* Note: if you uncomment following block everything works fine */
 /*
-  rc= mysql_query(mysql, "sellect * from v1");
+  rc= mysql_query(mysql, "select * from v1");
   myquery(rc);
   mysql_free_result(mysql_store_result(mysql));
 */
@@ -13921,7 +13917,7 @@ static void test_bug9159()
 }
 
 
-/* Crash when opening a cursor to a query with DISTICNT and no key */
+/* Crash when opening a cursor to a query with DISTINCT and no key */
 
 static void test_bug9520()
 {
@@ -14237,7 +14233,7 @@ static void test_bug11111()
 
 /*
   Check that proper cleanups are done for prepared statement when
-  fetching thorugh a cursor.
+  fetching through a cursor.
 */
 
 static void test_bug10729()
@@ -14439,8 +14435,8 @@ static void test_bug10794()
   for (i= 0; i < 42; i++)
   {
     id_val= (i+1)*10;
-    snprintf(a, sizeof(a), "a%d", i);
-    a_len= strlen(a); /* safety against broken snprintf */
+    sprintf(a, "a%d", i);
+    a_len= strlen(a); /* safety against broken sprintf */
     rc= mysql_stmt_execute(stmt);
     check_execute(stmt, rc);
   }
@@ -14802,7 +14798,7 @@ static void test_bug10760()
   for (; i < 42; ++i)
   {
     char buf[100];
-    snprintf(buf, sizeof(buf), "insert into t1 (id) values (%d)", i+1);
+    sprintf(buf, "insert into t1 (id) values (%d)", i+1);
     rc= mysql_query(mysql, buf);
     myquery(rc);
   }
@@ -15056,7 +15052,7 @@ static void test_bug11909()
   myquery(rc);
 }
 
-/* Cursors: opening a cursor to a compilicated query with ORDER BY */
+/* Cursors: opening a cursor to a complicated query with ORDER BY */
 
 static void test_bug11901()
 {
@@ -15931,7 +15927,7 @@ static void test_bug17667()
     char line_buffer[MAX_TEST_QUERY_LENGTH*2];
     /* more than enough room for the query and some marginalia. */
 
-    /* Prepared statments always occurs twice in log */
+    /* Prepared statements always occurs twice in log */
     if (statement_cursor->qt == QT_PREPARED)
       expected_hits++;
 
@@ -16771,24 +16767,24 @@ static void test_bug27876()
   mytest(result);
   mysql_free_result(result);
 
-  snprintf(query, sizeof(query), "DROP FUNCTION IF EXISTS %s", (char*) utf8_func);
+  sprintf(query, "DROP FUNCTION IF EXISTS %s", (char*) utf8_func);
   rc= mysql_query(mysql, query);
   myquery(rc);
 
-  snprintf(query, sizeof(query),
+  sprintf(query,
           "CREATE FUNCTION %s( %s VARCHAR(25))"
           " RETURNS VARCHAR(25) DETERMINISTIC RETURN %s",
           (char*) utf8_func, (char*) utf8_param, (char*) utf8_param);
   rc= mysql_query(mysql, query);
   myquery(rc);
-  snprintf(query, sizeof(query), "SELECT %s(VERSION())", (char*) utf8_func);
+  sprintf(query, "SELECT %s(VERSION())", (char*) utf8_func);
   rc= mysql_query(mysql, query);
   myquery(rc);
   result= mysql_store_result(mysql);
   mytest(result);
   mysql_free_result(result);
 
-  snprintf(query, sizeof(query), "DROP FUNCTION %s", (char*) utf8_func);
+  sprintf(query, "DROP FUNCTION %s", (char*) utf8_func);
   rc= mysql_query(mysql, query);
   myquery(rc);
 
@@ -16873,18 +16869,18 @@ static void test_change_user()
   myheader("test_change_user");
 
   /* Prepare environment */
-  snprintf(buff, sizeof(buff), "drop database if exists %s", db);
+  sprintf(buff, "drop database if exists %s", db);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff), "create database %s", db);
+  sprintf(buff, "create database %s", db);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
   rc= mysql_query(mysql, "SET SQL_MODE=''");
   myquery(rc);
 
-  snprintf(buff, sizeof(buff),
+  sprintf(buff,
           "grant select on %s.* to %s@'%%' identified by '%s'",
           db,
           user_pw,
@@ -16892,7 +16888,7 @@ static void test_change_user()
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff),
+  sprintf(buff,
           "grant select on %s.* to %s@'localhost' identified by '%s'",
           db,
           user_pw,
@@ -16900,14 +16896,14 @@ static void test_change_user()
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff),
+  sprintf(buff,
           "grant select on %s.* to %s@'%%'",
           db,
           user_no_pw);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff),
+  sprintf(buff,
           "grant select on %s.* to %s@'localhost'",
           db,
           user_no_pw);
@@ -17096,23 +17092,23 @@ static void test_change_user()
 
   mysql_close(conn);
 
-  snprintf(buff, sizeof(buff), "drop database %s", db);
+  sprintf(buff, "drop database %s", db);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff), "drop user %s@'%%'", user_pw);
+  sprintf(buff, "drop user %s@'%%'", user_pw);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff), "drop user %s@'%%'", user_no_pw);
+  sprintf(buff, "drop user %s@'%%'", user_no_pw);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff), "drop user %s@'localhost'", user_pw);
+  sprintf(buff, "drop user %s@'localhost'", user_pw);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
-  snprintf(buff, sizeof(buff), "drop user %s@'localhost'", user_no_pw);
+  sprintf(buff, "drop user %s@'localhost'", user_no_pw);
   rc= mysql_query(mysql, buff);
   myquery(rc);
 
@@ -17442,7 +17438,7 @@ static void test_bug30472()
   DIE_UNLESS(strcmp(character_set_name_4, "utf8mb3") == 0);
   DIE_UNLESS(strcmp(character_set_client_4, "utf8mb3") == 0);
   DIE_UNLESS(strcmp(character_set_results_4, "utf8mb3") == 0);
-  DIE_UNLESS(strcmp(collation_connnection_4, "utf8mb3_general_ci") == 0);
+  DIE_UNLESS(strcmp(collation_connnection_4, "utf8mb3_uca1400_ai_ci") == 0);
 
   /* That's it. Cleanup. */
 
@@ -18009,7 +18005,7 @@ static void test_wl4166_1()
   /* now, execute the prepared statement to insert 10 records.. */
   for (tiny_data= 0; tiny_data < 10; tiny_data++)
   {
-    length[1]= snprintf(str_data, sizeof(str_data), "MySQL%d", int_data);
+    length[1]= sprintf(str_data, "MySQL%d", int_data);
     rc= mysql_stmt_execute(stmt);
     check_execute(stmt, rc);
     int_data += 25;
@@ -18032,7 +18028,7 @@ static void test_wl4166_1()
 
   for (tiny_data= 50; tiny_data < 60; tiny_data++)
   {
-    length[1]= snprintf(str_data, sizeof(str_data), "MySQL%d", int_data);
+    length[1]= sprintf(str_data, "MySQL%d", int_data);
     rc= mysql_stmt_execute(stmt);
     check_execute(stmt, rc);
     int_data += 25;
@@ -19441,7 +19437,7 @@ static void test_progress_reporting()
   }
   
   progress_stage= progress_max_stage= progress_count= 0;
-  rc= mysql_query(conn, "alter table t1 add f1 int primary key auto_increment, order by f2");
+  rc= mysql_query(conn, "alter table t1 add f1 int primary key auto_increment, lock=shared, order by f2");
   myquery(rc);
   if (!opt_silent)
     printf("Got progress_count: %u  stage: %u  max_stage: %u\n",
@@ -19449,7 +19445,7 @@ static void test_progress_reporting()
   DIE_UNLESS(progress_count > 0 && progress_stage >=2 && progress_max_stage == 3);
 
   progress_stage= progress_max_stage= progress_count= 0;
-  rc= mysql_query(conn, "create index f2 on t1 (f2)");
+  rc= mysql_query(conn, "create index f2 on t1 (f2) lock=shared");
   myquery(rc);
   if (!opt_silent)
     printf("Got progress_count: %u  stage: %u  max_stage: %u\n",
@@ -19462,7 +19458,7 @@ static void test_progress_reporting()
   if (!opt_silent)
     printf("Got progress_count: %u  stage: %u  max_stage: %u\n",
            progress_count, progress_stage, progress_max_stage);
-  DIE_UNLESS(progress_count > 0 && progress_stage >=2 && progress_max_stage == 2);
+  DIE_UNLESS(progress_count > 0 && progress_stage >=2 && progress_max_stage == 4);
 
   rc= mysql_query(conn, "set @@global.progress_report_time=@save");
   myquery(rc);
@@ -20034,7 +20030,7 @@ static void test_bug17512527()
   check_stmt(stmt2);
 
   thread_id= mysql_thread_id(conn);
-  snprintf(query, sizeof(query), "KILL %lu", thread_id);
+  sprintf(query, "KILL %lu", thread_id);
   if (thread_query(query))
     exit(1);
 
@@ -20053,6 +20049,33 @@ static void test_bug17512527()
   mysql_stmt_close(stmt1);
 }
 #endif
+
+/**
+   Parser for optimizer hints
+*/
+static void test_optimizer_hints()
+{
+  MYSQL_RES *result;
+  int        rc;
+
+  myheader("test_optimizer_hints");
+
+  rc= mysql_query(mysql, "SELECT /*+ ");
+  DIE_UNLESS(rc);
+
+  rc= mysql_query(mysql, "SELECT /*+ ICP(`test");
+  DIE_UNLESS(rc);
+
+  rc= mysql_query(mysql, "SELECT /*+ ICP(`test*/ 1");
+  myquery(rc);
+  result= mysql_store_result(mysql);
+  mytest(result);
+  (void) my_process_result_set(result);
+  mysql_free_result(result);
+
+  rc= mysql_query(mysql, "SELECT /*+ ICP(`test*/`*/ 1");
+  DIE_UNLESS(rc);
+}
 
 
 /*
@@ -20536,7 +20559,7 @@ static void test_mdev14454()
 {
   myheader("test_mdev14454");
   test_mdev14454_internal("SET NAMES latin1", 8, "test\xFF");
-  test_mdev14454_internal("SET NAMES utf8", 33, "test\xC3\xBF");
+  test_mdev14454_internal("SET NAMES utf8 COLLATE utf8_general_ci", 33, "test\xC3\xBF");
 }
 
 
@@ -20584,7 +20607,7 @@ static void test_proxy_header_tcp(const char *ipaddr, int port)
   myheader("test_proxy_header_tcp");
 
   memset(&v2_header, 0, sizeof(v2_header));
-  snprintf(text_header, sizeof(text_header), "PROXY %s %s %s %d 3306\r\n",family == AF_INET?"TCP4":"TCP6", ipaddr, ipaddr, port);
+  sprintf(text_header,"PROXY %s %s %s %d 3306\r\n",family == AF_INET?"TCP4":"TCP6", ipaddr, ipaddr, port);
  
   inet_pton(family,ipaddr,addr_bin);
 
@@ -20609,7 +20632,7 @@ static void test_proxy_header_tcp(const char *ipaddr, int port)
     memcpy(v2_header.addr.ip6.dst_addr,addr_bin, sizeof (v2_header.addr.ip6.dst_addr));
   }
 
-  snprintf(query, sizeof(query), "CREATE USER 'u'@'%s' IDENTIFIED BY 'password'",normalized_addr);
+  sprintf(query,"CREATE USER 'u'@'%s' IDENTIFIED BY 'password'",normalized_addr);
   rc= mysql_query(mysql, query);
   myquery(rc);
 
@@ -20649,7 +20672,7 @@ static void test_proxy_header_tcp(const char *ipaddr, int port)
     }
     mysql_close(m);
   }
-  snprintf(query, sizeof(query), "DROP USER 'u'@'%s'",normalized_addr);
+  sprintf(query,"DROP USER 'u'@'%s'",normalized_addr);
   rc = mysql_query(mysql, query);
   myquery(rc);
 }
@@ -20727,6 +20750,40 @@ static void test_proxy_header_ignore()
 }
 
 
+#ifndef EMBEDDED_LIBRARY
+static void test_proxy_header_limits()
+{
+  MYSQL *m;
+  char text_header[256];
+  const char *prefix = "PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678";
+  size_t prefix_len;
+
+  myheader("test_proxy_header_limits");
+
+  /* Test maximum length PROXY header (256 bytes) to ensure no overflow */
+  memset(text_header, ' ', sizeof(text_header));
+
+  prefix_len = strlen(prefix);
+
+  memcpy(text_header, prefix, prefix_len);
+  text_header[sizeof(text_header) - 1] = '\n';
+
+  m = mysql_client_init(NULL);
+  DIE_UNLESS(m);
+
+  mysql_optionsv(m, MARIADB_OPT_PROXY_HEADER, text_header, sizeof(text_header));
+
+  if (mysql_real_connect(m, opt_host, "root", "", NULL, opt_port, opt_unix_socket, 0))
+  {
+    mysql_close(m);
+  }
+  else
+  {
+    /* Connection failure is acceptable, but server must remain stable */
+  }
+}
+#endif
+
 static void test_proxy_header()
 {
   myheader("test_proxy_header");
@@ -20735,6 +20792,9 @@ static void test_proxy_header()
   test_proxy_header_tcp("::ffff:192.0.2.1",2222);
   test_proxy_header_localhost();
   test_proxy_header_ignore();
+#ifndef EMBEDDED_LIBRARY
+  test_proxy_header_limits();
+#endif
 }
 
 
@@ -23192,10 +23252,88 @@ static void test_mdev_10075()
   mysql_query(mysql, "drop table t1");
 }
 
+#ifndef EMBEDDED_LIBRARY
+/*
+  MDEV-36080: Run a Prepared Statement that hits a failure when the query
+    optimizer is doing once-per-statement-life optimization. The server should
+    re-prepare the statement. Make sure the re-prepare happens when the
+    statement parameters are supplied through Array Binding.
+*/
+static void test_mdev_36080()
+{
+  MYSQL_STMT *stmt;
+  int rc;
+  const char *stmt_text;
+  MYSQL_BIND bind[1];
+  char       indicator[]= {0, STMT_INDICATOR_NULL, 0/*STMT_INDICATOR_IGNORE*/};
+  my_bool    error[1];
+  int        id[]= {2, 3, 777}, count= sizeof(id)/sizeof(id[0]);
+
+  myheader("mdev_36080");
+  rc= mysql_query(mysql, "SET SQL_MODE=DEFAULT");
+  myquery(rc);
+
+  rc= mysql_query(mysql, "drop table if exists t0");
+  myquery(rc);
+  rc= mysql_query(mysql, "create table t0(z int);");
+  myquery(rc);
+  rc= mysql_query(mysql, "insert into t0 values (1);");
+  myquery(rc);
+
+  rc= mysql_query(mysql, "drop table if exists t1");
+  myquery(rc);
+  rc= mysql_query(mysql, "create table t1 (a int, b int)");
+  myquery(rc);
+  rc= mysql_query(mysql, "insert into t1 values (1,1)");
+  myquery(rc);
+
+  rc= mysql_query(mysql, "drop table if exists t2");
+  myquery(rc);
+  rc= mysql_query(mysql, "create table t2 (a int)");
+  myquery(rc);
+  rc= mysql_query(mysql, "insert into t2 values (1),(2)");
+  myquery(rc);
+
+  stmt= mysql_stmt_init(mysql);
+  check_stmt(stmt);
+  stmt_text=
+    "update t0,t1 set a = a +? "
+    "  where b = (SELECT * "
+    "             FROM (select t_10.* from t2 t_10 join t2 t_11 on(t_10.a = t_11.a)) sq "
+    "             WHERE 'x'=0 LIMIT 1"
+    "            )";
+
+  rc= mysql_stmt_prepare(stmt, stmt_text, strlen(stmt_text));
+  check_execute(stmt, rc);
+
+  memset(bind, 0, sizeof(bind));
+  bind[0].buffer_type = MYSQL_TYPE_LONG;
+  bind[0].buffer = (void *)id;
+  bind[0].buffer_length = 0;
+  bind[0].is_null = NULL;
+  bind[0].length = NULL;
+  bind[0].error = error;
+  bind[0].u.indicator= indicator;
+
+  mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, (void*)&count);
+  rc= mysql_stmt_bind_param(stmt, bind);
+  check_execute(stmt, rc);
+
+  rc= mysql_stmt_execute(stmt);
+  check_execute_r(stmt, rc);
+
+  rc= mysql_stmt_execute(stmt);
+  check_execute_r(stmt, rc);
+
+  mysql_stmt_close(stmt);
+
+  rc= mysql_query(mysql, "drop table t0, t1, t2");
+  myquery(rc);
+}
+
 
 static void test_mdev35953()
 {
-#ifndef EMBEDDED_LIBRARY
   int rc;
   MYSQL_STMT *stmt;
   MYSQL_BIND bind[1];
@@ -23237,9 +23375,8 @@ static void test_mdev35953()
   mysql_close(con);
 
   mysql_query(mysql, "drop table t1");
-#endif
 }
-
+#endif
 
 static struct my_tests_st my_tests[]= {
   { "test_mdev_20516", test_mdev_20516 },
@@ -23523,6 +23660,7 @@ static struct my_tests_st my_tests[]= {
 #ifndef _WIN32
   { "test_bug17512527", test_bug17512527},
 #endif
+  { "test_optimizer_hints", test_optimizer_hints},
   { "test_compressed_protocol", test_compressed_protocol },
   { "test_big_packet", test_big_packet },
   { "test_prepare_analyze", test_prepare_analyze },
@@ -23562,7 +23700,10 @@ static struct my_tests_st my_tests[]= {
   { "test_mdev_36678", test_mdev_36678 },
 #endif
   { "test_mdev_10075", test_mdev_10075},
+#ifndef EMBEDDED_LIBRARY
+  { "test_mdev_36080", test_mdev_36080},
   { "test_mdev35953", test_mdev35953 },
+#endif
   { 0, 0 }
 };
 


### PR DESCRIPTION
Jira: MDEV-39466
The header parsing loop could append a null terminator past the end of
the buffer when processing maximum-length PROXY v1 headers.

Fix by increasing the buffer size by one byte and using bounded reads
while preserving full header parsing.

Treat zero-length reads as connection close in this context.

Add a regression test for maximum-length PROXY headers.