### PR TITLE
MDEV-35545 UBSAN Gis_geometry_collection::init_from_opresult

### DIFF
--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -3346,10 +3346,9 @@ uint Gis_geometry_collection::init_from_opresult(String *bin,
                                                  const char *opres,
                                                  uint res_len)
 {
-  const char *opres_orig= opres;
   Geometry_buffer buffer;
   Geometry *geom;
-  int g_len;
+  uint g_len, result= 0;
   uint32 wkb_type;
   int no_pos= bin->length();
   uint32 n_objects= 0;
@@ -3361,7 +3360,7 @@ uint Gis_geometry_collection::init_from_opresult(String *bin,
   if (res_len == 0)
   {
     /* Special case of GEOMETRYCOLLECTION EMPTY. */
-    opres+= 1;
+    result= 1;
     goto empty_geom;
   }
   
@@ -3386,11 +3385,12 @@ uint Gis_geometry_collection::init_from_opresult(String *bin,
       return 0;
     opres+= g_len;
     res_len-= g_len;
+    result+= g_len;
     n_objects++;
   }
 empty_geom:
   bin->write_at_position(no_pos, n_objects);
-  return (uint) (opres - opres_orig);
+  return result;
 }
 
 


### PR DESCRIPTION
From the UBSAN error:

sql/spatial.cc:3364:10: runtime error: applying non-zero offset 1 to null pointer

In Gis_geometry_collection::init_from_opresult, a pointer argument was being treated as a counter for the Special case of GEOMETRYCOLLECTION EMPTY. The memory location was never accessed.

Rather than use points to count and return a difference at the end, the code is replace to use g_len_total as a counter. This gets a 1 value for the GEOMETRYCOLLECTION EMPTY case and no ointer undefined behaviours occur.

As other init_from_opresult functions return uint both g_len and g_len_total use that type.