### PR TITLE
MDEV-6733: Add DEFINER support to ALTER PROCEDURE

### DIFF
--- a/mysql-test/main/alter_procedure_definer.result
+++ b/mysql-test/main/alter_procedure_definer.result
@@ -1,0 +1,17 @@
+# ALTER PROCEDURE DEFINER
+CREATE USER 'user1'@'localhost';
+GRANT ALL PRIVILEGES ON test.* TO 'user1'@'localhost';
+connect  con1, localhost, user1, , test;
+CREATE PROCEDURE p1() SELECT 1;
+ALTER PROCEDURE p1 DEFINER = 'user1'@'localhost';
+ALTER PROCEDURE p1 DEFINER = 'root'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SUPER, SET USER privilege(s) for this operation
+connection default;
+ALTER PROCEDURE p1 DEFINER = 'root'@'localhost';
+SELECT definer FROM mysql.proc WHERE name = 'p1';
+definer
+root@localhost
+DROP PROCEDURE p1;
+DROP USER 'user1'@'localhost';
+Warnings:
+Note	4227	Dropped users 'user1'@'localhost' have active connections. Use KILL CONNECTION if they should not be used anymore.

--- a/mysql-test/main/alter_procedure_definer.test
+++ b/mysql-test/main/alter_procedure_definer.test
@@ -1,0 +1,20 @@
+--echo # ALTER PROCEDURE DEFINER
+
+CREATE USER 'user1'@'localhost';
+GRANT ALL PRIVILEGES ON test.* TO 'user1'@'localhost';
+
+--connect (con1, localhost, user1, , test)
+CREATE PROCEDURE p1() SELECT 1;
+
+ALTER PROCEDURE p1 DEFINER = 'user1'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+ALTER PROCEDURE p1 DEFINER = 'root'@'localhost';
+
+--connection default
+ALTER PROCEDURE p1 DEFINER = 'root'@'localhost';
+
+SELECT definer FROM mysql.proc WHERE name = 'p1';
+
+DROP PROCEDURE p1;
+DROP USER 'user1'@'localhost';

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -1711,7 +1711,7 @@ Sp_handler::sp_drop_routine(THD *thd,
 
 int
 Sp_handler::sp_update_routine(THD *thd, const Database_qualified_name *name,
-                              const st_sp_chistics *chistics) const
+                              const st_sp_chistics *chistics, LEX_USER *definer) const
 {
   TABLE *table;
   int ret;
@@ -1768,6 +1768,20 @@ Sp_handler::sp_update_routine(THD *thd, const Database_qualified_name *name,
     if (chistics->agg_type != DEFAULT_AGGREGATE)
       table->field[MYSQL_PROC_FIELD_AGGREGATE]->
          store((longlong)chistics->agg_type, TRUE);
+    if (definer)
+    {
+      if (definer->user.str && definer->host.str)
+      {
+        char definer_str[USER_HOST_BUFF_SIZE];
+        uint definer_len= strxmov(definer_str, definer->user.str, "@",
+                                  definer->host.str, NullS) -
+                          definer_str;
+        table->field[MYSQL_PROC_FIELD_DEFINER]->set_notnull();
+        table->field[MYSQL_PROC_FIELD_DEFINER]->store(definer_str, definer_len,
+                                                      system_charset_info);
+        sp_cache_invalidate();
+      }
+    }
     if ((ret= table->file->ha_update_row(table->record[1],table->record[0])) &&
         ret != HA_ERR_RECORD_IS_THE_SAME)
       ret= SP_WRITE_ROW_FAILED;

--- a/sql/sp.h
+++ b/sql/sp.h
@@ -218,7 +218,7 @@ public:
   bool sp_create_routine(THD *thd, const sp_head *sp) const;
 
   int sp_update_routine(THD *thd, const Database_qualified_name *name,
-                        const st_sp_chistics *chistics) const;
+                        const st_sp_chistics *chistics, LEX_USER *definer = nullptr) const;
 
   int sp_drop_routine(THD *thd, const Database_qualified_name *name) const;
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6448,6 +6448,13 @@ alter_routine(THD *thd, LEX *lex)
   if (check_routine_access(thd, ALTER_PROC_ACL, &lex->spname->m_db,
                            &lex->spname->m_name, sph, 0))
     return 1;
+  if (lex->definer)
+  {
+    if ((!lex_string_eq(&lex->definer->user, thd->security_ctx->priv_user, strlen(thd->security_ctx->priv_user)) ||
+      !lex_string_eq(&lex->definer->host, thd->security_ctx->priv_host, strlen(thd->security_ctx->priv_host))) &&
+      check_global_access(thd, SET_USER_ACL | SUPER_ACL))
+      return 1;
+  }
   /*
     Note that if you implement the capability of ALTER FUNCTION to
     alter the body of the function, this command should be made to
@@ -6455,7 +6462,7 @@ alter_routine(THD *thd, LEX *lex)
     already puts on CREATE FUNCTION.
   */
   /* Conditionally writes to binlog */
-  sp_result= sph->sp_update_routine(thd, lex->spname, &lex->sp_chistics);
+  sp_result= sph->sp_update_routine(thd, lex->spname, &lex->sp_chistics, lex->definer);
   switch (sp_result) {
   case SP_OK:
     my_ok(thd);

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1777,7 +1777,7 @@ rule:
 
 %type <lex_user> user grant_user grant_role user_or_role current_role
                  admin_option_for_role user_maybe_role role_name
-                 user_name
+                 user_name sp_a_chistic
 
 %type <user_auth> opt_auth_str auth_expression auth_token
                   text_or_password
@@ -3395,7 +3395,12 @@ sp_name:
 
 sp_a_chistics:
           /* Empty */ {}
-        | sp_a_chistics sp_chistic {}
+        | sp_a_chistics sp_a_chistic {}
+        ;
+
+sp_a_chistic:
+        sp_chistic {}
+        | definer {}
         ;
 
 sp_c_chistics:


### PR DESCRIPTION
This PR implements the ALTER PROCEDURE ... DEFINER = ... syntax

- users with sufficient privileges (SUPER or SET USER) can change the definer of an existing stored procedure.
- no whitespace changes
- .test and .result commited