### PR TITLE
MDEV-39323: Wrong result with NOT BETWEEN and mismatched types

### DIFF
--- a/mysql-test/main/range.result
+++ b/mysql-test/main/range.result
@@ -3755,6 +3755,56 @@ id	key1
 3	2
 drop table t1;
 #
+# MDEV-39323: Wrong result with NOT BETWEEN and mismatched types
+#
+CREATE TABLE `t1` (
+`float_key` float,
+`int_key` int,
+UNIQUE KEY `float_key` (`float_key`),
+UNIQUE KEY `int_key` (`int_key`)
+);
+INSERT INTO `t1` VALUES
+(567621000,  NULL),
+(0.363988,   -1643936528),
+(-422810000, NULL),
+(0,          0),
+(NULL,       NULL),
+(NULL,       NULL),
+(NULL,       NULL);
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+COUNT(*)
+3
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index_merge	float_key,int_key	float_key,int_key	5,5	NULL	3	Using sort_union(float_key,int_key); Using where
+set optimizer_switch= @osw_tmp;
+DROP TABLE t1;
+# The ticket's column types, FLOAT and INT.  The FLOAT bound matches
+# the REAL comparison type and builds an exact range.  The INT bound
+# does not match, so it builds a superset range instead of being
+# dropped.  2.4 rounds down, so the INT range i < 2.4 becomes i <= 2
+# and the row with i=2 must appear.
+CREATE TABLE t1 (f FLOAT, i INT, UNIQUE KEY(f), UNIQUE KEY(i));
+INSERT INTO t1 VALUES
+(3.5,20),(5.5,21),(-1.5,2),(-9.5,1),
+(0.5,3),(1.5,4),(2.0,5),(-2.5,6),(-3.5,7),(-4.5,8),(-5.5,9),(-6.5,10);
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index_merge	f,i	f,i	5,5	NULL	4	Using sort_union(f,i); Using where
+SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+f	i
+-1.5	2
+-9.5	1
+3.5	20
+5.5	21
+set optimizer_switch= @osw_tmp;
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #
 set global innodb_stats_persistent= @innodb_stats_persistent_save;

--- a/mysql-test/main/range.test
+++ b/mysql-test/main/range.test
@@ -2557,6 +2557,54 @@ evalp $query;
 drop table t1;
 
 --echo #
+--echo # MDEV-39323: Wrong result with NOT BETWEEN and mismatched types
+--echo #
+CREATE TABLE `t1` (
+  `float_key` float,
+  `int_key` int,
+  UNIQUE KEY `float_key` (`float_key`),
+  UNIQUE KEY `int_key` (`int_key`)
+);
+
+INSERT INTO `t1` VALUES
+  (567621000,  NULL),
+  (0.363988,   -1643936528),
+  (-422810000, NULL),
+  (0,          0),
+  (NULL,       NULL),
+  (NULL,       NULL),
+  (NULL,       NULL);
+
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+set optimizer_switch= @osw_tmp;
+
+DROP TABLE t1;
+
+--echo # The ticket's column types, FLOAT and INT.  The FLOAT bound matches
+--echo # the REAL comparison type and builds an exact range.  The INT bound
+--echo # does not match, so it builds a superset range instead of being
+--echo # dropped.  2.4 rounds down, so the INT range i < 2.4 becomes i <= 2
+--echo # and the row with i=2 must appear.
+CREATE TABLE t1 (f FLOAT, i INT, UNIQUE KEY(f), UNIQUE KEY(i));
+INSERT INTO t1 VALUES
+  (3.5,20),(5.5,21),(-1.5,2),(-9.5,1),
+  (0.5,3),(1.5,4),(2.0,5),(-2.5,6),(-3.5,7),(-4.5,8),(-5.5,9),(-6.5,10);
+
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+--sorted_result
+SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+set optimizer_switch= @osw_tmp;
+
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.11 tests
 --echo #
 set global innodb_stats_persistent= @innodb_stats_persistent_save;

--- a/mysql-test/main/range_mrr_icp.result
+++ b/mysql-test/main/range_mrr_icp.result
@@ -3744,6 +3744,56 @@ id	key1
 3	2
 drop table t1;
 #
