### PR TITLE
MDEV-35747: Wrong result from prepared TVC with parameter markers

### DIFF
--- a/mysql-test/main/table_value_constr.result
+++ b/mysql-test/main/table_value_constr.result
@@ -3279,3 +3279,96 @@ drop table t1,t2;
 #
 # End of 10.4 tests
 #
+#
+# MDEV-35747 Prepared statement with WITH ... AS (VALUES ... ) returns
+#            wrong result
+#
+# The simplest form: a bare VALUES TVC as the prepared statement, no
+# CTE.  The column takes its type from the bound value, so a later
+# EXECUTE with a different type must report that new type.
+prepare stmt from 'values (?)';
+set @v= 1;
+execute stmt using @v;
+?
+1
+execute stmt using @v;
+?
+1
+set @v= 'abc';
+execute stmt using @v;
+?
+abc
+deallocate prepare stmt;
+# CTE whose body is a TVC with a parameter marker and an explicit column.
+prepare stmt from 'with t(id) as (values (?)) select t.id from t';
+set @v= 1;
+execute stmt using @v;
+id
+1
+execute stmt using @v;
+id
+1
+set @v= 'abc';
+execute stmt using @v;
+id
+abc
+deallocate prepare stmt;
+# Multi row VALUES with several parameter markers.
+prepare stmt from 'with t(id) as (values (?), (?)) select t.id from t order by id';
+set @v1= 10, @v2= 20;
+execute stmt using @v1, @v2;
+id
+10
+20
+execute stmt using @v1, @v2;
+id
+10
+20
+set @v1= 'aa', @v2= 'bb';
+execute stmt using @v1, @v2;
+id
+aa
+bb
+deallocate prepare stmt;
+# One row of several columns, so that each column has its own type
+# holder.  The two columns swap types between the executions.
+prepare stmt from 'with t(a,b) as (values (?,?)) select t.a, t.b from t';
+set @v1= 1, @v2= 'abc';
+execute stmt using @v1, @v2;
+a	b
+1	abc
+set @v1= 'xyz', @v2= 2;
+execute stmt using @v1, @v2;
+a	b
+xyz	2
+deallocate prepare stmt;
+# The column type below is computed again on each execution and
+# follows the value bound by that execution, so it reads as an
+# integer, then as NULL, then as an integer again.  Nullability
+# works differently.  A parameter marker has no value at PREPARE, so
+# the column is nullable from then on and nothing later clears that,
+# which is why Is_null stays Y throughout, including on the
+# execution that binds a value after the NULL.
+prepare stmt from 'values (?)';
+set @v= 1;
+execute stmt using @v;
+Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is_null	Flags	Decimals	Charsetnr
+def					?	8	20	1	Y	32896	0	63
+?
+1
+set @v= NULL;
+execute stmt using @v;
+Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is_null	Flags	Decimals	Charsetnr
+def					?	254	0	0	Y	0	0	8
+?
+NULL
+set @v= 2;
+execute stmt using @v;
+Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is_null	Flags	Decimals	Charsetnr
+def					?	8	20	1	Y	32896	0	63
+?
+2
+deallocate prepare stmt;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/table_value_constr.test
+++ b/mysql-test/main/table_value_constr.test
@@ -1824,3 +1824,68 @@ drop table t1,t2;
 --echo #
 --echo # End of 10.4 tests
 --echo #
