### PR TITLE
Add AppArmor notice for Debian/Ubuntu users during server startup

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5107,6 +5107,37 @@ static int init_server_components()
   }
 
 
+  /*
+    Print notice about AppArmor on Debian/Ubuntu systems to help users diagnose
+    permission issues that may be caused by AppArmor denials on systems where
+    the AppArmor profile is active.
+  */
+  if (!opt_help && !opt_bootstrap)
+  {
+    FILE *fp = fopen("/sys/kernel/security/apparmor/profiles", "r");
+    if (fp)
+    {
+      char line[256];
+      bool mariadb_profile_active = false;
+      while (fgets(line, sizeof(line), fp))
+      {
+        if (strstr(line, "mariadbd"))
+        {
+          mariadb_profile_active = true;
+          break;
+        }
+      }
+      fclose(fp);
+
+      if (mariadb_profile_active)
+      {
+        sql_print_information(
+          "AppArmor profile 'mariadbd' is active. For troubleshooting tips "
+          "see https://mariadb.com/docs/server/server-management/starting-and-stopping-mariadb/what-to-do-if-mariadb-doesnt-start#apparmor");
+      }
+    }
+  }
+
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
   /*
     Parsing the performance schema command line option may have reported


### PR DESCRIPTION
When MariaDB fails to start due to permission errors, users on Debian/Ubuntu might not be able to guess that AppArmor might be the cause, and they should check for AppArmor denials in the kernel audit log.

Add an informational message during startup that:
- Only prints when the 'mariadbd' profile is actually loaded
- Includes exact commands from the Debian packaging NEWS
- Provides actionable paths for local overrides
- Mentions both complain and enforce modes for troubleshooting

The message is printed once during normal server startup (not in help or bootstrap modes) through the existing logging infrastructure, ensuring it appears in both syslog and the error log where users will see it when troubleshooting startup failures.

This has been in Debian since MariaDB 1:11.8.6-6 via https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/0a896117012567f2325675442be199180eb20a95 and no regressions have been reported. Having this upstream will pave the way to also have the actual new AppArmor profile upstream, as this notice helps users understand what might be breaking their MariaDB instance.