### PR TITLE
MDEV-39600 Reduce contention in buf_flush_ahead()

### DIFF
--- a/include/my_atomic_wrapper.h
+++ b/include/my_atomic_wrapper.h
@@ -63,6 +63,10 @@ public:
                                std::memory_order o1= std::memory_order_relaxed,
                                std::memory_order o2= std::memory_order_relaxed)
   { return m.compare_exchange_strong(i1, i2, o1, o2); }
+  bool compare_exchange_weak(Type& i1, const Type i2,
+                             std::memory_order o1= std::memory_order_relaxed,
+                             std::memory_order o2= std::memory_order_relaxed)
+  { return m.compare_exchange_weak(i1, i2, o1, o2); }
   Type exchange(const Type i, std::memory_order o= std::memory_order_relaxed)
   { return m.exchange(i, o); }
 };

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -61,9 +61,54 @@ static constexpr ulint buf_flush_lsn_scan_factor = 3;
 /** Average redo generation rate */
 static lsn_t lsn_avg_rate = 0;
 
-/** Target oldest_modification for the page cleaner background flushing;
-writes are protected by buf_pool.flush_list_mutex */
-static Atomic_relaxed<lsn_t> buf_flush_async_lsn;
+namespace {
+/** Wrapper around Atomic_relaxed<lsn_t> that blocks direct operator=
+so every write goes through its controlled CAS-based methods. */
+class async_flush_lsn
+{
+  Atomic_relaxed<lsn_t> m_lsn;
+public:
+  operator lsn_t() const noexcept { return m_lsn; }
+  lsn_t load() const noexcept { return m_lsn; }
+
+  /** Initialize at startup (single-threaded). */
+  void init() noexcept { m_lsn= 0; }
+
+  /** Monotonic-max lock-free bump.
+  @param lsn  new target
+  @return whether the target was bumped */
+  bool bump(lsn_t lsn) noexcept
+  {
+    lsn_t snapshot= m_lsn.load();
+    while (snapshot < lsn)
+      if (m_lsn.compare_exchange_weak(snapshot, lsn))
+        return true;
+    return false;
+  }
+
+  /** Clear via snapshot+CAS iff the freshly snapshotted target is at
+  most threshold; a concurrent bump() between the snapshot and the CAS
+  is preserved across the clear.
+  @param threshold  clear iff the fresh snapshot is at most this value */
+  void try_clear_if_at_most(lsn_t threshold) noexcept
+  {
+    lsn_t snapshot= m_lsn.load();
+    if (threshold >= snapshot)
+      m_lsn.compare_exchange_strong(snapshot, 0);
+  }
+
+  /** Clear via CAS using the caller's expected value; a concurrent
+  bump() that moved the target away from expected is preserved across
+  the clear. */
+  void try_clear(lsn_t expected) noexcept
+  { m_lsn.compare_exchange_strong(expected, 0); }
+};
+}
+/** Target oldest_modification for the page cleaner background flushing.
+Bumped lock-free via monotonic-max CAS-loop from buf_flush_ahead();
+cleared with CAS under buf_pool.flush_list_mutex from
+buf_flush_page_cleaner() and buf_flush_sync_for_checkpoint(). */
+static async_flush_lsn buf_flush_async_lsn;
 /** Target oldest_modification for the page cleaner furious flushing;
 writes are protected by buf_pool.flush_list_mutex */
 static Atomic_relaxed<lsn_t> buf_flush_sync_lsn;
@@ -112,6 +157,7 @@ static void buf_flush_validate_skip() noexcept
 
 void buf_pool_t::page_cleaner_wakeup(bool for_LRU) noexcept
 {
+  mysql_mutex_assert_owner(&flush_list_mutex);
   ut_d(buf_flush_validate_skip());
   if (!page_cleaner_idle())
   {
@@ -154,7 +200,7 @@ void buf_pool_t::page_cleaner_wakeup(bool for_LRU) noexcept
                           last_activity_count == srv_get_activity_count())) ||
       srv_max_buf_pool_modified_pct <= dirty_pct)
   {
-    page_cleaner_status-= PAGE_CLEANER_IDLE;
+    page_cleaner_idle_flag= false;
     pthread_cond_signal(&do_flush_list);
   }
 }
@@ -2114,33 +2160,50 @@ ATTRIBUTE_COLD void buf_flush_ahead(lsn_t lsn, bool furious) noexcept
 
   DBUG_EXECUTE_IF("ib_log_checkpoint_avoid_hard", return;);
 
