### PR TITLE
MDEV-39473: main.mdev375, main.connect fail on macOS

### DIFF
--- a/mysql-test/main/connect.result
+++ b/mysql-test/main/connect.result
@@ -466,8 +466,8 @@ Variable_name	Value
 Threads_connected	1
 set @max_con.save= @@max_connections;
 set global max_connections= 10;
-# ERROR 1040
-# ERROR 1040
+# ERROR
+# ERROR
 show global status like 'Connection_errors%';
 Variable_name	Value
 Connection_errors_accept	0

--- a/mysql-test/main/connect.test
+++ b/mysql-test/main/connect.test
@@ -527,10 +527,13 @@ set global max_connections= 10;
 --let $n= 12
 while ($n)
 {
-  --error 0,ER_CON_COUNT_ERROR
+  # CR_SERVER_LOST (2013) is accepted because on macOS the client may
+  # fail to read the ER_CON_COUNT_ERROR packet before the server closes
+  # the rejected connection.
+  --error 0, ER_CON_COUNT_ERROR, 2013
   --connect (con$n,localhost,root)
   if ($mysql_errno) {
-    --echo # ERROR $mysql_errno
+    --echo # ERROR
   }
   --dec $n
 }

--- a/mysql-test/main/mdev375.result
+++ b/mysql-test/main/mdev375.result
@@ -17,7 +17,6 @@ connect  con2,localhost,root,,;
 SELECT 2;
 2
 2
-ERROR HY000: Too many connections
 connection default;
 SELECT 0;
 0

--- a/mysql-test/main/mdev375.test
+++ b/mysql-test/main/mdev375.test
@@ -24,8 +24,13 @@ SELECT 1;
 --connect (con2,localhost,root,,)
 SELECT 2;
 --disable_query_log
---error ER_CON_COUNT_ERROR
+--disable_result_log
+# CR_SERVER_LOST (2013) is accepted because on macOS the client may
+# fail to read the ER_CON_COUNT_ERROR packet before the server closes
+# the rejected connection.
+--error ER_CON_COUNT_ERROR, 2013
 --connect (con3,localhost,root,,)
+--enable_result_log
 --enable_query_log
 
 --connection default


### PR DESCRIPTION
When the server rejects a connection because connection_count exceeds the maximum allowed, the server will send ER_CON_COUNT_ERROR and immediately close the socket.  On macOS, the client's recv() of that error packet sometimes fails with errno EINVAL before the packet is actually delivered, surfacing as CR_SERVER_LOST instead of ER_CON_COUNT_ERROR.  Update the tests to account for this possibility.