### PR TITLE
MDEV-39458: Factor JOIN_TAB_RANGE allocation into static create()

### DIFF
--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -452,6 +452,20 @@ bool dbug_user_var_equals_str(THD *thd, const char *name, const char* value)
 }
 #endif /* DBUG_OFF */
 
+
+JOIN_TAB_RANGE *JOIN_TAB_RANGE::create(THD *thd, uint count)
+{
+  JOIN_TAB *jt;
+  JOIN_TAB_RANGE *jt_range;
+  if (!(jt= thd->alloc<JOIN_TAB>(count)) ||
+      !(jt_range= new JOIN_TAB_RANGE))
+    return nullptr;
+  jt_range->start= jt;
+  jt_range->end= jt + count;
+  return jt_range;
+}
+
+
 /*
   Intialize POSITION structure.
 */
@@ -13413,21 +13427,16 @@ bool JOIN::get_best_combination()
       j->cond_selectivity= 1.0;
       j->join_read_time= 0.0; /* Not saved currently */
       j->join_loops= 0.0;
-      JOIN_TAB *jt;
-      JOIN_TAB_RANGE *jt_range;
-      if (!(jt= thd->alloc<JOIN_TAB>(sjm->tables)) ||
-          !(jt_range= new JOIN_TAB_RANGE))
+      j->bush_children= JOIN_TAB_RANGE::create(thd, sjm->tables);
+      if (!j->bush_children)
         goto error;
-      jt_range->start= jt;
-      jt_range->end= jt + sjm->tables;
-      join_tab_ranges.push_back(jt_range, thd->mem_root);
-      j->bush_children= jt_range;
-      sjm_nest_end= jt + sjm->tables;
+      join_tab_ranges.push_back(j->bush_children, thd->mem_root);
+      sjm_nest_end= j->bush_children->end;
       sjm_nest_root= j;
 
-      j= jt;
+      j= j->bush_children->start;
     }
-    
+
     *j= *cur_pos->table;
 
     j->bush_root_tab= sjm_nest_root;

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -1158,8 +1158,30 @@ typedef struct st_rollup
 class JOIN_TAB_RANGE: public Sql_alloc
 {
 public:
-  JOIN_TAB *start;
-  JOIN_TAB *end;
+  // Points to the first JOIN_TAB in this range.
+  JOIN_TAB *start{nullptr};
+
+  /*
+    end should point one after the last.  For example, if we have
+    two JOIN_TABs in this range, then start and end will look like
+    this:
+
+      +---------------+---------------+
+      | JOIN_TAB jt_1 | JOIN_TAB jt_2 |
+      +---------------+---------------+
+       ^               ^               ^
+       |               |               |
+       start           start+1         end
+                       end-1
+
+  */
+  JOIN_TAB *end{nullptr};
+
+  /*
+    Create a new JOIN_TAB_RANGE containing `count` JOIN_TABs
+    laid out linearly in memory.
+  */
+  static JOIN_TAB_RANGE *create(THD *thd, uint count);
 };
 
 class Pushdown_query;


### PR DESCRIPTION
Adds a static JOIN_TAB_RANGE::create(thd, count) helper that allocates a JOIN_TAB array and wraps it in a JOIN_TAB_RANGE, replacing the inline allocation in JOIN::get_best_combination().  Also gives JOIN_TAB_RANGE::start and ::end default initializers and documents their half-open range convention.