-  Atomic_relaxed<lsn_t> &limit= furious
-    ? buf_flush_sync_lsn : buf_flush_async_lsn;
+  if (!furious)
+  {
+    if (!buf_flush_async_lsn.bump(lsn))
+      return;
 
-  if (limit < lsn)
+    /* In non-furious mode, concurrent writes to the log will remain
+    possible, and we are gently requesting buf_flush_page_cleaner()
+    to do more work to avoid a later call with furious=true.
+    We will only wake the buf_flush_page_cleaner() from an indefinite
+    my_cond_wait(), but we will not disturb the regular 1-second sleep.
+
+    To reduce contention for a gentle request case, the idle flag of
+    buf_pool is read outside of a buf_pool.flush_list_mutex critical
+    section, allowing early return.
+
+    If the decision to return early was (unlikely) wrong, subsequent
+    wake-side paths (including further buf_flush_ahead() calls under
+    redo-log pressure) are expected to perform the wake eventually. */
+    if (!buf_pool.page_cleaner_idle())
+      return;
+
+    /* Signal under buf_pool.flush_list_mutex. */
+    mysql_mutex_lock(&buf_pool.flush_list_mutex);
+    goto wake;
+  }
+
+  /* The furious path forces a log checkpoint via
+  log_sys.set_check_for_checkpoint(true), so the buf_flush_sync_lsn
+  bump, the checkpoint flag, and the cleaner wake must all be observed
+  together by any thread synchronising on buf_pool.flush_list_mutex. */
+  if (buf_flush_sync_lsn < lsn)
   {
     mysql_mutex_lock(&buf_pool.flush_list_mutex);
-    if (limit < lsn)
+    if (buf_flush_sync_lsn < lsn)
     {
-      limit= lsn;
-      if (furious)
-      {
-        /* Request any concurrent threads to wait for this batch to complete,
-        in log_free_check(). */
-        log_sys.set_check_for_checkpoint(true);
-        /* Immediately wake up buf_flush_page_cleaner(), even when it
-        is in the middle of a 1-second my_cond_timedwait(). */
-      wake:
-        buf_pool.page_cleaner_set_idle(false);
-        pthread_cond_signal(&buf_pool.do_flush_list);
-      }
-      else if (buf_pool.page_cleaner_idle())
-        /* In non-furious mode, concurrent writes to the log will remain
-        possible, and we are gently requesting buf_flush_page_cleaner()
-        to do more work to avoid a later call with furious=true.
-        We will only wake the buf_flush_page_cleaner() from an indefinite
-        my_cond_wait(), but we will not disturb the regular 1-second sleep. */
-        goto wake;
+      buf_flush_sync_lsn= lsn;
+      /* Request any concurrent threads to wait for this batch to complete,
+      in log_free_check(). */
+      log_sys.set_check_for_checkpoint(true);
+      /* Immediately wake up buf_flush_page_cleaner(), even when it
+      is in the middle of a 1-second my_cond_timedwait(). */
+    wake:
+      buf_pool.page_cleaner_set_idle(false);
+      pthread_cond_signal(&buf_pool.do_flush_list);
     }
     mysql_mutex_unlock(&buf_pool.flush_list_mutex);
   }
@@ -2230,8 +2293,8 @@ static void buf_flush_sync_for_checkpoint(lsn_t lsn) noexcept
   /* After attempting log checkpoint, check if we have reached our target. */
   if (measure >= buf_flush_sync_lsn)
     buf_flush_sync_lsn= 0;
-  else if (measure >= buf_flush_async_lsn)
-    buf_flush_async_lsn= 0;
+  else
+    buf_flush_async_lsn.try_clear_if_at_most(measure);
 
   log_sys.latch.wr_unlock();
   /* wake up buf_flush_wait() */
@@ -2588,7 +2651,10 @@ static void buf_flush_page_cleaner() noexcept
     if (UNIV_UNLIKELY(soft_lsn_limit != 0))
     {
       if (oldest_lsn >= soft_lsn_limit)
-        buf_flush_async_lsn= soft_lsn_limit= 0;
+      {
+        buf_flush_async_lsn.try_clear(soft_lsn_limit);
+        soft_lsn_limit= 0;
+      }
     }
     else if (buf_pool.need_LRU_eviction())
     {
@@ -2611,8 +2677,7 @@ static void buf_flush_page_cleaner() noexcept
       oldest_lsn= buf_pool.get_oldest_modification(0);
       if (!oldest_lsn)
         goto fully_unemployed;
-      if (oldest_lsn >= buf_flush_async_lsn)
-        buf_flush_async_lsn= 0;
+      buf_flush_async_lsn.try_clear_if_at_most(oldest_lsn);
       buf_pool.page_cleaner_set_idle(false);
       goto set_almost_idle;
     }
@@ -2658,6 +2723,14 @@ static void buf_flush_page_cleaner() noexcept
     }
     else if (dirty_pct < srv_max_buf_pool_modified_pct)
     possibly_unemployed:
+      /* Snapshot-based; no coordination with concurrent lock-free
+      buf_flush_ahead() bumpers. A bumper that observed
+      page_cleaner_idle()==false earlier in this iteration took its
+      early return; flipping idle=true here leaves its target
+      unacknowledged until another wake path fires. Same premise as the
+      bumper's early return: under sustained redo-log pressure,
+      subsequent buf_flush_ahead() calls observe
+      page_cleaner_idle()==true and take the wake path. */
       if (!soft_lsn_limit && !af_needed_for_redo(oldest_lsn))
         goto set_idle;
 
