### PR TITLE
MDEV-36808 json_array_intersect incorrect results

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -5331,7 +5331,7 @@ SET @obj1= '[1, 2, 3, 3, 3.0, "abc", true, true, {"key1":"val1" ]';
 SET @obj2= '[3.0, 3, 5, "abc", "abc", true, {"key2":"val2"}, {"key1":"val1"}, {"key1":"val2"}]';
 select json_array_intersect(@obj1, @obj2);
 json_array_intersect(@obj1, @obj2)
-NULL
+[3.0, 3, "abc", true]
 Warnings:
 Warning	4038	Syntax error in JSON text in argument 1 to function 'json_array_intersect' at position 53
 # Checking incorrect type for input
@@ -5489,4 +5489,15 @@ ERROR HY000: Invalid value for keyword properties
 select json_schema_valid('{"enum":[0]}', sformat('"{:#>200}"','0'));
 json_schema_valid('{"enum":[0]}', sformat('"{:#>200}"','0'))
 0
+#
+# MDEV-36808 json_array_intersect incorrect results after returning NULL in table scan
+#
+CREATE TABLE t1 (full text, overlap text);
+INSERT INTO t1 VALUES ('["2"]', '["2"]'), ('["2"]', '["0"]'),  ('["2"]', '["2"]');
+SELECT full, overlap, json_array_intersect(full, overlap) as jai from t1;
+full	overlap	jai
+["2"]	["2"]	["2"]
+["2"]	["0"]	NULL
+["2"]	["2"]	["2"]
+DROP TABLE t1;
 # End of 11.4 Test

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -4286,4 +4286,15 @@ SELECT JSON_SCHEMA_VALID('{"properties": "a_string": {"pattern": "^[5-9]$"}}}', 
 --echo #
 select json_schema_valid('{"enum":[0]}', sformat('"{:#>200}"','0'));
 
+--echo #
+--echo # MDEV-36808 json_array_intersect incorrect results after returning NULL in table scan
+--echo #
+
+CREATE TABLE t1 (full text, overlap text);
+INSERT INTO t1 VALUES ('["2"]', '["2"]'), ('["2"]', '["0"]'),  ('["2"]', '["2"]');
+
+SELECT full, overlap, json_array_intersect(full, overlap) as jai from t1;
+
+DROP TABLE t1;
+
 --echo # End of 11.4 Test

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -5467,7 +5467,7 @@ String* Item_func_json_array_intersect::val_str(String *str)
     prepare_json_and_create_hash(&je1, js1);
   }
 
-  if (null_value || args[1]->null_value)
+  if (!is_array || args[1]->null_value)
     goto null_return;
 
   str->set_charset(js2->charset());
@@ -5523,12 +5523,12 @@ bool Item_func_json_array_intersect::prepare_json_and_create_hash(json_engine_t 
     init_alloc_root(PSI_NOT_INSTRUMENTED, &hash_root, 1024, 0, MYF(0));
   root_inited= true;
 
-  if (json_read_value(je1) || je1->value_type != JSON_VALUE_ARRAY ||
+  if (json_read_value(je1)
+     || !(is_array= (je1->value_type == JSON_VALUE_ARRAY)) ||
       create_hash(je1, &items, item_hash_inited, &hash_root))
     {
       if (je1->s.error)
         report_json_error(js, je1, 0);
-      null_value= 1;
     }
 
     max_length= 2*(args[0]->max_length < args[1]->max_length ?

--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -939,11 +939,11 @@ protected:
   bool item_hash_inited, seen_hash_inited, root_inited;
   HASH items, seen;
   MEM_ROOT hash_root;
-  bool parse_for_each_row;
+  bool parse_for_each_row, is_array;
 public:
   Item_func_json_array_intersect(THD *thd, Item *a, Item *b):
     Item_str_func(thd, a, b)
-    { item_hash_inited= seen_hash_inited= root_inited= parse_for_each_row= false; }
+    { item_hash_inited= seen_hash_inited= root_inited= parse_for_each_row= is_array= false; }
   String *val_str(String *) override;
   bool fix_length_and_dec(THD *thd) override;
   LEX_CSTRING func_name_cstring() const override


### PR DESCRIPTION
After JSON_ARRAY_INTERSECT returned a NULL result, within the table scan, all subsequent values where NULL.

The checking of null_value in Item_func_json_array_intersect::val_str meant that after the first occurance of null, all values where null.

The purpose of this check started in
Item_func_json_array_intersect::prepare_json_and_create_hash where null_value=1 was used to indicate that an object wasn't an array.