+
+--echo #
+--echo # MDEV-35747 Prepared statement with WITH ... AS (VALUES ... ) returns
+--echo #            wrong result
+--echo #
+
+--echo # The simplest form: a bare VALUES TVC as the prepared statement, no
+--echo # CTE.  The column takes its type from the bound value, so a later
+--echo # EXECUTE with a different type must report that new type.
+prepare stmt from 'values (?)';
+set @v= 1;
+execute stmt using @v;
+execute stmt using @v;
+set @v= 'abc';
+execute stmt using @v;
+deallocate prepare stmt;
+
+--echo # CTE whose body is a TVC with a parameter marker and an explicit column.
+prepare stmt from 'with t(id) as (values (?)) select t.id from t';
+set @v= 1;
+execute stmt using @v;
+execute stmt using @v;
+set @v= 'abc';
+execute stmt using @v;
+deallocate prepare stmt;
+
+--echo # Multi row VALUES with several parameter markers.
+prepare stmt from 'with t(id) as (values (?), (?)) select t.id from t order by id';
+set @v1= 10, @v2= 20;
+execute stmt using @v1, @v2;
+execute stmt using @v1, @v2;
+set @v1= 'aa', @v2= 'bb';
+execute stmt using @v1, @v2;
+deallocate prepare stmt;
+
+--echo # One row of several columns, so that each column has its own type
+--echo # holder.  The two columns swap types between the executions.
+prepare stmt from 'with t(a,b) as (values (?,?)) select t.a, t.b from t';
+set @v1= 1, @v2= 'abc';
+execute stmt using @v1, @v2;
+set @v1= 'xyz', @v2= 2;
+execute stmt using @v1, @v2;
+deallocate prepare stmt;
+
+--echo # The column type below is computed again on each execution and
+--echo # follows the value bound by that execution, so it reads as an
+--echo # integer, then as NULL, then as an integer again.  Nullability
+--echo # works differently.  A parameter marker has no value at PREPARE, so
+--echo # the column is nullable from then on and nothing later clears that,
+--echo # which is why Is_null stays Y throughout, including on the
+--echo # execution that binds a value after the NULL.
+prepare stmt from 'values (?)';
+--enable_metadata
+set @v= 1;
+execute stmt using @v;
+set @v= NULL;
+execute stmt using @v;
+set @v= 2;
+execute stmt using @v;
+--disable_metadata
+deallocate prepare stmt;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/item.h
+++ b/sql/item.h
@@ -8203,14 +8203,23 @@ protected:
 public:
   Item_type_holder(THD *thd, Item *item, const Type_handler *handler,
                    const Type_all_attributes *attr, bool maybe_null_arg)
