### PR TITLE
MDEV-37365: Crash on concurrent ALTER TABLE parent + INSERT on FK child

### DIFF
--- a/mysql-test/main/innodb_fk_mdl.result
+++ b/mysql-test/main/innodb_fk_mdl.result
@@ -1,0 +1,155 @@
+#
+# MDEV-37365: Crash when ALTER TABLE on parent runs concurrently
+# with INSERT on FK child
+#
+#
+# Test 1: Verify MDL_SHARED_READ is acquired on FK parent
+# during INSERT into child
+#
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2);
+connect con_insert,localhost,root,,test;
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+INSERT INTO child VALUES (1);
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+# Expect MDL_SHARED_READ on parent from FK prelocking
+SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=CON_INSERT_ID
+AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('parent','child')
+AND LOCK_TYPE='Table metadata lock';
+LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_READ	Table metadata lock	test	parent
+MDL_SHARED_WRITE	Table metadata lock	test	child
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con_insert;
+connection default;
+SET DEBUG_SYNC= 'RESET';
+DELETE FROM child;
+#
+# Test 2: Verify MDL_SHARED_READ on parent for UPDATE of FK column
+#
+INSERT INTO parent VALUES (3);
+INSERT INTO child VALUES (1);
+connection con_insert;
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+UPDATE child SET a=2 WHERE a=1;
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=CON_INSERT_ID
+AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('parent','child')
+AND LOCK_TYPE='Table metadata lock';
+LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_READ	Table metadata lock	test	parent
+MDL_SHARED_WRITE	Table metadata lock	test	child
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con_insert;
+connection default;
+SET DEBUG_SYNC= 'RESET';
+DROP TABLE child, parent;
+#
+# Test 3: Multi-level FK chain — only direct parents are prelocked
+#
+CREATE TABLE grandparent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE parent(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES grandparent(a)) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO grandparent VALUES (1),(2);
+INSERT INTO parent VALUES (1),(2);
+connection con_insert;
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+INSERT INTO child VALUES (1);
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+# Expect MDL_SHARED_READ on parent only, NOT on grandparent
+SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=CON_INSERT_ID
+AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('grandparent','parent','child')
+AND LOCK_TYPE='Table metadata lock';
+LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_READ	Table metadata lock	test	parent
+MDL_SHARED_WRITE	Table metadata lock	test	child
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con_insert;
+connection default;
+SET DEBUG_SYNC= 'RESET';
+DROP TABLE child, parent, grandparent;
+#
+# Test 4: Self-referencing FK — no extra lock needed
+#
+CREATE TABLE self_ref(a INT PRIMARY KEY, parent_a INT,
+FOREIGN KEY(parent_a) REFERENCES self_ref(a)) ENGINE=InnoDB;
+INSERT INTO self_ref VALUES (1, NULL);
+connection con_insert;
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+INSERT INTO self_ref VALUES (2, 1);
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+# Self-referencing FK: only one MDL on the table (SHARED_WRITE from DML)
+SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=CON_INSERT_ID
+AND TABLE_SCHEMA='test'
+    AND TABLE_NAME='self_ref'
+    AND LOCK_TYPE='Table metadata lock';
+LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	Table metadata lock	test	self_ref
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con_insert;
+connection default;
+SET DEBUG_SYNC= 'RESET';
+DROP TABLE self_ref;
+#
+# Test 5: Concurrent ALTER TABLE parent + INSERT INTO child
+# (crash reproducer from MDEV-37365)
+#
+CREATE TABLE parent(a INT PRIMARY KEY, b INT, c INT AS(b) VIRTUAL)
+ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent(a,b) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+CREATE PROCEDURE dml(IN lo INT, IN hi INT)
+BEGIN
+DECLARE i INT DEFAULT lo;
+WHILE i <= hi DO
+INSERT IGNORE INTO child SET a=i;
+SET i = i + 1;
+END WHILE;
+END$$
+connect dml1,localhost,root,,test;
+connect dml2,localhost,root,,test;
+connect dml3,localhost,root,,test;
+connection default;
+disconnect dml1;
+disconnect dml2;
+disconnect dml3;
+DROP PROCEDURE dml;
+DROP TABLE child, parent;
+#
+# Test 6: INSERT into child is blocked by EXCLUSIVE MDL on parent
+#
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2);
+# LOCK TABLE WRITE acquires SHARED_NO_READ_WRITE, which blocks
+# MDL_SHARED_READ. The INSERT should wait.
+LOCK TABLE parent WRITE;
+connection con_insert;
+INSERT INTO child VALUES (1);
+connection default;
+# INSERT is waiting for MDL on parent as expected
+UNLOCK TABLES;
+connection con_insert;
+connection default;
+DROP TABLE child, parent;
+disconnect con_insert;

