### PR TITLE
MDEV-39480 sysusers.d: lock mysql user and use non-login account metadata

### DIFF
--- a/support-files/sysusers.conf.in
+++ b/support-files/sysusers.conf.in
@@ -1,1 +1,1 @@
-u @MYSQLD_USER@ - "MariaDB" @MYSQL_DATADIR@
+u! @MYSQLD_USER@ - "MariaDB Server" /nonexistent /bin/false


### PR DESCRIPTION
Use `u!` for `@MYSQLD_USER@` and set the account home and shell to `/nonexistent` and `/bin/false` instead of using the data directory as the home.

This makes the `mysql` account explicitly non-interactive and avoids using the datadir as login-related account metadata.