### PR TITLE
MDEV-39548 Cleanup MDL_request boilerplate with ACQUIRE_LOCK macro

### DIFF
--- a/sql/backup.cc
+++ b/sql/backup.cc
@@ -161,7 +161,6 @@ bool run_backup_stage(THD *thd, backup_stages stage)
 
 static bool backup_start(THD *thd)
 {
-  MDL_request mdl_request;
   DBUG_ENTER("backup_start");
 
   thd->current_backup_stage= BACKUP_FINISHED;   // For next test
@@ -182,20 +181,20 @@ static bool backup_start(THD *thd)
     Wait for old backup to finish and block ddl's so that we can start the
     ddl logger
   */
-  MDL_REQUEST_INIT(&mdl_request, MDL_key::BACKUP, "", "", MDL_BACKUP_BLOCK_DDL,
-                   MDL_EXPLICIT);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  MDL_ticket *ticket;
+  if (!(ticket= thd->mdl_context.MDL_ACQUIRE_LOCK(
+          MDL_key::BACKUP, "", "", MDL_BACKUP_BLOCK_DDL,
+          MDL_EXPLICIT, thd->variables.lock_wait_timeout)))
     DBUG_RETURN(1);
 
   if (start_ddl_logging())
   {
-    thd->mdl_context.release_lock(mdl_request.ticket);
+    thd->mdl_context.release_lock(ticket);
     DBUG_RETURN(1);
   }
 
   DBUG_ASSERT(backup_flush_ticket == 0);
-  backup_flush_ticket= mdl_request.ticket;
+  backup_flush_ticket= ticket;
 
   /* Downgrade lock to only block other backups */
   backup_flush_ticket->downgrade_lock(MDL_BACKUP_START);
@@ -541,11 +540,11 @@ bool backup_lock(THD *thd, TABLE_LIST *table)
     my_error(ER_LOCK_OR_ACTIVE_TRANSACTION, MYF(0));
     return 1;
   }
-  table->mdl_request.duration= MDL_EXPLICIT;
-  if (thd->mdl_context.acquire_lock(&table->mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  if (!(thd->mdl_backup_lock= thd->mdl_context.MDL_ACQUIRE_LOCK(
+          MDL_key::TABLE, table->db.str, table->table_name.str,
+          MDL_SHARED_HIGH_PRIO, MDL_EXPLICIT,
+          thd->variables.lock_wait_timeout)))
     return 1;
-  thd->mdl_backup_lock= table->mdl_request.ticket;
   return 0;
 }
 

--- a/sql/ddl_log.cc
+++ b/sql/ddl_log.cc
@@ -1252,16 +1252,14 @@ static void rename_triggers(THD *thd, DDL_LOG_ENTRY *ddl_log_entry,
       We have to create a MDL lock as change_table_names() checks that we
       have a mdl locks for the table
     */
-    MDL_request mdl_request;
+    MDL_ticket *mdl_ticket;
     TRIGGER_RENAME_PARAM trigger_param;
-    int error __attribute__((unused));
-    MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE,
+    mdl_ticket= thd->mdl_context.MDL_ACQUIRE_LOCK(MDL_key::TABLE,
                      from_db.str,
                      from_converted_name.str,
-                     MDL_EXCLUSIVE, MDL_EXPLICIT);
-    error= thd->mdl_context.acquire_lock(&mdl_request, 1);
-    /* acquire_locks() should never fail during recovery */
-    DBUG_ASSERT(error == 0);
+                     MDL_EXCLUSIVE, MDL_EXPLICIT, 1);
+    /* acquire_lock() should never fail during recovery */
+    DBUG_ASSERT(mdl_ticket != NULL);
 
     (void) Table_triggers_list::prepare_for_rename(thd,
                                                    &trigger_param,
@@ -1277,7 +1275,7 @@ static void rename_triggers(THD *thd, DDL_LOG_ENTRY *ddl_log_entry,
                                                   &from_converted_name,
                                                   &to_db,
                                                   &to_table);
-    thd->mdl_context.release_lock(mdl_request.ticket);
+    thd->mdl_context.release_lock(mdl_ticket);
   }
 }
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1080,13 +1080,11 @@ bool handler::log_not_redoable_operation(const char *operation)
       new log entry (and re-copy the table if needed).
     */
     THD *thd= table->in_use;
-    MDL_request mdl_backup;
     backup_log_info ddl_log;
 
