### PR TITLE
MDEV-39479 Mroonga: avoid hang on invalid index flags

### DIFF
--- a/storage/mroonga/ha_mroonga.cpp
+++ b/storage/mroonga/ha_mroonga.cpp
@@ -1710,6 +1710,7 @@ static bool mrn_parse_grn_index_column_flags(THD *thd,
                           ER_MRN_INVALID_INDEX_FLAG_NUM,
                           ER_MRN_INVALID_INDEX_FLAG_STR,
                           invalid_flag_name);
+      break;
     }
   }
   return found;

--- a/storage/mroonga/mysql-test/mroonga/storage/r/create_table_index_flags_invalid.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/create_table_index_flags_invalid.result
@@ -1,0 +1,13 @@
+#
+# MDEV-39479 Mroonga: avoid hang on invalid index flags
+#
+CREATE TABLE memos (
+content VARCHAR(64) NOT NULL,
+FULLTEXT INDEX (content) COMMENT 'flags "COMPRESS_ZSTD"'
+);
+Warnings:
+Warning	16508	The index flag 'COMPRESS_ZSTD' is invalid. It is ignored
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+mroonga_command("dump --dump_plugins no --dump_schema no")
+column_create memos#content index COLUMN_INDEX|WITH_POSITION memos content
+DROP TABLE memos;

--- a/storage/mroonga/mysql-test/mroonga/storage/t/create_table_index_flags_invalid.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/create_table_index_flags_invalid.test
@@ -1,0 +1,34 @@
+# Copyright(C) 2026
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
+
+--echo #
+--echo # MDEV-39479 Mroonga: avoid hang on invalid index flags
+--echo #
+
+--source ../../include/mroonga/have_mroonga.inc
+--source ../../include/mroonga/load_mroonga_functions.inc
+
+CREATE TABLE memos (
+  content VARCHAR(64) NOT NULL,
+  FULLTEXT INDEX (content) COMMENT 'flags "COMPRESS_ZSTD"'
+);
+
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+
+DROP TABLE memos;
+
+--source ../../include/mroonga/unload_mroonga_functions.inc
+--source ../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
Stop parsing index flags after reporting an invalid flag in `mrn_parse_grn_index_column_flags()`.

Otherwise, an invalid index comment such as flags "COMPRESS_ZSTD" can make CREATE TABLE loop forever while emitting warnings. Add a regression test for this case and check that the invalid flag is reported once and the default index flags are used.

This fix already exists in upstream Mroonga:
https://github.com/mroonga/mroonga/blob/main/ha_mroonga.cpp#L2102