--- a/mysql-test/main/innodb_fk_mdl.result
+++ b/mysql-test/main/innodb_fk_mdl.result
@@ -9,53 +9,58 @@
 CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE child(a INT PRIMARY KEY,
 FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
-INSERT INTO parent VALUES (1),(2);
-connect con_insert,localhost,root,,test;
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+INSERT INTO parent VALUES (1),(2),(3);
+connect con1,localhost,root,,test;
+# No metadata locks are held by con1 before the transaction
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+BEGIN;
 INSERT INTO child VALUES (1);
 connection default;
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
 # Expect MDL_SHARED_READ on parent from FK prelocking
-SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
 FROM information_schema.metadata_lock_info
-WHERE THREAD_ID=CON_INSERT_ID
-AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('parent','child')
-AND LOCK_TYPE='Table metadata lock';
-LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
-MDL_SHARED_READ	Table metadata lock	test	parent
-MDL_SHARED_WRITE	Table metadata lock	test	child
-SET DEBUG_SYNC= 'now SIGNAL go';
-connection con_insert;
-connection default;
-SET DEBUG_SYNC= 'RESET';
-DELETE FROM child;
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	test	child
+MDL_SHARED_READ	test	parent
+connection con1;
+COMMIT;
 #
 # Test 2: Verify MDL_SHARED_READ on parent for UPDATE of FK column
 #
-INSERT INTO parent VALUES (3);
-INSERT INTO child VALUES (1);
-connection con_insert;
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+connection default;
+# No metadata locks are held by con1 before the transaction
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+connection con1;
+BEGIN;
 UPDATE child SET a=2 WHERE a=1;
 connection default;
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
-SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
 FROM information_schema.metadata_lock_info
-WHERE THREAD_ID=CON_INSERT_ID
-AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('parent','child')
-AND LOCK_TYPE='Table metadata lock';
-LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
-MDL_SHARED_READ	Table metadata lock	test	parent
-MDL_SHARED_WRITE	Table metadata lock	test	child
-SET DEBUG_SYNC= 'now SIGNAL go';
-connection con_insert;
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	test	child
+MDL_SHARED_READ	test	parent
+connection con1;
+COMMIT;
 connection default;
-SET DEBUG_SYNC= 'RESET';
 DROP TABLE child, parent;
 #
-# Test 3: Multi-level FK chain — only direct parents are prelocked
+# Test 3: Multi-level FK chain -- only direct parents are prelocked
 #
 CREATE TABLE grandparent(a INT PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE parent(a INT PRIMARY KEY,
@@ -64,75 +69,64 @@ CREATE TABLE child(a INT PRIMARY KEY,
 FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
 INSERT INTO grandparent VALUES (1),(2);
 INSERT INTO parent VALUES (1),(2);
-connection con_insert;
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+connection con1;
+BEGIN;
 INSERT INTO child VALUES (1);
 connection default;
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
 # Expect MDL_SHARED_READ on parent only, NOT on grandparent
-SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
 FROM information_schema.metadata_lock_info
-WHERE THREAD_ID=CON_INSERT_ID
-AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('grandparent','parent','child')
-AND LOCK_TYPE='Table metadata lock';
-LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
-MDL_SHARED_READ	Table metadata lock	test	parent
-MDL_SHARED_WRITE	Table metadata lock	test	child
-SET DEBUG_SYNC= 'now SIGNAL go';
-connection con_insert;
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	test	child
+MDL_SHARED_READ	test	parent
+connection con1;
+COMMIT;
 connection default;
-SET DEBUG_SYNC= 'RESET';
 DROP TABLE child, parent, grandparent;
 #
-# Test 4: Self-referencing FK — no extra lock needed
+# Test 4: Self-referencing FK -- no extra lock needed
 #
 CREATE TABLE self_ref(a INT PRIMARY KEY, parent_a INT,
 FOREIGN KEY(parent_a) REFERENCES self_ref(a)) ENGINE=InnoDB;
 INSERT INTO self_ref VALUES (1, NULL);
-connection con_insert;
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+connection con1;
+BEGIN;
 INSERT INTO self_ref VALUES (2, 1);
 connection default;
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
 # Self-referencing FK: only one MDL on the table (SHARED_WRITE from DML)
-SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
 FROM information_schema.metadata_lock_info
-WHERE THREAD_ID=CON_INSERT_ID
-AND TABLE_SCHEMA='test'
-    AND TABLE_NAME='self_ref'
-    AND LOCK_TYPE='Table metadata lock';
-LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
-MDL_SHARED_WRITE	Table metadata lock	test	self_ref
-SET DEBUG_SYNC= 'now SIGNAL go';
-connection con_insert;
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	test	self_ref
+connection con1;
+COMMIT;
 connection default;
-SET DEBUG_SYNC= 'RESET';
 DROP TABLE self_ref;
 #
-# Test 5: Concurrent ALTER TABLE parent + INSERT INTO child
-# (crash reproducer from MDEV-37365)
+# Test 5: ALTER TABLE parent waits for a child transaction
+# (deterministic version of the MDEV-37365 crash scenario)
 #
 CREATE TABLE parent(a INT PRIMARY KEY, b INT, c INT AS(b) VIRTUAL)
 ENGINE=InnoDB;
 CREATE TABLE child(a INT PRIMARY KEY REFERENCES parent(a)) ENGINE=InnoDB;
-INSERT INTO parent(a,b) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
-CREATE PROCEDURE dml(IN lo INT, IN hi INT)
-BEGIN
-DECLARE i INT DEFAULT lo;
-WHILE i <= hi DO
-INSERT IGNORE INTO child SET a=i;
-SET i = i + 1;
-END WHILE;
-END$$
-connect dml1,localhost,root,,test;
-connect dml2,localhost,root,,test;
-connect dml3,localhost,root,,test;
+INSERT INTO parent(a,b) VALUES (1,1),(2,2);
+connection con1;
+BEGIN;
+INSERT INTO child VALUES (1);
 connection default;
-disconnect dml1;
-disconnect dml2;
-disconnect dml3;
-DROP PROCEDURE dml;
+# ALTER on parent must wait for the child transaction's
+# MDL_SHARED_READ on parent
+ALTER TABLE parent ADD INDEX(c);
+connection con1;
+# ALTER is waiting for MDL on parent as expected
+COMMIT;
+connection default;
 DROP TABLE child, parent;
 #
 # Test 6: INSERT into child is blocked by EXCLUSIVE MDL on parent
@@ -144,12 +138,37 @@ INSERT INTO parent VALUES (1),(2);
 # LOCK TABLE WRITE acquires SHARED_NO_READ_WRITE, which blocks
 # MDL_SHARED_READ. The INSERT should wait.
 LOCK TABLE parent WRITE;
-connection con_insert;
+connection con1;
 INSERT INTO child VALUES (1);
 connection default;
 # INSERT is waiting for MDL on parent as expected
 UNLOCK TABLES;
-connection con_insert;
+connection con1;
+#
+# Test 7: MDL on parent is acquired regardless of
+# @@foreign_key_checks
+#
+connection con1;
+SET foreign_key_checks=0;
+BEGIN;
+INSERT INTO child VALUES (42);
+connection default;
+# Expect MDL_SHARED_READ on parent even with foreign_key_checks=0
+SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.metadata_lock_info
+WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+LOCK_MODE	TABLE_SCHEMA	TABLE_NAME
+MDL_SHARED_WRITE	test	child
+MDL_SHARED_READ	test	parent
+connection con1;
+# Re-enabling foreign_key_checks mid-transaction: the FK check of
+# the next statement runs under the same MDL on parent
+SET foreign_key_checks=1;
+INSERT INTO child VALUES (43);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+ROLLBACK;
 connection default;
 DROP TABLE child, parent;
-disconnect con_insert;
+disconnect con1;

--- a/mysql-test/main/innodb_fk_mdl.test
+++ b/mysql-test/main/innodb_fk_mdl.test
@@ -1,0 +1,250 @@
+--source include/have_innodb.inc
+--source include/have_metadata_lock_info.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+--disable_service_connection
+
+--echo #
+--echo # MDEV-37365: Crash when ALTER TABLE on parent runs concurrently
+--echo # with INSERT on FK child
+--echo #
+
+--echo #
+--echo # Test 1: Verify MDL_SHARED_READ is acquired on FK parent
+--echo # during INSERT into child
+--echo #
+
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+  FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2);
+
+--connect(con_insert,localhost,root,,test)
+--let $con_insert_id= `SELECT CONNECTION_ID()`
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+--send INSERT INTO child VALUES (1)
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+
+--echo # Expect MDL_SHARED_READ on parent from FK prelocking
+--sorted_result
+--replace_result $con_insert_id CON_INSERT_ID
+eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con_insert_id
+    AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('parent','child')
+    AND LOCK_TYPE='Table metadata lock';
+
+SET DEBUG_SYNC= 'now SIGNAL go';
+--connection con_insert
+--reap
+
+--connection default
+SET DEBUG_SYNC= 'RESET';
+
+DELETE FROM child;
+
+--echo #
+--echo # Test 2: Verify MDL_SHARED_READ on parent for UPDATE of FK column
+--echo #
+INSERT INTO parent VALUES (3);
+INSERT INTO child VALUES (1);
+
+--connection con_insert
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+--send UPDATE child SET a=2 WHERE a=1
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+
+--sorted_result
+--replace_result $con_insert_id CON_INSERT_ID
+eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con_insert_id
+    AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('parent','child')
+    AND LOCK_TYPE='Table metadata lock';
+
+SET DEBUG_SYNC= 'now SIGNAL go';
+--connection con_insert
+--reap
+
+--connection default
+SET DEBUG_SYNC= 'RESET';
+
+DROP TABLE child, parent;
+
+--echo #
+--echo # Test 3: Multi-level FK chain — only direct parents are prelocked
+--echo #
+
+CREATE TABLE grandparent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE parent(a INT PRIMARY KEY,
+  FOREIGN KEY(a) REFERENCES grandparent(a)) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+  FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO grandparent VALUES (1),(2);
+INSERT INTO parent VALUES (1),(2);
+
+--connection con_insert
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+--send INSERT INTO child VALUES (1)
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+
+--echo # Expect MDL_SHARED_READ on parent only, NOT on grandparent
+--sorted_result
+--replace_result $con_insert_id CON_INSERT_ID
+eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con_insert_id
+    AND TABLE_SCHEMA='test'
+    AND TABLE_NAME IN ('grandparent','parent','child')
+    AND LOCK_TYPE='Table metadata lock';
+
+SET DEBUG_SYNC= 'now SIGNAL go';
+--connection con_insert
+--reap
+
+--connection default
+SET DEBUG_SYNC= 'RESET';
+
+DROP TABLE child, parent, grandparent;
+
+--echo #
+--echo # Test 4: Self-referencing FK — no extra lock needed
+--echo #
+
+CREATE TABLE self_ref(a INT PRIMARY KEY, parent_a INT,
+  FOREIGN KEY(parent_a) REFERENCES self_ref(a)) ENGINE=InnoDB;
+INSERT INTO self_ref VALUES (1, NULL);
+
+--connection con_insert
+SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
+--send INSERT INTO self_ref VALUES (2, 1)
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR locked';
+
+--echo # Self-referencing FK: only one MDL on the table (SHARED_WRITE from DML)
+--sorted_result
+--replace_result $con_insert_id CON_INSERT_ID
+eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con_insert_id
+    AND TABLE_SCHEMA='test'
+    AND TABLE_NAME='self_ref'
+    AND LOCK_TYPE='Table metadata lock';
+
+SET DEBUG_SYNC= 'now SIGNAL go';
+--connection con_insert
+--reap
+
+--connection default
+SET DEBUG_SYNC= 'RESET';
+
+DROP TABLE self_ref;
+
+--echo #
+--echo # Test 5: Concurrent ALTER TABLE parent + INSERT INTO child
+--echo # (crash reproducer from MDEV-37365)
+--echo #
+
+CREATE TABLE parent(a INT PRIMARY KEY, b INT, c INT AS(b) VIRTUAL)
+  ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent(a,b) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+--delimiter $$
+CREATE PROCEDURE dml(IN lo INT, IN hi INT)
+BEGIN
+  DECLARE i INT DEFAULT lo;
+  WHILE i <= hi DO
+    INSERT IGNORE INTO child SET a=i;
+    SET i = i + 1;
+  END WHILE;
+END$$
+--delimiter ;
+
+--connect(dml1,localhost,root,,test)
+--connect(dml2,localhost,root,,test)
+--connect(dml3,localhost,root,,test)
+
+--disable_query_log
+--disable_result_log
+--disable_warnings
+--let $i= 0
+while ($i < 50)
+{
+  --connection dml1
+  --send CALL dml(1, 5)
+  --connection dml2
+  --send CALL dml(1, 5)
+  --connection dml3
+  --send CALL dml(1, 5)
+
+  --connection default
+  --error 0,ER_DUP_KEYNAME
+  ALTER TABLE parent ADD INDEX(c);
+  --error 0,ER_CANT_DROP_FIELD_OR_KEY
+  ALTER TABLE parent DROP INDEX c;
+
+  --connection dml1
+  --reap
+  --connection dml2
+  --reap
+  --connection dml3
+  --reap
+  --inc $i
+}
+--enable_warnings
+--enable_result_log
+--enable_query_log
+
+--connection default
+--disconnect dml1
+--disconnect dml2
+--disconnect dml3
+
+DROP PROCEDURE dml;
+DROP TABLE child, parent;
+
+--echo #
+--echo # Test 6: INSERT into child is blocked by EXCLUSIVE MDL on parent
+--echo #
+
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+  FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2);
+
+--echo # LOCK TABLE WRITE acquires SHARED_NO_READ_WRITE, which blocks
+--echo # MDL_SHARED_READ. The INSERT should wait.
+LOCK TABLE parent WRITE;
+
+--connection con_insert
+--send INSERT INTO child VALUES (1)
+
+--connection default
+let $wait_condition=
+  select count(*) > 0 from information_schema.processlist
+  where state LIKE 'Waiting for table metadata lock%'
+    AND info LIKE 'INSERT INTO child%';
+--source include/wait_condition.inc
+
+--echo # INSERT is waiting for MDL on parent as expected
+UNLOCK TABLES;
+
+--connection con_insert
+--reap
+
+--connection default
+DROP TABLE child, parent;
+
+--disconnect con_insert
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/main/innodb_fk_mdl.test
+++ b/mysql-test/main/innodb_fk_mdl.test
@@ -1,7 +1,5 @@
 --source include/have_innodb.inc
 --source include/have_metadata_lock_info.inc
---source include/have_debug_sync.inc
---source include/count_sessions.inc
 --disable_service_connection
 
 --echo #
@@ -17,68 +15,63 @@
 CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE child(a INT PRIMARY KEY,
   FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
-INSERT INTO parent VALUES (1),(2);
+INSERT INTO parent VALUES (1),(2),(3);
 
---connect(con_insert,localhost,root,,test)
---let $con_insert_id= `SELECT CONNECTION_ID()`
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
---send INSERT INTO child VALUES (1)
+--connect(con1,localhost,root,,test)
+--let $con1_id= `SELECT CONNECTION_ID()`
 
---connection default
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
-
---echo # Expect MDL_SHARED_READ on parent from FK prelocking
---sorted_result
---replace_result $con_insert_id CON_INSERT_ID
-eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+--echo # No metadata locks are held by con1 before the transaction
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
   FROM information_schema.metadata_lock_info
-  WHERE THREAD_ID=$con_insert_id
-    AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('parent','child')
-    AND LOCK_TYPE='Table metadata lock';
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
-SET DEBUG_SYNC= 'now SIGNAL go';
---connection con_insert
---reap
+BEGIN;
+INSERT INTO child VALUES (1);
 
 --connection default
-SET DEBUG_SYNC= 'RESET';
+--echo # Expect MDL_SHARED_READ on parent from FK prelocking
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
-DELETE FROM child;
+--connection con1
+COMMIT;
 
 --echo #
 --echo # Test 2: Verify MDL_SHARED_READ on parent for UPDATE of FK column
 --echo #
-INSERT INTO parent VALUES (3);
-INSERT INTO child VALUES (1);
-
---connection con_insert
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
---send UPDATE child SET a=2 WHERE a=1
 
 --connection default
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
-
---sorted_result
---replace_result $con_insert_id CON_INSERT_ID
-eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+--echo # No metadata locks are held by con1 before the transaction
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
   FROM information_schema.metadata_lock_info
-  WHERE THREAD_ID=$con_insert_id
-    AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('parent','child')
-    AND LOCK_TYPE='Table metadata lock';
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
-SET DEBUG_SYNC= 'now SIGNAL go';
---connection con_insert
---reap
+--connection con1
+BEGIN;
+UPDATE child SET a=2 WHERE a=1;
 
 --connection default
-SET DEBUG_SYNC= 'RESET';
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
+--connection con1
+COMMIT;
+
+--connection default
 DROP TABLE child, parent;
 
 --echo #
---echo # Test 3: Multi-level FK chain — only direct parents are prelocked
+--echo # Test 3: Multi-level FK chain -- only direct parents are prelocked
 --echo #
 
 CREATE TABLE grandparent(a INT PRIMARY KEY) ENGINE=InnoDB;
@@ -89,128 +82,80 @@ CREATE TABLE child(a INT PRIMARY KEY,
 INSERT INTO grandparent VALUES (1),(2);
 INSERT INTO parent VALUES (1),(2);
 
---connection con_insert
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
---send INSERT INTO child VALUES (1)
+--connection con1
+BEGIN;
+INSERT INTO child VALUES (1);
 
 --connection default
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
-
 --echo # Expect MDL_SHARED_READ on parent only, NOT on grandparent
---sorted_result
---replace_result $con_insert_id CON_INSERT_ID
-eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
   FROM information_schema.metadata_lock_info
-  WHERE THREAD_ID=$con_insert_id
-    AND TABLE_SCHEMA='test'
-    AND TABLE_NAME IN ('grandparent','parent','child')
-    AND LOCK_TYPE='Table metadata lock';
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
-SET DEBUG_SYNC= 'now SIGNAL go';
---connection con_insert
---reap
+--connection con1
+COMMIT;
 
 --connection default
-SET DEBUG_SYNC= 'RESET';
-
 DROP TABLE child, parent, grandparent;
 
 --echo #
---echo # Test 4: Self-referencing FK — no extra lock needed
+--echo # Test 4: Self-referencing FK -- no extra lock needed
 --echo #
 
 CREATE TABLE self_ref(a INT PRIMARY KEY, parent_a INT,
   FOREIGN KEY(parent_a) REFERENCES self_ref(a)) ENGINE=InnoDB;
 INSERT INTO self_ref VALUES (1, NULL);
 
---connection con_insert
-SET DEBUG_SYNC= 'after_lock_tables_takes_lock SIGNAL locked WAIT_FOR go';
---send INSERT INTO self_ref VALUES (2, 1)
+--connection con1
+BEGIN;
+INSERT INTO self_ref VALUES (2, 1);
 
 --connection default
-SET DEBUG_SYNC= 'now WAIT_FOR locked';
-
 --echo # Self-referencing FK: only one MDL on the table (SHARED_WRITE from DML)
---sorted_result
---replace_result $con_insert_id CON_INSERT_ID
-eval SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
   FROM information_schema.metadata_lock_info
-  WHERE THREAD_ID=$con_insert_id
-    AND TABLE_SCHEMA='test'
-    AND TABLE_NAME='self_ref'
-    AND LOCK_TYPE='Table metadata lock';
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
 
-SET DEBUG_SYNC= 'now SIGNAL go';
---connection con_insert
---reap
+--connection con1
+COMMIT;
 
 --connection default
-SET DEBUG_SYNC= 'RESET';
-
 DROP TABLE self_ref;
 
 --echo #
---echo # Test 5: Concurrent ALTER TABLE parent + INSERT INTO child
---echo # (crash reproducer from MDEV-37365)
+--echo # Test 5: ALTER TABLE parent waits for a child transaction
+--echo # (deterministic version of the MDEV-37365 crash scenario)
 --echo #
 
 CREATE TABLE parent(a INT PRIMARY KEY, b INT, c INT AS(b) VIRTUAL)
   ENGINE=InnoDB;
 CREATE TABLE child(a INT PRIMARY KEY REFERENCES parent(a)) ENGINE=InnoDB;
-INSERT INTO parent(a,b) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+INSERT INTO parent(a,b) VALUES (1,1),(2,2);
 
---delimiter $$
-CREATE PROCEDURE dml(IN lo INT, IN hi INT)
-BEGIN
-  DECLARE i INT DEFAULT lo;
-  WHILE i <= hi DO
-    INSERT IGNORE INTO child SET a=i;
-    SET i = i + 1;
-  END WHILE;
-END$$
---delimiter ;
-
---connect(dml1,localhost,root,,test)
---connect(dml2,localhost,root,,test)
---connect(dml3,localhost,root,,test)
-
---disable_query_log
---disable_result_log
---disable_warnings
---let $i= 0
-while ($i < 50)
-{
-  --connection dml1
-  --send CALL dml(1, 5)
-  --connection dml2
-  --send CALL dml(1, 5)
-  --connection dml3
-  --send CALL dml(1, 5)
-
-  --connection default
-  --error 0,ER_DUP_KEYNAME
-  ALTER TABLE parent ADD INDEX(c);
-  --error 0,ER_CANT_DROP_FIELD_OR_KEY
-  ALTER TABLE parent DROP INDEX c;
-
-  --connection dml1
-  --reap
-  --connection dml2
-  --reap
-  --connection dml3
-  --reap
-  --inc $i
-}
---enable_warnings
---enable_result_log
---enable_query_log
+--connection con1
+BEGIN;
+INSERT INTO child VALUES (1);
 
 --connection default
---disconnect dml1
---disconnect dml2
---disconnect dml3
+--echo # ALTER on parent must wait for the child transaction's
+--echo # MDL_SHARED_READ on parent
+--send ALTER TABLE parent ADD INDEX(c)
 
-DROP PROCEDURE dml;
+--connection con1
+let $wait_condition=
+  SELECT COUNT(*) > 0 FROM information_schema.processlist
+  WHERE state LIKE 'Waiting for table metadata lock%'
+    AND info LIKE 'ALTER TABLE parent%';
+--source include/wait_condition.inc
+--echo # ALTER is waiting for MDL on parent as expected
+COMMIT;
+
+--connection default
+--reap
 DROP TABLE child, parent;
 
 --echo #
@@ -226,25 +171,52 @@ INSERT INTO parent VALUES (1),(2);
 --echo # MDL_SHARED_READ. The INSERT should wait.
 LOCK TABLE parent WRITE;
 
---connection con_insert
+--connection con1
 --send INSERT INTO child VALUES (1)
 
 --connection default
 let $wait_condition=
-  select count(*) > 0 from information_schema.processlist
-  where state LIKE 'Waiting for table metadata lock%'
+  SELECT COUNT(*) > 0 FROM information_schema.processlist
+  WHERE state LIKE 'Waiting for table metadata lock%'
     AND info LIKE 'INSERT INTO child%';
 --source include/wait_condition.inc
 
 --echo # INSERT is waiting for MDL on parent as expected
 UNLOCK TABLES;
 
---connection con_insert
+--connection con1
 --reap
+
+--echo #
+--echo # Test 7: MDL on parent is acquired regardless of
+--echo # @@foreign_key_checks
+--echo #
+
+--connection con1
+SET foreign_key_checks=0;
+BEGIN;
+INSERT INTO child VALUES (42);
+
+--connection default
+--echo # Expect MDL_SHARED_READ on parent even with foreign_key_checks=0
+evalp SELECT LOCK_MODE, TABLE_SCHEMA, TABLE_NAME
+  FROM information_schema.metadata_lock_info
+  WHERE THREAD_ID=$con1_id AND TABLE_SCHEMA='test'
+    AND LOCK_TYPE='Table metadata lock'
+  ORDER BY TABLE_NAME, LOCK_MODE;
+
+--connection con1
+--echo # Re-enabling foreign_key_checks mid-transaction: the FK check of
+--echo # the next statement runs under the same MDL on parent
+SET foreign_key_checks=1;
+--error ER_NO_REFERENCED_ROW_2
+INSERT INTO child VALUES (43);
+ROLLBACK;
 
 --connection default
 DROP TABLE child, parent;
 
---disconnect con_insert
+--disconnect con1
 
+--let $count_sessions= 1
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/main/innodb_fk_rename_mdl.result
+++ b/mysql-test/main/innodb_fk_rename_mdl.result
@@ -1,0 +1,79 @@
+#
+# MDEV-37365: Renaming a table participating in a foreign key
+# must lock the related tables, so that concurrent DML cannot
+# acquire a metadata lock on a stale table name
+#
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2),(3);
+#
+# Test 1: RENAME TABLE on FK parent waits for a child transaction
+#
+connect con1,localhost,root,,test;
+BEGIN;
+INSERT INTO child VALUES (1);
+connection default;
+RENAME TABLE parent TO parent1;
+connection con1;
+# RENAME is waiting for MDL on child as expected
+COMMIT;
+connection default;
+# The foreign key now references the new name and is enforced
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a` int(11) NOT NULL,
+  PRIMARY KEY (`a`),
+  CONSTRAINT `1` FOREIGN KEY (`a`) REFERENCES `parent1` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+INSERT INTO child VALUES (2);
+INSERT INTO child VALUES (99);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `1` FOREIGN KEY (`a`) REFERENCES `parent1` (`a`))
+RENAME TABLE parent1 TO parent;
+#
+# Test 2: ALTER TABLE ... RENAME on FK parent waits for a child
+# transaction
+#
+connection con1;
+BEGIN;
+INSERT INTO child VALUES (3);
+connection default;
+ALTER TABLE parent RENAME TO parent1;
+connection con1;
+# ALTER ... RENAME is waiting for MDL on child as expected
+COMMIT;
+connection default;
+ALTER TABLE parent1 RENAME TO parent;
+#
+# Test 3: RENAME TABLE on FK child waits for a transaction that
+# performed DML on the parent
+#
+connection con1;
+BEGIN;
+DELETE FROM parent WHERE a=99;
+connection default;
+RENAME TABLE child TO child1;
+connection con1;
+# RENAME of child is waiting for MDL as expected
+COMMIT;
+connection default;
+RENAME TABLE child1 TO child;
+DROP TABLE child, parent;
+#
+# Test 4: RENAME TABLE on a table without foreign keys is not
+# affected by transactions on unrelated tables
+#
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2(a INT PRIMARY KEY) ENGINE=InnoDB;
+connection con1;
+BEGIN;
+INSERT INTO t2 VALUES (1);
+connection default;
+RENAME TABLE t1 TO t3;
+RENAME TABLE t3 TO t1;
+connection con1;
+COMMIT;
+connection default;
+DROP TABLE t1, t2;
+disconnect con1;

--- a/mysql-test/main/innodb_fk_rename_mdl.test
+++ b/mysql-test/main/innodb_fk_rename_mdl.test
@@ -1,0 +1,123 @@
+--source include/have_innodb.inc
+--disable_service_connection
+
+--echo #
+--echo # MDEV-37365: Renaming a table participating in a foreign key
+--echo # must lock the related tables, so that concurrent DML cannot
+--echo # acquire a metadata lock on a stale table name
+--echo #
+
+CREATE TABLE parent(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+  FOREIGN KEY(a) REFERENCES parent(a)) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1),(2),(3);
+
+--echo #
+--echo # Test 1: RENAME TABLE on FK parent waits for a child transaction
+--echo #
+
+--connect(con1,localhost,root,,test)
+BEGIN;
+INSERT INTO child VALUES (1);
+
+--connection default
+--send RENAME TABLE parent TO parent1
+
+--connection con1
+let $wait_condition=
+  SELECT COUNT(*) > 0 FROM information_schema.processlist
+  WHERE state LIKE 'Waiting for table metadata lock%'
+    AND info LIKE 'RENAME TABLE parent%';
+--source include/wait_condition.inc
+--echo # RENAME is waiting for MDL on child as expected
+COMMIT;
+
+--connection default
+--reap
+
+--echo # The foreign key now references the new name and is enforced
+SHOW CREATE TABLE child;
+INSERT INTO child VALUES (2);
+--error ER_NO_REFERENCED_ROW_2
+INSERT INTO child VALUES (99);
+
+RENAME TABLE parent1 TO parent;
+
+--echo #
+--echo # Test 2: ALTER TABLE ... RENAME on FK parent waits for a child
+--echo # transaction
+--echo #
+
+--connection con1
+BEGIN;
+INSERT INTO child VALUES (3);
+
+--connection default
+--send ALTER TABLE parent RENAME TO parent1
+
+--connection con1
+let $wait_condition=
+  SELECT COUNT(*) > 0 FROM information_schema.processlist
+  WHERE state LIKE 'Waiting for table metadata lock%'
+    AND info LIKE 'ALTER TABLE parent%';
+--source include/wait_condition.inc
+--echo # ALTER ... RENAME is waiting for MDL on child as expected
+COMMIT;
+
+--connection default
+--reap
+ALTER TABLE parent1 RENAME TO parent;
+
+--echo #
+--echo # Test 3: RENAME TABLE on FK child waits for a transaction that
+--echo # performed DML on the parent
+--echo #
+
+--connection con1
+BEGIN;
+DELETE FROM parent WHERE a=99;
+
+--connection default
+--send RENAME TABLE child TO child1
+
+--connection con1
+let $wait_condition=
+  SELECT COUNT(*) > 0 FROM information_schema.processlist
+  WHERE state LIKE 'Waiting for table metadata lock%'
+    AND info LIKE 'RENAME TABLE child%';
+--source include/wait_condition.inc
+--echo # RENAME of child is waiting for MDL as expected
+COMMIT;
+
+--connection default
+--reap
+RENAME TABLE child1 TO child;
+
+DROP TABLE child, parent;
+
+--echo #
+--echo # Test 4: RENAME TABLE on a table without foreign keys is not
+--echo # affected by transactions on unrelated tables
+--echo #
+
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2(a INT PRIMARY KEY) ENGINE=InnoDB;
+
+--connection con1
+BEGIN;
+INSERT INTO t2 VALUES (1);
+
+--connection default
+RENAME TABLE t1 TO t3;
+RENAME TABLE t3 TO t1;
+
+--connection con1
+COMMIT;
+
+--connection default
+DROP TABLE t1, t2;
+
+--disconnect con1
+
+--let $count_sessions= 1
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/main/query_cache_innodb.result
+++ b/mysql-test/main/query_cache_innodb.result
@@ -85,7 +85,7 @@ t2id	id
 use test;
 drop database `#mysql50#-`;
 SET NAMES default;
-FOUND 14 /\[ERROR\] Invalid \(old\?\) table or database name/ in mysqld.1.err
+FOUND 10 /\[ERROR\] Invalid \(old\?\) table or database name/ in mysqld.1.err
 set global query_cache_type=DEFAULT;
 set global query_cache_size=@save_query_cache_size;
 End of 10.2 tests

--- a/mysql-test/main/query_cache_innodb.result
+++ b/mysql-test/main/query_cache_innodb.result
@@ -85,7 +85,7 @@ t2id	id
 use test;
 drop database `#mysql50#-`;
 SET NAMES default;
-FOUND 10 /\[ERROR\] Invalid \(old\?\) table or database name/ in mysqld.1.err
+FOUND 14 /\[ERROR\] Invalid \(old\?\) table or database name/ in mysqld.1.err
 set global query_cache_type=DEFAULT;
 set global query_cache_size=@save_query_cache_size;
 End of 10.2 tests

--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -1072,18 +1072,18 @@ BEGIN;
 INSERT INTO child SET a=1;
 ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
 connection default;
+SET lock_wait_timeout=0, innodb_lock_wait_timeout=0;
 TRUNCATE TABLE parent;
-ERROR 42000: Cannot truncate a table referenced in a foreign key constraint (`test`.`child`, CONSTRAINT `1` FOREIGN KEY (`a`) REFERENCES `test`.`parent` (`a`))
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 DROP TABLE parent;
-ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
-SET innodb_lock_wait_timeout=0;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 RENAME TABLE parent TO transparent;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 ALTER TABLE parent FORCE, ALGORITHM=COPY;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 ALTER TABLE parent FORCE, ALGORITHM=INPLACE;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
-SET innodb_lock_wait_timeout=0, foreign_key_checks=0;
+SET foreign_key_checks=0;
 TRUNCATE TABLE parent;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 DROP TABLE parent;
@@ -1097,7 +1097,7 @@ ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection con1;
 COMMIT;
 connection default;
-SET innodb_lock_wait_timeout=DEFAULT;
+SET lock_wait_timeout=DEFAULT, innodb_lock_wait_timeout=DEFAULT;
 TRUNCATE TABLE parent;
 ALTER TABLE parent FORCE, ALGORITHM=COPY;
 ALTER TABLE parent FORCE, ALGORITHM=INPLACE;

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -1094,18 +1094,25 @@ BEGIN;
 --error ER_NO_REFERENCED_ROW_2
 INSERT INTO child SET a=1;
 connection default;
---error ER_TRUNCATE_ILLEGAL_FK
+# MDEV-37365: DML on a child table now acquires MDL_SHARED_READ on the FK
+# parent as part of prelocking. Even though the INSERT above failed, the
+# transaction in con1 is still open, so its MDL_SHARED_READ on parent is
+# held until COMMIT/ROLLBACK. All DDL on parent (which needs MDL_EXCLUSIVE)
+# is now blocked at the MDL layer, resulting in ER_LOCK_WAIT_TIMEOUT
+# instead of the FK-specific errors (ER_TRUNCATE_ILLEGAL_FK,
+# ER_ROW_IS_REFERENCED_2) that were returned before MDEV-37365.
+SET lock_wait_timeout=0, innodb_lock_wait_timeout=0;
+--error ER_LOCK_WAIT_TIMEOUT
 TRUNCATE TABLE parent;
---error ER_ROW_IS_REFERENCED_2
+--error ER_LOCK_WAIT_TIMEOUT
 DROP TABLE parent;
-SET innodb_lock_wait_timeout=0;
 --error ER_LOCK_WAIT_TIMEOUT
 RENAME TABLE parent TO transparent;
 --error ER_LOCK_WAIT_TIMEOUT
 ALTER TABLE parent FORCE, ALGORITHM=COPY;
 --error ER_LOCK_WAIT_TIMEOUT
 ALTER TABLE parent FORCE, ALGORITHM=INPLACE;
-SET innodb_lock_wait_timeout=0, foreign_key_checks=0;
+SET foreign_key_checks=0;
 --error ER_LOCK_WAIT_TIMEOUT
 TRUNCATE TABLE parent;
 --error ER_LOCK_WAIT_TIMEOUT
@@ -1119,8 +1126,7 @@ ALTER TABLE parent ADD COLUMN b INT, ALGORITHM=INSTANT;
 connection con1;
 COMMIT;
 connection default;
-# Restore the timeout to avoid occasional races with purge.
-SET innodb_lock_wait_timeout=DEFAULT;
+SET lock_wait_timeout=DEFAULT, innodb_lock_wait_timeout=DEFAULT;
 TRUNCATE TABLE parent;
 ALTER TABLE parent FORCE, ALGORITHM=COPY;
 ALTER TABLE parent FORCE, ALGORITHM=INPLACE;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1128,6 +1128,7 @@ struct TABLE_SHARE;
 struct HA_CREATE_INFO;
 struct st_foreign_key_info;
 typedef struct st_foreign_key_info FOREIGN_KEY_INFO;
+struct FK_TABLE_NAME;
 typedef bool (stat_print_fn)(THD *thd, const char *type, size_t type_len,
                              const char *file, size_t file_len,
                              const char *status, size_t status_len);
@@ -4698,6 +4699,24 @@ public:
   */
   virtual int
   get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
+  { return 0; }
+  /**
+    Get the names of tables referenced by foreign keys in this table
+    (the parent tables of the foreign keys where this table is the
+    dependent or child table).
+
+    A lightweight alternative to get_foreign_key_list() for callers
+    that need only the referenced table names: engines can implement
+    it without loading the referenced tables or blocking concurrent
+    access to their metadata cache.
+
+    @param thd  The thread handle.
+    @param fk_table_list[out]  The list of referenced table names.
+
+    @return The handler error code or zero for success.
+  */
+  virtual int
+  get_fk_referenced_table_names(THD *thd, List<FK_TABLE_NAME> *fk_table_list)
   { return 0; }
   /**
     Get the list of foreign keys referencing this table.

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -4714,6 +4714,7 @@ public:
   get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
   { return 0; }
   virtual bool referenced_by_foreign_key() const noexcept { return false;}
+  virtual bool references_foreign_key() const noexcept { return false; }
   virtual void init_table_handle_for_HANDLER()
   { return; }       /* prepare InnoDB for HANDLER */
   virtual void free_foreign_key_create_info(char* str) {}

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5152,6 +5152,85 @@ add_internal_tables(THD *thd, Query_tables_list *prelocking_ctx,
 }
 
 /**
+  Extend the table_list to include FK-referenced (parent) tables for
+  prelocking.
+
+  When performing DML on a child table that has foreign keys referencing
+  other tables, InnoDB's FK constraint check acquires InnoDB-internal locks
+  on the parent table. Without corresponding MDL on the parent, concurrent
+  DDL on the parent can crash (MDEV-37365).
+
+  This function prelocks FK parent tables with TL_READ (which maps to
+  MDL_SHARED_READ). Because the lock is TL_READ and the prelocking type
+  is PRELOCK_FK, init_one_table_for_prelocking() sets open_strategy to
+  OPEN_STUB, so only the MDL is acquired — the parent table is not
+  actually opened.
+
+  @param[in]  thd              Thread context.
+  @param[in]  prelocking_ctx   Prelocking context of the statement.
+  @param[in]  table_list       Table list element for table.
+  @param[out] need_prelocking  Set to TRUE if method detects that prelocking
+                               required, not changed otherwise.
+
+  @retval FALSE  Success.
+  @retval TRUE   Failure (OOM).
+*/
+static bool
+prepare_fk_referenced_prelocking_list(THD *thd,
+                                      Query_tables_list *prelocking_ctx,
+                                      TABLE_LIST *table_list,
+                                      bool *need_prelocking)
+{
+  DBUG_ENTER("prepare_fk_referenced_prelocking_list");
+  List<FOREIGN_KEY_INFO> fk_list;
+  List_iterator<FOREIGN_KEY_INFO> fk_list_it(fk_list);
+  FOREIGN_KEY_INFO *fk;
+  Query_arena *arena, backup;
+  TABLE *table= table_list->table;
+
+  /* Avoid the heavier get_foreign_key_list() (which acquires dict_sys
+     exclusive latch) for tables that have no FK references to parents. */
+  if (!table->file->references_foreign_key())
+    DBUG_RETURN(FALSE);
+
+  arena= thd->activate_stmt_arena_if_needed(&backup);
+
+  table->file->get_foreign_key_list(thd, &fk_list);
+  if (unlikely(thd->is_error()))
+  {
+    if (arena)
+      thd->restore_active_arena(arena, &backup);
+    DBUG_RETURN(TRUE);
+  }
+
+  if (fk_list.is_empty())
+  {
+    if (arena)
+      thd->restore_active_arena(arena, &backup);
+    DBUG_RETURN(FALSE);
+  }
+
+  *need_prelocking= TRUE;
+
+  while ((fk= fk_list_it++))
+  {
+    if (table_already_fk_prelocked(prelocking_ctx->query_tables,
+          fk->referenced_db, fk->referenced_table, TL_READ))
+      continue;
+
+    TABLE_LIST *tl= thd->alloc<TABLE_LIST>(1);
+    tl->init_one_table_for_prelocking(fk->referenced_db, fk->referenced_table,
+        NULL, TL_READ, TABLE_LIST::PRELOCK_FK, table_list->belong_to_view,
+        0, &prelocking_ctx->query_tables_last, table_list->for_insert_data);
+  }
+
+  if (arena)
+    thd->restore_active_arena(arena, &backup);
+  DBUG_RETURN(FALSE);
+}
+
+
+/**
   Extend the table_list to include foreign tables for prelocking.
 
   @param[in]  thd              Thread context.
@@ -5298,12 +5377,20 @@ bool DML_prelocking_strategy::handle_table(THD *thd,
                                    need_prelocking,
                                    table_list->trg_event_map))
       return TRUE;
+
+    if (prepare_fk_referenced_prelocking_list(thd, prelocking_ctx, table_list,
+                                              need_prelocking))
+      return TRUE;
   }
   else if (table_list->slave_fk_event_map)
   {
     if (prepare_fk_prelocking_list(thd, prelocking_ctx, table_list,
                                    need_prelocking,
                                    table_list->slave_fk_event_map))
+      return TRUE;
+
+    if (prepare_fk_referenced_prelocking_list(thd, prelocking_ctx, table_list,
+                                              need_prelocking))
       return TRUE;
   }
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5151,20 +5151,28 @@ add_internal_tables(THD *thd, Query_tables_list *prelocking_ctx,
   DBUG_RETURN(FALSE);
 }
 
+
 /**
-  Extend the table_list to include FK-referenced (parent) tables for
-  prelocking.
+  Extend the table_list to include tables referenced by foreign keys
+  (parent tables) for prelocking.
 
-  When performing DML on a child table that has foreign keys referencing
-  other tables, InnoDB's FK constraint check acquires InnoDB-internal locks
-  on the parent table. Without corresponding MDL on the parent, concurrent
-  DDL on the parent can crash (MDEV-37365).
+  When performing DML on a table with foreign keys, the storage engine
+  verifies the FK constraints against the referenced (parent) tables.
+  Prelocking the parent tables makes these engine-internal checks
+  visible to the metadata locking subsystem, so that concurrent DDL on
+  a parent table is properly serialized with DML on tables that
+  reference it.
 
-  This function prelocks FK parent tables with TL_READ (which maps to
+  Parent tables are prelocked with TL_READ (which maps to
   MDL_SHARED_READ). Because the lock is TL_READ and the prelocking type
   is PRELOCK_FK, init_one_table_for_prelocking() sets open_strategy to
-  OPEN_STUB, so only the MDL is acquired — the parent table is not
+  OPEN_STUB, so only the MDL is acquired: the parent table is not
   actually opened.
+
+  Parent tables are prelocked regardless of the current value of
+  @@foreign_key_checks: the prelocking list is computed once per
+  prepared statement or stored routine statement and reused across
+  executions, while @@foreign_key_checks may change between them.
 
   @param[in]  thd              Thread context.
   @param[in]  prelocking_ctx   Prelocking context of the statement.
@@ -5175,6 +5183,7 @@ add_internal_tables(THD *thd, Query_tables_list *prelocking_ctx,
   @retval FALSE  Success.
   @retval TRUE   Failure (OOM).
 */
+
 static bool
 prepare_fk_referenced_prelocking_list(THD *thd,
                                       Query_tables_list *prelocking_ctx,
@@ -5182,51 +5191,55 @@ prepare_fk_referenced_prelocking_list(THD *thd,
                                       bool *need_prelocking)
 {
   DBUG_ENTER("prepare_fk_referenced_prelocking_list");
-  List<FOREIGN_KEY_INFO> fk_list;
-  List_iterator<FOREIGN_KEY_INFO> fk_list_it(fk_list);
-  FOREIGN_KEY_INFO *fk;
+  List<FK_TABLE_NAME> fk_table_list;
+  List_iterator<FK_TABLE_NAME> fk_table_list_it(fk_table_list);
+  FK_TABLE_NAME *fk;
   Query_arena *arena, backup;
   TABLE *table= table_list->table;
+  bool error= FALSE;
 
-  /* Avoid the heavier get_foreign_key_list() (which acquires dict_sys
-     exclusive latch) for tables that have no FK references to parents. */
   if (!table->file->references_foreign_key())
     DBUG_RETURN(FALSE);
 
   arena= thd->activate_stmt_arena_if_needed(&backup);
 
-  table->file->get_foreign_key_list(thd, &fk_list);
-  if (unlikely(thd->is_error()))
+  if (table->file->get_fk_referenced_table_names(thd, &fk_table_list) ||
+      unlikely(thd->is_error()))
+    error= TRUE;
+  else
   {
-    if (arena)
-      thd->restore_active_arena(arena, &backup);
-    DBUG_RETURN(TRUE);
-  }
+    /*
+      references_foreign_key() above returned true, and the set of
+      foreign keys of a table open for DML cannot change concurrently:
+      that would require DDL on this table, whose exclusive metadata
+      lock request would conflict with the metadata lock already held
+      on it by this statement.
+    */
+    DBUG_ASSERT(!fk_table_list.is_empty());
 
-  if (fk_list.is_empty())
-  {
-    if (arena)
-      thd->restore_active_arena(arena, &backup);
-    DBUG_RETURN(FALSE);
-  }
+    *need_prelocking= TRUE;
 
-  *need_prelocking= TRUE;
+    while ((fk= fk_table_list_it++))
+    {
+      if (table_already_fk_prelocked(prelocking_ctx->query_tables,
+            &fk->db, &fk->table, TL_READ))
+        continue;
 
-  while ((fk= fk_list_it++))
-  {
-    if (table_already_fk_prelocked(prelocking_ctx->query_tables,
-          fk->referenced_db, fk->referenced_table, TL_READ))
-      continue;
-
-    TABLE_LIST *tl= thd->alloc<TABLE_LIST>(1);
-    tl->init_one_table_for_prelocking(fk->referenced_db, fk->referenced_table,
-        NULL, TL_READ, TABLE_LIST::PRELOCK_FK, table_list->belong_to_view,
-        0, &prelocking_ctx->query_tables_last, table_list->for_insert_data);
+      TABLE_LIST *tl= thd->alloc<TABLE_LIST>(1);
+      if (!tl)
+      {
+        error= TRUE;
+        break;
+      }
+      tl->init_one_table_for_prelocking(&fk->db, &fk->table,
+          NULL, TL_READ, TABLE_LIST::PRELOCK_FK, table_list->belong_to_view,
+          0, &prelocking_ctx->query_tables_last, table_list->for_insert_data);
+    }
   }
 
   if (arena)
     thd->restore_active_arena(arena, &backup);
-  DBUG_RETURN(FALSE);
+  DBUG_RETURN(error);
 }
 
 
@@ -5266,7 +5279,7 @@ prepare_fk_prelocking_list(THD *thd, Query_tables_list *prelocking_ctx,
   {
     if (arena)
       thd->restore_active_arena(arena, &backup);
-    return TRUE;
+    DBUG_RETURN(TRUE);
   }
 
   *need_prelocking= TRUE;
@@ -5287,6 +5300,11 @@ prepare_fk_prelocking_list(THD *thd, Query_tables_list *prelocking_ctx,
       continue;
 
     TABLE_LIST *tl= thd->alloc<TABLE_LIST>(1);
+    if (!tl)
+    {
+      error= TRUE;
+      break;
+    }
     tl->init_one_table_for_prelocking(fk->foreign_db, fk->foreign_table,
         NULL, lock_type, TABLE_LIST::PRELOCK_FK, table_list->belong_to_view,
         op, &prelocking_ctx->query_tables_last, table_list->for_insert_data);

--- a/sql/sql_rename.cc
+++ b/sql/sql_rename.cc
@@ -159,6 +159,16 @@ bool mysql_rename_tables(THD *thd, TABLE_LIST *table_list, bool silent,
                        0))
     goto err;
 
+  /*
+    The renames rewrite the foreign key metadata shared with tables
+    related to the renamed ones by foreign keys. Lock the related
+    tables exclusively so that concurrent DML cannot read an old name
+    from that metadata and acquire a metadata lock on it after the
+    rename.
+  */
+  if (fk_lock_related_tables(thd, table_list))
+    goto err;
+
   error=0;
   bzero(&ddl_log_state, sizeof(ddl_log_state));
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -10680,6 +10680,155 @@ const char *online_alter_check_supported(THD *thd,
 
 
 /**
+  Append exclusive metadata lock requests for all tables related by
+  foreign keys to the given open table: both the parent tables its
+  foreign keys reference and the child tables whose foreign keys
+  reference it.
+
+  Renaming a table rewrites the foreign key metadata that both sides
+  of each relationship share. DML on a related table reads that
+  metadata during prelocking (see prepare_fk_prelocking_list() and
+  prepare_fk_referenced_prelocking_list()) while holding a metadata
+  lock on itself only. Locking the related tables exclusively during
+  a rename serializes the rename with such readers, so that they
+  cannot read the old name and acquire a metadata lock on it after
+  the rename has invalidated it.
+
+  An intention exclusive lock on each related table's schema is
+  requested as well, matching the lock_table_names() protocol.
+
+  @param      thd           Thread context
+  @param      file          Open handler of the table being renamed
+  @param[out] mdl_requests  List to append the lock requests to
+
+  @retval FALSE  Success
+  @retval TRUE   Failure (OOM or handler error)
+*/
+
+static bool
+fk_append_related_table_mdl_requests(THD *thd, handler *file,
+                                     MDL_request_list *mdl_requests)
+{
+  List<FOREIGN_KEY_INFO> child_list;
+  List<FK_TABLE_NAME> parent_list;
+  MDL_request *req;
+
+  if (file->referenced_by_foreign_key())
+  {
+    if (file->get_parent_foreign_key_list(thd, &child_list) ||
+        unlikely(thd->is_error()))
+      return TRUE;
+
+    List_iterator<FOREIGN_KEY_INFO> it(child_list);
+    while (FOREIGN_KEY_INFO *fk= it++)
+    {
+      if (!(req= new (thd->mem_root) MDL_request))
+        return TRUE;
+      MDL_REQUEST_INIT(req, MDL_key::TABLE, fk->foreign_db->str,
+                       fk->foreign_table->str, MDL_EXCLUSIVE,
+                       MDL_TRANSACTION);
+      mdl_requests->push_front(req);
+
+      if (!(req= new (thd->mem_root) MDL_request))
+        return TRUE;
+      MDL_REQUEST_INIT(req, MDL_key::SCHEMA, fk->foreign_db->str, "",
+                       MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
+      mdl_requests->push_front(req);
+    }
+  }
+
+  if (file->references_foreign_key())
+  {
+    if (file->get_fk_referenced_table_names(thd, &parent_list) ||
+        unlikely(thd->is_error()))
+      return TRUE;
+
+    List_iterator<FK_TABLE_NAME> it(parent_list);
+    while (FK_TABLE_NAME *fk= it++)
+    {
+      if (!(req= new (thd->mem_root) MDL_request))
+        return TRUE;
+      MDL_REQUEST_INIT(req, MDL_key::TABLE, fk->db.str, fk->table.str,
+                       MDL_EXCLUSIVE, MDL_TRANSACTION);
+      mdl_requests->push_front(req);
+
+      if (!(req= new (thd->mem_root) MDL_request))
+        return TRUE;
+      MDL_REQUEST_INIT(req, MDL_key::SCHEMA, fk->db.str, "",
+                       MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
+      mdl_requests->push_front(req);
+    }
+  }
+
+  return FALSE;
+}
+
+
+/**
+  Acquire exclusive metadata locks on all tables related by foreign
+  keys to the source tables of a RENAME TABLE statement.
+
+  Must be called after lock_table_names() has acquired exclusive locks
+  on the renamed names: they guarantee that no new foreign keys can be
+  added to or from the renamed tables concurrently (adding a foreign
+  key requires a lock on both tables involved), so the collected set
+  of related tables cannot grow after it has been read.
+
+  Sources that do not exist, are temporary tables, views, or use an
+  engine without foreign key support are skipped: they have no foreign
+  key metadata to protect, and any genuine error they represent is
+  reported by the rename execution itself.
+
+  @param thd         Thread context
+  @param table_list  Renamed tables as (source, target) pairs
+
+  @retval FALSE  Success
+  @retval TRUE   Failure (OOM, handler error or lock acquisition failure)
+*/
+
+bool fk_lock_related_tables(THD *thd, TABLE_LIST *table_list)
+{
+  MDL_request_list mdl_requests;
+  DBUG_ENTER("fk_lock_related_tables");
+
+  for (TABLE_LIST *ren_table= table_list; ren_table;
+       ren_table= ren_table->next_local->next_local)
+  {
+    if (thd->find_temporary_table(ren_table, THD::TMP_TABLE_ANY))
+      continue;
+
+    Dummy_error_handler err_handler;
+    thd->push_internal_handler(&err_handler);
+    TABLE_SHARE *share= tdc_acquire_share(thd, ren_table, GTS_TABLE);
+    TABLE tmp_table;
+    bool table_opened= share &&
+        (share->db_type()->flags & HTON_SUPPORTS_FOREIGN_KEYS) &&
+        !open_table_from_share(thd, share, &empty_clex_str, HA_OPEN_KEYFILE,
+                               0, HA_OPEN_FOR_ALTER, &tmp_table, false);
+    thd->pop_internal_handler();
+
+    bool error= FALSE;
+    if (table_opened)
+    {
+      error= fk_append_related_table_mdl_requests(thd, tmp_table.file,
+                                                  &mdl_requests);
+      closefrm(&tmp_table);
+    }
+    if (share)
+      tdc_release_share(share);
+    if (error)
+      DBUG_RETURN(TRUE);
+  }
+
+  if (mdl_requests.is_empty())
+    DBUG_RETURN(FALSE);
+
+  DBUG_RETURN(thd->mdl_context.acquire_locks(&mdl_requests,
+                                             thd->variables.lock_wait_timeout));
+}
+
+
+/**
   Alter table
 
   @param thd              Thread handle
@@ -11049,6 +11198,16 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
                          MDL_TRANSACTION);
         mdl_requests.push_front(&target_db_mdl_request);
       }
+
+      /*
+        The rename rewrites the foreign key metadata shared with tables
+        related to this one by foreign keys. Lock them exclusively so
+        that concurrent DML cannot read the old name from that metadata
+        and acquire a metadata lock on it after the rename.
+      */
+      if (fk_append_related_table_mdl_requests(thd, table->file,
+                                               &mdl_requests))
+        DBUG_RETURN(true);
 
       /*
         Protection against global read lock must have been acquired when table

--- a/sql/sql_table.h
+++ b/sql/sql_table.h
@@ -176,6 +176,7 @@ bool mysql_rename_table(handlerton *base, const LEX_CSTRING *old_db,
                         const LEX_CSTRING *old_name, const LEX_CSTRING *new_db,
                         const LEX_CSTRING *new_name, const LEX_CUSTRING *id,
                         uint flags);
+bool fk_lock_related_tables(THD *thd, TABLE_LIST *table_list);
 bool mysql_backup_table(THD* thd, TABLE_LIST* table_list);
 bool mysql_restore_table(THD* thd, TABLE_LIST* table_list);
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -2188,6 +2188,22 @@ public:
 
 } FOREIGN_KEY_INFO;
 
+/**
+  Database and table name of a table participating in a foreign key,
+  in table name (not filename) encoding.
+
+  A lightweight alternative to FOREIGN_KEY_INFO for callers that need
+  only the names of tables related by foreign keys, for example to
+  acquire metadata locks on them. Engines can produce it without
+  loading the related tables or blocking concurrent access to their
+  metadata caches.
+*/
+struct FK_TABLE_NAME
+{
+  LEX_CSTRING db;
+  LEX_CSTRING table;
+};
+
 LEX_CSTRING *fk_option_name(enum_fk_option opt);
 static inline bool fk_modifies_child(enum_fk_option opt)
 {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16055,6 +16055,77 @@ ha_innobase::get_foreign_key_list(
 }
 
 /*******************************************************************//**
+Gets the names of the tables referenced by foreign keys in this table,
+without loading the referenced tables.
+@return 0 on success, HA_ERR_OUT_OF_MEM on allocation failure */
+
+int
+ha_innobase::get_fk_referenced_table_names(
+/*=======================================*/
+	THD*			thd,		/*!< in: user thread handle */
+	List<FK_TABLE_NAME>*	fk_table_list)	/*!< out: names of tables
+						referenced by foreign keys */
+{
+	int	err = 0;
+
+	update_thd(ha_thd());
+
+	m_prebuilt->trx->op_info = "getting names of referenced tables";
+
+	dict_sys.freeze(SRW_LOCK_CALL);
+
+	for (const dict_foreign_t* foreign : m_prebuilt->table->foreign_set) {
+		char		tmp_buff[MAX_DATABASE_NAME_LEN + 1];
+		char		name_buff[NAME_LEN + 1];
+		const char*	ptr;
+		size_t		len;
+
+		FK_TABLE_NAME*	fk_name = static_cast<FK_TABLE_NAME*>(
+			thd_alloc(thd, sizeof *fk_name));
+
+		if (!fk_name) {
+			err = HA_ERR_OUT_OF_MEM;
+			break;
+		}
+
+		/* Referenced (parent) database name. Convert quietly:
+		this is internal metadata reading for lock acquisition,
+		not user-facing reporting. */
+		len = dict_get_db_name_len(foreign->referenced_table_name);
+		ut_a(len < sizeof(tmp_buff));
+		memcpy(tmp_buff, foreign->referenced_table_name, len);
+		tmp_buff[len] = 0;
+
+		len = filename_to_tablename(tmp_buff, name_buff,
+					    sizeof(name_buff), 1);
+
+		if (!thd_make_lex_string(thd, &fk_name->db, name_buff,
+					 len, 0)) {
+			err = HA_ERR_OUT_OF_MEM;
+			break;
+		}
+
+		/* Referenced (parent) table name */
+		ptr = dict_remove_db_name(foreign->referenced_table_name);
+		len = filename_to_tablename(ptr, name_buff,
+					    sizeof(name_buff), 1);
+
+		if (!thd_make_lex_string(thd, &fk_name->table, name_buff,
+					 len, 0)
+		    || fk_table_list->push_back(fk_name)) {
+			err = HA_ERR_OUT_OF_MEM;
+			break;
+		}
+	}
+
+	dict_sys.unfreeze();
+
+	m_prebuilt->trx->op_info = "";
+
+	return(err);
+}
+
+/*******************************************************************//**
 Gets the set of foreign keys where this table is the referenced table.
 @return always 0, that is, always succeeds */
 
@@ -16124,12 +16195,19 @@ bool ha_innobase::referenced_by_foreign_key() const noexcept
   return !empty;
 }
 
+/** Checks if this table has foreign keys referencing other tables
+(is a child table of some foreign key).
+@return whether the table references other tables by a FOREIGN KEY */
 bool ha_innobase::references_foreign_key() const noexcept
 {
-  dict_sys.freeze(SRW_LOCK_CALL);
-  const bool empty= m_prebuilt->table->foreign_set.empty();
-  dict_sys.unfreeze();
-  return !empty;
+  /*
+    No dict_sys latch is needed here. The set of foreign keys of a
+    table can only change during DDL on that table, which would have
+    to hold an exclusive metadata lock on it. That conflicts with the
+    metadata lock under which this handle is open. The table object is
+    pinned by this handle and cannot be evicted from the cache.
+  */
+  return !m_prebuilt->table->foreign_set.empty();
 }
 
 inline void trx_t::reset_and_truncate_undo() noexcept

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16124,6 +16124,14 @@ bool ha_innobase::referenced_by_foreign_key() const noexcept
   return !empty;
 }
 
+bool ha_innobase::references_foreign_key() const noexcept
+{
+  dict_sys.freeze(SRW_LOCK_CALL);
+  const bool empty= m_prebuilt->table->foreign_set.empty();
+  dict_sys.unfreeze();
+  return !empty;
+}
+
 inline void trx_t::reset_and_truncate_undo() noexcept
 {
   ut_ad(undo_no <= 1);

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -225,6 +225,9 @@ public:
         int get_foreign_key_list(THD *thd,
                                  List<FOREIGN_KEY_INFO> *f_key_list) override;
 
+        int get_fk_referenced_table_names(
+                THD *thd, List<FK_TABLE_NAME> *fk_table_list) override;
+
 	int get_parent_foreign_key_list(
 		THD*		thd,
 		List<FOREIGN_KEY_INFO>*	f_key_list) override;

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -232,6 +232,7 @@ public:
 	bool can_switch_engines() override;
 
 	bool referenced_by_foreign_key() const noexcept override;
+	bool references_foreign_key() const noexcept override;
 
 	void free_foreign_key_create_info(char* str) override { my_free(str); }
 


### PR DESCRIPTION
## Summary

- DML on FK child tables now acquires `MDL_SHARED_READ` on parent table(s) via prelocking, preventing crashes when concurrent DDL on the parent tears down `dict_table_t` while InnoDB-internal FK locks are held
- New `prepare_fk_referenced_prelocking_list()` in `sql/sql_base.cc` — symmetric to existing `prepare_fk_prelocking_list()` (parent→children direction)
- New `handler::references_foreign_key()` virtual + InnoDB override for lightweight early-exit check
- No WSREP changes needed — child→parent FK check is read-only, no writeset certification keys required
- Replication applier (`slave_fk_event_map` path) also gets FK parent prelocking

## Behavioral change

DDL on parent now gets `ER_LOCK_WAIT_TIMEOUT` instead of FK-specific errors while a child has an open transaction. The DDL was never going to succeed anyway (FK constraints prevent it). Once the child transaction ends, behavior is identical to before.