### PR TITLE
MDEV-38838 Memory loss in CONNECT from handler::ha_rnd_init

### DIFF
--- a/mysql-test/lsan.supp
+++ b/mysql-test/lsan.supp
@@ -15,3 +15,7 @@ leak:gnutls_x509_trust_list_init
 leak:gnutls_subject_alt_names_init
 leak:__gmp_default_allocate
 leak:__gmp_default_reallocate
+
+# unixODBC leak <=unixODBC 2.3.15
+leak:save_ini_cache
+leak:logOpen


### PR DESCRIPTION
This was a leak in unixODBC 2.3.14 where a cache was allocated but not returned. The LD_PRELOAD is so the resolution will be aware of the resolution for save_ini_cache that caused the leak.