### PR TITLE
MDEV-39397: Wrong result for GROUP_CONCAT(BIT(8)) in a window function

### DIFF
--- a/mysql-test/main/func_gconcat.result
+++ b/mysql-test/main/func_gconcat.result
@@ -836,42 +836,42 @@ create table t1(a bit not null);
 insert ignore into t1 values (), (), ();
 Warnings:
 Warning	1364	Field 'a' doesn't have a default value
-select group_concat(distinct a) from t1;
-group_concat(distinct a)
+select group_concat(distinct a+0) from t1;
+group_concat(distinct a+0)
 0
-select group_concat(distinct a order by a) from t1;
-group_concat(distinct a order by a)
+select group_concat(distinct a+0 order by a) from t1;
+group_concat(distinct a+0 order by a)
 0
 drop table t1;
 create table t1(a bit(2) not null);
 insert into t1 values (1), (0), (0), (3), (1);
-select group_concat(distinct a) from t1;
-group_concat(distinct a)
+select group_concat(distinct a+0) from t1;
+group_concat(distinct a+0)
 0,1,3
-select group_concat(distinct a order by a) from t1;
-group_concat(distinct a order by a)
+select group_concat(distinct a+0 order by a) from t1;
+group_concat(distinct a+0 order by a)
 0,1,3
