### PR TITLE
MDEV-39513 connect table_type=INI memory leak

### DIFF
--- a/storage/connect/inihandl.cpp
+++ b/storage/connect/inihandl.cpp
@@ -621,18 +621,18 @@ void PROFILE_End(void)
   if (trace(3))
     htrc("PROFILE_End: CurProfile=%p N=%d\n", CurProfile, N_CACHED_PROFILES);
 
-	if (!CurProfile)						   //	Sergey Vojtovich
-		return;
-
   /* Close all opened files and free the cache structure */
   for (i = 0; i < N_CACHED_PROFILES; i++) {
+    CurProfile = MRUProfile[i];
+    if (!CurProfile)
+      continue;
     if (trace(3))
-      htrc("MRU=%s i=%d\n", SVP(MRUProfile[i]->filename), i);
+      htrc("MRU=%s i=%d\n", SVP(CurProfile->filename), i);
 
-//  CurProfile = MRUProfile[i];			Sergey Vojtovich
-//  PROFILE_ReleaseFile();					see MDEV-9997
-    free(MRUProfile[i]);
+    PROFILE_ReleaseFile();
+    memfree(CurProfile);
     } // endfor i
+    CurProfile = NULL;
 
 }  // end of PROFILE_End
 

--- a/storage/connect/mysql-test/connect/r/ini_alone.result
+++ b/storage/connect/mysql-test/connect/r/ini_alone.result
@@ -1,0 +1,7 @@
+#
+# MDEV-39513 connect table_type=INI memory leak
+#
+CREATE TABLE t (c INT) ENGINE=CONNECT table_type=INI file_name='TMP/foobar';;
+UPDATE t SET c=0;
+DROP TABLE t;
+# End of 11.4 tests

--- a/storage/connect/mysql-test/connect/t/ini_alone.opt
+++ b/storage/connect/mysql-test/connect/t/ini_alone.opt
@@ -1,0 +1,1 @@
+--secure_file_priv=$MYSQL_TMP_DIR

--- a/storage/connect/mysql-test/connect/t/ini_alone.test
+++ b/storage/connect/mysql-test/connect/t/ini_alone.test
@@ -1,0 +1,19 @@
+
+# This test requires that the ini subsystem of connect
+# hasn't been touched. Any call to PROFILE_Open will invalid
+# the that the MDEV causes.
+#
+--echo #
+--echo # MDEV-39513 connect table_type=INI memory leak
+--echo #
+
+--source include/force_restart.inc
+
+--replace_result $MYSQL_TMP_DIR TMP
+--eval CREATE TABLE t (c INT) ENGINE=CONNECT table_type=INI file_name='$MYSQL_TMP_DIR/foobar';
+UPDATE t SET c=0;
+
+--source include/force_restart.inc
+DROP TABLE t;
+
+--echo # End of 11.4 tests


### PR DESCRIPTION
The MRUProfile structure, of which CurProfile=MRUProfile[0] can contain a filename that is allocated. It is possible for the CurProfile to be null, while others are allocated, including those with a MRUProfile.filename already malloc.

As such the full PROFILE_ReleaseFile needs to be called on all non-null MRUProfile entries to prevent a memory leak.

Corrects MDEV-9997