### PR TITLE
MDEV-36344: UBSAN DsMrr_impl::dsmrr_init on null ptr

### DIFF
--- a/sql/multi_range_read.cc
+++ b/sql/multi_range_read.cc
@@ -1193,7 +1193,7 @@ int DsMrr_impl::dsmrr_init(handler *h_arg, RANGE_SEQ_IF *seq_funcs,
       buf_manager.reset_buffer_sizes= reset_buffer_sizes;
       buf_manager.redistribute_buffer_space= redistribute_buffer_space;
     }
-    else
+    else if (full_buf)
     {
       /* index strategy doesn't need buffer, give all space to rowids*/
       rowid_buffer.set_buffer_space(full_buf, full_buf_end);
@@ -1201,6 +1201,8 @@ int DsMrr_impl::dsmrr_init(handler *h_arg, RANGE_SEQ_IF *seq_funcs,
                                        (int)is_mrr_assoc * sizeof(range_id_t)))
         goto use_default_impl;
     }
+    else
+        goto use_default_impl;
 
     // setup_two_handlers() will call dsmrr_close() will clears the filter.
     // Save its value and restore afterwards.

--- a/sql/sql_lifo_buffer.h
+++ b/sql/sql_lifo_buffer.h
@@ -174,7 +174,7 @@ public:
   uchar *end_of_space() override { return pos; }
   bool have_space_for(size_t bytes) override
   {
-    return (pos + bytes < end);
+    return (size_t) (end - pos) > bytes;
   }
 
   void write() override


### PR DESCRIPTION
Under SQL_SELECT::test_quick_select there isn't a mrr buffer. The TRP_RANGE.mrr_buf_size is explictly sets its size to 0 in get_best_index_intersect.

Rather than hit undefined behaviour in what eventually results in full_buf being nullptr, jump the case and go directly to use_default_impl.