-select group_concat(distinct a order by a desc) from t1;
-group_concat(distinct a order by a desc)
+select group_concat(distinct a+0 order by a desc) from t1;
+group_concat(distinct a+0 order by a desc)
 3,1,0
 drop table t1;
 create table t1(a bit(2), b varchar(10), c bit);
 insert into t1 values (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
 (1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
-select group_concat(distinct a, c) from t1;
-group_concat(distinct a, c)
+select group_concat(distinct a+0, c+0) from t1;
+group_concat(distinct a+0, c+0)
 00,01,10,11,31
-select group_concat(distinct a, c order by a) from t1;
-group_concat(distinct a, c order by a)
+select group_concat(distinct a+0, c+0 order by a) from t1;
+group_concat(distinct a+0, c+0 order by a)
 00,01,11,10,31
-select group_concat(distinct a, c) from t1;
-group_concat(distinct a, c)
+select group_concat(distinct a+0, c+0) from t1;
+group_concat(distinct a+0, c+0)
 00,01,10,11,31
-select group_concat(distinct a, c order by a, c) from t1;
-group_concat(distinct a, c order by a, c)
+select group_concat(distinct a+0, c+0 order by a, c) from t1;
+group_concat(distinct a+0, c+0 order by a, c)
 00,01,10,11,31
-select group_concat(distinct a, c order by a desc, c desc) from t1;
-group_concat(distinct a, c order by a desc, c desc)
+select group_concat(distinct a+0, c+0 order by a desc, c desc) from t1;
+group_concat(distinct a+0, c+0 order by a desc, c desc)
 31,11,10,01,00
 drop table t1;
 create table t1 (f1 char(20));
@@ -1556,3 +1556,76 @@ Warning	1260	Row 1 was cut by GROUP_CONCAT()
 disconnect u;
 connection default;
 # End of 10.6 tests
+#
+# MDEV-39397 GROUP_CONCAT(BIT ... ORDER BY ...) returns decimal-string
+#            instead of bit byte representation
+#
+# This test runs the same query but in two shapes that must
+# agree: a SELECT with GROUP BY, and then the same query but
+# wrapped in a VIEW.  Before the fix the first form returned the
+# decimal-stringified value (e.g., 38 for BIT(8) value 0x08) while
+# the VIEW form returned the expected result 0x08.
+#
+CREATE PROCEDURE run_pair()
+BEGIN
+WITH wf_anchor AS (
+SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
+FROM (SELECT 1 AS grp_id, 1 AS ord_id
+UNION ALL
+SELECT 1, 2) AS seed
+WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
+)
+SELECT HEX(GROUP_CONCAT(cte.col_4 ORDER BY cte.col_4)) AS col_1_hex
+FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte
+WHERE EXISTS (SELECT 1 FROM wf_anchor
+WHERE grp_id = 1 AND wf_rn = 1);
+DROP VIEW IF EXISTS v1;
+CREATE VIEW v1 AS
+SELECT * FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte;
+WITH wf_anchor AS (
+SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
+FROM (SELECT 1 AS grp_id, 1 AS ord_id
+UNION ALL
+SELECT 1, 2) AS seed
+WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
+)
+SELECT HEX(GROUP_CONCAT(v1.col_4 ORDER BY v1.col_4)) AS col_1_hex
+FROM v1
+WHERE EXISTS (SELECT 1 FROM wf_anchor
+WHERE grp_id = 1 AND wf_rn = 1);
+END$$
+# BIT(8): both forms must give 012C022C082C80.
+CREATE TABLE t1 (c12 BIT(8) NULL);
+INSERT INTO t1 VALUES (b'00000001'), (b'00001000'),
+(b'00000010'), (b'10000000');
+CALL run_pair();
+col_1_hex
+012C022C082C80
+col_1_hex
+012C022C082C80
+DROP VIEW v1;
+DROP TABLE t1;
+# BIT(7): width that is not a multiple of 8.  Both forms must give 012C022C402C7F.
+CREATE TABLE t1 (c12 BIT(7) NULL);
+INSERT INTO t1 VALUES (b'0000001'), (b'1000000'),
+(b'0000010'), (b'1111111');
+CALL run_pair();
+col_1_hex
+012C022C402C7F
+col_1_hex
+012C022C402C7F
+DROP VIEW v1;
+DROP TABLE t1;
+# BIT(16): multibyte width.  Both forms must give 00012C00022C01002C1000.
+CREATE TABLE t1 (c12 BIT(16) NULL);
+INSERT INTO t1 VALUES (b'0000000000000001'), (b'0000000100000000'),
+(b'0000000000000010'), (b'0001000000000000');
+CALL run_pair();
+col_1_hex
+00012C00022C01002C1000
+col_1_hex
+00012C00022C01002C1000
+DROP VIEW v1;
+DROP TABLE t1;
+DROP PROCEDURE run_pair;
+# End of 10.11 tests

--- a/mysql-test/main/func_gconcat.result
+++ b/mysql-test/main/func_gconcat.result
@@ -836,43 +836,43 @@ create table t1(a bit not null);
 insert ignore into t1 values (), (), ();
 Warnings:
 Warning	1364	Field 'a' doesn't have a default value
-select group_concat(distinct a+0) from t1;
-group_concat(distinct a+0)
-0
-select group_concat(distinct a+0 order by a) from t1;
-group_concat(distinct a+0 order by a)
-0
+select hex(group_concat(distinct a)) from t1;
+hex(group_concat(distinct a))
+00
+select hex(group_concat(distinct a order by a)) from t1;
+hex(group_concat(distinct a order by a))
+00
 drop table t1;
 create table t1(a bit(2) not null);
 insert into t1 values (1), (0), (0), (3), (1);
-select group_concat(distinct a+0) from t1;
-group_concat(distinct a+0)
-0,1,3
-select group_concat(distinct a+0 order by a) from t1;
-group_concat(distinct a+0 order by a)
-0,1,3
-select group_concat(distinct a+0 order by a desc) from t1;
-group_concat(distinct a+0 order by a desc)
-3,1,0
+select hex(group_concat(distinct a)) from t1;
+hex(group_concat(distinct a))
+002C012C03
+select hex(group_concat(distinct a order by a)) from t1;
+hex(group_concat(distinct a order by a))
+002C012C03
+select hex(group_concat(distinct a order by a desc)) from t1;
+hex(group_concat(distinct a order by a desc))
+032C012C00
 drop table t1;
 create table t1(a bit(2), b varchar(10), c bit);
 insert into t1 values (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
 (1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
-select group_concat(distinct a+0, c+0) from t1;
-group_concat(distinct a+0, c+0)
-00,01,10,11,31
-select group_concat(distinct a+0, c+0 order by a) from t1;
-group_concat(distinct a+0, c+0 order by a)
-00,01,11,10,31
-select group_concat(distinct a+0, c+0) from t1;
-group_concat(distinct a+0, c+0)
-00,01,10,11,31
-select group_concat(distinct a+0, c+0 order by a, c) from t1;
-group_concat(distinct a+0, c+0 order by a, c)
-00,01,10,11,31
-select group_concat(distinct a+0, c+0 order by a desc, c desc) from t1;
-group_concat(distinct a+0, c+0 order by a desc, c desc)
-31,11,10,01,00
+select hex(group_concat(distinct a, c)) from t1;
+hex(group_concat(distinct a, c))
+00002C00012C01002C01012C0301
+select hex(group_concat(distinct a, c order by a)) from t1;
+hex(group_concat(distinct a, c order by a))
+00002C00012C01012C01002C0301
+select hex(group_concat(distinct a, c)) from t1;
+hex(group_concat(distinct a, c))
+00002C00012C01002C01012C0301
+select hex(group_concat(distinct a, c order by a, c)) from t1;
+hex(group_concat(distinct a, c order by a, c))
+00002C00012C01002C01012C0301
+select hex(group_concat(distinct a, c order by a desc, c desc)) from t1;
+hex(group_concat(distinct a, c order by a desc, c desc))
+03012C01012C01002C00012C0000
 drop table t1;
 create table t1 (f1 char(20));
 insert into t1 values (''),('');
@@ -1560,72 +1560,53 @@ connection default;
 # MDEV-39397 GROUP_CONCAT(BIT ... ORDER BY ...) returns decimal-string
 #            instead of bit byte representation
 #
-# This test runs the same query but in two shapes that must
-# agree: a SELECT with GROUP BY, and then the same query but
-# wrapped in a VIEW.  Before the fix the first form returned the
-# decimal-stringified value (e.g., 38 for BIT(8) value 0x08) while
-# the VIEW form returned the expected result 0x08.
+# The same query is run in two shapes that must agree.  The first
+# reads a BIT column through a derived table with GROUP BY, the
+# second wraps that derived table in a view.  Before the fix the
+# derived table form returned the value as a decimal string while
+# the view form returned the packed bit bytes.  HEX() keeps the
+# packed bytes readable in the recorded result.
 #
-CREATE PROCEDURE run_pair()
-BEGIN
-WITH wf_anchor AS (
-SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
-FROM (SELECT 1 AS grp_id, 1 AS ord_id
-UNION ALL
-SELECT 1, 2) AS seed
-WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
-)
-SELECT HEX(GROUP_CONCAT(cte.col_4 ORDER BY cte.col_4)) AS col_1_hex
-FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte
-WHERE EXISTS (SELECT 1 FROM wf_anchor
-WHERE grp_id = 1 AND wf_rn = 1);
-DROP VIEW IF EXISTS v1;
-CREATE VIEW v1 AS
-SELECT * FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte;
-WITH wf_anchor AS (
-SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
-FROM (SELECT 1 AS grp_id, 1 AS ord_id
-UNION ALL
-SELECT 1, 2) AS seed
-WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
-)
-SELECT HEX(GROUP_CONCAT(v1.col_4 ORDER BY v1.col_4)) AS col_1_hex
-FROM v1
-WHERE EXISTS (SELECT 1 FROM wf_anchor
-WHERE grp_id = 1 AND wf_rn = 1);
-END$$
-# BIT(8): both forms must give 012C022C082C80.
-CREATE TABLE t1 (c12 BIT(8) NULL);
+# BIT(8) width.  Both forms must give 012C022C082C80.
+CREATE TABLE t1 (a BIT(8) NULL);
 INSERT INTO t1 VALUES (b'00000001'), (b'00001000'),
 (b'00000010'), (b'10000000');
-CALL run_pair();
-col_1_hex
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+HEX(GROUP_CONCAT(a ORDER BY a))
 012C022C082C80
-col_1_hex
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
+HEX(GROUP_CONCAT(a ORDER BY a))
 012C022C082C80
 DROP VIEW v1;
 DROP TABLE t1;
-# BIT(7): width that is not a multiple of 8.  Both forms must give 012C022C402C7F.
-CREATE TABLE t1 (c12 BIT(7) NULL);
+# BIT(7) is not a multiple of 8 bits.  Both forms must give 012C022C402C7F.
+CREATE TABLE t1 (a BIT(7) NULL);
 INSERT INTO t1 VALUES (b'0000001'), (b'1000000'),
 (b'0000010'), (b'1111111');
-CALL run_pair();
-col_1_hex
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+HEX(GROUP_CONCAT(a ORDER BY a))
 012C022C402C7F
-col_1_hex
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
+HEX(GROUP_CONCAT(a ORDER BY a))
 012C022C402C7F
 DROP VIEW v1;
 DROP TABLE t1;
-# BIT(16): multibyte width.  Both forms must give 00012C00022C01002C1000.
-CREATE TABLE t1 (c12 BIT(16) NULL);
+# BIT(16) spans two bytes.  Both forms must give 00012C00022C01002C1000.
+CREATE TABLE t1 (a BIT(16) NULL);
 INSERT INTO t1 VALUES (b'0000000000000001'), (b'0000000100000000'),
 (b'0000000000000010'), (b'0001000000000000');
-CALL run_pair();
-col_1_hex
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+HEX(GROUP_CONCAT(a ORDER BY a))
 00012C00022C01002C1000
-col_1_hex
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
+HEX(GROUP_CONCAT(a ORDER BY a))
 00012C00022C01002C1000
 DROP VIEW v1;
 DROP TABLE t1;
-DROP PROCEDURE run_pair;
 # End of 10.11 tests

--- a/mysql-test/main/func_gconcat.test
+++ b/mysql-test/main/func_gconcat.test
@@ -584,25 +584,25 @@ drop table t1;
 #
 create table t1(a bit not null);
 insert ignore into t1 values (), (), ();
-select group_concat(distinct a+0) from t1;
-select group_concat(distinct a+0 order by a) from t1;
+select hex(group_concat(distinct a)) from t1;
+select hex(group_concat(distinct a order by a)) from t1;
 drop table t1;
 
 create table t1(a bit(2) not null);
 insert into t1 values (1), (0), (0), (3), (1);
-select group_concat(distinct a+0) from t1;
-select group_concat(distinct a+0 order by a) from t1;
-select group_concat(distinct a+0 order by a desc) from t1;
+select hex(group_concat(distinct a)) from t1;
+select hex(group_concat(distinct a order by a)) from t1;
+select hex(group_concat(distinct a order by a desc)) from t1;
 drop table t1;
 
 create table t1(a bit(2), b varchar(10), c bit);
 insert into t1 values (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
 (1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
-select group_concat(distinct a+0, c+0) from t1;
-select group_concat(distinct a+0, c+0 order by a) from t1;
-select group_concat(distinct a+0, c+0) from t1;
-select group_concat(distinct a+0, c+0 order by a, c) from t1;
-select group_concat(distinct a+0, c+0 order by a desc, c desc) from t1;
+select hex(group_concat(distinct a, c)) from t1;
+select hex(group_concat(distinct a, c order by a)) from t1;
+select hex(group_concat(distinct a, c)) from t1;
+select hex(group_concat(distinct a, c order by a, c)) from t1;
+select hex(group_concat(distinct a, c order by a desc, c desc)) from t1;
 
 drop table t1;
 
@@ -1142,70 +1142,45 @@ connection default;
 --echo # MDEV-39397 GROUP_CONCAT(BIT ... ORDER BY ...) returns decimal-string
 --echo #            instead of bit byte representation
 --echo #
---echo # This test runs the same query but in two shapes that must
---echo # agree: a SELECT with GROUP BY, and then the same query but
---echo # wrapped in a VIEW.  Before the fix the first form returned the
---echo # decimal-stringified value (e.g., 38 for BIT(8) value 0x08) while
---echo # the VIEW form returned the expected result 0x08.
+--echo # The same query is run in two shapes that must agree.  The first
+--echo # reads a BIT column through a derived table with GROUP BY, the
+--echo # second wraps that derived table in a view.  Before the fix the
+--echo # derived table form returned the value as a decimal string while
+--echo # the view form returned the packed bit bytes.  HEX() keeps the
+--echo # packed bytes readable in the recorded result.
 --echo #
 
-DELIMITER $$;
-CREATE PROCEDURE run_pair()
-BEGIN
-  WITH wf_anchor AS (
-    SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
-    FROM (SELECT 1 AS grp_id, 1 AS ord_id
-          UNION ALL
-          SELECT 1, 2) AS seed
-    WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
-  )
-  SELECT HEX(GROUP_CONCAT(cte.col_4 ORDER BY cte.col_4)) AS col_1_hex
-  FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte
-  WHERE EXISTS (SELECT 1 FROM wf_anchor
-                WHERE grp_id = 1 AND wf_rn = 1);
-
-  DROP VIEW IF EXISTS v1;
-  CREATE VIEW v1 AS
-    SELECT * FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte;
-
-  WITH wf_anchor AS (
-    SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
-    FROM (SELECT 1 AS grp_id, 1 AS ord_id
-          UNION ALL
-          SELECT 1, 2) AS seed
-    WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
-  )
-  SELECT HEX(GROUP_CONCAT(v1.col_4 ORDER BY v1.col_4)) AS col_1_hex
-  FROM v1
-  WHERE EXISTS (SELECT 1 FROM wf_anchor
-                WHERE grp_id = 1 AND wf_rn = 1);
-END$$
-DELIMITER ;$$
-
---echo # BIT(8): both forms must give 012C022C082C80.
-CREATE TABLE t1 (c12 BIT(8) NULL);
+--echo # BIT(8) width.  Both forms must give 012C022C082C80.
+CREATE TABLE t1 (a BIT(8) NULL);
 INSERT INTO t1 VALUES (b'00000001'), (b'00001000'),
                       (b'00000010'), (b'10000000');
-CALL run_pair();
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+  FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
 DROP VIEW v1;
 DROP TABLE t1;
 
---echo # BIT(7): width that is not a multiple of 8.  Both forms must give 012C022C402C7F.
-CREATE TABLE t1 (c12 BIT(7) NULL);
+--echo # BIT(7) is not a multiple of 8 bits.  Both forms must give 012C022C402C7F.
+CREATE TABLE t1 (a BIT(7) NULL);
 INSERT INTO t1 VALUES (b'0000001'), (b'1000000'),
                       (b'0000010'), (b'1111111');
-CALL run_pair();
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+  FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
 DROP VIEW v1;
 DROP TABLE t1;
 
---echo # BIT(16): multibyte width.  Both forms must give 00012C00022C01002C1000.
-CREATE TABLE t1 (c12 BIT(16) NULL);
+--echo # BIT(16) spans two bytes.  Both forms must give 00012C00022C01002C1000.
+CREATE TABLE t1 (a BIT(16) NULL);
 INSERT INTO t1 VALUES (b'0000000000000001'), (b'0000000100000000'),
                       (b'0000000000000010'), (b'0001000000000000');
-CALL run_pair();
-
+SELECT HEX(GROUP_CONCAT(a ORDER BY a))
+  FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+CREATE VIEW v1 AS SELECT * FROM (SELECT a FROM t1 GROUP BY a) AS dt;
+SELECT HEX(GROUP_CONCAT(a ORDER BY a)) FROM v1;
 DROP VIEW v1;
 DROP TABLE t1;
-DROP PROCEDURE run_pair;
 
 --echo # End of 10.11 tests

--- a/mysql-test/main/func_gconcat.test
+++ b/mysql-test/main/func_gconcat.test
@@ -584,25 +584,25 @@ drop table t1;
 #
 create table t1(a bit not null);
 insert ignore into t1 values (), (), ();
-select group_concat(distinct a) from t1;
-select group_concat(distinct a order by a) from t1;
+select group_concat(distinct a+0) from t1;
+select group_concat(distinct a+0 order by a) from t1;
 drop table t1;
 
 create table t1(a bit(2) not null);
 insert into t1 values (1), (0), (0), (3), (1);
-select group_concat(distinct a) from t1;
-select group_concat(distinct a order by a) from t1;
-select group_concat(distinct a order by a desc) from t1;
+select group_concat(distinct a+0) from t1;
+select group_concat(distinct a+0 order by a) from t1;
+select group_concat(distinct a+0 order by a desc) from t1;
 drop table t1;
 
 create table t1(a bit(2), b varchar(10), c bit);
 insert into t1 values (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
 (1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
-select group_concat(distinct a, c) from t1;
-select group_concat(distinct a, c order by a) from t1;
-select group_concat(distinct a, c) from t1;
-select group_concat(distinct a, c order by a, c) from t1;
-select group_concat(distinct a, c order by a desc, c desc) from t1;
+select group_concat(distinct a+0, c+0) from t1;
+select group_concat(distinct a+0, c+0 order by a) from t1;
+select group_concat(distinct a+0, c+0) from t1;
+select group_concat(distinct a+0, c+0 order by a, c) from t1;
+select group_concat(distinct a+0, c+0 order by a desc, c desc) from t1;
 
 drop table t1;
 
@@ -1137,3 +1137,75 @@ disconnect u;
 connection default;
 
 --echo # End of 10.6 tests
+
+--echo #
+--echo # MDEV-39397 GROUP_CONCAT(BIT ... ORDER BY ...) returns decimal-string
+--echo #            instead of bit byte representation
+--echo #
+--echo # This test runs the same query but in two shapes that must
+--echo # agree: a SELECT with GROUP BY, and then the same query but
+--echo # wrapped in a VIEW.  Before the fix the first form returned the
+--echo # decimal-stringified value (e.g., 38 for BIT(8) value 0x08) while
+--echo # the VIEW form returned the expected result 0x08.
+--echo #
+
+DELIMITER $$;
+CREATE PROCEDURE run_pair()
+BEGIN
+  WITH wf_anchor AS (
+    SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
+    FROM (SELECT 1 AS grp_id, 1 AS ord_id
+          UNION ALL
+          SELECT 1, 2) AS seed
+    WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
+  )
+  SELECT HEX(GROUP_CONCAT(cte.col_4 ORDER BY cte.col_4)) AS col_1_hex
+  FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte
+  WHERE EXISTS (SELECT 1 FROM wf_anchor
+                WHERE grp_id = 1 AND wf_rn = 1);
+
+  DROP VIEW IF EXISTS v1;
+  CREATE VIEW v1 AS
+    SELECT * FROM (SELECT c12 AS col_4 FROM t1 GROUP BY c12) AS cte;
+
+  WITH wf_anchor AS (
+    SELECT seed.grp_id, seed.ord_id, ROW_NUMBER() OVER w_main AS wf_rn
+    FROM (SELECT 1 AS grp_id, 1 AS ord_id
+          UNION ALL
+          SELECT 1, 2) AS seed
+    WINDOW w_main AS (PARTITION BY seed.grp_id ORDER BY seed.ord_id)
+  )
+  SELECT HEX(GROUP_CONCAT(v1.col_4 ORDER BY v1.col_4)) AS col_1_hex
+  FROM v1
+  WHERE EXISTS (SELECT 1 FROM wf_anchor
+                WHERE grp_id = 1 AND wf_rn = 1);
+END$$
+DELIMITER ;$$
+
+--echo # BIT(8): both forms must give 012C022C082C80.
+CREATE TABLE t1 (c12 BIT(8) NULL);
+INSERT INTO t1 VALUES (b'00000001'), (b'00001000'),
+                      (b'00000010'), (b'10000000');
+CALL run_pair();
+DROP VIEW v1;
+DROP TABLE t1;
+
+--echo # BIT(7): width that is not a multiple of 8.  Both forms must give 012C022C402C7F.
+CREATE TABLE t1 (c12 BIT(7) NULL);
+INSERT INTO t1 VALUES (b'0000001'), (b'1000000'),
+                      (b'0000010'), (b'1111111');
+CALL run_pair();
+DROP VIEW v1;
+DROP TABLE t1;
+
+--echo # BIT(16): multibyte width.  Both forms must give 00012C00022C01002C1000.
+CREATE TABLE t1 (c12 BIT(16) NULL);
+INSERT INTO t1 VALUES (b'0000000000000001'), (b'0000000100000000'),
+                      (b'0000000000000010'), (b'0001000000000000');
+CALL run_pair();
+
+DROP VIEW v1;
+DROP TABLE t1;
+DROP PROCEDURE run_pair;
+
+--echo # End of 10.11 tests

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -3874,56 +3874,154 @@ String *Item_func_group_concat::get_str_from_field(Item *i, Field *f,
 
 
 /**
-  Append data from current leaf to item->result.
+  Append the current leaf's row to the GROUP_CONCAT output buffer.
+
+  Called once per row that the aggregator wants to emit, in three contexts.
+  In all of them the leaf is one row's worth of bytes from the GROUP_CONCAT
+  internal temp table, laid out the way create_tmp_table() arranged the
+  temp record.  This will be called primarily during the join machinery
+  execution which starts from do_select but for GROUP BY will include calls
+  to the end_send_group function (these are places to debug from).
+
+    1. ORDER BY present (with or without DISTINCT):
+         val_str() drives tree_walk(tree, &dump_leaf_key, this, left_root_right)
+         to visit the sort tree's leaves in order.
+    2. DISTINCT only, no ORDER BY:
+         val_str() drives unique_filter->walk(table, &dump_leaf_key, this).
+    3. Plain GROUP_CONCAT (no DISTINCT, no ORDER BY):
+         add() calls dump_leaf_key(get_record_pointer(), 1, this) inline as
+         each source row arrives, so we never buffer.  The tree walk paths
+         instead defer all dumping to val_str() time.
+
+  Parameters:
+
+    key_arg   Pointer to the leaf's payload bytes (one temp table record's
+              worth, minus the null byte prefix when skip_nulls() is true,
+              see get_record_pointer() and get_null_bytes()).  A field's bytes
+              live at
+                key + (field->offset(record[0]) - null_bytes) + get_null_bytes()
+              which simplifies to
+                key + field->offset()
+              when nulls are skipped.
+
+    count     Tree walk callback API hands us how many duplicates the leaf
+              represents.  We ignore it because each tree leaf in this
+              aggregator is one logical row.
+
+    item_arg  The owning Item_func_group_concat (passed back to us by
+              tree_walk / unique_filter->walk as their opaque arg).
+
+  Return value:
+    0  keep walking
+    1  stop the walk (LIMIT count exhausted or group_concat_max_len reached)
+
+  Side effects:
+    - Appends bytes to item->result (the SQL-visible GROUP_CONCAT output).
+    - Maintains item->row_count and the LIMIT counters, per group.
+    - On overflow, trims the item->result to a well formed prefix and raises
+      ER_CUT_VALUE_GROUP_CONCAT.
 */
 
 extern "C"
 int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
                   void* item_arg)
 {
-  Item_func_group_concat *item= (Item_func_group_concat *) item_arg;
-  TABLE *table= item->table;
-  uint max_length= table->in_use->gconcat_max_len();
-  String tmp((char *)table->record[1], table->s->reclength,
-             default_charset_info);
-  String tmp2;
-  uchar *key= (uchar *) key_arg;
-  String *result= &item->result;
-  Item **arg= item->args, **arg_end= item->args + item->arg_count_field;
-  uint old_length= result->length();
+  Item_func_group_concat *item= static_cast<Item_func_group_concat *>(item_arg);
+  /*
+    Support for LIMIT.  GROUP_CONCAT accepts a LIMIT clause of the form:
 
-  ulonglong *offset_limit= &item->copy_offset_limit;
+       GROUP_CONCAT([DISTINCT] expr [, ...] [ORDER BY ...] [SEPARATOR s]
+                    [LIMIT [offset,] count])
+
+    item->limit_clause is true if the parser saw that clause.  When set,
+    item->row_limit and item->offset_limit refer to the LIMIT and [offset,]
+    as noted above.  copy_row_limit and copy_offset_limit are proxies for
+    these limits, and clear() initializes them at the start of each group.
+
+    Because clear() runs once per group, LIMIT applies once per group
+    rather than once across the whole query.  Once one group is
+    emitted as constrained by LIMIT, then the item's row_limit will be
+    reset for the next group.
+
+    When the LIMIT count is exhausted, stop the walk.
+  */
   ulonglong *row_limit = &item->copy_row_limit;
-  if (item->limit_clause && !(*row_limit))
+  if (item->limit_clause && *row_limit == 0)
   {
     item->result_finalized= true;
     return 1;
   }
 
-  tmp.length(0);
-
-  if (item->limit_clause && (*offset_limit))
+  /*
+    While still inside the OFFSET window, count this row toward the offset
+    and skip it.  We need to skip OFFSET number of rows before we can emit
+    entries for the group.
+  */
+  ulonglong *offset_limit= &item->copy_offset_limit;
+  if (item->limit_clause && *offset_limit > 0)
   {
     item->row_count++;
     (*offset_limit)--;
     return 0;
   }
 
+  /*
+    Separator handling.  result_finalized doubles as "have we already
+    written at least one row to result?" (the first leaf flips it to true
+    with no separator emitted; every subsequent leaf prepends one).  The
+    same flag is also used by the path above that handles the exhausted
+    LIMIT, and by val_str() to skip walking the tree again, and the
+    meaning depends on the caller's state.
+  */
+  String *result= &item->result;
+  const uint starting_len= result->length();
   if (!item->result_finalized)
     item->result_finalized= true;
   else
     result->append(*item->separator);
 
-  for (; arg < arg_end; arg++)
+  /*
+    tmp is scratch space that get_str_from_field() or
+    get_str_from_item() write each individual field's string
+    representation into before we append it to result.  We borrow
+    table->record[1] as a fixed byte buffer of size reclength.
+    Borrowing it is safe because the GROUP_CONCAT internal temp table
+    never has any handler updates in flight (we don't write rows into
+    it via the storage engine, see HA_EXTRA_NO_ROWS and
+    table->no_rows=1 set during setup()), so record[1], which the
+    engine layer would normally use as the "old row" copy for updates
+    in place, is unused here and large enough for any single field's
+    string form (since reclength is the sum of every field's pack_length
+    plus null bytes).
+
+    The String(char*, uint32, CHARSET_INFO*) constructor adopts the buffer
+    as already containing reclength valid bytes; tmp.length(0) then
+    truncates the logical length to zero while keeping the full reclength
+    of capacity.
+  */
+  TABLE *table= item->table;
+  String tmp((char *)table->record[1], table->s->reclength,
+             default_charset_info);
+  tmp.length(0);
+
+  /*
+    Walk the selected items list only, args from indices
+    [0, ..., arg_count_field) which is a subset of the total
+    fields available.
+  */
+  Item** arg_end= item->args + item->arg_count_field;
+  for (Item** arg= item->args; arg < arg_end; arg++)
   {
     String *res;
+
     /*
       We have to use get_tmp_table_field() instead of
       real_item()->get_tmp_table_field() because we want the field in
-      the temporary table, not the original field
+      the temporary table, not the original field.
+
       We also can't use table->field array to access the fields
-      because it contains both order and arg list fields.
-     */
+      because it contains both ORDER and arg list fields.
+    */
     if ((*arg)->const_item())
       res= item->get_str_from_item(*arg, &tmp);
     else
@@ -3931,9 +4029,17 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
       Field *field= (*arg)->get_tmp_table_field();
       if (field)
       {
+        /*
+          Translate the temp table field offset into a leaf payload
+          offset.  Subtract null_bytes because the leaf is stored without
+          the null prefix when skip_nulls() is true.  Add get_null_bytes()
+          back for the JSON_ARRAYAGG case where nulls are preserved and
+          the leaf does carry a null prefix.
+        */
         uint offset= (field->offset(field->table->record[0]) -
                       table->s->null_bytes);
         DBUG_ASSERT(offset < table->s->reclength);
+        uchar *key= static_cast<uchar *>(key_arg);
         res= item->get_str_from_field(*arg, field, &tmp, key,
                                       offset + item->get_null_bytes());
       }
@@ -3945,25 +4051,73 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
       result->append(*res);
   }
 
+  /*
+    Bookkeeping for LIMIT, per group.  We only reach this point after the
+    row has been successfully appended to result, so consume one row of
+    the remaining row_limit budget.  The next call sees one fewer rows,
+    and the short circuit at the top of the function will provoke an
+    early return when the budget is gone.
+
+    row_count is the running ordinal of processed rows for this group,
+    not just emitted ones, and the OFFSET branch above also bumps it.
+    Its only consumer is report_cut_value_error() below, which uses it as
+    "row N" in the ER_CUT_VALUE_GROUP_CONCAT warning text, so callers can
+    pinpoint which input row caused truncation.  Bumping it here (after
+    emission) and in the OFFSET branch (instead of emission) keeps the
+    ordinal aligned with the input rows even when LIMIT or OFFSET drops some.
+  */
   if (item->limit_clause)
     (*row_limit)--;
   item->row_count++;
 
-  /* stop if length of result more than max_length */
+  /*
+    Enforce the group_concat_max_len cap, per thread.
+
+    We let the row's bytes land in result first, then trim back if
+    the total has exceeded it.  Trimming, not refusing the row, matches
+    the documented MySQL and MariaDB behavior, where the result is truncated
+    to a well-formed prefix and a single ER_CUT_VALUE_GROUP_CONCAT warning
+    is raised per group.
+  */
+  const uint max_length= table->in_use->gconcat_max_len();
   if (result->length() > max_length)
   {
     THD *thd= current_thd;
-    item->cut_max_length(result, old_length, max_length);
+
+    /*
+      Walks Well_formed_prefix() over [starting_len, ..., max_length) so
+      the cut lands on a character boundary.   starting_len was
+      captured before this row's separator+args were appended, so
+      the trim is guaranteed to land inside this row's contribution.
+     */
+    item->cut_max_length(result, starting_len, max_length);
+
+    /*
+      Emit the warning once for this group, tagged with the row ordinal.
+      warning_for_row tells val_str() not to emit it a second time.
+    */
     item->warning_for_row= TRUE;
     report_cut_value_error(thd, item->row_count, item->func_name());
 
-    /**
-       To avoid duplicated warnings in Item_func_group_concat::val_str()
+    /*
+      Only relevant when DISTINCT or ORDER BY is in play and there are
+      BLOB args, which is when setup() attaches a Blob_mem_storage to
+      the temp table.  That storage tracks its own truncation flag for
+      oversized blobs; val_str()  checks it after the walk completes
+      and emits its own ER_CUT_VALUE_GROUP_CONCAT.  We just emitted
+      that warning ourselves, so clear the blob storage flag to keep
+      val_str() from raising a duplicate for the same group.
     */
     if (table && table->blob_storage)
       table->blob_storage->set_truncated_value(false);
+
+    /*
+      Returning 1 stops the tree_walk or unique_filter walk because there's
+      no point producing more bytes that we'd then have to trim away.
+    */
     return 1;
   }
+
   return 0;
 }
 

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -53,6 +53,10 @@ size_t Item_sum::ram_limitation(THD *thd)
   This is needed because BIT fields store parts of their data in table's
   null bits, and we don't have methods to compare two table records with
   bit fields.
+
+  A BIT column reaching GROUP_CONCAT through a view or a nested derived
+  table arrives as an Item_ref rather than an Item_field, so the BIT
+  field is found behind real_item().
 */
 
 static void store_bit_fields_as_bigint_in_tempory_table(List<Item> *list)
@@ -61,8 +65,9 @@ static void store_bit_fields_as_bigint_in_tempory_table(List<Item> *list)
   Item *item;
   while ((item= li++))
   {
-    if (item->type() == Item::FIELD_ITEM &&
-        ((Item_field*) item)->field->type() == FIELD_TYPE_BIT)
+    Item *real= item->real_item();
+    if (real->type() == Item::FIELD_ITEM &&
+        ((Item_field*) real)->field->type() == FIELD_TYPE_BIT)
       item->marker= MARKER_NULL_KEY;
   }
 }
@@ -3817,6 +3822,54 @@ void Item_func_group_concat::cut_max_length(String *result,
                                       ptr + max_length,
                                       result->length()).length();
   result->length(old_length + add_length);
+}
+
+
+String *Item_func_group_concat::get_str_from_field(Item *i, Field *f,
+                                                   String *tmp,
+                                                   const uchar *key,
+                                                   size_t offset)
+{
+  /*
+    Whenever the argument is BIT, emit the packed bytes of its bit value,
+    matching what Field_bit::val_str() returns.
+
+    store_bit_fields_as_bigint_in_tempory_table() converts direct BIT
+    Item_field arguments to LONG or LONGLONG in that temp table so the
+    records can be compared by memcmp; reading the value back via
+    val_str() on the converted field would emit a decimal string instead
+    of the packed bytes.
+  */
+  if (i->field_type() == MYSQL_TYPE_BIT)
+  {
+    // Pack the bits into the buffer, byte by byte.
+    ulonglong bits= f->val_int(key + offset);
+    char buff[sizeof(ulonglong)];
+    for (int b= sizeof(buff) - 1; b >= 0; b--)
+    {
+      buff[b]= static_cast<char>(bits & 0xff);
+      bits>>= 8;
+    }
+
+    // Copy the buffer into the output String tmp.
+    uint length= MY_MIN((uint) ((i->max_length + 7) / 8),
+                        (uint) sizeof(longlong));
+    DBUG_ASSERT(length <= table->s->reclength);
+    memcpy(const_cast<char*>(tmp->ptr()),
+           buff + (sizeof(longlong) - length),
+           length);
+
+    /*
+      The length was zeroed-out by the caller, so update it to reflect
+      the data stored into tmp.
+    */
+    tmp->length(length);
+    tmp->set_charset(&my_charset_bin);
+
+    return tmp;
+  }
+
+  return f->val_str(tmp, key + offset);
 }
 
 

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2066,8 +2066,7 @@ protected:
   virtual String *get_str_from_item(Item *i, String *tmp)
     { return i->val_str(tmp); }
   virtual String *get_str_from_field(Item *i, Field *f, String *tmp,
-                                     const uchar *key, size_t offset)
-    { return f->val_str(tmp, key + offset); }
+                                     const uchar *key, size_t offset);
   virtual void cut_max_length(String *result,
                               uint old_length, uint max_length) const;
   bool uses_non_standard_aggregator_for_distinct() const override


### PR DESCRIPTION
This PR consists of two commits.  One commit implements the fix for the bug and another commit documents and cleans up the implementation of `dump_leaf_key`.  There should be no functional change in the latter commit.

    MDEV-39397: Wrong result for GROUP_CONCAT(BIT(8)) in a window function

    When DISTINCT or ORDER BY is in play, GROUP_CONCAT builds an
    internal temp table and converts BIT arguments to integers so records
    can be compared by memcmp.  Calling val_str() on that field
    then returned the decimal form ("0", "1", "3") instead of the
    packed bit bytes that Field_bit::val_str() emits everywhere else,
    including the "plain" GROUP_CONCAT path.

    Override get_str_from_field() for Item_func_group_concat to detect
    when the argument is BIT, read the value as an integer from the
    temp table field, and pack it into (max_length + 7) / 8 bytes,
    mirroring Field_bit::val_str().  This makes DISTINCT and ORDER BY
    agree with the plain path.

    Before this change, BIT fields in group_concat were rendered
    as ASCII which was incorrect and produced the wrong result as
    described in the ticket.  With this fix, we also update the
    existing test cases to wrap BIT columns with '+0' so the recorded
    output stays in ASCII format.  Now, with this patch and the test
    case from the ticket, MariaDB and MySQL produce identical resultset
    of a single row, single column having value 08.

    By default, a group_concat including BIT fields on MySQL returns a
    hexified value for its resultset whereas MariaDB requires the
    hex() function to wrap group_concat for the same result:

    Setup:
      create table t1(a bit(2), b varchar(10), c bit);
      insert into t1 values (1, 'a', 0), (0, 'b', 1);

    MySQL:
      mysql> select group_concat(a, c) from t1;
      +----------------------------------------+
      | group_concat(a, c)                     |
      +----------------------------------------+
      | 0x01002C0001                           |
      +----------------------------------------+
      1 row in set (0.001 sec)

    MariaDB:
      MariaDB [test]> select hex(group_concat(a, c)) from t1;
      +-------------------------+
      | hex(group_concat(a, c)) |
      +-------------------------+
      | 01002C0001              |
      +-------------------------+
      1 row in set (0.001 sec)


The cleanup commit:


    MDEV-39397: Document and clean up dump_leaf_key

    Add a docblock for dump_leaf_key that describes each parameter
    and the leaf payload layout, and documents the return values and
    side effects.

    Sprinkle inline comments through the body to explain the LIMIT and
    OFFSET bookkeeping, the dual purpose of result_finalized, why
    borrowing table->record[1] as scratch space is safe, the offset
    translation for skipped null bytes, and why the blob_storage
    truncation flag is cleared after raising ER_CUT_VALUE_GROUP_CONCAT.

    Implement other code cleanups, too, like dropping the unused tmp2
    String object and rename old_length to starting_len so the cut_max_length
    call reads more directly.  Other changes include narrowing loop
    variables to the loop scope, move declarations next to their
    first use, and replacing the C casts with static_cast.

    There should be no behavior changes at this commit.