### PR TITLE
MDEV-39494: UBSAN error on division by zero.

### DIFF
--- a/mysql-test/main/merge.result
+++ b/mysql-test/main/merge.result
@@ -3968,20 +3968,11 @@ a
 5
 DROP TABLE t1;
 #
-# End of 10.11 tests
+# MDEV-39494 UBSAN failure
 #
-#
-# MDEV-30088 Assertion `cond_selectivity <= 1.0' failed in get_range_limit_read_cost
-#
-CREATE TABLE t1 (a TIMESTAMP, KEY(a)) ENGINE=MRG_MyISAM;
-explain SELECT a, COUNT(*) FROM t1 WHERE a >= '2000-01-01 00:00:00' GROUP BY a;
-id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
-SELECT a, COUNT(*) FROM t1 WHERE a >= '2000-01-01 00:00:00' GROUP BY a;
-a	COUNT(*)
-DROP TABLE t1;
-#
-# MDEV-30525: Assertion `ranges > 0' fails in IO_AND_CPU_COST handler::keyread_time
+# This test was ported down from 11.x and was originally implemented under MDEV-30525.
+# Under 10.11, this scenario results in a divide-by-zero failure because there are zero
+# table records available.
 #
 CREATE TABLE t1 (a INT, KEY(a)) ENGINE=MyISAM;
 CREATE TABLE t2 (a INT, KEY(a)) ENGINE=MyISAM;
@@ -3989,52 +3980,6 @@ CREATE TABLE tm (a INT, KEY(a)) ENGINE=MRG_MyISAM UNION=(t1,t2);
 SELECT DISTINCT a FROM tm WHERE a > 50;
 a
 DROP TABLE tm, t1, t2;
-# Testcase 2:
-CREATE TABLE t1 (a INT, KEY(a)) ENGINE=MyISAM;
-CREATE TABLE t2 (a INT, KEY(a)) ENGINE=MyISAM;
-CREATE TABLE tm (a INT, KEY(a)) ENGINE=MERGE UNION = (t1, t2) INSERT_METHOD=FIRST;
-ANALYZE TABLE tm PERSISTENT FOR ALL;
-Table	Op	Msg_type	Msg_text
-test.tm	analyze	status	Engine-independent statistics collected
-test.tm	analyze	note	The storage engine for the table doesn't support analyze
-SELECT DISTINCT a FROM (SELECT * FROM tm WHERE a iS NOT NULL) AS sq;
-a
-DROP TABLE tm, t1, t2;
-#
-# MDEV-30568 Assertion `cond_selectivity <= 1.000000001' failed in get_range_limit_read_cost
-#
-CREATE TABLE t1 (f INT, KEY(f)) ENGINE=MyISAM;
-CREATE TABLE t2 (f INT, KEY(f)) ENGINE=MyISAM;
-CREATE TABLE tm (f INT, KEY(f)) ENGINE=MERGE UNION = (t1, t2);
-SELECT DISTINCT f FROM tm WHERE f IN (47, 126, 97, 48, 73, 0);
-f
-DROP TABLE tm, t1, t2;
-#
-# MDEV-30786 SIGFPE in cost_group_min_max on EXP
-#
-SET use_stat_tables='preferably';
-CREATE TABLE t1 (a INT,b INT,KEY i1 (a),KEY i2 (b)) ENGINE=MRG_MyISAM;
-ANALYZE LOCAL TABLE t1;
-Table	Op	Msg_type	Msg_text
-test.t1	analyze	status	Engine-independent statistics collected
-test.t1	analyze	note	The storage engine for the table doesn't support analyze
-EXPLAIN SELECT DISTINCT a FROM t1;
-id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	range	NULL	i1	5	NULL	1	Using index for group-by
-drop table t1;
-set use_stat_tables=default;
-#
-# End of 11.0 tests
-#
-#
-# MDEV-29174: UPDATE of view that uses MERGE table
-#
-CREATE TABLE t1 (a int) ENGINE=MERGE;
-CREATE VIEW v1 AS SELECT a FROM t1;
-UPDATE v1 SET a=0;
-DROP VIEW v1;
-DROP TABLE t1;
-# End of 11.1 tests
 #
 # MDEV-38474 Double free or corruption, ASAN heap-use-after-free in st_join_table::cleanup
 #