+# MDEV-39323: Wrong result with NOT BETWEEN and mismatched types
+#
+CREATE TABLE `t1` (
+`float_key` float,
+`int_key` int,
+UNIQUE KEY `float_key` (`float_key`),
+UNIQUE KEY `int_key` (`int_key`)
+);
+INSERT INTO `t1` VALUES
+(567621000,  NULL),
+(0.363988,   -1643936528),
+(-422810000, NULL),
+(0,          0),
+(NULL,       NULL),
+(NULL,       NULL),
+(NULL,       NULL);
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+COUNT(*)
+3
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN
+SELECT COUNT(*) FROM t1 WHERE NOT (1 BETWEEN t1.float_key AND t1.int_key);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index_merge	float_key,int_key	float_key,int_key	5,5	NULL	3	Using sort_union(float_key,int_key); Using where
+set optimizer_switch= @osw_tmp;
+DROP TABLE t1;
+# The ticket's column types, FLOAT and INT.  The FLOAT bound matches
+# the REAL comparison type and builds an exact range.  The INT bound
+# does not match, so it builds a superset range instead of being
+# dropped.  2.4 rounds down, so the INT range i < 2.4 becomes i <= 2
+# and the row with i=2 must appear.
+CREATE TABLE t1 (f FLOAT, i INT, UNIQUE KEY(f), UNIQUE KEY(i));
+INSERT INTO t1 VALUES
+(3.5,20),(5.5,21),(-1.5,2),(-9.5,1),
+(0.5,3),(1.5,4),(2.0,5),(-2.5,6),(-3.5,7),(-4.5,8),(-5.5,9),(-6.5,10);
+set @osw_tmp= @@optimizer_switch;
+set optimizer_switch='index_merge=on,index_merge_sort_union=on';
+EXPLAIN SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index_merge	f,i	f,i	5,5	NULL	4	Using sort_union(f,i); Using where
+SELECT f,i FROM t1 WHERE 2.4 NOT BETWEEN f AND i;
+f	i
+-1.5	2
+-9.5	1
+3.5	20
+5.5	21
+set optimizer_switch= @osw_tmp;
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #
 set global innodb_stats_persistent= @innodb_stats_persistent_save;

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -1058,6 +1058,12 @@ class Item_func_between :public Item_func_opt_neg
                              of the BETWEEN operator.
    */
   bool can_optimize_range_const(Item_field *field_item) const;
+  /*
+    True when, despite can_optimize_range_const() failing for a bound
+    field of a NOT BETWEEN predicate, we can still build a valid superset
+    range for that bound (see Item_func_between::get_mm_tree()).
+  */
+  bool can_build_superset_range_const(const Item_field *field_item) const;
 
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,

