### PR TITLE
MDEV-39608: Derive command_lengths from command_array at compile time

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -9420,37 +9420,52 @@ static void add_user_parameters(THD *thd, String *result, ACL_USER* acl_user,
   }
 }
 
-static const char *command_array[]=
+static const LEX_CSTRING command_array[]=
 {
-  "SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "RELOAD",
-  "SHUTDOWN", "PROCESS","FILE", "GRANT", "REFERENCES", "INDEX",
-  "ALTER", "SHOW DATABASES", "SUPER", "CREATE TEMPORARY TABLES",
-  "LOCK TABLES", "EXECUTE", "REPLICATION SLAVE", "BINLOG MONITOR",
-  "CREATE VIEW", "SHOW VIEW", "CREATE ROUTINE", "ALTER ROUTINE",
-  "CREATE USER", "EVENT", "TRIGGER", "CREATE TABLESPACE", "DELETE HISTORY",
-  "SET USER", "FEDERATED ADMIN", "CONNECTION ADMIN", "READ_ONLY ADMIN",
-  "REPLICATION SLAVE ADMIN", "REPLICATION MASTER ADMIN", "BINLOG ADMIN",
-  "BINLOG REPLAY", "SLAVE MONITOR", "SHOW CREATE ROUTINE"
+  {STRING_WITH_LEN("SELECT")},
+  {STRING_WITH_LEN("INSERT")},
+  {STRING_WITH_LEN("UPDATE")},
+  {STRING_WITH_LEN("DELETE")},
+  {STRING_WITH_LEN("CREATE")},
+  {STRING_WITH_LEN("DROP")},
+  {STRING_WITH_LEN("RELOAD")},
+  {STRING_WITH_LEN("SHUTDOWN")},
+  {STRING_WITH_LEN("PROCESS")},
+  {STRING_WITH_LEN("FILE")},
+  {STRING_WITH_LEN("GRANT")},
+  {STRING_WITH_LEN("REFERENCES")},
+  {STRING_WITH_LEN("INDEX")},
+  {STRING_WITH_LEN("ALTER")},
+  {STRING_WITH_LEN("SHOW DATABASES")},
+  {STRING_WITH_LEN("SUPER")},
+  {STRING_WITH_LEN("CREATE TEMPORARY TABLES")},
+  {STRING_WITH_LEN("LOCK TABLES")},
+  {STRING_WITH_LEN("EXECUTE")},
+  {STRING_WITH_LEN("REPLICATION SLAVE")},
+  {STRING_WITH_LEN("BINLOG MONITOR")},
+  {STRING_WITH_LEN("CREATE VIEW")},
+  {STRING_WITH_LEN("SHOW VIEW")},
+  {STRING_WITH_LEN("CREATE ROUTINE")},
+  {STRING_WITH_LEN("ALTER ROUTINE")},
+  {STRING_WITH_LEN("CREATE USER")},
+  {STRING_WITH_LEN("EVENT")},
+  {STRING_WITH_LEN("TRIGGER")},
+  {STRING_WITH_LEN("CREATE TABLESPACE")},
+  {STRING_WITH_LEN("DELETE HISTORY")},
+  {STRING_WITH_LEN("SET USER")},
+  {STRING_WITH_LEN("FEDERATED ADMIN")},
+  {STRING_WITH_LEN("CONNECTION ADMIN")},
+  {STRING_WITH_LEN("READ_ONLY ADMIN")},
+  {STRING_WITH_LEN("REPLICATION SLAVE ADMIN")},
+  {STRING_WITH_LEN("REPLICATION MASTER ADMIN")},
+  {STRING_WITH_LEN("BINLOG ADMIN")},
+  {STRING_WITH_LEN("BINLOG REPLAY")},
+  {STRING_WITH_LEN("SLAVE MONITOR")},
+  {STRING_WITH_LEN("SHOW CREATE ROUTINE")}
 };
-
-static uint command_lengths[]=
-{
-  6, 6, 6, 6, 6, 4, 6,
-  8, 7, 4, 5, 10, 5,
-  5, 14, 5, 23,
-  11, 7, 17, 14,
-  11, 9, 14, 13,
-  11, 5, 7, 17, 14,
-  8, 15, 16, 15,
-  23, 24, 12,
-  13, 13, 19
-};
-
 
 static_assert(array_elements(command_array) == PRIVILEGE_T_MAX_BIT + 1,
               "The definition of command_array does not match privilege_t");
-static_assert(array_elements(command_lengths) == PRIVILEGE_T_MAX_BIT + 1,
-              "The definition of command_lengths does not match privilege_t");
 
 
 static bool print_grants_for_role(THD *thd, ACL_ROLE * role)
@@ -9937,7 +9952,7 @@ static bool show_global_privileges(THD *thd, ACL_USER_BASE *acl_entry,
         if (found)
           global.append(STRING_WITH_LEN(", "));
         found=1;
-        global.append(command_array[counter],command_lengths[counter]);
+        global.append(command_array[counter].str, command_array[counter].length);
       }
     }
   }
@@ -10036,7 +10051,7 @@ static bool show_database_privileges(THD *thd, const char *username,
               if (found)
                 db.append(STRING_WITH_LEN(", "));
               found = 1;
-              db.append(command_array[cnt],command_lengths[cnt]);
+              db.append(command_array[cnt].str, command_array[cnt].length);
             }
           }
         }
