### PR TITLE
MDEV-36451: blackhole float-cast-overflow

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3588,6 +3588,8 @@ public:
   }
   virtual double scan_time()
   {
+    if (!stats.block_size)
+      return 0.0;
     return ((ulonglong2double(stats.data_file_length) / stats.block_size + 2) *
             avg_io_cost());
   }


### PR DESCRIPTION
As UBSAN error, the attempt of evaluating a best_acess_path in the optmizer was using -nan as its worst_seeks value. Didn't didn't cast to an integer value resulting in the UBSAN error.

The blackhole engine had a worst_seeks derived from read_time (same value). This was derived in the default handler::scan_time as stats.data_file_length / stats.block_size expression where both where 0.

Corrected this by giving ha_blackhole::scan_time an implementation that just returns 0.