### PR TITLE
MDEV-26814: UBSAN: offset to nullptr in JSON_ARRAY_INSERT

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -2877,4 +2877,10 @@ Warning	4038	Syntax error in JSON text in argument 1 to function 'json_extract' 
 SELECT JSON_EXTRACT('0E+0','$');
 JSON_EXTRACT('0E+0','$')
 0E+0
+#
+# MDEV-26814: UBSAN: offset to nullptr in JSON_ARRAY_INSERT
+#
+SELECT JSON_ARRAY_INSERT (0,NULL,1) as j;
+j
+NULL
 # End of 10.11 Test

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -2093,4 +2093,10 @@ SELECT JSON_VALID('{ "A": [0,] }');
 SELECT JSON_EXTRACT('{a:true}','$.a')=TRUE;
 SELECT JSON_EXTRACT('0E+0','$');
 
+--echo #
+--echo # MDEV-26814: UBSAN: offset to nullptr in JSON_ARRAY_INSERT
+--echo #
+
+SELECT JSON_ARRAY_INSERT (0,NULL,1) as j;
+
 --echo # End of 10.11 Test

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -2240,11 +2240,13 @@ String *Item_func_json_array_insert::val_str(String *str)
     if (!c_path->parsed)
     {
       String *s_p= args[n_arg]->val_str(tmp_paths+n_path);
-      if (s_p &&
-          (path_setup_nwc(&c_path->p,s_p->charset(),(const uchar *) s_p->ptr(),
+      if (!s_p)
+        goto return_null;
+
+      if (path_setup_nwc(&c_path->p,s_p->charset(),(const uchar *) s_p->ptr(),
                           (const uchar *) s_p->ptr() + s_p->length()) ||
            c_path->p.last_step - 1 < c_path->p.steps ||
-           c_path->p.last_step->type != JSON_PATH_ARRAY))
+           c_path->p.last_step->type != JSON_PATH_ARRAY)
       {
         if (c_path->p.s.error == 0)
           c_path->p.s.error= SHOULD_END_WITH_ARRAY;


### PR DESCRIPTION
SELECT JSON_ARRAY_INSERT (0,NULL,1); triggered a UBSAN error. Specification of JSON_ARRAY_INSERT should return NULL if any arguments are null.

SQL NULL, aka Item_null::val_str will return a nullptr so check this and then return a NULL value.