### PR TITLE
MDEV-39213: json range syntax crash

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -1774,6 +1774,12 @@ null<=>json_extract('1',json_object(null,'{ }',null,null),'{}')
 Warnings:
 Warning	4042	Syntax error in JSON path in argument 2 to function 'json_extract' at position 1
 #
+# MDEV-39213: json range syntax crash
+#
+SELECT JSON_EXISTS(CONCAT('[', REPEAT('[', 4000), 'Y', REPEAT(']', 4000), ', 1]'), '$[100]');
+JSON_EXISTS(CONCAT('[', REPEAT('[', 4000), 'Y', REPEAT(']', 4000), ', 1]'), '$[100]')
+NULL
+#
 # MDEV-35548 UBSAN: runtime error: index -1 out of bounds for type 'json_path_step_t[32]'
 # (aka 'struct st_json_path_step_t[32]')
 #

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -1239,6 +1239,12 @@ FROM JSON_TABLE (@data, '$[*]' COLUMNS (data text PATH '$.Data')) AS t;
 select null<=>json_extract('1',json_object(null,'{ }',null,null),'{}');
 
 --echo #
+--echo # MDEV-39213: json range syntax crash
+--echo #
+
+SELECT JSON_EXISTS(CONCAT('[', REPEAT('[', 4000), 'Y', REPEAT(']', 4000), ', 1]'), '$[100]');
+
+--echo #
 --echo # MDEV-35548 UBSAN: runtime error: index -1 out of bounds for type 'json_path_step_t[32]'
 --echo # (aka 'struct st_json_path_step_t[32]')
 --echo #

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -549,7 +549,7 @@ bool Item_func_json_exists::fix_length_and_dec()
 bool Item_func_json_exists::val_bool()
 {
   json_engine_t je;
-  uint array_counters[JSON_DEPTH_LIMIT];
+  uint array_counters[JSON_DEPTH_LIMIT]= {0};
 
   String *js= args[0]->val_json(&tmp_js);
 
@@ -614,7 +614,7 @@ bool Json_path_extractor::extract(String *str, Item *item_js, Item *item_jp,
 {
   String *js= item_js->val_json(&tmp_js);
   int error= 0;
-  uint array_counters[JSON_DEPTH_LIMIT];
+  uint array_counters[JSON_DEPTH_LIMIT]= {0};
 
   if (!parsed)
   {
@@ -1368,7 +1368,7 @@ bool Item_func_json_contains::val_bool()
 
   if (arg_count>2) /* Path specified. */
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     if (!path.parsed)
     {
       String *s_p= args[2]->val_str(&tmp_path);
@@ -1505,7 +1505,7 @@ longlong Item_func_json_contains_path::val_int()
   result= !mode_one;
   for (n_arg=2; n_arg < arg_count; n_arg++)
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     json_path_with_flags *c_path= paths + n_arg - 2;
     if (!c_path->parsed)
     {
@@ -1895,7 +1895,7 @@ String *Item_func_json_array_append::val_str(String *str)
 
   for (n_arg=1, n_path=0; n_arg < arg_count; n_arg+=2, n_path++)
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     json_path_with_flags *c_path= paths + n_path;
     if (!c_path->parsed)
     {
@@ -2025,7 +2025,7 @@ String *Item_func_json_array_insert::val_str(String *str)
 
   for (n_arg=1, n_path=0; n_arg < arg_count; n_arg+=2, n_path++)
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     json_path_with_flags *c_path= paths + n_path;
     const char *item_pos;
     uint n_item;
@@ -2821,7 +2821,7 @@ longlong Item_func_json_length::val_int()
   String *js= args[0]->val_json(&tmp_js);
   json_engine_t je;
   uint length= 0;
-  uint array_counters[JSON_DEPTH_LIMIT];
+  uint array_counters[JSON_DEPTH_LIMIT]= {0};
   int err;
 
   if ((null_value= args[0]->null_value))
@@ -3060,7 +3060,7 @@ String *Item_func_json_insert::val_str(String *str)
 
   for (n_arg=1, n_path=0; n_arg < arg_count; n_arg+=2, n_path++)
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     json_path_with_flags *c_path= paths + n_path;
     const char *v_to;
     const json_path_step_t *lp;
@@ -3314,7 +3314,7 @@ String *Item_func_json_remove::val_str(String *str)
 
   for (n_arg=1, n_path=0; n_arg < arg_count; n_arg++, n_path++)
   {
-    uint array_counters[JSON_DEPTH_LIMIT];
+    uint array_counters[JSON_DEPTH_LIMIT]= {0};
     json_path_with_flags *c_path= paths + n_path;
     const char *rem_start= 0, *rem_end;
     const json_path_step_t *lp;
@@ -3526,7 +3526,7 @@ String *Item_func_json_keys::val_str(String *str)
   json_engine_t je;
   String *js= args[0]->val_json(&tmp_js);
   uint n_keys= 0;
-  uint array_counters[JSON_DEPTH_LIMIT];
+  uint array_counters[JSON_DEPTH_LIMIT]= {0};
 
   if ((args[0]->null_value))
     goto null_return;

--- a/sql/json_table.cc
+++ b/sql/json_table.cc
@@ -550,7 +550,7 @@ int ha_json_table::fill_column_values(THD *thd, uchar * buf, uchar *pos)
       {
         json_engine_t je;
         json_path_step_t *cur_step;
-        uint array_counters[JSON_DEPTH_LIMIT];
+        uint array_counters[JSON_DEPTH_LIMIT]= {0};
         int not_found;
         const uchar* node_start;
         const uchar* node_end;

--- a/strings/json_lib.c
+++ b/strings/json_lib.c
@@ -1371,14 +1371,26 @@ int json_find_path(json_engine_t *je,
         json_skip_array_item(je);
       break;
     case JST_OBJ_END:
-      do
-      {
-        (*p_cur_step)--;
-      } while (*p_cur_step > p->steps &&
-               array_counters[*p_cur_step - p->steps] == SKIPPED_STEP_MARK);
+        /*
+          MSAN-safe block
+        */
+        while (*p_cur_step > p->steps)
+        {
+          json_path_step_t *prev = *p_cur_step;
+          prev--;
+
+          if (prev < p->steps)
+            break;
+
+         *p_cur_step = prev;
+
+         if (array_counters[prev - p->steps] != SKIPPED_STEP_MARK)
+           break;
+        }
       break;
     case JST_ARRAY_END:
-      (*p_cur_step)--;
+      if (*p_cur_step > p->steps)
+        (*p_cur_step)--;
       break;
     default:
       DBUG_ASSERT(0);

--- a/unittest/json_lib/json_lib-t.c
+++ b/unittest/json_lib/json_lib-t.c
@@ -140,7 +140,7 @@ test_search()
   json_path_t p;
   json_path_step_t *cur_step;
   int n_matches, scal_values;
-  uint array_counters[JSON_DEPTH_LIMIT];
+  uint array_counters[JSON_DEPTH_LIMIT]= {0};
 
   if (json_scan_start(&je, ci, s_e(fj0)) ||
       json_path_setup(&p, ci, s_e(fp0)))


### PR DESCRIPTION
Analysis:
When json is being parsed, the step decreases without a out-of-bound check resulting in failure.
Fix:
Before decreasing the step, check if it will result into out of bound.