### PR TITLE
MDEV-39660 Replica Crashes on Malformed Partial_rows_log_event

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_fragment_row_event_errs.result
+++ b/mysql-test/suite/rpl/r/rpl_fragment_row_event_errs.result
@@ -33,7 +33,7 @@ insert into t1 values (2, repeat("a",3104));
 include/save_master_gtid.inc
 connection slave;
 include/wait_for_slave_sql_error.inc [errno=4253]
-Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found 2 / 4, expected Partial_rows_log_event 1 / 4'
+Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found fragment 2 / 4, expected fragment 1 / 4'
 connection master;
 set debug_dbug= @old_dbug;
 connection slave;
@@ -50,7 +50,7 @@ insert into t1 values (3, repeat("a",3104));
 include/save_master_gtid.inc
 connection slave;
 include/wait_for_slave_sql_error.inc [errno=4253]
-Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found 3 / 4, expected Partial_rows_log_event 2 / 4'
+Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found fragment 3 / 4, expected fragment 2 / 4'
 connection master;
 set debug_dbug= @old_dbug;
 connection slave;
@@ -67,7 +67,7 @@ insert into t1 values (4, repeat("a",3104));
 include/save_master_gtid.inc
 connection slave;
 include/wait_for_slave_sql_error.inc [errno=4253]
-Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found Xid, expected Partial_rows_log_event 4 / 4'
+Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found type Xid, expected fragment 4 / 4'
 connection master;
 set debug_dbug= @old_dbug;
 connection slave;
@@ -108,6 +108,44 @@ include/save_master_gtid.inc
 connection slave;
 include/wait_for_slave_sql_error.inc [errno=1594]
 Last_SQL_Error = 'Relay log read failure: Could not parse Rows_log_event re-assembled from Partial_rows_log_events. The possible reasons are: the master's binary log is corrupted (you can check this by running 'mysqlbinlog' on the binary log), the slave's relay log is corrupted (you can check this by running 'mysqlbinlog' on the relay log), a network problem, or a bug in the master's or slave's MariaDB code. If you want to check the master's binary log or slave's relay log, you will be able to know their names by issuing 'SHOW SLAVE STATUS' on this slave.'
+STOP SLAVE;
+include/wait_for_slave_to_stop.inc
+set @@global.debug_dbug= @old_dbug;
+include/start_slave.inc
+#
+#
+# Error Case 5) Corrupt original_event_size (smaller than actual row
+# data size)
+connection master;
+set @old_dbug= @@debug_dbug;
+set debug_dbug= "+d,too_small_orig_event_size";
+insert into t1 values (7, repeat("a",1536));
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=4253]
+Last_SQL_Error = 'Broken Partial_rows_log_event stream. Found row data size 1572, expected row data size 1316'
+connection master;
+set debug_dbug= @old_dbug;
+connection slave;
+STOP SLAVE;
+include/wait_for_slave_to_stop.inc
+set @@global.gtid_slave_pos= "0-1-7";
+include/start_slave.inc
+#
+#
+# Error Case 6) Emulate a 32-bit slave that can't re-construct a > 4GB
+# event
+connection slave;
+include/stop_slave.inc
+set @old_dbug= @@global.debug_dbug;
+set @@global.debug_dbug= "+d,mock_32_bit_slave";
+include/start_slave.inc
+connection master;
+insert into t1 values (8, repeat("a",1536));
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1037]
+Last_SQL_Error = 'Can't reconstruct original row event size of 1572 on 32-bit system'
 STOP SLAVE;
 include/wait_for_slave_to_stop.inc
 set @@global.debug_dbug= @old_dbug;

--- a/mysql-test/suite/rpl/t/rpl_fragment_row_event_errs.test
+++ b/mysql-test/suite/rpl/t/rpl_fragment_row_event_errs.test
@@ -180,6 +180,61 @@ set @@global.debug_dbug= @old_dbug;
 --source include/start_slave.inc
 
 --echo #
