### PR TITLE
MDEV-39594 Assertion failure during MYSQL_BIN_LOG::recover

### DIFF
--- a/mysql-test/main/tc_heuristic_recover.test
+++ b/mysql-test/main/tc_heuristic_recover.test
@@ -48,10 +48,9 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SELECT * FROM t1;
 --enable_ps2_protocol
 
-# TODO: MDEV-12700 Allow innodb_read_only startup without prior slow shutdown.
 --source include/kill_mysqld.inc
 --error 1
---exec $MYSQLD_LAST_CMD --log-bin=master-bin --binlog-format=mixed --core-file --loose-debug-sync-timeout=300 --debug_dbug="+d,innobase_xa_fail"
+--exec $MYSQLD_LAST_CMD --log-bin=master-bin --binlog-format=mixed --core-file --loose-debug-sync-timeout=300 --innodb-log-recovery-target=18446744073709551615
 
 --let SEARCH_PATTERN= was in the XA prepared state
 --source include/search_pattern_in_file.inc
@@ -61,7 +60,7 @@ SELECT * FROM t1;
 --source include/search_pattern_in_file.inc
 
 --error 1
---exec $MYSQLD_LAST_CMD --log-bin=master-bin --binlog-format=mixed --core-file --loose-debug-sync-timeout=300 --debug_dbug="+d,innobase_xa_fail" --tc-heuristic-recover=COMMIT
+--exec $MYSQLD_LAST_CMD --log-bin=master-bin --binlog-format=mixed --core-file --loose-debug-sync-timeout=300 --innodb-log-recovery-target=18446744073709551615 --tc-heuristic-recover=COMMIT
 --let SEARCH_PATTERN= was in the XA prepared state
 --source include/search_pattern_in_file.inc
 --let SEARCH_PATTERN= Found 1 prepared transactions!

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2809,7 +2809,6 @@ static int innobase_close_connection(THD *thd) noexcept
 */
 static int innobase_rollback_by_xid(XID *xid) noexcept
 {
-  DBUG_EXECUTE_IF("innobase_xa_fail", return XAER_RMFAIL;);
   if (high_level_read_only || recv_sys.rpo)
     return XAER_RMFAIL;
   if (trx_t *trx= trx_get_trx_by_xid(xid))
@@ -17438,9 +17437,6 @@ innobase_commit_by_xid(
 /*===================*/
 	XID*		xid)	/*!< in: X/Open XA transaction identification */
 {
-	DBUG_EXECUTE_IF("innobase_xa_fail",
-			return XAER_RMFAIL;);
-
 	if (high_level_read_only || recv_sys.rpo) {
 		return(XAER_RMFAIL);
 	}
@@ -17472,9 +17468,7 @@ innobase_commit_by_xid(
 */
 static int innobase_recover_rollback_by_xid(const XID *xid)
 {
-  DBUG_EXECUTE_IF("innobase_xa_fail", return XAER_RMFAIL;);
-
-  if (high_level_read_only)
+  if (high_level_read_only || recv_sys.rpo)
     return XAER_RMFAIL;
 
   /*

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1206,31 +1206,20 @@ innobase_commit_by_xid(
 	XID*		xid);		/*!< in: X/Open XA transaction
 					identification */
 #ifndef EMBEDDED_LIBRARY
-/*******************************************************************//**
-This function is used to rollback one X/Open XA distributed transaction
-which is in the prepared state asynchronously.
+/**
+   In binlog recovery, persistently mark that a transaction will be
+   rolled back.
 
-It only set the transaction's status to ACTIVE and persist the status.
-The transaction will be rolled back by background rollback thread.
-
-@return 0 or error number
+   @param xid  Internal MySQLXid identificier
+   @return 0 or error number
 */
-static
-int
-innobase_recover_rollback_by_xid(
-/*===================*/
-	const XID*	xid);		/*!< in: X/Open XA transaction
-					identification */
-/*******************************************************************//**
-  This function is called after tc log is opened(typically binlog recovery)
-  has done. It starts rollback thread to rollback the transactions
-  have been changed from PREPARED to ACTIVE.
-
-  @return 0 or error number
+static int innobase_recover_rollback_by_xid(const XID *xid) noexcept;
+/**
+   Signal that the binlog based recovery is completed and request
+   the completion of the rollback of any transactions on which
+   innobase_recover_rollback_by_xid() was invoked.
 */
-static
-void
-innobase_tc_log_recovery_done();
+static void innobase_tc_log_recovery_done() noexcept;
 #endif
 
 
@@ -17455,18 +17444,7 @@ innobase_commit_by_xid(
 }
 
 #ifndef EMBEDDED_LIBRARY
-/**
-  This function is used to rollback one X/Open XA distributed transaction
-  which is in the prepared state asynchronously.
-
-  It only set the transaction's status to ACTIVE and persist the status.
-  The transaction will be rolled back by background rollback thread.
-
-  @param xid X/Open XA transaction identification
-
-  @return 0 or error number
-*/
-static int innobase_recover_rollback_by_xid(const XID *xid)
+static int innobase_recover_rollback_by_xid(const XID *xid) noexcept
 {
   if (high_level_read_only || recv_sys.rpo)
     return XAER_RMFAIL;
@@ -17510,7 +17488,7 @@ static int innobase_recover_rollback_by_xid(const XID *xid)
   return 0;
 }
 
-static void innobase_tc_log_recovery_done()
+static void innobase_tc_log_recovery_done() noexcept
 {
   if (high_level_read_only || recv_sys.rpo)
     return;


### PR DESCRIPTION
`innobase_recover_rollback_by_xid()`: Add a similar condition to the one that was in `innobase_rollback_by_xid()` and `innobase_commit_by_xid()`. Also, remove the now-redundant `DBUG_EXECUTE_IF` fault injection and exercise this code by specifying a nonzero `innodb_log_recovery_target`.

This function had been introduced in #3030 which was not present in the development branch of #4405, which had been applied to the `main` branch in 3394a9d1148a76268a48ffaaf057b7e333fdb846.