-    MDL_REQUEST_INIT(&mdl_backup, MDL_key::BACKUP, "", "", MDL_BACKUP_DDL,
-                     MDL_STATEMENT);
-    if (thd->mdl_context.acquire_lock(&mdl_backup,
-                                      thd->variables.lock_wait_timeout))
+    if (!thd->mdl_context.MDL_ACQUIRE_LOCK(MDL_key::BACKUP, "", "", MDL_BACKUP_DDL,
+                                       MDL_STATEMENT,
+                                       thd->variables.lock_wait_timeout))
       DBUG_RETURN(1);
 
     bzero(&ddl_log, sizeof(ddl_log));

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4375,14 +4375,11 @@ longlong Item_func_get_lock::val_int()
     DBUG_RETURN(0);
   }
 
-  MDL_request ull_request;
-  MDL_REQUEST_INIT(&ull_request, MDL_key::USER_LOCK, res->c_ptr_safe(), "",
-                   MDL_SHARED_NO_WRITE, MDL_EXPLICIT);
-  MDL_key *ull_key= &ull_request.key;
+  const MDL_key ull_key(MDL_key::USER_LOCK, res->c_ptr_safe(), "");
 
 
   if ((ull= (User_level_lock*)
-       my_hash_search(&thd->ull_hash, ull_key->ptr(), ull_key->length())))
+       my_hash_search(&thd->ull_hash, ull_key.ptr(), ull_key.length())))
   {
     /* Recursive lock */
     ull->refs++;
@@ -4393,9 +4390,10 @@ longlong Item_func_get_lock::val_int()
 
   Lock_wait_timeout_handler lock_wait_timeout_handler;
   thd->push_internal_handler(&lock_wait_timeout_handler);
-  bool error= thd->mdl_context.acquire_lock(&ull_request, timeout);
+  MDL_ticket *ticket= thd->mdl_context.MDL_ACQUIRE_LOCK_BY_KEY(
+      &ull_key, MDL_SHARED_NO_WRITE, MDL_EXPLICIT, timeout);
   (void) thd->pop_internal_handler();
-  if (unlikely(error))
+  if (unlikely(!ticket))
   {
     if (lock_wait_timeout_handler.m_lock_wait_timeout)
       null_value= 0;
@@ -4407,11 +4405,11 @@ longlong Item_func_get_lock::val_int()
                                     MYF(MY_WME|MY_THREAD_SPECIFIC));
   if (ull == NULL)
   {
-    thd->mdl_context.release_lock(ull_request.ticket);
+    thd->mdl_context.release_lock(ticket);
     DBUG_RETURN(0);
   }
 
-  ull->lock= ull_request.ticket;
+  ull->lock= ticket;
   ull->refs= 1;
 
   if (my_hash_insert(&thd->ull_hash, (uchar*) ull))

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1109,8 +1109,6 @@ bool Global_read_lock::lock_global_read_lock(THD *thd)
   if (!m_state)
   {
     MDL_deadlock_and_lock_abort_error_handler mdl_deadlock_handler;
-    MDL_request mdl_request;
-    bool result;
 
     if (thd->current_backup_stage != BACKUP_FINISHED)
     {
@@ -1129,22 +1127,20 @@ bool Global_read_lock::lock_global_read_lock(THD *thd)
                                                  MDL_BACKUP_FTWRL1));
     DBUG_ASSERT(! thd->mdl_context.is_lock_owner(MDL_key::BACKUP, "", "",
                                                  MDL_BACKUP_FTWRL2));
-    MDL_REQUEST_INIT(&mdl_request, MDL_key::BACKUP, "", "", MDL_BACKUP_FTWRL1,
-                     MDL_EXPLICIT);
 
     do
     {
       mdl_deadlock_handler.init();
       thd->push_internal_handler(&mdl_deadlock_handler);
-      result= thd->mdl_context.acquire_lock(&mdl_request,
-                                            thd->variables.lock_wait_timeout);
+      m_mdl_global_read_lock= thd->mdl_context.MDL_ACQUIRE_LOCK(
+          MDL_key::BACKUP, "", "", MDL_BACKUP_FTWRL1,
+          MDL_EXPLICIT, thd->variables.lock_wait_timeout);
       thd->pop_internal_handler();
     } while (mdl_deadlock_handler.need_reopen());
 
-    if (result)
+    if (!m_mdl_global_read_lock)
       DBUG_RETURN(true);
 
-    m_mdl_global_read_lock= mdl_request.ticket;
     m_state= GRL_ACQUIRED;
   }
   /*

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -2665,6 +2665,22 @@ MDL_context::try_acquire_lock(MDL_request *mdl_request)
 }
 
 
+MDL_ticket *
+MDL_context::try_acquire_lock(MDL_key::enum_mdl_namespace mdl_namespace,
+                              const char *db, const char *name,
+                              enum_mdl_type mdl_type,
+                              enum_mdl_duration mdl_duration,
+                              bool &error,
+                              const char *src_file, uint src_line)
+{
+  MDL_request mdl_request;
+  mdl_request.init_with_source(mdl_namespace, db, name, mdl_type, mdl_duration,
+                               src_file, src_line);
+  error= try_acquire_lock_impl(&mdl_request, nullptr);
+  return mdl_request.ticket;
+}
+
+
 /**
   Auxiliary method for acquiring lock without waiting.
 
@@ -3072,6 +3088,37 @@ MDL_context::acquire_lock(MDL_request *mdl_request, double lock_wait_timeout)
 
   DBUG_PRINT("mdl", ("Acquired: %s", ticket_msg));
   DBUG_RETURN(FALSE);
+}
+
+
+MDL_ticket *
+MDL_context::acquire_lock(MDL_key::enum_mdl_namespace mdl_namespace,
+                          const char *db, const char *name,
+                          enum_mdl_type mdl_type,
+                          enum_mdl_duration mdl_duration,
+                          double lock_wait_timeout,
+                          const char *src_file, uint src_line)
+{
+  MDL_request mdl_request;
+  mdl_request.init_with_source(mdl_namespace, db, name, mdl_type, mdl_duration,
+                               src_file, src_line);
+  acquire_lock(&mdl_request, lock_wait_timeout);
+  return mdl_request.ticket;
+}
+
+
+MDL_ticket *
+MDL_context::acquire_lock(const MDL_key *key,
+                          enum_mdl_type mdl_type,
+                          enum_mdl_duration mdl_duration,
+                          double lock_wait_timeout,
+                          const char *src_file, uint src_line)
+{
+  MDL_request mdl_request;
+  mdl_request.init_by_key_with_source(key, mdl_type, mdl_duration,
+                                      src_file, src_line);
+  acquire_lock(&mdl_request, lock_wait_timeout);
+  return mdl_request.ticket;
 }
 
 

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -565,6 +565,15 @@ typedef void (*mdl_cached_object_release_hook)(void *);
 #define MDL_REQUEST_INIT_BY_KEY(R, P1, P2, P3) \
   (*R).init_by_key_with_source(P1, P2, P3, __FILE__, __LINE__)
 
+#define MDL_ACQUIRE_LOCK(NAMESPACE, DB, NAME, TYPE, DURATION, TIMEOUT) \
+  acquire_lock(NAMESPACE, DB, NAME, TYPE, DURATION, TIMEOUT, __FILE__, __LINE__)
+
+#define MDL_ACQUIRE_LOCK_BY_KEY(KEY, TYPE, DURATION, TIMEOUT) \
+  acquire_lock(KEY, TYPE, DURATION, TIMEOUT, __FILE__, __LINE__)
+
+#define MDL_TRY_ACQUIRE_LOCK(NAMESPACE, DB, NAME, TYPE, DURATION, ERROR) \
+  try_acquire_lock(NAMESPACE, DB, NAME, TYPE, DURATION, ERROR, __FILE__, __LINE__)
+
 
 /**
   An abstract class for inspection of a connected
@@ -805,11 +814,29 @@ public:
   void destroy();
 
   bool try_acquire_lock(MDL_request *mdl_request);
+  MDL_ticket *try_acquire_lock(MDL_key::enum_mdl_namespace mdl_namespace,
+                               const char *db, const char *name,
+                               enum_mdl_type mdl_type,
+                               enum_mdl_duration mdl_duration,
+                               bool &error,
+                               const char *src_file, uint src_line);
   bool acquire_lock(MDL_request *mdl_request, double lock_wait_timeout);
   bool acquire_locks(MDL_request_list *requests, double lock_wait_timeout);
   bool upgrade_shared_lock(MDL_ticket *mdl_ticket,
                            enum_mdl_type new_type,
                            double lock_wait_timeout);
+
+  MDL_ticket *acquire_lock(MDL_key::enum_mdl_namespace mdl_namespace,
+                           const char *db, const char *name,
+                           enum_mdl_type mdl_type,
+                           enum_mdl_duration mdl_duration,
+                           double lock_wait_timeout,
+                           const char *src_file, uint src_line);
+  MDL_ticket *acquire_lock(const MDL_key *key,
+                           enum_mdl_type mdl_type,
+                           enum_mdl_duration mdl_duration,
+                           double lock_wait_timeout,
+                           const char *src_file, uint src_line);
 
   bool clone_ticket(MDL_request *mdl_request);
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -430,7 +430,6 @@ bool close_cached_tables(THD *thd, TABLE_LIST *tables,
       Get an explicit MDL lock for all requested tables to ensure they are
       not used by any other thread
     */
