### PR TITLE
MDEV-39505: Diff in rows column of explain plan for delete table stmt

### DIFF
--- a/mysql-test/main/opt_context_replay_basic.result
+++ b/mysql-test/main/opt_context_replay_basic.result
@@ -253,6 +253,7 @@ select context into dumpfile "../../tmp/dump1.sql"
 from information_schema.optimizer_context;
 set optimizer_record_context=OFF;
 drop table t1;
+set optimizer_replay_context='';
 drop table t1;
 #
 # MDEV-39409: Context replay doesnt handle MIN/MAX optimization
@@ -272,5 +273,26 @@ set optimizer_replay_context='opt_context';
 EXPLAIN SELECT MAX(a) FROM t1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Select tables optimized away
+set optimizer_replay_context='';
+drop table t1;
+#
+# MDEV-39505: Explain delete all from table shows difference in number of rows
+#
+create table t1 (c1 integer);
+insert into t1 values (1), (2), (3);
+set optimizer_record_context=1;
+explain delete from t1 order by c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	3	Deleting all rows
+select context into dumpfile "../../tmp/dump1.sql"
+from information_schema.optimizer_context;
+set optimizer_record_context=0;
+drop table t1;
+set optimizer_replay_context='opt_context';
+# Same query as above, must have same explain:
+explain delete from t1 order by c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	3	Deleting all rows
+set optimizer_replay_context='';
 drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_replay_basic.test
+++ b/mysql-test/main/opt_context_replay_basic.test
@@ -92,6 +92,7 @@ drop table t1;
 --enable_query_log
 --enable_result_log
 
+set optimizer_replay_context='';
 --remove_file "$MYSQLTEST_VARDIR/tmp/dump1.sql"
 drop table t1;
 
@@ -116,6 +117,33 @@ set optimizer_replay_context='opt_context';
 --echo # Same query as above, must have same explain:
 EXPLAIN SELECT MAX(a) FROM t1;
 
+set optimizer_replay_context='';
+--remove_file "$MYSQLTEST_VARDIR/tmp/dump1.sql"
+drop table t1;
+
+--echo #
+--echo # MDEV-39505: Explain delete all from table shows difference in number of rows
+--echo #
+create table t1 (c1 integer);
+insert into t1 values (1), (2), (3);
+
+set optimizer_record_context=1;
+explain delete from t1 order by c1;
+
+select context into dumpfile "../../tmp/dump1.sql"
+from information_schema.optimizer_context;
+set optimizer_record_context=0;
+drop table t1;
+--disable_query_log
+--disable_result_log
+--source "$MYSQLTEST_VARDIR/tmp/dump1.sql"
+--enable_query_log
+--enable_result_log
+set optimizer_replay_context='opt_context';
+--echo # Same query as above, must have same explain:
+explain delete from t1 order by c1;
+
+set optimizer_replay_context='';
 --remove_file "$MYSQLTEST_VARDIR/tmp/dump1.sql"
 drop table t1;
 

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -527,6 +527,7 @@ bool Sql_cmd_delete::delete_from_single_table(THD *thd)
   {
     /* Update the table->file->stats.records number */
     table->file->info(HA_STATUS_VARIABLE | HA_STATUS_NO_LOCK);
+    set_statistics_for_table(thd, table);
     ha_rows const maybe_deleted= table->file->stats.records;
     DBUG_PRINT("debug", ("Trying to use delete_all_rows()"));
 


### PR DESCRIPTION
Although, number of rows for a table got recorded in the context, for a delete from table statement, but when replayed explain plan showed only 1 in the rows column.

There was no call being made to set_statistics_for_table() from delete_from_single_table() when all rows are deleted from a table.