### PR TITLE
MDEV-30518: JSON functions cannot be killed on big-endian (fix)

### DIFF
--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -2208,9 +2208,11 @@ String *Item_func_json_array_append::val_str(String *str)
 
 js_error:
   report_json_error(js, &je, 0);
-  thd->check_killed(); // to get the error message right
 
 return_null:
+  /* intentionally after return_null label */
+  thd->check_killed();
+
   null_value= 1;
   return 0;
 }


### PR DESCRIPTION
Test func_json_notembedded became unreliable after 509e40e706d0cea33e1b1486bc9f0929b5991553 where JSON_ARRAY_APPEND would return NULL rather than:
ERROR 70100: Query execution was interrupted (max_statement_time exceeded)

Restore the original fragment.