### PR TITLE
MDEV-39438: Empty optimizer context is noticed after an explain query

### DIFF
--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -848,3 +848,58 @@ CALL p1;
 f1
 DROP PROCEDURE p1;
 DROP TABLE t1,t2;
+#
+# MDEV-39438: Empty optimizer_context with use_stat_tables=PREFERABLY
+# and a stored procedure in the query
+#
+set @saved_use_stat_tables=@@use_stat_tables;
+SET use_stat_tables = 'PREFERABLY';
+CREATE TABLE t1 (a INT, b INT, KEY(a));
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+create function add1(i int) returns int deterministic
+return i+1;
+set optimizer_record_context=1;
+explain select * from t1 where b < add1(3);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	Using where
+set @opt_context=
+(select REGEXP_SUBSTR(
+context,
+'(?<=set @opt_context=\')([\n\r].*)*(?=\'\;#opt_context_ends)')
+from information_schema.optimizer_context);
+set @records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+3
+set @file_stat_records=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.file_stat_records')));
+select *from json_table(@file_stat_records,
+'$[*]' columns(file_stat_records text path '$')) as jt;
+file_stat_records
+3
+set @indexes=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.indexes')));
+select *from json_table(
+@indexes, '$[*][*]' columns(index_name text path '$.index_name',
+rec_per_key json path '$.rec_per_key')) as jt;
+index_name	rec_per_key
+a	["1"]
+set @list_ranges=
+(select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.list_ranges')));
+select *from json_table(
+@list_ranges,
+'$[*][*]' columns(index_name text path '$.index_name',
+ranges json path '$.ranges',
+num_rows int path '$.num_rows',
+max_index_blocks int path '$.max_index_blocks',
+max_row_blocks int path '$.max_row_blocks')) as jt;
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+drop function add1;
+DROP TABLE t1;
+set session use_stat_tables=@saved_use_stat_tables;

--- a/mysql-test/main/opt_context_store_stats.test
+++ b/mysql-test/main/opt_context_store_stats.test
@@ -400,3 +400,24 @@ CALL p1; ###CRASH
 DROP PROCEDURE p1;
 DROP TABLE t1,t2;
 
+--echo #
+--echo # MDEV-39438: Empty optimizer_context with use_stat_tables=PREFERABLY
+--echo # and a stored procedure in the query
+--echo #
+set @saved_use_stat_tables=@@use_stat_tables;
+SET use_stat_tables = 'PREFERABLY';
+CREATE TABLE t1 (a INT, b INT, KEY(a));
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+
+analyze table t1;
+
+create function add1(i int) returns int deterministic
+  return i+1;
+
+set optimizer_record_context=1;
+explain select * from t1 where b < add1(3);
+--source include/get_rec_idx_ranges_from_opt_ctx.inc
+
+drop function add1;
+DROP TABLE t1;
+set session use_stat_tables=@saved_use_stat_tables;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2496,6 +2496,10 @@ void THD::cleanup_after_query()
       (not just in the end of a stored routine individual statement).
     */
     statement_rcontext_reinit();
+    delete opt_ctx_recorder;
+    opt_ctx_recorder= NULL;
+    delete opt_ctx_replay;
+    opt_ctx_replay= NULL;
   }
 
   /*
@@ -2563,10 +2567,6 @@ void THD::cleanup_after_query()
     wsrep_affected_rows= 0;
 #endif /* WITH_WSREP */
   gap_tracker_data.init();
-  delete opt_ctx_recorder;
-  opt_ctx_recorder= NULL;
-  delete opt_ctx_replay;
-  opt_ctx_replay= NULL;
   DBUG_VOID_RETURN;
 }
 


### PR DESCRIPTION
When the variable "use_stat_tables" is set to 'preferably', the explain plan query containing a stored procedure generated no context, even when the optimizer_record_context flag was set.

The reason being context recorder (for the entire query) was getting cleared after the stored procedure evaluation was done.

The solution is to not clear the context recorder as soon as the stored procedure evaluation is finished.