### PR TITLE
MDEV-39459 Fix bad sync pattern for chain replication MTR tests

### DIFF
--- a/mysql-test/suite/rpl/include/rpl_row_img_sequence.inc
+++ b/mysql-test/suite/rpl/include/rpl_row_img_sequence.inc
@@ -28,6 +28,9 @@ SELECT SETVAL(s1, 10);
 --source include/save_master_gtid.inc
 
 --echo # Validate SETVAL replicated correctly to other servers
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/save_master_gtid.inc
 --connection server_3
 --source include/sync_with_master_gtid.inc
 --let $diff_tables= server_1:test.s1,server_2:test.s1,server_3:test.s1
@@ -60,6 +63,9 @@ SELECT NEXTVAL(s1);
 --source include/save_master_gtid.inc
 
 --echo # Validate NEXTVAL replicated correctly to other servers
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/save_master_gtid.inc
 --connection server_3
 --source include/sync_with_master_gtid.inc
 --let $diff_tables= server_1:test.s1,server_2:test.s1,server_3:test.s1
@@ -87,6 +93,9 @@ FLUSH LOGS;
 --echo # Cleanup
 --connection server_1
 DROP TABLE s1;
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
 --source include/save_master_gtid.inc
 --connection server_3
 --source include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/include/rpl_xa_empty_transaction_test_case.inc
+++ b/mysql-test/suite/rpl/include/rpl_xa_empty_transaction_test_case.inc
@@ -34,6 +34,10 @@ CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 --source include/save_master_gtid.inc
 
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/save_master_gtid.inc
+
 --connection server_3
 --source include/sync_with_master_gtid.inc
 
@@ -125,6 +129,10 @@ FLUSH LOGS;
 # Cleanup
 --connection server_1
 DROP TABLE ti,tm;
+--source include/save_master_gtid.inc
+
+--connection server_2
+--source include/sync_with_master_gtid.inc
 --source include/save_master_gtid.inc
 
 --connection server_3