-    MDL_request_list mdl_requests;
 
     DBUG_PRINT("info", ("Waiting for other threads to close their open tables"));
     DEBUG_SYNC(thd, "after_flush_unlock");
@@ -440,19 +439,16 @@ bool close_cached_tables(THD *thd, TABLE_LIST *tables,
 
     for (TABLE_LIST *table= tables; table; table= table->next_local)
     {
-      MDL_request *mdl_request= new (thd->mem_root) MDL_request;
-      if (mdl_request == NULL)
+      if (MDL_ticket *ticket= thd->mdl_context.MDL_ACQUIRE_LOCK(
+              MDL_key::TABLE, table->db.str, table->table_name.str,
+              MDL_EXCLUSIVE, MDL_EXPLICIT, timeout))
+      {
+        tdc_remove_table(thd, table->db.str, table->table_name.str);
+        thd->mdl_context.release_lock(ticket);
+      }
+      else
         DBUG_RETURN(true);
-      MDL_REQUEST_INIT_BY_KEY(mdl_request, &table->mdl_request.key,
-                              MDL_EXCLUSIVE, MDL_STATEMENT);
-      mdl_requests.push_front(mdl_request);
     }
-
-    if (thd->mdl_context.acquire_locks(&mdl_requests, timeout))
-      DBUG_RETURN(true);
-
-    for (TABLE_LIST *table= tables; table; table= table->next_local)
-      tdc_remove_table(thd, table->db.str, table->table_name.str);
   }
   DBUG_RETURN(false);
 }
