### PR TITLE
MDEV-39545 Fix missing embedded TokenMecab finalization in Mroonga

### DIFF
--- a/storage/mroonga/vendor/groonga/lib/db.c
+++ b/storage/mroonga/vendor/groonga/lib/db.c
@@ -446,9 +446,6 @@ grn_db_close(grn_ctx *ctx, grn_obj *db)
 
   ctx_used_db = ctx->impl && ctx->impl->db == db;
   if (ctx_used_db) {
-#ifdef GRN_WITH_MECAB
-    grn_db_fin_mecab_tokenizer(ctx);
-#endif
     grn_ctx_loader_clear(ctx);
     if (ctx->impl->parser) {
       grn_expr_parser_close(ctx);
@@ -468,6 +465,10 @@ grn_db_close(grn_ctx *ctx, grn_obj *db)
       grn_array_truncate(ctx, ctx->impl->values);
     }
   }
+
+#ifdef GRN_WITH_MECAB
+  grn_db_fin_mecab_tokenizer(ctx);
+#endif
 
 /* grn_tiny_array_fin should be refined.. */
 #ifdef WIN32


### PR DESCRIPTION
We embed the `TokenMecab` plugin into Groonga and we embed Groonga into Mroonga. If we embed a Groonga plugin, we need to initialize/finalize it manually.

We have `grn_db_fin_mecab_tokenizer()` for finalizing the `TokenMecab` plugin but it's called only when the current `grn_ctx` refers the close target Groonga DB. Mroonga manages multiple Groonga DBs by `mrn::DatabaseManager`. `mrn::DatabaseManager` uses one `grn_ctx` for multiple Groonga DBs. So the current `grn_ctx` may have a different Groonga DB when the current `grn_ctx` closes a Groonga DB. (It's not a problem in Groonga API usage.)

We should always finalize the embedded `TokenMecab` plugin even if the current `grn_ctx` refers a different Groonga DB because we always initialize the embedded `TokenMecab` plugin.