### PR TITLE
MDEV-39561 : Galera test failure on mysql-wsrep-features#8

### DIFF
--- a/mysql-test/suite/galera_sr/r/mysql-wsrep-features#8.result
+++ b/mysql-test/suite/galera_sr/r/mysql-wsrep-features#8.result
@@ -1,39 +1,47 @@
 connection node_2;
 connection node_1;
 SET SESSION wsrep_trx_fragment_size = 1;
-CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
+CREATE TABLE ten (f1 INTEGER NOT NULL PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
 connection node_1;
+SET SESSION wsrep_sync_wait=15;
 CREATE TABLE t1 (f1 INT PRIMARY KEY AUTO_INCREMENT, f2 VARCHAR(100), FULLTEXT (f2)) ENGINE=InnoDB;
 connection node_2;
-SELECT COUNT(*) = 13 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
-COUNT(*) = 13
-1
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_13 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
+EXPECT_13
+13
 connection node_1;
+# Insert 10K rows
 INSERT INTO t1 (f2) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4;
 connection node_2;
-SELECT COUNT(f2) = 10000 FROM t1 WHERE MATCH(f2) AGAINST ('foobarbaz');
-COUNT(f2) = 10000
-1
+SELECT COUNT(f2) AS EXPECT_10000 FROM t1 WHERE MATCH(f2) AGAINST ('foobarbaz');
+EXPECT_10000
+10000
 UPDATE t1 SET f2 = 'abcdefjhk';
 connection node_1;
-SELECT COUNT(f2) = 10000 FROM t1 WHERE MATCH(f2) AGAINST ('abcdefjhk');
-COUNT(f2) = 10000
-1
-connection node_2;
+SELECT COUNT(f2) AS EXPECT_10000 FROM t1 WHERE MATCH(f2) AGAINST ('abcdefjhk');
+EXPECT_10000
+10000
 DROP TABLE t1;
-connection node_1;
-CREATE TABLE t1 (f1 VARCHAR(100), FULLTEXT (f1)) ENGINE=InnoDB;
-connection node_2;
-INSERT INTO t1 (f1) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3;
-connection node_1;
-SELECT COUNT(f1) = 1000 FROM t1 WHERE MATCH(f1) AGAINST ('foobarbaz');
-COUNT(f1) = 1000
+SELECT COUNT(*) AS EXPECT_1 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
+EXPECT_1
 1
-UPDATE t1 SET f1 = 'abcdefjhk';
+CREATE TABLE t2 (f1 VARCHAR(100), FULLTEXT (f1)) ENGINE=InnoDB;
 connection node_2;
-SELECT COUNT(f1) = 1000 FROM t1 WHERE MATCH(f1) AGAINST ('abcdefjhk');
-COUNT(f1) = 1000
-1
-DROP TABLE t1;
+# We insert only 1K rows here, because updates without a PK are very slow
+INSERT INTO t2 (f1) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3;
+connection node_1;
+SELECT COUNT(f1) AS EXPECT_1000 FROM t2 WHERE MATCH(f1) AGAINST ('foobarbaz');
+EXPECT_1000
+1000
+UPDATE t2 SET f1 = 'abcdefjhk';
+connection node_2;
+SELECT COUNT(f1) AS EXPECT_1000 FROM t2 WHERE MATCH(f1) AGAINST ('abcdefjhk');
+EXPECT_1000
+1000
+connection node_1;
+DROP TABLE t2;
 DROP TABLE ten;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#8.test
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#8.test
@@ -1,13 +1,14 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
-
+--source include/force_restart.inc
+--source include/no_protocol.inc
 #
 # InnoDB FULLTEXT indexes
 #
 
 SET SESSION wsrep_trx_fragment_size = 1;
-CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
+CREATE TABLE ten (f1 INTEGER NOT NULL PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
 
 #
@@ -15,28 +16,28 @@ INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
 #
 
 --connection node_1
+SET SESSION wsrep_sync_wait=15;
 CREATE TABLE t1 (f1 INT PRIMARY KEY AUTO_INCREMENT, f2 VARCHAR(100), FULLTEXT (f2)) ENGINE=InnoDB;
 
 --connection node_2
-SELECT COUNT(*) = 13 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_13 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
 
 #
 # Fulltext insertion causes a flurry of updates on those system tables
 #
 
 --connection node_1
-# Insert 10K rows
+--echo # Insert 10K rows
 INSERT INTO t1 (f2) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4;
 
 --connection node_2
-SELECT COUNT(f2) = 10000 FROM t1 WHERE MATCH(f2) AGAINST ('foobarbaz');
+SELECT COUNT(f2) AS EXPECT_10000 FROM t1 WHERE MATCH(f2) AGAINST ('foobarbaz');
 
 UPDATE t1 SET f2 = 'abcdefjhk';
 
 --connection node_1
-SELECT COUNT(f2) = 10000 FROM t1 WHERE MATCH(f2) AGAINST ('abcdefjhk');
-
---connection node_2
+SELECT COUNT(f2) AS EXPECT_10000 FROM t1 WHERE MATCH(f2) AGAINST ('abcdefjhk');
 
 DROP TABLE t1;
 
@@ -44,20 +45,24 @@ DROP TABLE t1;
 # Same on a table with no PK
 #
 
---connection node_1
-CREATE TABLE t1 (f1 VARCHAR(100), FULLTEXT (f1)) ENGINE=InnoDB;
+# table test/ten is still there
+SELECT COUNT(*) AS EXPECT_1 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE name LIKE 'test/%';
+CREATE TABLE t2 (f1 VARCHAR(100), FULLTEXT (f1)) ENGINE=InnoDB;
 
 --connection node_2
-# We insert only 1K rows here, because updates without a PK are very slow
-INSERT INTO t1 (f1) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3;
+--echo # We insert only 1K rows here, because updates without a PK are very slow
+INSERT INTO t2 (f1) SELECT 'foobarbaz' FROM ten AS a1, ten AS a2, ten AS a3;
 
 --connection node_1
-SELECT COUNT(f1) = 1000 FROM t1 WHERE MATCH(f1) AGAINST ('foobarbaz');
+SELECT COUNT(f1) AS EXPECT_1000 FROM t2 WHERE MATCH(f1) AGAINST ('foobarbaz');
 
-UPDATE t1 SET f1 = 'abcdefjhk';
+UPDATE t2 SET f1 = 'abcdefjhk';
 
 --connection node_2
-SELECT COUNT(f1) = 1000 FROM t1 WHERE MATCH(f1) AGAINST ('abcdefjhk');
+SELECT COUNT(f1) AS EXPECT_1000 FROM t2 WHERE MATCH(f1) AGAINST ('abcdefjhk');
 
-DROP TABLE t1;
+--connection node_1
+DROP TABLE t2;
 DROP TABLE ten;
+
+--source include/galera_end.inc


### PR DESCRIPTION
wait_condition_with_debug does not have --disable-query-log. This causes ghost lines to result set. This test does not need any wait_conditions as we can use causal reads instead.