@@ -618,13 +614,9 @@ bool flush_tables(THD *thd, flush_tables_type flag)
         In this case we cannot sending the HA_EXTRA_FLUSH signal.
       */
 
-      MDL_request mdl_request;
-      MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE,
-                       share->db.str,
-                       share->table_name.str,
-                       MDL_SHARED, MDL_EXPLICIT);
-
-      if (!thd->mdl_context.acquire_lock(&mdl_request, 0))
+      if (MDL_ticket *mdl_ticket= thd->mdl_context.MDL_ACQUIRE_LOCK(
+              MDL_key::TABLE, share->db.str, share->table_name.str,
+              MDL_SHARED, MDL_EXPLICIT, 0))
       {
         /*
           HA_OPEN_FOR_FLUSH is used to allow us to open the table even if
@@ -646,7 +638,7 @@ bool flush_tables(THD *thd, flush_tables_type flag)
           */
           closefrm(tmp_table);
         }
-        thd->mdl_context.release_lock(mdl_request.ticket);
+        thd->mdl_context.release_lock(mdl_ticket);
       }
     }
     tdc_release_share(share);
@@ -2403,7 +2395,6 @@ retry_share:
                     MYSQL_OPEN_SKIP_SCOPED_MDL_LOCK)) &&
         ! ot_ctx->has_protection_against_grl(mdl_type))
     {
-      MDL_request protection_request;
       MDL_deadlock_handler mdl_deadlock_handler(ot_ctx);
 
       if (thd->has_read_only_protection())
@@ -2414,16 +2405,15 @@ retry_share:
         DBUG_RETURN(TRUE);
       }
 
-      MDL_REQUEST_INIT(&protection_request, MDL_key::BACKUP, "", "", mdl_type,
-                       MDL_STATEMENT);
-
       /*
         Install error handler which if possible will convert deadlock error
         into request to back-off and restart process of opening tables.
       */
       thd->push_internal_handler(&mdl_deadlock_handler);
-      bool result= thd->mdl_context.acquire_lock(&protection_request,
-                                                 ot_ctx->get_timeout());
+      bool result= !thd->mdl_context.MDL_ACQUIRE_LOCK(MDL_key::BACKUP, "", "",
+                                                   mdl_type,
+                                                   MDL_STATEMENT,
+                                                   ot_ctx->get_timeout());
       thd->pop_internal_handler();
 
       if (result)
