### PR TITLE
Cleanup trx_sys.find() calls

### DIFF
--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -668,7 +668,7 @@ dict_sys_tables_rec_read(
 		rec, DICT_FLD__SYS_TABLES__DB_TRX_ID, &len);
 	ut_ad(len == 6 || len == UNIV_SQL_NULL);
 	trx_id_t id = len == 6 ? trx_read_trx_id(field) : 0;
-	if (id && !uncommitted && trx_sys.find(nullptr, id, false)) {
+	if (id && !uncommitted && trx_sys.is_registered_nonzero(id)) {
 		const auto savepoint = mtr->get_savepoint();
 		heap = mem_heap_create(1024);
 		dict_index_t* index = UT_LIST_GET_FIRST(
@@ -1079,7 +1079,7 @@ err_len:
 	const trx_id_t trx_id = trx_read_trx_id(field);
 
 	if (trx_id && mtr && use_uncommitted < 2
-	    && trx_sys.find(nullptr, trx_id, false)) {
+	    && trx_sys.is_registered_nonzero(trx_id)) {
 		if (use_uncommitted) {
 			return dict_load_column_instant;
 		}
@@ -1288,7 +1288,7 @@ err_len:
 	const trx_id_t trx_id = trx_read_trx_id(field);
 
 	if (trx_id && column && !uncommitted
-	    && trx_sys.find(nullptr, trx_id, false)) {
+	    && trx_sys.is_registered_nonzero(trx_id)) {
 		if (!rec_get_deleted_flag(rec, 0)) {
 			return dict_load_virtual_none;
 		}
@@ -1639,7 +1639,7 @@ err_len:
 	if (!trx_id) {
 		ut_ad(!rec_get_deleted_flag(rec, 0));
 	} else if (!mtr || uncommitted) {
-	} else if (trx_sys.find(nullptr, trx_id, false)) {
+	} else if (trx_sys.is_registered_nonzero(trx_id)) {
 		const auto savepoint = mtr->get_savepoint();
 		dict_index_t* sys_field = UT_LIST_GET_FIRST(
 			dict_sys.sys_fields->indexes);
@@ -1856,7 +1856,7 @@ err_len:
 	if (!trx_id) {
 		ut_ad(!rec_get_deleted_flag(rec, 0));
 	} else if (!mtr || uncommitted) {
-	} else if (trx_sys.find(nullptr, trx_id, false)) {
+	} else if (trx_sys.is_registered_nonzero(trx_id)) {
 		const auto savepoint = mtr->get_savepoint();
 		dict_index_t* sys_index = UT_LIST_GET_FIRST(
 			dict_sys.sys_indexes->indexes);
@@ -2744,7 +2744,7 @@ static dberr_t dict_load_foreign_cols(dict_foreign_t *foreign, trx_id_t trx_id)
 
 		const trx_id_t id = trx_read_trx_id(field);
 		if (!id) {
-		} else if (id != trx_id && trx_sys.find(nullptr, id, false)) {
+		} else if (id != trx_id && trx_sys.is_registered_nonzero(id)) {
 			const auto savepoint = mtr.get_savepoint();
 			rec_offs* offsets = rec_get_offsets(
 				rec, sys_index, nullptr, true, ULINT_UNDEFINED,
@@ -2934,7 +2934,7 @@ err_exit:
 	const trx_id_t tid = trx_read_trx_id(field);
 
 	if (tid && tid != trx_id && !uncommitted
-	    && trx_sys.find(nullptr, tid, false)) {
+	    && trx_sys.is_registered_nonzero(tid)) {
 		const auto savepoint = mtr.get_savepoint();
 		rec_offs* offsets = rec_get_offsets(
 			rec, sys_index, nullptr, true, ULINT_UNDEFINED, &heap);

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -1166,7 +1166,7 @@ invalid:
 		}
 
 		const auto bulk_trx_id = index->table->bulk_trx_id;
-		if (bulk_trx_id && trx_sys.find(nullptr, bulk_trx_id, false)) {
+		if (trx_sys.is_registered(nullptr, bulk_trx_id)) {
 			err= DB_SUCCESS_LOCKED_REC;
 			goto invalid;
 		}
@@ -1231,11 +1231,9 @@ dberr_t dict_stats_update_transient(dict_table_t *table) noexcept
 		return DB_SUCCESS;
 	}
 
-	if (trx_id_t bulk_trx_id = table->bulk_trx_id) {
-		if (trx_sys.find(nullptr, bulk_trx_id, false)) {
-			dict_stats_empty_table(table, false);
-			return DB_SUCCESS_LOCKED_REC;
-		}
+	if (trx_sys.is_registered(nullptr, table->bulk_trx_id)) {
+		dict_stats_empty_table(table, false);
+		return DB_SUCCESS_LOCKED_REC;
 	}
 
 	for (; index != NULL; index = dict_table_get_next_index(index)) {
@@ -2365,7 +2363,7 @@ empty_index:
 	result.n_leaf_pages = size ? size : 1;
 
 	const auto bulk_trx_id = index->table->bulk_trx_id;
-	if (bulk_trx_id && trx_sys.find(nullptr, bulk_trx_id, false)) {
+	if (trx_sys.is_registered(nullptr, bulk_trx_id)) {
 		result.set_bulk_operation();
 		goto empty_index;
 	}
@@ -2634,11 +2632,9 @@ dberr_t dict_stats_update_persistent(dict_table_t *table) noexcept
 
 	DEBUG_SYNC_C("dict_stats_update_persistent");
 
-	if (trx_id_t bulk_trx_id = table->bulk_trx_id) {
-		if (trx_sys.find(nullptr, bulk_trx_id, false)) {
-			dict_stats_empty_table(table, false);
-			return DB_SUCCESS_LOCKED_REC;
-		}
+	if (trx_sys.is_registered(nullptr, table->bulk_trx_id)) {
+		dict_stats_empty_table(table, false);
+		return DB_SUCCESS_LOCKED_REC;
 	}
 
 	/* analyze the clustered index first */

--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -1164,6 +1164,13 @@ public:
   }
 
 
+  bool is_registered_nonzero(trx_id_t id, trx_t *caller_trx= nullptr)
+  {
+    ut_ad(id);
+    return find(caller_trx, id, false);
+  }
+
+
   bool is_registered(trx_t *caller_trx, trx_id_t id)
   {
     return id && find(caller_trx, id, false);


### PR DESCRIPTION
Replaced some trx_sys.find() calls with trx_sys.is_registered(). The latter is more appropriate in this context as it documents the intention and may provide more optimal implementation if we ever decide to.