@@ -10124,7 +10139,7 @@ static bool show_table_and_column_privileges(THD *thd, const char *username,
               if (found)
                 global.append(STRING_WITH_LEN(", "));
               found= 1;
-              global.append(command_array[counter],command_lengths[counter]);
+              global.append(command_array[counter].str, command_array[counter].length);
 
               if (grant_table->cols)
               {
@@ -10151,8 +10166,8 @@ static bool show_table_and_column_privileges(THD *thd, const char *username,
                       if (table_access & j)
                       {
                         global.append(STRING_WITH_LEN(", "));
-                        global.append(command_array[counter],
-                                      command_lengths[counter]);
+                        global.append(command_array[counter].str,
+                                      command_array[counter].length);
                       }
                       global.append(STRING_WITH_LEN(" ("));
                     }
@@ -10247,7 +10262,7 @@ static int show_routine_grants(THD* thd, const char *username,
 	      if (found)
 		global.append(STRING_WITH_LEN(", "));
 	      found= 1;
-	      global.append(command_array[counter],command_lengths[counter]);
+	      global.append(command_array[counter].str, command_array[counter].length);
 	    }
 	  }
 	}
@@ -10293,9 +10308,9 @@ void get_privilege_desc(char *to, uint max_length, privilege_t access_arg)
     for (pos=0 ; access ; pos++, access>>=1)
     {
       if ((access & 1) &&
-	  command_lengths[pos] + (uint) (to-start) < max_length)
+	  command_array[pos].length + (uint) (to-start) < max_length)
       {
-	to= strmov(to, command_array[pos]);
+	to= strmov(to, command_array[pos].str);
         *to++= ',';
         *to++= ' ';
       }
@@ -12998,7 +13013,7 @@ int wild_case_compare(CHARSET_INFO *cs, const char *str,const char *wildstr)
 static bool update_schema_privilege(THD *thd, TABLE *table, const char *buff,
                                     const char* db, const char* t_name,
                                     const char* column, uint col_length,
-                                    const char *priv, uint priv_length,
+                                    const LEX_CSTRING &priv,
                                     const char* is_grantable)
 {
   int i= 2;
@@ -13012,7 +13027,7 @@ static bool update_schema_privilege(THD *thd, TABLE *table, const char *buff,
     table->field[i++]->store(t_name, (uint) strlen(t_name), cs);
   if (column)
     table->field[i++]->store(column, col_length, cs);
-  table->field[i++]->store(priv, priv_length, cs);
+  table->field[i++]->store(priv.str, priv.length, cs);
   table->field[i]->store(is_grantable, strlen(is_grantable), cs);
   return schema_table_store_record(thd, table);
 }
@@ -13069,7 +13084,7 @@ int fill_schema_user_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
     if (!(want_access & ~GRANT_ACL))
     {
       if (update_schema_privilege(thd, table, grantee, 0, 0, 0, 0,
-                                  STRING_WITH_LEN("USAGE"), is_grantable))
+                                  {STRING_WITH_LEN("USAGE")}, is_grantable))
       {
         error= 1;
         goto err;
@@ -13085,8 +13100,7 @@ int fill_schema_user_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
         if (test_access & j)
         {
           if (update_schema_privilege(thd, table, grantee, 0, 0, 0, 0,
-                                      command_array[priv_id],
-                                      command_lengths[priv_id], is_grantable))
+                                      command_array[priv_id], is_grantable))
           {
             error= 1;
             goto err;
@@ -13144,7 +13158,7 @@ int fill_schema_schema_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
       if (!(want_access & ~GRANT_ACL))
       {
         if (update_schema_privilege(thd, table, grantee, acl_db->db, 0, 0,
-                                    0, STRING_WITH_LEN("USAGE"), is_grantable))
+                                    0, {STRING_WITH_LEN("USAGE")}, is_grantable))
         {
           error= 1;
           goto err;
@@ -13160,8 +13174,7 @@ int fill_schema_schema_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
           {
             if (update_schema_privilege(thd, table,
                                         grantee, acl_db->db, 0, 0, 0,
-                                        command_array[cnt], command_lengths[cnt],
-                                        is_grantable))
+                                        command_array[cnt], is_grantable))
             {
               error= 1;
               goto err;
@@ -13224,7 +13237,7 @@ int fill_schema_table_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
         if (update_schema_privilege(thd, table,
                                     grantee, grant_table->db,
                                     grant_table->tname, 0, 0,
-                                    STRING_WITH_LEN("USAGE"), is_grantable))
+                                    {STRING_WITH_LEN("USAGE")}, is_grantable))
         {
           error= 1;
           goto err;
@@ -13241,8 +13254,7 @@ int fill_schema_table_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
             if (update_schema_privilege(thd, table,
                                         grantee, grant_table->db,
                                         grant_table->tname, 0, 0,
-                                        command_array[cnt],
-                                        command_lengths[cnt], is_grantable))
+                                        command_array[cnt], is_grantable))
             {
               error= 1;
               goto err;
@@ -13319,8 +13331,7 @@ int fill_schema_column_privileges(THD *thd, TABLE_LIST *tables, COND *cond)
                                             grant_table->tname,
                                             grant_column->column,
                                             grant_column->key_length,
-                                            command_array[cnt],
-                                            command_lengths[cnt], is_grantable))
+                                            command_array[cnt], is_grantable))
                 {
                   error= 1;
                   goto err;


### PR DESCRIPTION
## Description

Replace the manually-maintained command_lengths array with a constexpr
lambda that computes string lengths from command_array using
std::char_traits<char>::length(). This eliminates the error-prone need
to keep the two arrays in sync manually.

## How can this PR be tested?
There's no functional change. The code should compile and pass exists MTR tests.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.