@@ -2763,7 +2836,7 @@ ATTRIBUTE_COLD void buf_flush_page_cleaner_init() noexcept
   ut_ad(srv_operation <= SRV_OPERATION_EXPORT_RESTORED ||
         srv_operation == SRV_OPERATION_RESTORE ||
         srv_operation == SRV_OPERATION_RESTORE_EXPORT);
-  buf_flush_async_lsn= 0;
+  buf_flush_async_lsn.init();
   buf_flush_sync_lsn= 0;
   buf_page_cleaner_is_active= true;
   std::thread(buf_flush_page_cleaner).detach();

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1532,13 +1532,18 @@ public:
   TPOOL_SUPPRESS_TSAN void add_flush_list_requests(size_t size)
   { ut_ad(size); flush_list_requests+= size; }
 private:
-  static constexpr unsigned PAGE_CLEANER_IDLE= 1;
-  static constexpr unsigned FLUSH_LIST_ACTIVE= 2;
-  static constexpr unsigned LRU_FLUSH= 4;
+  static constexpr unsigned FLUSH_LIST_ACTIVE= 1;
+  static constexpr unsigned LRU_FLUSH= 2;
 
-  /** Number of pending LRU flush * LRU_FLUSH +
-  PAGE_CLEANER_IDLE + FLUSH_LIST_ACTIVE flags */
+  /** Number of pending LRU flush * LRU_FLUSH + FLUSH_LIST_ACTIVE flag.
+  Protected by flush_list_mutex. */
   unsigned page_cleaner_status;
+
+  /** Whether the page cleaner is sleeping due to being idle.
+  Writes occur under flush_list_mutex; reads are lock-free (used by
+  the early-return in buf_flush_ahead() on a busy cleaner). */
+  Atomic_relaxed<bool> page_cleaner_idle_flag;
+
   /** track server activity count for signaling idle flushing */
   ulint last_activity_count;
 public:
@@ -1580,19 +1585,19 @@ public:
     page_cleaner_status-= FLUSH_LIST_ACTIVE;
   }
 
-  /** @return whether the page cleaner must sleep due to being idle */
+  /** @return whether the page cleaner must sleep due to being idle.
+  Lock-free read of page_cleaner_idle_flag; safe to call without
+  flush_list_mutex (used by the early-return in buf_flush_ahead()). */
   bool page_cleaner_idle() const noexcept
   {
-    mysql_mutex_assert_owner(&flush_list_mutex);
-    return page_cleaner_status & PAGE_CLEANER_IDLE;
+    return page_cleaner_idle_flag;
   }
 
   /** @return whether the page cleaner may be initiating writes */
   bool page_cleaner_active() const noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
-    static_assert(PAGE_CLEANER_IDLE == 1, "efficiency");
-    return page_cleaner_status > PAGE_CLEANER_IDLE;
+    return page_cleaner_status != 0;
   }
 
   /** Wake up the page cleaner if needed.
@@ -1603,8 +1608,7 @@ public:
   void page_cleaner_set_idle(bool deep_sleep) noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
-    page_cleaner_status= (page_cleaner_status & ~PAGE_CLEANER_IDLE) |
-      (PAGE_CLEANER_IDLE * deep_sleep);
+    page_cleaner_idle_flag= deep_sleep;
   }
 
   /** Update server last activity count */


### PR DESCRIPTION
```
When calling buf_flush_ahead() with furious=false, the function
updates the async target buf_flush_async_lsn and, if necessary notifies
the page cleaner thread to start flushing more eagerly, to avoid
a long stall later when checkpoint will be required.

When many threads call buf_flush_ahead() with furious=false, if
the update of buf_flush_async_lsn is gated inside
buf_pool.flush_list_mutex, this can cause significant contention,
just to deliver the new buf_flush_async_lsn value and a potential
notification to the page cleaner thread.

This commit enables, for the non furious case, lock-free update
of buf_flush_async_lsn and lock-free check of the page cleaner idle
flag, to avoid the contention on buf_pool.flush_list_mutex.
The lock is acquired by the CAS-loop winner thread and only
after the page cleaner is observed idle.
The cleaner clears buf_flush_async_lsn via CAS, so a concurrent
lock-free bump is preserved across the clear.
Since the reads are not protected by the mutex, there is a chance that
the decision to not signal the page cleaner thread is wrong.
In the worst case though, under sustained redo-log pressure,
eventually a wakeup signal will be delivered to the page cleaner thread
anyway, so the risk of a long stall is limited.

Similar reasoning applies to the possibly wrong decision taken by the
page cleaner thread to go to idle: eventually it will be woken up.
```