@@ -4061,5 +4006,5 @@ UPDATE t1 STRAIGHT_JOIN t2 SET a = 89 WHERE 9 IN (SELECT c FROM t3 WHERE c IN (S
 ERROR HY000: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
 DROP TABLE t1, t2, t3, t4;
 #
-# End of 11.4 tests
+# End of 10.11 tests
 #

--- a/mysql-test/main/merge.test
+++ b/mysql-test/main/merge.test
@@ -2903,68 +2903,18 @@ EXECUTE nested;
 DROP TABLE t1;
 
 --echo #
---echo # End of 10.11 tests
+--echo # MDEV-39494 UBSAN failure
 --echo #
-
---echo #
---echo # MDEV-30088 Assertion `cond_selectivity <= 1.0' failed in get_range_limit_read_cost
---echo #
-
-CREATE TABLE t1 (a TIMESTAMP, KEY(a)) ENGINE=MRG_MyISAM;
-explain SELECT a, COUNT(*) FROM t1 WHERE a >= '2000-01-01 00:00:00' GROUP BY a;
-SELECT a, COUNT(*) FROM t1 WHERE a >= '2000-01-01 00:00:00' GROUP BY a;
-DROP TABLE t1;
-
---echo #
---echo # MDEV-30525: Assertion `ranges > 0' fails in IO_AND_CPU_COST handler::keyread_time
+--echo # This test was ported down from 11.x and was originally implemented under MDEV-30525.
+--echo # Under 10.11, this scenario results in a divide-by-zero failure because there are zero
+--echo # table records available.
 --echo #
 CREATE TABLE t1 (a INT, KEY(a)) ENGINE=MyISAM;
 CREATE TABLE t2 (a INT, KEY(a)) ENGINE=MyISAM;
 CREATE TABLE tm (a INT, KEY(a)) ENGINE=MRG_MyISAM UNION=(t1,t2);
+# Must have zero records to produce UBSAN failure on divide-by-zero.
 SELECT DISTINCT a FROM tm WHERE a > 50;
 DROP TABLE tm, t1, t2;
-
---echo # Testcase 2:
-CREATE TABLE t1 (a INT, KEY(a)) ENGINE=MyISAM;
-CREATE TABLE t2 (a INT, KEY(a)) ENGINE=MyISAM;
-CREATE TABLE tm (a INT, KEY(a)) ENGINE=MERGE UNION = (t1, t2) INSERT_METHOD=FIRST;
-ANALYZE TABLE tm PERSISTENT FOR ALL;
-SELECT DISTINCT a FROM (SELECT * FROM tm WHERE a iS NOT NULL) AS sq;
-DROP TABLE tm, t1, t2;
-
---echo #
---echo # MDEV-30568 Assertion `cond_selectivity <= 1.000000001' failed in get_range_limit_read_cost
---echo #
-CREATE TABLE t1 (f INT, KEY(f)) ENGINE=MyISAM;
-CREATE TABLE t2 (f INT, KEY(f)) ENGINE=MyISAM;
-CREATE TABLE tm (f INT, KEY(f)) ENGINE=MERGE UNION = (t1, t2);
-SELECT DISTINCT f FROM tm WHERE f IN (47, 126, 97, 48, 73, 0);
-DROP TABLE tm, t1, t2;
-
---echo #
---echo # MDEV-30786 SIGFPE in cost_group_min_max on EXP
---echo #
-SET use_stat_tables='preferably';
-CREATE TABLE t1 (a INT,b INT,KEY i1 (a),KEY i2 (b)) ENGINE=MRG_MyISAM;
-ANALYZE LOCAL TABLE t1;
-EXPLAIN SELECT DISTINCT a FROM t1;
-drop table t1;
-set use_stat_tables=default;
-
---echo #
---echo # End of 11.0 tests
---echo #
---echo #
---echo # MDEV-29174: UPDATE of view that uses MERGE table
---echo #
-
-CREATE TABLE t1 (a int) ENGINE=MERGE;
-CREATE VIEW v1 AS SELECT a FROM t1;
-UPDATE v1 SET a=0;
-DROP VIEW v1;
-DROP TABLE t1;
-
---echo # End of 11.1 tests
 
 --echo #
 --echo # MDEV-38474 Double free or corruption, ASAN heap-use-after-free in st_join_table::cleanup
@@ -2997,6 +2947,5 @@ UPDATE t1 STRAIGHT_JOIN t2 SET a = 89 WHERE 9 IN (SELECT c FROM t3 WHERE c IN (S
 DROP TABLE t1, t2, t3, t4;
 
 --echo #
---echo # End of 11.4 tests
+--echo # End of 10.11 tests
 --echo #
-

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -15071,8 +15071,16 @@ void cost_group_min_max(TABLE* table, KEY *index_info, uint used_key_parts,
     keys_per_group= (table_records / 10) + 1;
   num_groups= (table_records / keys_per_group) + 1;
 
-  /* Apply the selectivity of the quick select for group prefixes. */
-  if (range_tree && (quick_prefix_records != HA_POS_ERROR))
+  DBUG_ASSERT(keys_per_group > 0);
+  DBUG_ASSERT(num_groups > 0);
+
+  /*
+    Apply the selectivity of the quick select for group prefixes.
+
+    If there are no records in the table, then there's nothing to select so
+    let num_groups continue to be 1 as set above.
+  */
+  if (range_tree && (quick_prefix_records != HA_POS_ERROR) && table_records > 0)
   {
     quick_prefix_selectivity= (double) quick_prefix_records /
                               (double) table_records;


### PR DESCRIPTION
An incorrectly backported test from 11.x revealed an UBSAN error in 10.11, so fix that problem by preventing a division-by-zero from happening.

Remove the other incorrectly backported tests and relabel the retained test in terms of the current ticket.