-   :Item(thd), Type_handler_hybrid_field_type(handler),
-    enum_set_typelib(attr->get_typelib())
+   :Item(thd), Type_handler_hybrid_field_type(),
+    enum_set_typelib(nullptr)
   {
     name= item->name;
-    Type_std_attributes::set(*attr);
-    set_maybe_null(maybe_null_arg);
+    refresh(handler, attr, maybe_null_arg);
     copy_flags(item, item_base_t::IS_EXPLICIT_NAME |
                      item_base_t::IS_IN_WITH_CYCLE);
+  }
+
+  void refresh(const Type_handler *type_handler,
+               const Type_all_attributes *attr,
+               bool maybe_null_arg)
+  {
+    set_handler(type_handler);
+    Type_std_attributes::set(attr);
+    set_maybe_null(maybe_null_arg);
+    enum_set_typelib= attr->get_typelib();
   }
 
   const Type_handler *type_handler() const override

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -8261,6 +8261,13 @@ public:
   bool aggregate_attributes(THD *thd)
   {
     static LEX_CSTRING union_name= { STRING_WITH_LEN("UNION") };
+    /*
+      m_maybe_null is OR-accumulated and never reset here, so it is
+      sticky across calls.  In a prepared statement context this means
+      that once any EXECUTE has observed a NULL for a given column, that
+      column stays nullable for the rest of the statement's lifetime
+      even if later EXECUTEs only bind non-NULL values.
+    */
     for (uint i= 0; i < arg_count; i++)
       m_maybe_null|= args[i]->maybe_null();
     return

--- a/sql/sql_tvc.cc
+++ b/sql/sql_tvc.cc
@@ -200,11 +200,15 @@ bool get_type_attributes_for_tvc(THD *thd,
   List_item *lst;
   li.rewind();
   
+  /*
+    Reset arg_count on each call.  The args[] buffer itself was allocated
+    on stmt_arena when the Type_holder[] array was first set up in
+    table_value_constr::prepare(), so we reuse that buffer across
+    executions of the prepared statement instead of allocating again on
+    every call.
+  */
   for (uint pos= 0; pos < first_list_el_count; pos++)
-  {
-    if (holders[pos].alloc_arguments(thd, count_of_lists))
-      DBUG_RETURN(true);
-  }
+    holders[pos].remove_arguments();
   
   while ((lst= li++))
   {
@@ -269,23 +273,83 @@ bool table_value_constr::prepare(THD *thd, SELECT_LEX *sl,
   if (fix_fields_for_tvc(thd, li))
     DBUG_RETURN(true);
 
-  if (!holders)
+  /*
+    type_holders is NULL only on the first call of this function for a
+    given statement and stays set for the rest of that statement's
+    lifetime.  That first call happens at PREPARE for a prepared
+    statement whose TVC comes from the parser.  For a statement of a
+    stored procedure, and for a TVC that the conversion of an IN
+    predicate into an IN subquery creates, it happens instead on the
+    first execution.  The SELECT list of Item_type_holder instances is
+    built on that same first call, so the holder array and that list are
+    either both already set up or both still empty.
+  */
+  const bool first_call= !holders;
+
+  if (first_call)
   {
     DBUG_ASSERT(thd->stmt_arena->is_stmt_prepare_or_first_stmt_execute() ||
                 thd->stmt_arena->is_conventional());
-    holders= type_holders=
+    /*
+      Fill in a local pointer and assign it to type_holders only after
+      every holder's args[] buffer has been allocated.  first_call is
+      computed from type_holders, so type_holders must stay NULL until
+      this block completes.  Were it assigned up front and a later
+      alloc_arguments() then failed, type_holders would be non-NULL
+      while some holders still had no args[] buffer.  The next call
+      would skip this block and let add_argument() store an item through
+      that unallocated args pointer.
+    */
+    Type_holder *new_holders=
       new (thd->active_stmt_arena_to_use()->mem_root) Type_holder[cnt];
-    if (!holders ||
-         join_type_handlers_for_tvc(thd, li, holders, cnt) ||
-         get_type_attributes_for_tvc(thd, li, holders,
-				     lists_of_values.elements, cnt))
+    if (!new_holders)
        DBUG_RETURN(true);
+
+    /*
+      Allocate each Type_holder's args[] buffer on stmt_arena so that
+      we have stable storage that can be refilled in place on every
+      EXECUTE instead of being reallocated each time.
+    */
+    Query_arena *arena, backup;
+    arena= thd->activate_stmt_arena_if_needed(&backup);
+    bool args_err= false;
+    for (uint pos= 0; pos < cnt && !args_err; pos++)
+    {
+      if (new_holders[pos].alloc_arguments(thd, lists_of_values.elements))
+        args_err= true;
+    }
+    if (arena)
+      thd->restore_active_arena(arena, &backup);
+    if (args_err)
+      DBUG_RETURN(true);
+
+    holders= type_holders= new_holders;
+  }
+
+  /*
+    Collect the column types from the list of values.  This runs on
+    every call, not just the first, so that a value whose type is not
+    yet known at PREPARE time picks up its actual type once a value is
+    bound at EXECUTE time.
+  */
+  if (join_type_handlers_for_tvc(thd, li, holders, cnt) ||
+      get_type_attributes_for_tvc(thd, li, holders,
+                                  lists_of_values.elements, cnt))
+     DBUG_RETURN(true);
+
+  /*
+    Populate the SELECT list with the Item_type_holder instances that
+    describe the columns of the TVC.  On every later execution these same
+    instances are refreshed in place (see the 'else' case following).
+  */
+  if (first_call)
+  {
+    DBUG_ASSERT(sl->item_list.is_empty());
     List_iterator_fast<Item> it(*first_elem);
     Item *item;
     Query_arena *arena, backup;
     arena=thd->activate_stmt_arena_if_needed(&backup);
 
-    sl->item_list.empty();
     for (uint pos= 0; (item= it++); pos++)
     {
       /* Error's in 'new' will be detected after loop */
@@ -300,6 +364,24 @@ bool table_value_constr::prepare(THD *thd, SELECT_LEX *sl,
 
     if (unlikely(thd->is_fatal_error))
       DBUG_RETURN(true); // out of memory
+  }
+  else
+  {
+    /*
+      Refresh the cached type info on the existing Item_type_holder
+      instances so that the types reported for the TVC reflect the values
+      seen on the current execution.
+    */
+    List_iterator_fast<Item> it(sl->item_list);
+    for (uint pos= 0; pos < cnt; pos++)
+    {
+      Item* elem= it++;
+      DBUG_ASSERT(elem->type() == Item::TYPE_HOLDER);
+      Item_type_holder *ith= static_cast<Item_type_holder*>(elem);
+      ith->refresh(holders[pos].type_handler(),
+                   &holders[pos],
+                   holders[pos].get_maybe_null());
+    }
   }
     
   result= tmp_result;


### PR DESCRIPTION
The setup of column type information in table_value_constr::prepare() was wrapped in an "if (!holders)" guard so that it runs only once per prepared statement.  However, the guard was too wide because it bound the allocation of item holders (which should happen only once) to the collection of type information (which should happen on each execution).

This leaves the TVC stuck with whatever placeholder type the parameter had at PREPARE time which likely won't match the type of the next substitution (because a type holder has no actual type at PREPARE time).  Its type only becomes known when a value is bound at EXECUTE time.  So both the TVC types and the corresponding Item_type_holder instance in the SELECT item list must be computed again on every EXECUTE.

This patch does just that, and separates the work done once per prepared statement from the work done on every execution as implied above.