+--echo #
+--echo # Error Case 5) Corrupt original_event_size (smaller than actual row
+--echo # data size)
+--connection master
+set @old_dbug= @@debug_dbug;
+set debug_dbug= "+d,too_small_orig_event_size";
+--eval insert into t1 values ($ins_num, repeat("a",1536))
+--inc $ins_num
+--source include/save_master_gtid.inc
+--let $broken_gtid= `SELECT @@global.gtid_binlog_pos`
+
+--connection slave
+--let $slave_sql_errno=4253
+--let $show_slave_sql_error= 1
+--let $slave_timeout=5
+--source include/wait_for_slave_sql_error.inc
+
+--connection master
+set debug_dbug= @old_dbug;
+
+--connection slave
+STOP SLAVE;
+--let $rpl_allow_error= 1
+--source include/wait_for_slave_to_stop.inc
+--eval set @@global.gtid_slave_pos= "$broken_gtid"
+--source include/start_slave.inc
+
+--echo #
+--echo #
+--echo # Error Case 6) Emulate a 32-bit slave that can't re-construct a > 4GB
+--echo # event
+--connection slave
+--source include/stop_slave.inc
+set @old_dbug= @@global.debug_dbug;
+set @@global.debug_dbug= "+d,mock_32_bit_slave";
+--source include/start_slave.inc
+
+--connection master
+--eval insert into t1 values ($ins_num, repeat("a",1536))
+--inc $ins_num
+--source include/save_master_gtid.inc
+
+--connection slave
+--let $slave_sql_errno=1037
+--let $show_slave_sql_error= 1
+--let $slave_timeout=5
+--source include/wait_for_slave_sql_error.inc
+
+STOP SLAVE;
+--let $rpl_allow_error= 1
+--source include/wait_for_slave_to_stop.inc
+set @@global.debug_dbug= @old_dbug;
+--source include/start_slave.inc
+
+--echo #
 --echo # Cleanup
 --connection master
 drop table t1;

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -608,6 +608,18 @@ class String;
 */
 #define HB_SUB_HEADER_LEN 8
 
+// Len of "fragment %u / %u"
+#define PARTIAL_ROWS_EVENT_BAD_FRAGMENT_ERRSTR_LEN                            \
+  (sizeof("fragment ") + 10 + sizeof(" / ") + 10 + 1)
+
+// Len of "row data size %" PRIu64
+#define PARTIAL_ROWS_EVENT_BAD_ORIG_SIZE_ERRSTR_LEN                           \
+  (sizeof("row data size ") + 20 + 1)
+
+// Len of "type %s" where %s is Log_event::get_type_str()
+constexpr size_t MAX_LOG_EVENT_TYPE_STR_LEN= 25; // Log_event::get_type_str()
+#define PARTIAL_ROWS_EVENT_BAD_EV_TYPE_ERRSTR_LEN                             \
+  (sizeof("type ") + MAX_LOG_EVENT_TYPE_STR_LEN + 1)
 
 /**
   @enum Log_event_type
@@ -6107,6 +6119,7 @@ public:
   */
   uint32_t last_fragment_seen;
 
+  rpl_group_info *rgi;
 
   /*
     Memory buffer, initialized to the maximum size of the Rows_log_event
@@ -6115,7 +6128,11 @@ public:
   */
   char *rows_ev_buf_builder_ptr;
 
