### PR TITLE
MDEV-39528 SET SESSION AUTHORIZATION should use exact user@host matching instead of wildcard resolution

### DIFF
--- a/mysql-test/main/set_authorization.result
+++ b/mysql-test/main/set_authorization.result
@@ -34,19 +34,9 @@ select user(), current_user(), database();
 user()	current_user()	database()
 root@localhost	root@localhost	test
 set session authorization fist@list;
-select user(), current_user(), database();
-user()	current_user()	database()
-fist@list	@l%t	NULL
-set @a:='not changed';
-set session authorization first@last;
-ERROR 28000: Access denied trying to change to user 'first'@'last'
-select @a;
-@a
-not changed
-set session authorization fist@list;
-select @a;
-@a
-NULL
+ERROR HY000: The user 'fist'@'list' does not exist
+set session authorization ''@'l%t';
+ERROR HY000: The user ''@'l%t' does not exist
 disconnect con1;
 connection default;
 drop user ''@'l%t';
@@ -104,7 +94,7 @@ drop user u1@localhost;
 #
 # MDEV-36399 SET SESSION AUTHORIZATION allows an unrpivileged user to bypass resource limits
 #
-create user u1 with max_queries_per_hour 2;
+create user u1@localhost with max_queries_per_hour 2;
 connect u1,localhost,u1;
 set session authorization u1@localhost;
 select 1;
@@ -114,7 +104,7 @@ select 2;
 ERROR 42000: User 'u1' has exceeded the 'max_queries_per_hour' resource (current value: 2)
 disconnect u1;
 connection default;
-drop user u1;
+drop user u1@localhost;
 #
 # MDEV-36401 Access denied errors produced by SET SESSION AUTHORIZATION not reflected in status values
 #

--- a/mysql-test/main/set_authorization.test
+++ b/mysql-test/main/set_authorization.test
@@ -29,20 +29,17 @@ connection default;
 drop user foo@bar;
 
 # user() != current_user() (w/ wildcards)
+# With exact matching, anonymous/wildcard users cannot be targeted.
+# Anonymous users (empty username) are rejected before lookup.
 create user ''@'l%t' identified via mysql_native_password using password('foo');
 connect con1, localhost, root;
 select user(), current_user(), database();
-# sudo, with SET USER privilege
+# exact matching: fist@list does not exist as an exact account
+--error ER_NO_SUCH_USER
 set session authorization fist@list;
-select user(), current_user(), database();
-set @a:='not changed';
-# sudo without SET USER privilege (note, same CURRENT_USER)
---error ER_ACCESS_DENIED_CHANGE_USER_ERROR
-set session authorization first@last;
-select @a;
-# to self, no privileges needed
-set session authorization fist@list;
-select @a;
+# anonymous user (empty username) is always rejected
+--error ER_NO_SUCH_USER
+set session authorization ''@'l%t';
 disconnect con1;
 connection default;
 drop user ''@'l%t';
@@ -105,7 +102,7 @@ drop user u1@localhost;
 --echo # MDEV-36399 SET SESSION AUTHORIZATION allows an unrpivileged user to bypass resource limits
 --echo #
 
-create user u1 with max_queries_per_hour 2;
+create user u1@localhost with max_queries_per_hour 2;
 connect u1,localhost,u1;
 
 set session authorization u1@localhost;
@@ -114,7 +111,7 @@ select 1;
 select 2;
 disconnect u1;
 connection default;
-drop user u1;
+drop user u1@localhost;
 
 --echo #
 --echo # MDEV-36401 Access denied errors produced by SET SESSION AUTHORIZATION not reflected in status values

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -12770,7 +12770,7 @@ int acl_setauthorization(THD *thd, const LEX_USER *user)
   }
 
   mysql_mutex_lock(&acl_cache->lock);
-  ACL_USER *acl_user= find_user_or_anon(user->host.str, user->user.str, user->host.str);
+  ACL_USER *acl_user= find_user_exact(user->host, user->user);
   if (acl_user)
     acl_user= acl_user->copy(thd->mem_root);
   mysql_mutex_unlock(&acl_cache->lock);


### PR DESCRIPTION
## Description

`SET SESSION AUTHORIZATION user@host` uses `find_user_or_anon()` to resolve the target, applying wildcard host matching identical to connection-time resolution. This allows `SET SESSION AUTHORIZATION testuser@localhost` to silently match `testuser@'%'` when `testuser@localhost` does not exist as an exact account.

During connection, the host is determined by the network layer due to same the server resolves it based on the client's actual address. With `SET SESSION AUTHORIZATION`, the user explicitly specifies both username and host as input, expressing intent to assume a specific identity. Granting a different account's privileges through wildcard fallback violates that explicit intent and bypasses host-based access control.

This also causes functional issues: after wildcard resolution, `user()` reports the specified host while `current_user()` reports the matched account. Operations like `SET PASSWORD` fail due to this mismatch.

**Fix** 
`sql_acl.cc` (`acl_setauthorization`): Replace `find_user_or_anon(user->host.str, user->user.str, user->host.str)` with `find_user_exact(user->host, user->user)`. This ensures the target must exist as an exact account. If the caller wants `testuser@'%'` privileges, they specify `SET SESSION AUTHORIZATION testuser@'%'` explicitly.

`mysql-test/main/set_authorization.test` (`set_authorization.result`): Update anonymous user test cases to expect `ER_NO_SUCH_USER` since wildcard/anonymous matching no longer applies. Fix `u1` user creation to use explicit `u1@localhost` for exact matching compatibility.

## How can this PR be tested?

After the change, MTR test `main.set_authorization` should pass, otherwise the exact matching is not working.

The MTR test covers:

- Exact user@host match succeeds
- Non-existent user@host fails with `ER_NO_SUCH_USER` (no wildcard fallback)
- Anonymous user (empty username) rejected before lookup
- Resource limits with explicit `u1@localhost` account
- Access denied for unprivileged user attempting to switch identity

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.