### PR TITLE
MDEV-39662 : Wrong results sent to client after BF abort

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -3441,6 +3441,14 @@ bool select_send::send_eof()
   if (unlikely(thd->lex->sql_command != SQLCOM_SELECT))
     goto end;                                   // For DELETE RETURNING
 
+  /*
+    A WSREP connection may encounter a deadlock error because of MDL
+    conflict after the early eof is sent below. Therefore the early eof
+    is unsafe for WSREP.
+   */
+  if (WSREP(thd))
+    goto end;
+
   if (likely(!thd->transaction->stmt.is_trx_read_write()))
   {
     /*


### PR DESCRIPTION
This issue is regression caused by MDEV-38019 Send ok packet to client earlier.

BF aborts may be detected very late in command exectution, somewhere near the end of do_command(). If the ok packet has already been sent and BF abort is detected very late, this could cause the protocol packets becoming out of sync.

This is a result of reverting order of releasing MDL and sending ok packet to the client. If it happens in the opposite order than before, there will remain some time window where the select is complete and MDL locks still held. DROP hits that time window, causing a BF abort, and extra error packet gets injected into client-server communication stream.

Fixed by not sending ok packet to client earlier
in wsrep case.

There is a repeatable test case that shows failure if ok packet is sent client earlier by using
debug sync point. However, this fix skips sending ok packet earlier causing also skipping the sync
point. Therefore, test case is not usable.

Test case galera_sr.mysql-wsrep-features#8 was failing because of this regression but it is sporadic.

Co-Authored by : Teemu Ollakka <teemu.ollakka@mariadb.com>