--- a/mysql-test/suite/rpl/r/rpl_row_img_sequence_full.result
+++ b/mysql-test/suite/rpl/r/rpl_row_img_sequence_full.result
@@ -53,6 +53,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -90,6 +93,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -123,6 +129,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -144,6 +153,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -181,6 +193,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -214,6 +229,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -235,6 +253,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -272,6 +293,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -305,6 +329,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -326,6 +353,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -363,6 +393,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -396,6 +429,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -417,6 +453,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -454,6 +493,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -487,6 +529,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -508,6 +553,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -545,6 +593,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -578,6 +629,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -599,6 +653,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -636,6 +693,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -669,6 +729,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -690,6 +753,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -727,6 +793,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -760,6 +829,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_row_img_sequence_full_nodup.result
+++ b/mysql-test/suite/rpl/r/rpl_row_img_sequence_full_nodup.result
@@ -53,6 +53,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -90,6 +93,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -123,6 +129,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -144,6 +153,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -181,6 +193,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -214,6 +229,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -235,6 +253,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -272,6 +293,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -305,6 +329,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -326,6 +353,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -363,6 +393,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -396,6 +429,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -417,6 +453,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -454,6 +493,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -487,6 +529,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -508,6 +553,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -545,6 +593,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -578,6 +629,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -599,6 +653,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -636,6 +693,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -669,6 +729,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -690,6 +753,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -727,6 +793,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -760,6 +829,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_row_img_sequence_min.result
+++ b/mysql-test/suite/rpl/r/rpl_row_img_sequence_min.result
@@ -54,6 +54,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -91,6 +94,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -124,6 +130,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -145,6 +154,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -182,6 +194,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -215,6 +230,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -236,6 +254,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -273,6 +294,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -306,6 +330,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -327,6 +354,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -364,6 +394,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -397,6 +430,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -418,6 +454,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -455,6 +494,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -488,6 +530,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -509,6 +554,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -546,6 +594,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -579,6 +630,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -600,6 +654,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -637,6 +694,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -670,6 +730,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -691,6 +754,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -728,6 +794,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -761,6 +830,9 @@ include/ensure_binlog_row_event_columns.inc [(1,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_row_img_sequence_noblob.result
+++ b/mysql-test/suite/rpl/r/rpl_row_img_sequence_noblob.result
@@ -53,6 +53,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -90,6 +93,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -123,6 +129,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -144,6 +153,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -181,6 +193,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -214,6 +229,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -235,6 +253,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -272,6 +293,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -305,6 +329,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -326,6 +353,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -363,6 +393,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -396,6 +429,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -417,6 +453,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -454,6 +493,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -487,6 +529,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -508,6 +553,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -545,6 +593,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -578,6 +629,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -599,6 +653,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -636,6 +693,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -669,6 +729,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -690,6 +753,9 @@ SETVAL(s1, 10)
 10
 include/save_master_gtid.inc
 # Validate SETVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -727,6 +793,9 @@ NEXTVAL(s1)
 11
 include/save_master_gtid.inc
 # Validate NEXTVAL replicated correctly to other servers
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 include/diff_tables.inc [server_1:test.s1,server_2:test.s1,server_3:test.s1]
@@ -760,6 +829,9 @@ include/ensure_binlog_row_event_columns.inc [(1,2,3,4,5,6,7,8)]
 # Cleanup
 connection server_1;
 DROP TABLE s1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_start_alter_chain_basic.result
+++ b/mysql-test/suite/rpl/r/rpl_start_alter_chain_basic.result
@@ -66,6 +66,9 @@ domain_id	seq_no
 0	12
 connection server_1;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 select domain_id, seq_no from mysql.gtid_slave_pos order by seq_no desc limit 1;

--- a/mysql-test/suite/rpl/r/rpl_xa_empty_transaction.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_empty_transaction.result
@@ -13,6 +13,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -37,6 +40,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -45,6 +51,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -77,6 +86,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -85,6 +97,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -110,6 +125,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -118,6 +136,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -149,6 +170,9 @@ FLUSH LOGS;
 include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -162,6 +186,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -188,6 +215,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -196,6 +226,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -230,6 +263,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -238,6 +274,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -265,6 +304,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -273,6 +315,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -306,6 +351,9 @@ FLUSH LOGS;
 include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -323,6 +371,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -349,6 +400,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -357,6 +411,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -391,6 +448,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -399,6 +459,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -428,6 +491,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -436,6 +502,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -470,6 +539,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -485,6 +557,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -513,6 +588,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -521,6 +599,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -557,6 +638,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -565,6 +649,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -594,6 +681,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -602,6 +692,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -637,6 +730,9 @@ FLUSH LOGS;
 include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -655,6 +751,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -683,6 +782,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -691,6 +793,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -727,6 +832,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -735,6 +843,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -766,6 +877,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -774,6 +888,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -809,6 +926,9 @@ FLUSH LOGS;
 include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -830,6 +950,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -858,6 +981,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -866,6 +992,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -902,6 +1031,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -910,6 +1042,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -941,6 +1076,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -949,6 +1087,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -984,6 +1125,9 @@ FLUSH LOGS;
 include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -1004,6 +1148,9 @@ connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -1032,6 +1179,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -1040,6 +1190,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -1076,6 +1229,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -1084,6 +1240,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -1115,6 +1274,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -1123,6 +1285,9 @@ connection server_3;
 connection server_1;
 CREATE TABLE tm (a INT PRIMARY KEY) engine=myisam;
 CREATE TABLE ti (a INT PRIMARY KEY) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
@@ -1159,6 +1324,9 @@ include/assert_grep.inc [server_3 should not binlog XA transaction]
 connection server_1;
 DROP TABLE ti,tm;
 include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc
 connection server_1;
@@ -1172,6 +1340,9 @@ connection server_1;
 create database db1;
 create database db2;
 create table db1.t1 (a int) engine=innodb;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
 include/save_master_gtid.inc
 connection server_3;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/t/rpl_start_alter_chain_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_start_alter_chain_basic.test
@@ -41,6 +41,9 @@ select domain_id, seq_no from mysql.gtid_slave_pos order by seq_no desc limit 1;
 
 --connection server_1
 --source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/save_master_gtid.inc
 --connection server_3
 --source include/sync_with_master_gtid.inc
 

--- a/mysql-test/suite/rpl/t/rpl_xa_empty_transaction.test
+++ b/mysql-test/suite/rpl/t/rpl_xa_empty_transaction.test
@@ -187,6 +187,9 @@ create database db1;
 create database db2;
 create table db1.t1 (a int) engine=innodb;
 --source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+--source include/save_master_gtid.inc
 --connection server_3
 --source include/sync_with_master_gtid.inc
 --source include/stop_slave.inc


### PR DESCRIPTION
## Description

In chain replication (1->2->3), several rpl MTR tests synchronize by calling `save_master_gtid` on `server_1` followed by `sync_with_master_gtid` on `server_3`, skipping `server_2`. 

This is unsafe because `server_2`'s binlog dump thread can send events to `server_3` before `commit_ordered()` completes on `server_2`. Any operations on `server_2` that depend on the replicated data can then fail intermittently.

Fix by explicitly syncing `server_2` before `server_3` in all affected tests, and update result files accordingly.

## Release Notes

N/A

## How can this PR be tested?

Execute the rpl test suite in mysql-test-run:
```
--------------------------------------------------------------------------
The servers were restarted 546 times
Spent 2684.439 of 472 seconds executing testcases

Completed: All 1223 tests were successful.

88 tests were skipped, 75 by the test itself.
```

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix, and the PR is based against the 11.8 branch._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.