### PR TITLE
MDEV-30953: Add MariaDB-server-galera (RPM) fix

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -325,6 +325,7 @@ ELSE()
         DESTINATION ${INSTALL_BINDIR}
         COMPONENT server-galera
       )
+      EXECUTE_PROCESS(COMMAND chmod +x ${CMAKE_CURRENT_BINARY_DIR}/${file})
     ENDFOREACH()
 
     # The following script is sourced from other SST scripts, so it should


### PR DESCRIPTION
In the build directory the galera sst scripts where without executable permissions.

This is as a result of [1]. In this patch removing WSREP_SST_SCRIPTS out of SERVER_SCRIPTS resulting
in the missing from BIN_SCRIPTS which all had an
explicit chmod executed on the script.

Corrected by explictly changing the permission on
the script as would have been done previously.

Thanks Marko Mäkelä for reporting.

[1] efb70285b908be57cc50934a6c8f994773d7583

unbreaks #5015