### PR TITLE
MDEV-35920: Fix assertion failure "decimals == 0" in Item_func_mod::fix_length_and_dec_int

### DIFF
--- a/mysql-test/main/bug35920.result
+++ b/mysql-test/main/bug35920.result
@@ -1,0 +1,15 @@
+#
+# MDEV-35920: Hex hybrid type causing invalid decimals in arithmetic context
+#
+SELECT MOD(COALESCE(0x30), 1);
+MOD(COALESCE(0x30), 1)
+0
+SELECT MOD(LEAST(0x30,0x30), 1);
+MOD(LEAST(0x30,0x30), 1)
+0
+SELECT MOD(IFNULL(0x30,0x30), 1);
+MOD(IFNULL(0x30,0x30), 1)
+0
+SELECT MOD(IF(0,0x30,0x30), 1);
+MOD(IF(0,0x30,0x30), 1)
+0

--- a/mysql-test/main/bug35920.test
+++ b/mysql-test/main/bug35920.test
@@ -1,0 +1,11 @@
+--echo #
+--echo # MDEV-35920: Hex hybrid type causing invalid decimals in arithmetic context
+--echo #
+
+SELECT MOD(COALESCE(0x30), 1);
+
+SELECT MOD(LEAST(0x30,0x30), 1);
+
+SELECT MOD(IFNULL(0x30,0x30), 1);
+
+SELECT MOD(IF(0,0x30,0x30), 1);

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -1392,6 +1392,26 @@ aggregate_attributes_string(const LEX_CSTRING &func_name,
   return false;
 }
 
+/**
+  Aggregate result type attributes for hexadecimal/hybrid string functions.
+
+  @param field_type  Field type.
+  @param items       Argument array.
+  @param nitems      Number of arguments.
+
+  @retval            False on success, true on error.
+*/
+bool Type_std_attributes::
+aggregate_attributes_hex_hybrid(const LEX_CSTRING &func_name,
+                                Item **items, uint nitems)
+{
+  if (aggregate_attributes_string(func_name, items, nitems))
+    return true;
+  unsigned_flag= true;
+  decimals= 0;
+  return false;
+}
+
 
 /*
   Find a handler by its ODBC literal data type.
@@ -4786,7 +4806,16 @@ bool Type_handler_string_result::
   return func->aggregate_attributes_string(func_name, items, nitems);
 }
 
-
+bool Type_handler_hex_hybrid::
+        Item_hybrid_func_fix_attributes(THD *thd,
+                                        const LEX_CSTRING &name,
+                                        Type_handler_hybrid_field_type *,
+                                        Type_all_attributes *attr,
+                                        Item **items,
+                                        uint nitems) const
+{
+  return attr->aggregate_attributes_hex_hybrid(name, items, nitems);
+}
 
 /*
   We can have enum/set type after merging only if we have one enum|set

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -3287,6 +3287,8 @@ public:
   }
   bool aggregate_attributes_string(const LEX_CSTRING &func_name,
                                    Item **item, uint nitems);
+  bool aggregate_attributes_hex_hybrid(const LEX_CSTRING &func_name,
+                                     Item **item, uint nitems);
   void aggregate_attributes_temporal(uint int_part_length,
                                      Item **item, uint nitems)
   {
@@ -7182,6 +7184,12 @@ public:
   const Type_handler *cast_to_int_type_handler() const override;
   bool Item_func_round_fix_length_and_dec(Item_func_round *) const override;
   bool Item_func_int_val_fix_length_and_dec(Item_func_int_val*) const override;
+  bool Item_hybrid_func_fix_attributes(THD *thd,
+                                     const LEX_CSTRING &name,
+                                     Type_handler_hybrid_field_type *,
+                                     Type_all_attributes *attr,
+                                     Item **items,
+                                     uint nitems) const override;
 };
 
 


### PR DESCRIPTION
fixes [MDEV-35920](https://jira.mariadb.org/browse/MDEV-35920)

### Problem:
Hex hybrid literals (0x...) were incorrectly treated as string values
during hybrid expression aggregation (CASE/COALESCE/IF/LEAST/IFNULL).
This allowed NOT_FIXED_DEC to propagate into numeric contexts and
triggered an assertion failure in MOD(), which requires
decimals == 0 for integer arithmetic.

### Cause:
Hybrid expression type aggregation preserved string semantics for hex
literals but did not enforce the integer properties expected in numeric
contexts. As a result, decimals remained NOT_FIXED_DEC instead of 0.

### Fix:
Keep the existing string collation behavior for hex hybrid values while
enforcing numeric semantics by setting decimals = 0 and
unsigned_flag = true.

Add a regression test for MOD() using hex literals in hybrid
expressions.