### PR TITLE
MDEV-39597: Remove save/restore of proc_info in free_tmp_table

### DIFF
--- a/mysql-test/main/mdev-39597.result
+++ b/mysql-test/main/mdev-39597.result
@@ -1,0 +1,31 @@
+#
+# MDEV-39597: SHOW PROFILE reports duplicate sending data
+# stage for INSERT...SELECT due to save/restore in free_tmp_table
+#
+CREATE TABLE profile_test (
+id INT PRIMARY KEY AUTO_INCREMENT,
+name VARCHAR(100),
+value INT
+);
+INSERT INTO profile_test (name, value) VALUES
+('alpha',1),('beta',2),('gamma',3),('delta',4),('epsilon',5),
+('zeta',6),('eta',7),('theta',8),('iota',9),('kappa',10);
+SET profiling = 1;
+INSERT INTO profile_test (name, value)
+SELECT name, value FROM profile_test LIMIT 5;
+# Check that no stage appears twice consecutivley around removing tmp table
+SELECT COUNT(*) AS duplicate_stage_found
+FROM (
+SELECT
+STATE,
+LAG(STATE) OVER (ORDER BY SEQ) AS prev_status,
+LEAD(STATE) OVER (ORDER BY SEQ) AS next_status
+FROM information_schema.profiling
+WHERE QUERY_ID = 1
+) t
+WHERE STATE = 'Removing tmp table'
+AND prev_status = next_status;
+duplicate_stage_found
+0
+SET profiling = 0;
+DROP TABLE profile_test;

--- a/mysql-test/main/mdev-39597.test
+++ b/mysql-test/main/mdev-39597.test
@@ -1,0 +1,39 @@
+--echo #
+--echo # MDEV-39597: SHOW PROFILE reports duplicate sending data
+--echo # stage for INSERT...SELECT due to save/restore in free_tmp_table
+--echo #
+
+--source include/have_profiling.inc
+--disable_ps2_protocol
+
+CREATE TABLE profile_test (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(100),
+  value INT
+);
+INSERT INTO profile_test (name, value) VALUES
+  ('alpha',1),('beta',2),('gamma',3),('delta',4),('epsilon',5),
+  ('zeta',6),('eta',7),('theta',8),('iota',9),('kappa',10);
+SET profiling = 1;
+INSERT INTO profile_test (name, value)
+  SELECT name, value FROM profile_test LIMIT 5;
+
+--echo # Check that no stage appears twice consecutivley around removing tmp table
+
+SELECT COUNT(*) AS duplicate_stage_found
+FROM (
+  SELECT
+    STATE,
+    LAG(STATE) OVER (ORDER BY SEQ) AS prev_status,
+    LEAD(STATE) OVER (ORDER BY SEQ) AS next_status
+  FROM information_schema.profiling
+  WHERE QUERY_ID = 1
+) t
+WHERE STATE = 'Removing tmp table'
+AND prev_status = next_status;
+
+--enable_ps2_protocol
+
+# clean up
+SET profiling = 0;
+DROP TABLE profile_test;

--- a/mysql-test/main/query_cache_executable_comments.test
+++ b/mysql-test/main/query_cache_executable_comments.test
@@ -1,6 +1,9 @@
 --source include/have_query_cache.inc
 --source include/not_embedded.inc
-
+if (!$QUERY_CACHE_INFO_SO)
+{
+  --skip Need query_cache_info plugin
+}
 --disable_ps_protocol
 --disable_ps2_protocol
 --disable_cursor_protocol

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -23932,12 +23932,10 @@ void
 free_tmp_table(THD *thd, TABLE *entry)
 {
   MEM_ROOT own_root= entry->mem_root;
-  const char *save_proc_info;
   DBUG_ENTER("free_tmp_table");
   DBUG_PRINT("enter",("table: %s  alias: %s",entry->s->table_name.str,
                       entry->alias.c_ptr()));
 
-  save_proc_info=thd->proc_info;
   THD_STAGE_INFO(thd, stage_removing_tmp_table);
 
   if (entry->file && entry->is_created())
@@ -23980,7 +23978,6 @@ free_tmp_table(THD *thd, TABLE *entry)
   }
 
   free_root(&own_root, MYF(0)); /* the table is allocated in its own root */
-  thd_proc_info(thd, save_proc_info);
 
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
### MDEV-39597: Remove save/restore of proc_info in free_tmp_table
**Problem**
```SHOW PROFILE``` reports duplicate stage entries for ```INSERT...SELECT``` queries. The duplicate appears immediately after "Removing tmp table" and is caused by a save/restore pattern in ```free_tmp_table``` that blindly restores the previous stage name on exit, regardless of whether that stage is still accurate.
The same pattern implicitly also caused a duplicate "Creating sort index" entry in ```GROUP BY``` with filesort queries.
**Fix**
Removed the save and restore of proc_info in ```free_tmp_table```. The "Removing tmp table" stage now remains active until the caller sets the next stage.
**Trade-off**
"Removing tmp table" will now appear slightly longer in profiles as it remains active briefly after the function returns. This is considered less misleading than restoring an incorrect stage name.
**Scope**
```free_tmp_table``` is called from multiple files. A broader audit of all call sites is out of scope for this fix:
``` bash
grep -rn "free_tmp_table" sql/ --include="*.cc" -l
```
**Further investigation**
The same save/restore pattern appears in other locations in the codebase. I intend to investigate these separately, any guidance on what to prioritise or test would be welcome.

**SHOW PROFILE results  abbreviated:**
----
Before (INSERT...SELECT)

| Sending data           | 0.002404 |
| Removing tmp table     | 0.000098 |
| Sending data           | 0.000079 |  ← duplicate
| End of update loop     | 0.000074 |

----
After

| Sending data           | 0.002482 |
| Removing tmp table     | 0.000172 |
| End of update loop     | 0.000077 |

----
Provided under BSD New 3 Clause License.