### PR TITLE
MDEV-39523 UBSAN on ST_COLLECT (has_cached_value)

### DIFF
--- a/mysql-test/main/spatial_utility_function_collect.result
+++ b/mysql-test/main/spatial_utility_function_collect.result
@@ -268,3 +268,15 @@ select st_collect(1), st_collect(1) is null;
 st_collect(1)	st_collect(1) is null
 NULL	1
 # End of 12.2 tests
+#
+# MDEV-39523 UBSAN on ST_COLLECT (has_cached_value)
+#
+CREATE TABLE t (c INT);
+SELECT ST_COLLECT(c) FROM t;
+ST_COLLECT(c)
+NULL
+SELECT ST_ASTEXT(ST_ENVELOPE(ST_COLLECT(c))) FROM t;
+ST_ASTEXT(ST_ENVELOPE(ST_COLLECT(c)))
+NULL
+DROP TABLE t;
+# End of 12.3 tests

--- a/mysql-test/main/spatial_utility_function_collect.test
+++ b/mysql-test/main/spatial_utility_function_collect.test
@@ -229,3 +229,15 @@ SELECT 1 FROM dual WHERE group_concat(1, 1);
 select st_collect(1), st_collect(1) is null;
 
 --echo # End of 12.2 tests
+
+--echo #
+--echo # MDEV-39523 UBSAN on ST_COLLECT (has_cached_value)
+--echo #
+
+CREATE TABLE t (c INT);
+SELECT ST_COLLECT(c) FROM t;
+SELECT ST_ASTEXT(ST_ENVELOPE(ST_COLLECT(c))) FROM t;
+
+DROP TABLE t;
+
+--echo # End of 12.3 tests

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -4702,6 +4702,7 @@ bool Item_func_collect::list_contains_element(String *wkb) {
 
 Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item *item_par) :
   Item_sum_str(thd, item_par),
+  has_cached_result(false),
   mem_root(thd->mem_root),
   is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
@@ -4712,11 +4713,14 @@ Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item *item_par)
 
 Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item_func_collect *item) :
   Item_sum_str(thd, item),
+  has_cached_result(false),
   mem_root(thd->mem_root),
   is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
 {
   quick_group= false;
+  has_cached_result= item->has_cached_result;
+  cached_result= item->cached_result;
 }
 
 


### PR DESCRIPTION
UBSAN errored with UBSAN: load of value 165, which is not a valid value for type 'bool' on SELECT ST_COLLECT.

This was Item_func_collect::val_str reading the has_cached_value. The member variable has_cached_value was set to true later in this function when it had a cached value. There was no initialization of has_cached_value to false in the constructor.