--- a/sql/json_table.cc
+++ b/sql/json_table.cc
@@ -376,8 +376,7 @@ static void store_json_in_field(Field *f, const json_engine_t *je)
   case JSON_VALUE_TRUE:
   case JSON_VALUE_FALSE:
   {
-    Item_result rt= f->result_type();
-    if (rt == INT_RESULT || rt == DECIMAL_RESULT || rt == REAL_RESULT)
+    if (f->type_handler()->is_numeric())
     {
       f->store(je->value_type == JSON_VALUE_TRUE, false);
       return;

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -8621,6 +8621,9 @@ SEL_TREE *Item::get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
 }
 
 
+/*
+  Disallow range creation when BETWEEN arguments' types don't match.
+*/
 bool
 Item_func_between::can_optimize_range_const(Item_field *field_item) const
 {
@@ -8631,6 +8634,37 @@ Item_func_between::can_optimize_range_const(Item_field *field_item) const
       return false;  // Cannot optimize range because of type mismatch.
 
   return true;
+}
+
+
+/*
+  can_optimize_range_const() failed for a bound field of a NOT BETWEEN
+  predicate, meaning that bound would be compared against args[0] using
+  a different type than the BETWEEN's own comparator.  A NOT BETWEEN
+  range is the OR of one range per bound, so the bound cannot simply be
+  dropped; that would make the range miss rows that satisfy the NOT
+  BETWEEN.
+
+  Return true when the bound's range can still be built the normal way
+  because the result is a valid superset of the matching rows.  That
+  holds when the field, args[0], and the BETWEEN comparator are all
+  numeric types (INT, REAL, or DECIMAL).  Numeric conversions preserve
+  ordering, and boundary rounding is handled conservatively, so the
+  range never drops a matching row; any extra rows it covers are
+  removed when the predicate is evaluated again on each row the scan
+  returns.
+
+  When a string or temporal comparison is involved the ordering is not
+  preserved (e.g., MDEV-36235, a numeric comparison over a string key),
+  so no safe superset range exists and the whole tree must be abandoned.
+*/
+bool
+Item_func_between::can_build_superset_range_const(const Item_field *field_item)
+                                                  const
+{
+  return field_item->type_handler_for_comparison()->is_numeric() &&
+         args[0]->type_handler_for_comparison()->is_numeric() &&
+         m_comparator.type_handler()->is_numeric();
 }
 
 
@@ -8660,7 +8694,32 @@ Item_func_between::get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
     {
       Item_field *field_item= (Item_field*) (arguments()[i]->real_item());
       if (!can_optimize_range_const(field_item))
-        continue;
+      {
+        if (!negated)
+        {
+          /*
+            For BETWEEN, dropping a conjunct is fine because the
+            remaining tree is a superset of matching rows and the WHERE
+            clause will filter any extra rows out.
+          */
+          continue;
+        }
+
+        /*
+          For NOT BETWEEN the range is the OR of one range per bound, so
+          a bound cannot simply be skipped; the remaining range would
+          miss rows that satisfy the NOT BETWEEN.  When the range for
+          this bound is still a valid superset we fall through and build
+          it the normal way below; otherwise we abandon the whole tree
+          to avoid building a bad range (see
+          can_build_superset_range_const()).
+        */
+        if (!can_build_superset_range_const(field_item))
+        {
+          tree= nullptr;
+          break;
+        }
+      }
       SEL_TREE *tmp= get_full_func_mm_tree(param, field_item,
                                            (Item*)(intptr) i);
       if (negated)

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -165,7 +165,7 @@ public:
     case GET_BIT:
       return type != STRING_RESULT && type != INT_RESULT;
     case GET_DOUBLE:
-      return type != INT_RESULT && type != REAL_RESULT && type != DECIMAL_RESULT;
+      return !item->type_handler()->is_numeric();
     default:
       return true;
     }

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -3941,6 +3941,12 @@ public:
   virtual bool can_return_extract_source(interval_type type) const;
   virtual bool is_bool_type() const { return false; }
   virtual bool is_general_purpose_string_type() const { return false; }
+  /*
+    True for types that compare as numbers (INT, REAL, DECIMAL).  False for
+    string, temporal and row types, whose ordering differs from numeric
+    ordering.
+  */
+  virtual bool is_numeric() const { return false; }
   virtual Type_std_attributes Item_type_std_attributes_generic(
                                                        const Item *item) const;
   virtual decimal_digits_t Item_time_precision(THD *thd, Item *item) const;
@@ -4839,6 +4845,7 @@ public:
 class Type_handler_numeric: public Type_handler
 {
 public:
+  bool is_numeric() const override { return true; }
   const Name &default_value() const override;
   String *print_item_value(THD *thd, Item *item, String *str) const override;
   bool Column_definition_prepare_stage1(THD *thd,

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -279,9 +279,7 @@ setup_windows(THD *thd, Ref_ptr_array ref_pointer_array, TABLE_LIST *tables,
         "The declared type of SK shall be numeric, datetime, or interval"
         we don't support datetime or interval, yet.
       */
-      Item_result rtype= win_spec->order_list->first->item[0]->result_type();
-      if (rtype != REAL_RESULT && rtype != INT_RESULT && 
-          rtype != DECIMAL_RESULT)
+      if (!win_spec->order_list->first->item[0]->type_handler()->is_numeric())
       {
         my_error(ER_WRONG_TYPE_FOR_RANGE_FRAME, MYF(0));
         DBUG_RETURN(1);
@@ -301,9 +299,7 @@ setup_windows(THD *thd, Ref_ptr_array ref_pointer_array, TABLE_LIST *tables,
             ((*pbound)->precedence_type == Window_frame_bound::FOLLOWING ||
              (*pbound)->precedence_type == Window_frame_bound::PRECEDING))
         {
-          Item_result rtype= (*pbound)->offset->result_type();
-          if (rtype != REAL_RESULT && rtype != INT_RESULT && 
-              rtype != DECIMAL_RESULT)
+          if (!(*pbound)->offset->type_handler()->is_numeric())
           {
             my_error(ER_WRONG_TYPE_FOR_RANGE_FRAME, MYF(0));
             DBUG_RETURN(1);


### PR DESCRIPTION
    MDEV-39323: Wrong result with NOT BETWEEN and mismatched types

    For 1 NOT BETWEEN float_key AND int_key, the range optimizer was
    building a SEL_TREE for only float_key > 1 and dropping the
    int_key < 1 disjunct.  can_optimize_range_const rejected int_key
    because of a type mismatch.

    The case from the ticket returned no rows (instead of the expected six
    rows) because the index range scan on float_key fetched only matches for
    float_key > 1 but then they were discarded by the t1.c1 = t1.int_key
    predicate.

    Plan before the fix (range scan on float_key, key_len 5):
      +----+-------+-------+-------------+---------+------+
      | id | table | type  | key         | key_len | rows |
      +----+-------+-------+-------------+---------+------+
      |  1 | t1    | range | float_key   |       5 |    1 |
      |  1 | t2    | index | float_key   |       6 |    3 |
      +----+-------+-------+-------------+---------+------+

    Plan after the fix (Item_func_between::get_mm_tree returns no
    usable range tree, so the optimizer falls back to using the
    covering index scan on i0):
      +----+-------+-------+-------------+---------+------+
      | id | table | type  | key         | key_len | rows |
      +----+-------+-------+-------------+---------+------+
      |  1 | t2    | index | float_key   |       6 |    6 |
      |  1 | t1    | index | i0          |      14 |    8 |
      +----+-------+-------+-------------+---------+------+

    In Item_func_between::get_mm_tree, when can_optimize_range_const fails
    for a range bound argument and the predicate is negated, we now
    abandon the whole tree instead of continuing the loop.  The new code
    mirrors the existing guard in the same function for non FIELD_ITEM
    arguments.

    The bug was introduced by MDEV-36235 which added
    can_optimize_range_const without considering the negated path.
    While we could fine tune the rejection behavior in
    can_optimize_range_const, I think that should be a separate patch as
    it requires careful consideration for each pair of types that could
    be supplied to [NOT] BETWEEN and that's outside the scope of this
    ticket (which is intended to fix the wrong result issue).

    This behavior matches MySQL 9.