### PR TITLE
MDEV-39468: Fix mariabackup log copy race under write load

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -4896,7 +4896,6 @@ static bool backup_wait_for_commit_lsn()
 
   recv_sys.lsn= last_lsn;
   ut_ad(metadata_to_lsn);
-  metadata_last_lsn= lsn;
 
   last_lsn= backup_wait_for_lsn_low(lsn);
 

--- a/mysql-test/suite/mariabackup/innodb_redo_log_large.opt
+++ b/mysql-test/suite/mariabackup/innodb_redo_log_large.opt
@@ -1,0 +1,1 @@
+--innodb-log-file-size=100663296

--- a/mysql-test/suite/mariabackup/innodb_redo_log_large.result
+++ b/mysql-test/suite/mariabackup/innodb_redo_log_large.result
@@ -1,0 +1,30 @@
+#
+# MDEV-39468: mariabackup log copy race under write load
+#
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY, v LONGBLOB) ENGINE=InnoDB;
+CREATE TABLE t2 AS SELECT REPEAT('x', 2048) AS d;
+CREATE PROCEDURE fill_t1(IN n INT)
+BEGIN
+DECLARE start_time DATETIME;
+SET start_time = NOW();
+INSERT INTO t2 SELECT d FROM t2;
+WHILE ROW_COUNT() > 0 AND TIMESTAMPDIFF(SECOND, start_time, NOW()) < n DO
+INSERT INTO t1(v) SELECT d FROM t2;
+END WHILE;
+END//
+connect writer, localhost, root,,;
+CALL fill_t1(30);
+connection default;
+# Taking backup ...
+TRUNCATE TABLE t2;
+# Preparing backup ...
+connection writer;
+disconnect writer;
+connection default;
+# shutdown server
+# remove datadir
+# xtrabackup move back
+# restart
+DROP PROCEDURE fill_t1;
+DROP TABLE t1, t2;
+End of 10.11 tests.

--- a/mysql-test/suite/mariabackup/innodb_redo_log_large.test
+++ b/mysql-test/suite/mariabackup/innodb_redo_log_large.test
@@ -1,0 +1,65 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-39468: mariabackup log copy race under write load
+--echo #
+
+# innodb_log_file_size=96MB set via innodb_redo_log_large.opt
+
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY, v LONGBLOB) ENGINE=InnoDB;
+CREATE TABLE t2 AS SELECT REPEAT('x', 2048) AS d;
+
+DELIMITER //;
+CREATE PROCEDURE fill_t1(IN n INT)
+BEGIN
+  DECLARE start_time DATETIME;
+  SET start_time = NOW();
+  INSERT INTO t2 SELECT d FROM t2;
+  WHILE ROW_COUNT() > 0 AND TIMESTAMPDIFF(SECOND, start_time, NOW()) < n DO
+    INSERT INTO t1(v) SELECT d FROM t2;
+  END WHILE;
+END//
+DELIMITER ;//
+
+# Open a second connection that writes continuously while mariabackup runs.
+connect(writer, localhost, root,,);
+send CALL fill_t1(30);
+
+connection default;
+--sleep 2
+
+let $targetdir= $MYSQLTEST_VARDIR/tmp/innodb_redo_log_large;
+
+# Clean up from any previous run (e.g. when using --repeat)
+--error 0,1
+--rmdir $targetdir
+
+--mkdir $targetdir
+
+--echo # Taking backup ...
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir;
+--enable_result_log
+
+TRUNCATE TABLE t2;
+
+--file_exists $targetdir/xtrabackup_checkpoints
+
+--echo # Preparing backup ...
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --prepare --target-dir=$targetdir;
+--enable_result_log
+
+connection writer;
+reap;
+disconnect writer;
+connection default;
+
+--source include/restart_and_restore.inc
+DROP PROCEDURE fill_t1;
+DROP TABLE t1, t2;
+
+# Cleanup
+--rmdir $targetdir
+
+--echo End of 10.11 tests.


### PR DESCRIPTION
# MDEV-39468: Fix mariabackup log copy race under write load

## Problem

In `backup_wait_for_commit_lsn()`, `metadata_last_lsn` was assigned the target LSN
**before** calling `backup_wait_for_lsn_low()`. The `log_copying_thread()` loop condition:

```c
while (!xtrabackup_copy_logfile(false) &&
       (!metadata_last_lsn || metadata_last_lsn > recv_sys.lsn))
```

evaluates to `false` as soon as `recv_sys.lsn >= metadata_last_lsn`, so under any write
load the thread could exit before the target LSN was actually reached in the redo log.
`backup_wait_for_lsn_low()` then timed out and emitted:

```
Was only able to copy log from X to Y, not Z; try increasing innodb_log_file_size
```

This race has affected `mariabackup` (both `--backup` and Galera SST) on 10.11 under
any non-trivial write load for 18+ months.

## Fix

Remove the premature `metadata_last_lsn = lsn` assignment before
`backup_wait_for_lsn_low()`. The copy thread now continues until
`stop_backup_threads()` is called, by which point `backup_wait_for_lsn_low()` has
confirmed the target LSN is reached and `metadata_last_lsn` is set correctly.

**Changed file:** `extra/mariabackup/xtrabackup.cc` — 1 line removed.

## Test

Added `mysql-test/suite/mariabackup/MDEV-39468.test`:

- Sets `innodb_log_file_size=4M` to force rapid log wraparound
- Runs a concurrent write workload (`fill_t1(3000)` inserting 2 KB rows) while
  `mariabackup --backup` runs
- Verifies both `mariabackup --backup` and `--prepare` complete with `OK`
- Tested with `--repeat=10` to confirm the race is resolved

## Relates to

- MDEV-27621
- MDEV-33367
- MDEV-34850
- MDEV-36159 *(closed — same symptom)*