### PR TITLE
MDEV-39262: galera_new_cluster.sh ignores service name argument due to hardcoded mariadb.service

### DIFF
--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -22,7 +22,7 @@ EOF
 fi
 
 echo _WSREP_NEW_CLUSTER='--wsrep-new-cluster' > "@INSTALL_RUNDATADIR@/wsrep-new-cluster" && \
-    systemctl restart mariadb.service
+    systemctl restart "${1:-mariadb.service}"
 
 extcode=$?
 


### PR DESCRIPTION
## Problem

In the script galera_new_cluster.sh, the service restart command has been modified from:
`systemctl restart ${1:-mariadb}` to `systemctl restart mariadb.service`.
Related PR: https://github.com/MariaDB/server/pull/4329/changes#diff-c4e1aa182a1b96143d20e9e8e915e27463ab137befa432d7b68f6361e54874d1
This change effectively ignores the optional positional parameter $1, which was previously used to specify a custom service name.
As a result, it is no longer possible to override the service name when invoking the script, breaking previous behavior.

## Steps to Reproduce

* Use a recent MariaDB version
* Run: `galera_new_cluster.sh mariadb-custom.service`
* Observe that the script still executes: `systemctl restart mariadb.service`

## Fix

Restore the previous behavior: `systemctl restart ${1:-mariadb}`

## JIRA
https://jira.mariadb.org/browse/MDEV-39262