-  rpl_group_info *rgi;
+  /*
+    Size of rows_ev_buf_builder_ptr (i.e. the original_event_size taken from
+    the first fragment in the group)
+  */
+  uint64_t rows_ev_buf_len;
 
   /*
     Total length of the Rows_log_event to construct
@@ -6138,8 +6155,9 @@ public:
   my_bool row_ev_created;
 
   Rows_log_event_assembler(rpl_group_info *rgi, uint32_t total_fragments)
-      : last_fragment_seen(0), rows_ev_buf_builder_ptr(NULL), rgi(rgi),
-        total_fragments(total_fragments), row_ev_created(false){};
+      : last_fragment_seen(0), rgi(rgi), rows_ev_buf_builder_ptr(NULL),
+        rows_ev_buf_len(0), ev_len(0), total_fragments(total_fragments),
+        row_ev_created(false){};
 
   ~Rows_log_event_assembler()
   {

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -5978,7 +5978,9 @@ bool Partial_rows_log_event::write_data_header(Log_event_writer *writer)
   if(flags2 & FL_ORIG_EVENT_SIZE)
   {
     DBUG_ASSERT(original_event_size && seq_no == 1);
-    int8store(buf + header_size, original_event_size);
+    int8store(buf + header_size, DBUG_IF("too_small_orig_event_size")
+                                     ? original_event_size - 256
+                                     : original_event_size);
     header_size+= 8;
   }
 
@@ -6204,21 +6206,21 @@ Rows_log_event_fragmenter::fragment()
 }
 
 #ifdef HAVE_REPLICATION
-// Len of "%u / %u"
-#define PARTIAL_ROWS_EVENT_BAD_STREAM_ERRSTR_LEN (10 + 3 + 10 + 1)
 int Rows_log_event_assembler::append(Partial_rows_log_event *partial_ev)
 {
-  if ((partial_ev->total_fragments != this->total_fragments) ||
-      (partial_ev->seq_no != this->last_fragment_seen + 1))
+  if (unlikely((partial_ev->total_fragments != this->total_fragments) ||
+               (partial_ev->seq_no != this->last_fragment_seen + 1)))
   {
-    char buf[PARTIAL_ROWS_EVENT_BAD_STREAM_ERRSTR_LEN];
-    buf[PARTIAL_ROWS_EVENT_BAD_STREAM_ERRSTR_LEN - 1]= '\0';
-    my_snprintf(buf, sizeof(buf), "%u / %u", partial_ev->seq_no,
-                partial_ev->total_fragments);
+    char found_buf[PARTIAL_ROWS_EVENT_BAD_FRAGMENT_ERRSTR_LEN];
+    char expect_buf[PARTIAL_ROWS_EVENT_BAD_FRAGMENT_ERRSTR_LEN];
+    my_snprintf(found_buf, sizeof(found_buf), "fragment %u / %u",
+                partial_ev->seq_no, partial_ev->total_fragments);
+    my_snprintf(expect_buf, sizeof(expect_buf), "fragment %u / %u",
+                this->last_fragment_seen + 1, this->total_fragments);
     rgi->rli->report(ERROR_LEVEL, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM,
                      rgi->gtid_info(),
                      ER_THD(rgi->thd, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM),
-                     buf, this->last_fragment_seen + 1, this->total_fragments);
+                     found_buf, expect_buf);
     return ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM;
   }
 
@@ -6228,15 +6230,34 @@ int Rows_log_event_assembler::append(Partial_rows_log_event *partial_ev)
                 partial_ev->flags2 &
                     Partial_rows_log_event::FL_ORIG_EVENT_SIZE &&
                 partial_ev->original_event_size);
+
+    if (unlikely((sizeof(size_t) < sizeof(uint64_t) &&
+                  partial_ev->original_event_size >
+                      static_cast<uint64_t>(SIZE_MAX)) ||
+                 DBUG_IF("mock_32_bit_slave")))
+    {
+      /*
+        The error isn't actually ER_OUTOFMEMORY, but the error itself is not
+        practical enough to justify a new error code; so just re-use
+        ER_OUTOFMEMORY with a clear error message.
+      */
+      rgi->rli->report(ERROR_LEVEL, ER_OUTOFMEMORY, rgi->gtid_info(),
+                       "Can't reconstruct original row event size of %" PRIu64
+                       " on 32-bit system",
+                       partial_ev->original_event_size);
+      return ER_OUTOFMEMORY;
+    }
+
     rows_ev_buf_builder_ptr=
         DBUG_IF("oom_reassembling_large_rows_ev_buf")
             ? NULL
             : (char *) my_malloc(PSI_INSTRUMENT_ME,
                                  partial_ev->original_event_size, MYF(MY_WME));
     DBUG_EXECUTE("oom_reassembling_large_rows_ev_buf", my_errno= ENOMEM;);
+    rows_ev_buf_len= partial_ev->original_event_size;
     ev_len= 0;
   }