@@ -4441,7 +4431,6 @@ lock_table_names(THD *thd, const DDL_options_st &options,
 {
   MDL_request_list mdl_requests;
   TABLE_LIST *table;
-  MDL_request global_request;
   MDL_savepoint mdl_savepoint;
   DBUG_ENTER("lock_table_names");
 
@@ -4494,32 +4483,35 @@ lock_table_names(THD *thd, const DDL_options_st &options,
   if (thd->has_read_only_protection())
     DBUG_RETURN(true);
 
-  MDL_REQUEST_INIT(&global_request, MDL_key::BACKUP, "", "", MDL_BACKUP_DDL,
-                   MDL_STATEMENT);
   mdl_savepoint= thd->mdl_context.mdl_savepoint();
 
   while (!thd->mdl_context.acquire_locks(&mdl_requests, lock_wait_timeout) &&
          !upgrade_lock_if_not_exists(thd, options, tables_start,
-                                     lock_wait_timeout) &&
-         !thd->mdl_context.try_acquire_lock(&global_request))
+                                     lock_wait_timeout))
   {
-    if (global_request.ticket)
+    bool error;
+    MDL_ticket *backup_ticket= thd->mdl_context.MDL_TRY_ACQUIRE_LOCK(
+        MDL_key::BACKUP, "", "", MDL_BACKUP_DDL, MDL_STATEMENT, error);
+    if (backup_ticket)
     {
-      thd->mdl_backup_ticket= global_request.ticket;
+      thd->mdl_backup_ticket= backup_ticket;
       DBUG_RETURN(false);
     }
+    else if (error)
+      break;
 
     /*
       There is ongoing or pending BACKUP STAGE or FTWRL.
       Wait until it finishes and re-try.
     */
     thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
-    if (thd->mdl_context.acquire_lock(&global_request, lock_wait_timeout))
+    if (!thd->mdl_context.MDL_ACQUIRE_LOCK(MDL_key::BACKUP, "", "",
+                                           MDL_BACKUP_DDL, MDL_STATEMENT,
+                                           lock_wait_timeout))
       break;
     thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
 
     /* Reset tickets for all acquired locks */
-    global_request.ticket= 0;
     MDL_request_list::Iterator it(mdl_requests);
     while (auto mdl_request= it++)
       mdl_request->ticket= 0;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -90,7 +90,7 @@
 #endif /* WITH_WSREP */
 
 #ifndef EMBEDDED_LIBRARY
-static bool delayed_get_table(THD *thd, MDL_request *grl_protection_request,
+static bool delayed_get_table(THD *thd, MDL_ticket *grl_protection_ticket,
                               TABLE_LIST *table_list);
 static int write_delayed(THD *thd, TABLE *table, enum_duplicates duplic,
                          LEX_STRING query, bool ignore, bool log_on);
@@ -560,7 +560,6 @@ void upgrade_lock_type(THD *thd, thr_lock_type *lock_type,
 static
 bool open_and_lock_for_insert_delayed(THD *thd, TABLE_LIST *table_list)
 {
-  MDL_request protection_request;
   DBUG_ENTER("open_and_lock_for_insert_delayed");
 
 #ifndef EMBEDDED_LIBRARY
@@ -582,11 +581,11 @@ bool open_and_lock_for_insert_delayed(THD *thd, TABLE_LIST *table_list)
   if (thd->has_read_only_protection())
     DBUG_RETURN(TRUE);
 
-  MDL_REQUEST_INIT(&protection_request, MDL_key::BACKUP, "", "",
-                   MDL_BACKUP_DML, MDL_STATEMENT);
-
-  if (thd->mdl_context.acquire_lock(&protection_request,
-                                    thd->variables.lock_wait_timeout))
+  MDL_ticket *protection_ticket;
+  if (!(protection_ticket= thd->mdl_context.MDL_ACQUIRE_LOCK(
+          MDL_key::BACKUP, "", "",
+          MDL_BACKUP_DML, MDL_STATEMENT,
+          thd->variables.lock_wait_timeout)))
     DBUG_RETURN(TRUE);
 
   if (thd->mdl_context.acquire_lock(&table_list->mdl_request,
@@ -598,7 +597,7 @@ bool open_and_lock_for_insert_delayed(THD *thd, TABLE_LIST *table_list)
     DBUG_RETURN(TRUE);
 
   bool error= FALSE;
-  if (delayed_get_table(thd, &protection_request, table_list))
+  if (delayed_get_table(thd, protection_ticket, table_list))
     error= TRUE;
   else if (table_list->table)
   {
@@ -2830,7 +2829,7 @@ Delayed_insert *find_handler(THD *thd, TABLE_LIST *table_list)
 */
 
 static
-bool delayed_get_table(THD *thd, MDL_request *grl_protection_request,
+bool delayed_get_table(THD *thd, MDL_ticket *grl_protection_ticket,
                        TABLE_LIST *table_list)
 {
   int error;
@@ -2893,7 +2892,7 @@ bool delayed_get_table(THD *thd, MDL_request *grl_protection_request,
       */
       MDL_REQUEST_INIT(&di->grl_protection, MDL_key::BACKUP, "", "",
                        MDL_BACKUP_DML, MDL_STATEMENT);
-      di->grl_protection.ticket= grl_protection_request->ticket;
+      di->grl_protection.ticket= grl_protection_ticket;
       init_mdl_requests(&di->table_list);
       di->table_list.mdl_request.ticket= table_list->mdl_request.ticket;
 

--- a/sql/sql_sequence.cc
+++ b/sql/sql_sequence.cc
@@ -624,7 +624,6 @@ int SEQUENCE::read_initial_values(TABLE *table)
 {
   int error= 0;
   enum thr_lock_type save_lock_type;
-  MDL_request mdl_request;                      // Empty constructor!
   DBUG_ENTER("SEQUENCE::read_initial_values");
 
   if (likely(initialized != SEQ_UNINTIALIZED))
@@ -633,7 +632,7 @@ int SEQUENCE::read_initial_values(TABLE *table)
   if (likely(initialized == SEQ_UNINTIALIZED))
   {
     MYSQL_LOCK *lock;
-    bool mdl_lock_used= 0;
+    MDL_ticket *mdl_ticket_seq= NULL;
     THD *thd= table->in_use;
     bool has_active_transaction= !thd->transaction->stmt.is_empty();
     /*
@@ -643,19 +642,15 @@ int SEQUENCE::read_initial_values(TABLE *table)
     */
     if (table->mdl_ticket == 0)
     {
-      MDL_request_list mdl_requests;
-      mdl_lock_used= 1;
       /*
         This happens if first request is SHOW CREATE TABLE or LIST FIELDS
         where we don't have a mdl lock on the table
       */
 
-      MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->s->db.str,
-                       table->s->table_name.str, MDL_SHARED_READ,
-                       MDL_EXPLICIT);
-      mdl_requests.push_front(&mdl_request);
-      if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                         thd->variables.lock_wait_timeout))
+      if (!(mdl_ticket_seq= thd->mdl_context.MDL_ACQUIRE_LOCK(
+              MDL_key::TABLE, table->s->db.str, table->s->table_name.str,
+              MDL_SHARED_READ, MDL_EXPLICIT,
+              thd->variables.lock_wait_timeout)))
       {
         write_unlock(table);
         DBUG_RETURN(HA_ERR_LOCK_WAIT_TIMEOUT);
@@ -666,8 +661,8 @@ int SEQUENCE::read_initial_values(TABLE *table)
     if (!(lock= mysql_lock_tables(thd, &table, 1,
                                   MYSQL_LOCK_IGNORE_GLOBAL_READ_ONLY)))
     {
-      if (mdl_lock_used)
-        thd->mdl_context.release_lock(mdl_request.ticket);
+      if (mdl_ticket_seq)
+        thd->mdl_context.release_lock(mdl_ticket_seq);
       write_unlock(table);
 
       if (!has_active_transaction && !thd->transaction->stmt.is_empty() &&
@@ -679,8 +674,8 @@ int SEQUENCE::read_initial_values(TABLE *table)
     if (likely(!(error= read_stored_values(table))))
       initialized= SEQ_READY_TO_USE;
     mysql_unlock_tables(thd, lock);
-    if (mdl_lock_used)
-      thd->mdl_context.release_lock(mdl_request.ticket);
+    if (mdl_ticket_seq)
+      thd->mdl_context.release_lock(mdl_ticket_seq);
 
     /* Reset value to default */
     table->reginfo.lock_type= save_lock_type;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -10080,7 +10080,6 @@ static bool fk_prepare_copy_alter_table(THD *thd, TABLE *table,
       IdentBuffer<NAME_LEN> dbuf, tbuf;
       LEX_CSTRING ref_db= fk->ref_db.str ? fk->ref_db : alter_ctx->new_db;
       LEX_CSTRING ref_table= fk->ref_table;
-      MDL_request mdl_request;
 
       if (lower_case_table_names)
       {
@@ -10088,10 +10087,10 @@ static bool fk_prepare_copy_alter_table(THD *thd, TABLE *table,
         ref_table= tbuf.copy_casedn(ref_table).to_lex_cstring();
       }
 
-      MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE,
-                       ref_db.str, ref_table.str,
-                       MDL_SHARED_NO_WRITE, MDL_TRANSACTION);
-      if (thd->mdl_context.acquire_lock(&mdl_request,
+      if (!thd->mdl_context.MDL_ACQUIRE_LOCK(MDL_key::TABLE,
+                                        ref_db.str, ref_table.str,
+                                        MDL_SHARED_NO_WRITE,
+                                        MDL_TRANSACTION,
                                         thd->variables.lock_wait_timeout))
         DBUG_RETURN(true);
     }
@@ -11170,12 +11169,10 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
   else if (table_creation_was_logged && mysql_bin_log.is_open())
   {
     /* Protect against MDL error in binary logging */
-    MDL_request mdl_request;
     DBUG_ASSERT(!mdl_ticket);
-    MDL_REQUEST_INIT(&mdl_request, MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
-                     MDL_TRANSACTION);
-    if (thd->mdl_context.acquire_lock(&mdl_request,
-                                      thd->variables.lock_wait_timeout))
+    if (!thd->mdl_context.MDL_ACQUIRE_LOCK(
+            MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
+            MDL_TRANSACTION, thd->variables.lock_wait_timeout))
       DBUG_RETURN(true);
   }
 

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -440,7 +440,7 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
   bool lock_upgrade_done= FALSE;
   bool backup_of_table_list_done= 0;;
   MDL_ticket *mdl_ticket= NULL;
-  MDL_request mdl_request_for_trn;
+  MDL_ticket *mdl_ticket_for_trn= NULL;
   Query_tables_list backup;
   DDL_LOG_STATE ddl_log_state, ddl_log_state_tmp_file;
   char trn_path_buff[FN_REFLEN];
@@ -497,12 +497,11 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
   }
 
   /* Protect against concurrent create/drop */
-  MDL_REQUEST_INIT(&mdl_request_for_trn, MDL_key::TRIGGER,
-                   create ? tables->db.str : thd->lex->spname->m_db.str,
-                   thd->lex->spname->m_name.str,
-                   MDL_EXCLUSIVE, MDL_EXPLICIT);
-  if (thd->mdl_context.acquire_lock(&mdl_request_for_trn,
-                                    thd->variables.lock_wait_timeout))
+  if (!(mdl_ticket_for_trn= thd->mdl_context.MDL_ACQUIRE_LOCK(
+          MDL_key::TRIGGER,
+          create ? tables->db.str : thd->lex->spname->m_db.str,
+          thd->lex->spname->m_name.str,
+          MDL_EXCLUSIVE, MDL_EXPLICIT, thd->variables.lock_wait_timeout)))
     goto end;
 
   if (!create)
@@ -711,8 +710,8 @@ end:
   /* delete any created log files */
   result|= ddl_log_revert(thd, &ddl_log_state_tmp_file);
 
-  if (mdl_request_for_trn.ticket)
-    thd->mdl_context.release_lock(mdl_request_for_trn.ticket);
+  if (mdl_ticket_for_trn)
+    thd->mdl_context.release_lock(mdl_ticket_for_trn);
 
   if (refresh_metadata)
   {

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -654,26 +654,21 @@ retry:
     dict_sys.unfreeze();
 
   {
-    MDL_request request;
-    MDL_REQUEST_INIT(&request,MDL_key::TABLE, db_buf, tbl_buf, MDL_SHARED,
-                     MDL_EXPLICIT);
-    if (trylock
-        ? mdl_context->try_acquire_lock(&request)
-        : mdl_context->acquire_lock(&request,
-                                    /* FIXME: use compatible type, and maybe
-                                    remove this parameter altogether! */
-                                    static_cast<double>(global_system_variables
-                                                        .lock_wait_timeout)))
+    if (trylock)
     {
-      *mdl= nullptr;
-      if (trylock)
+      bool error;
+      *mdl= mdl_context->MDL_TRY_ACQUIRE_LOCK(MDL_key::TABLE, db_buf, tbl_buf,
+                                               MDL_SHARED, MDL_EXPLICIT, error);
+      if (!*mdl)
         return nullptr;
     }
     else
     {
-      *mdl= request.ticket;
-      if (trylock && !*mdl)
-        return nullptr;
+      *mdl= mdl_context->MDL_ACQUIRE_LOCK(MDL_key::TABLE, db_buf, tbl_buf,
+                                           MDL_SHARED, MDL_EXPLICIT,
+                                           static_cast<double>(
+                                             global_system_variables
+                                             .lock_wait_timeout));
     }
   }
 
@@ -1091,17 +1086,14 @@ bool dict_stats::open(THD *thd) noexcept
   mdl_context= &thd->mdl_context;
   /* FIXME: use compatible type, and maybe remove this parameter altogether! */
   const double timeout= double(global_system_variables.lock_wait_timeout);
-  MDL_request request;
-  MDL_REQUEST_INIT(&request, MDL_key::TABLE, "mysql", "innodb_table_stats",
-                   MDL_SHARED, MDL_EXPLICIT);
-  if (UNIV_UNLIKELY(mdl_context->acquire_lock(&request, timeout)))
+  if (!(mdl_table= mdl_context->MDL_ACQUIRE_LOCK(
+          MDL_key::TABLE, "mysql", "innodb_table_stats",
+          MDL_SHARED, MDL_EXPLICIT, timeout)))
     return true;
-  mdl_table= request.ticket;
-  MDL_REQUEST_INIT(&request, MDL_key::TABLE, "mysql", "innodb_index_stats",
-                   MDL_SHARED, MDL_EXPLICIT);
-  if (UNIV_UNLIKELY(mdl_context->acquire_lock(&request, timeout)))
+  if (!(mdl_index= mdl_context->MDL_ACQUIRE_LOCK(
+          MDL_key::TABLE, "mysql", "innodb_index_stats",
+          MDL_SHARED, MDL_EXPLICIT, timeout)))
     goto release_mdl;
-  mdl_index= request.ticket;
   table_stats= dict_table_open_on_name("mysql/innodb_table_stats", false,
                                        DICT_ERR_IGNORE_NONE);
   if (!table_stats)

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1108,12 +1108,9 @@ static dict_table_t *trx_purge_table_acquire(dict_table_t *table,
     goto got_table;
 
   {
-    MDL_request request;
-    MDL_REQUEST_INIT(&request,MDL_key::TABLE, db_buf, tbl_buf, MDL_SHARED,
-                     MDL_EXPLICIT);
-    if (mdl_context->try_acquire_lock(&request))
-      goto must_wait;
-    *mdl= request.ticket;
+    bool error;
+    *mdl= mdl_context->MDL_TRY_ACQUIRE_LOCK(MDL_key::TABLE, db_buf, tbl_buf,
+                                             MDL_SHARED, MDL_EXPLICIT, error);
     if (!*mdl)
       goto must_wait;
   }


### PR DESCRIPTION
## Description

MDL (Metadata Lock) is MariaDB's locking subsystem that protects database objects (tables, schemas, stored procedures, etc.) from concurrent DDL — for example, preventing a table from being dropped while another thread is reading from it. MDL_request is the "lock request form" that callers must create, initialize, submit, and then extract the resulting MDL_ticket from.

Currently, every MDL lock acquisition requires repetitive boilerplate:
```
> MDL_request mdl_request;
> MDL_REQUEST_INIT(&mdl_request, namespace, db, object, lock_type, duration);
> if (mdl_context.acquire_lock(&mdl_request, lock_wait_timeout))
>   /* error */;
> ticket = mdl_request.ticket;
```
This patch introduces MDL_context::ACQUIRE_LOCK() — a set of overloaded methods (wrapped in a macro for __FILE__/__LINE__ tracking) that combine the above steps into a single call returning MDL_ticket* directly:
```
> if (!(ticket = mdl_context.ACQUIRE_LOCK(namespace, db, object, lock_type, lock_wait_timeout)))
>   /* error */;
> 
```
This is a step toward making MDL_request a private implementation detail of the MDL subsystem, reducing its exposure to callers and preventing the class of bugs where stale or misused MDL_request objects cause issues (MDEV-39241, MDEV-39184).

## Release Notes

N/A

## How can this PR be tested?

* [x] All MTR tests pass, confirming no regressions introduced by this refactoring.

# **Basing the PR against the correct MariaDB version**

* [x] _This is a refactoring change, and the PR is based against the latest MariaDB development branch._

## **Copyright**

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.