-  if (!rows_ev_buf_builder_ptr)
+  if (unlikely(!rows_ev_buf_builder_ptr))
   {
     my_error(ER_OUTOFMEMORY, MYF(0), total_fragments*partial_ev->get_rows_size());
     rgi->rli->report(
@@ -6247,6 +6268,23 @@ int Rows_log_event_assembler::append(Partial_rows_log_event *partial_ev)
         partial_ev->seq_no, partial_ev->total_fragments,
         rgi->thd->get_stmt_da()->message());
     return ER_OUTOFMEMORY;
+  }
+
+  if (unlikely(this->ev_len +
+                   static_cast<uint64_t>(partial_ev->get_rows_size()) >
+               this->rows_ev_buf_len))
+  {
+    char found_buf[PARTIAL_ROWS_EVENT_BAD_ORIG_SIZE_ERRSTR_LEN];
+    char expect_buf[PARTIAL_ROWS_EVENT_BAD_ORIG_SIZE_ERRSTR_LEN];
+    my_snprintf(found_buf, sizeof(found_buf), "row data size %" PRIu64,
+                this->ev_len + partial_ev->get_rows_size());
+    my_snprintf(expect_buf, sizeof(expect_buf), "row data size %" PRIu64,
+                this->rows_ev_buf_len);
+    rgi->rli->report(ERROR_LEVEL, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM,
+                     rgi->gtid_info(),
+                     ER_THD(rgi->thd, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM),
+                     found_buf, expect_buf);
+    return ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM;
   }
 
   memcpy(rows_ev_buf_builder_ptr + ev_len,

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12383,7 +12383,7 @@ ER_BINLOG_POS_INVALID
 ER_READING_BINLOG_FILE
 	eng "Error reading from page number %u in binlog file (error code: %d)"
 ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM
-        eng "Broken Partial_rows_log_event stream. Found %s, expected Partial_rows_log_event %u / %u"
+        eng "Broken Partial_rows_log_event stream. Found %s, expected %s"
 ER_SLAVE_INCOMPATIBLE_TABLE_DEF
         eng "Table structure for binlog event is not compatible with the table definition on this slave: %s"
 ER_UNSUPPORTED_DATA_TYPE_ATTRIBUTE

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -3630,11 +3630,16 @@ apply_event_and_update_pos_apply(Log_event* ev, THD* thd, rpl_group_info *rgi,
     if (rgi->assembler && ev->get_type_code() != PARTIAL_ROW_DATA_EVENT &&
         !ev->is_artificial_event() && !ev->is_relay_log_event())
     {
-      rgi->rli->report(
-          ERROR_LEVEL, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM, rgi->gtid_info(),
-          ER_THD(rgi->thd, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM),
-          ev->get_type_str(), rgi->assembler->last_fragment_seen + 1,
-          rgi->assembler->total_fragments);
+      char found_buf[PARTIAL_ROWS_EVENT_BAD_EV_TYPE_ERRSTR_LEN];
+      char expect_buf[PARTIAL_ROWS_EVENT_BAD_FRAGMENT_ERRSTR_LEN];
+      my_snprintf(found_buf, sizeof(found_buf), "type %s", ev->get_type_str());
+      my_snprintf(expect_buf, sizeof(expect_buf), "fragment %u / %u",
+                  rgi->assembler->last_fragment_seen + 1,
+                  rgi->assembler->total_fragments);
+      rgi->rli->report(ERROR_LEVEL, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM,
+                       rgi->gtid_info(),
+                       ER_THD(rgi->thd, ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM),
+                       found_buf, expect_buf);
       exec_res= ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM;
 
       rgi->assembler->~Rows_log_event_assembler();


### PR DESCRIPTION
If the first Partial_rows_log_event in a group provides an original_event_size that is smaller than the actual size of the underlying Rows_log_event, the slave will not allocate enough memory to hold the actual Rows_log_event content, but still try to copy that much memory, resulting in the slave crashing.

This patch adds validation checking for this condition, and will error with code ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM when detected.

Additionally, the error message for ER_PARTIAL_ROWS_LOG_EVENT_BAD_STREAM is generalized to better support various types of broken streams. The previous message was hard-coded to be about detecting out-of-sequence fragments. The new message is updated to allow general "found %s" and "expected %s" conditions.