### PR TITLE
MDEV-39603 Convert HASH interface from uchar* to void*

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -855,10 +855,10 @@ static void write_footer(FILE *sql_file)
 } /* write_footer */
 
 
-const uchar *get_table_key(const void *entry, size_t *length,
-                           my_bool not_used __attribute__((unused)))
+const void *get_table_key(const void *entry, size_t *length,
+                          my_bool not_used __attribute__((unused)))
 {
-  *length= strlen(entry);
+  *length= strlen((const char*) entry);
   return entry;
 }
 

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -2774,12 +2774,10 @@ static void strip_parentheses(struct st_command *command)
 
 C_MODE_START
 
-static const uchar *get_var_key(const void *var, size_t *len, my_bool)
+static const void *get_var_key(const void *var, size_t *len, my_bool)
 {
-  char* key;
-  key= (static_cast<const VAR *>(var))->name;
   *len= (static_cast<const VAR *>(var))->name_len;
-  return reinterpret_cast<const uchar *>(key);
+  return (static_cast<const VAR *>(var))->name;
 }
 
 

--- a/extra/mariabackup/xbstream.cc
+++ b/extra/mariabackup/xbstream.cc
@@ -365,12 +365,12 @@ err:
 }
 
 static
-const uchar *
+const void *
 get_file_entry_key(const void *entry_, size_t *length, my_bool)
 {
   const file_entry_t *entry= static_cast<const file_entry_t *>(entry_);
   *length= entry->pathlen;
-  return reinterpret_cast<const uchar *>(entry->path);
+  return entry->path;
 }
 
 static

--- a/include/hash.h
+++ b/include/hash.h
@@ -42,7 +42,7 @@ extern "C" {
 #define HASH_THREAD_SPECIFIC 2  /* Mark allocated memory THREAD_SPECIFIC */
 
 typedef uint32 my_hash_value_type;
-typedef const uchar *(*my_hash_get_key)(const void *, size_t *, my_bool);
+typedef const void *(*my_hash_get_key)(const void *, size_t *, my_bool);
 typedef my_hash_value_type (*my_hash_function)(CHARSET_INFO *,
                                                const uchar *, size_t);
 typedef void (*my_hash_free_key)(void *);
@@ -71,28 +71,28 @@ my_bool my_hash_init2(PSI_memory_key psi_key, HASH *hash, size_t growth_size,
                       void (*free_element)(void*), uint flags);
 void my_hash_free(HASH *tree);
 void my_hash_reset(HASH *hash);
-uchar *my_hash_element(HASH *hash, size_t idx);
-uchar *my_hash_search(const HASH *info, const uchar *key, size_t length);
-uchar *my_hash_search_using_hash_value(const HASH *info,
-                                       my_hash_value_type hash_value,
-                                       const uchar *key, size_t length);
+void *my_hash_element(HASH *hash, size_t idx);
+void *my_hash_search(const HASH *info, const uchar *key, size_t length);
+void *my_hash_search_using_hash_value(const HASH *info,
+                                      my_hash_value_type hash_value,
+                                      const uchar *key, size_t length);
 my_hash_value_type my_hash_sort(CHARSET_INFO *cs,
                                 const uchar *key, size_t length);
 #define my_calc_hash(A, B, C) my_hash_sort((A)->charset, B, C)
-uchar *my_hash_first(const HASH *info, const uchar *key, size_t length,
-                     HASH_SEARCH_STATE *state);
-uchar *my_hash_first_from_hash_value(const HASH *info,
-                                     my_hash_value_type hash_value,
-                                     const uchar *key,
-                                     size_t length,
-                                     HASH_SEARCH_STATE *state);
-uchar *my_hash_next(const HASH *info, const uchar *key, size_t length,
+void *my_hash_first(const HASH *info, const uchar *key, size_t length,
                     HASH_SEARCH_STATE *state);
-my_bool my_hash_insert(HASH *info, const uchar *data);
-my_bool my_hash_delete(HASH *hash, uchar *record);
-my_bool my_hash_update(HASH *hash, uchar *record, uchar *old_key,
+void *my_hash_first_from_hash_value(const HASH *info,
+                                    my_hash_value_type hash_value,
+                                    const uchar *key,
+                                    size_t length,
+                                    HASH_SEARCH_STATE *state);
+void *my_hash_next(const HASH *info, const uchar *key, size_t length,
+                   HASH_SEARCH_STATE *state);
+my_bool my_hash_insert(HASH *info, const void *data);
+my_bool my_hash_delete(HASH *hash, void *record);
+my_bool my_hash_update(HASH *hash, void *record, uchar *old_key,
                        size_t old_key_length);
-void my_hash_replace(HASH *hash, HASH_SEARCH_STATE *state, uchar *new_row);
+void my_hash_replace(HASH *hash, HASH_SEARCH_STATE *state, void *new_row);
 my_bool my_hash_check(HASH *hash); /* Only in debug library */
 my_bool my_hash_iterate(HASH *hash, my_hash_walk_action action, void *argument);
 

--- a/mysys/charset.c
+++ b/mysys/charset.c
@@ -690,12 +690,17 @@ const char *my_collation_get_tailoring(uint id)
 
 HASH charset_name_hash;
 
-static const uchar *get_charset_key(const void *object, size_t *size,
-                                    my_bool not_used __attribute__((unused)))
+static const void *get_charset_key(const void *object, size_t *size,
+                                   my_bool not_used __attribute__((unused)))
+
+
+
+
+
 {
   CHARSET_INFO *cs= object;
   *size= cs->cs_name.length;
-  return (const uchar*) cs->cs_name.str;
+  return cs->cs_name.str;
 }
 
 static void init_available_charsets(void)

--- a/mysys/hash.c
+++ b/mysys/hash.c
@@ -32,7 +32,7 @@
 typedef struct st_hash_info {
   uint32 next;					/* index to next key */
   my_hash_value_type hash_nr;
-  uchar *data;					/* data for current entry */
+  void *data;					/* data for current entry */
 } HASH_LINK;
 
 static uint my_hash_mask(my_hash_value_type hashnr,
@@ -190,7 +190,7 @@ void my_hash_reset(HASH *hash)
 */
 
 static inline char*
-my_hash_key(const HASH *hash, const uchar *record, size_t *length,
+my_hash_key(const HASH *hash, const void *record, size_t *length,
             my_bool first)
 {
   if (hash->get_key)
@@ -222,7 +222,7 @@ static
 #if !defined(__USLC__) && !defined(__sgi)
 inline
 #endif
-my_hash_value_type rec_hashnr(HASH *hash,const uchar *record)
+my_hash_value_type rec_hashnr(HASH *hash, const void *record)
 {
   size_t length;
   uchar *key= (uchar*) my_hash_key(hash, record, &length, 0);
@@ -230,16 +230,16 @@ my_hash_value_type rec_hashnr(HASH *hash,const uchar *record)
 }
 
 
-uchar* my_hash_search(const HASH *hash, const uchar *key, size_t length)
+void* my_hash_search(const HASH *hash, const uchar *key, size_t length)
 {
   HASH_SEARCH_STATE state;
   return my_hash_first(hash, key, length, &state);
 }
 
-uchar* my_hash_search_using_hash_value(const HASH *hash, 
-                                       my_hash_value_type hash_value,
-                                       const uchar *key,
-                                       size_t length)
+void* my_hash_search_using_hash_value(const HASH *hash,
+                                      my_hash_value_type hash_value,
+                                      const uchar *key,
+                                      size_t length)
 {
   HASH_SEARCH_STATE state;
   return my_hash_first_from_hash_value(hash, hash_value,
@@ -254,10 +254,10 @@ uchar* my_hash_search_using_hash_value(const HASH *hash,
    Assigns the number of the found record to HASH_SEARCH_STATE state
 */
 
-uchar* my_hash_first(const HASH *hash, const uchar *key, size_t length,
-                     HASH_SEARCH_STATE *current_record)
+void* my_hash_first(const HASH *hash, const uchar *key, size_t length,
+                    HASH_SEARCH_STATE *current_record)
 {
-  uchar *res;
+  void *res;
   DBUG_ASSERT(my_hash_inited(hash));
 
   res= my_hash_first_from_hash_value(hash,
@@ -269,11 +269,11 @@ uchar* my_hash_first(const HASH *hash, const uchar *key, size_t length,
 }
 
 
-uchar* my_hash_first_from_hash_value(const HASH *hash,
-                                     my_hash_value_type hash_value,
-                                     const uchar *key,
-                                     size_t length,
-                                     HASH_SEARCH_STATE *current_record)
+void* my_hash_first_from_hash_value(const HASH *hash,
+                                    my_hash_value_type hash_value,
+                                    const uchar *key,
+                                    size_t length,
+                                    HASH_SEARCH_STATE *current_record)
 {
   HASH_LINK *pos;
   DBUG_ENTER("my_hash_first_from_hash_value");
@@ -310,8 +310,8 @@ uchar* my_hash_first_from_hash_value(const HASH *hash,
 	/* Get next record with identical key */
 	/* Can only be called if previous calls was my_hash_search */
 
-uchar* my_hash_next(const HASH *hash, const uchar *key, size_t length,
-                    HASH_SEARCH_STATE *current_record)
+void* my_hash_next(const HASH *hash, const uchar *key, size_t length,
+                   HASH_SEARCH_STATE *current_record)
 {
   HASH_LINK *pos;
   uint idx;
@@ -392,7 +392,7 @@ static int hashcmp(const HASH *hash, HASH_LINK *pos, const uchar *key,
    @retval  1  Duplicate key or out of memory
 */
 
-my_bool my_hash_insert(HASH *info, const uchar *record)
+my_bool my_hash_insert(HASH *info, const void *record)
 {
   int flag;
   size_t idx, halfbuff, first_index;
@@ -532,7 +532,7 @@ my_bool my_hash_insert(HASH *info, const uchar *record)
       movelink(data,(uint) (pos-data),(uint) (gpos-data),(uint) (empty-data));
     }
   }
-  pos->data=    (uchar*) record;
+  pos->data=    (void*) record;
   pos->hash_nr= current_hash_nr;
   if (++info->records == info->blength)
     info->blength+= info->blength;
@@ -559,7 +559,7 @@ my_bool my_hash_insert(HASH *info, const uchar *record)
    @retval  1 Record not found
 */
 
-my_bool my_hash_delete(HASH *hash, uchar *record)
+my_bool my_hash_delete(HASH *hash, void *record)
 {
   uint pos2,idx,empty_index;
   my_hash_value_type pos_hashnr, lastpos_hashnr;
@@ -638,7 +638,7 @@ my_bool my_hash_delete(HASH *hash, uchar *record)
 exit:
   (void) pop_dynamic(&hash->array);
   if (hash->free)
-    (*hash->free)((uchar*) record);
+    (*hash->free)(record);
   DBUG_RETURN(0);
 }
 
@@ -648,7 +648,7 @@ exit:
    This is much more efficient than using a delete & insert.
 */
 
-my_bool my_hash_update(HASH *hash, uchar *record, uchar *old_key,
+my_bool my_hash_update(HASH *hash, void *record, uchar *old_key,
                        size_t old_key_length)
 {
   uint new_index, new_pos_index, org_index, records, idx;
@@ -660,11 +660,11 @@ my_bool my_hash_update(HASH *hash, uchar *record, uchar *old_key,
 
   new_key= (uchar*) my_hash_key(hash, record, &length, 1);
   hash_nr= hash->hash_function(hash->charset, new_key, length);
-  
+
   if (HASH_UNIQUE & hash->flags)
   {
     HASH_SEARCH_STATE state;
-    uchar *found;
+    void *found;
 
     if ((found= my_hash_first_from_hash_value(hash, hash_nr, new_key, length,
                                               &state)))
@@ -763,7 +763,7 @@ my_bool my_hash_update(HASH *hash, uchar *record, uchar *old_key,
 }
 
 
-uchar *my_hash_element(HASH *hash, size_t idx)
+void *my_hash_element(HASH *hash, size_t idx)
 {
   if (idx < hash->records)
     return dynamic_element(&hash->array,idx,HASH_LINK*)->data;
@@ -777,7 +777,7 @@ uchar *my_hash_element(HASH *hash, size_t idx)
 */
 
 void my_hash_replace(HASH *hash, HASH_SEARCH_STATE *current_record,
-                     uchar *new_row)
+                     void *new_row)
 {
   if (*current_record != NO_RECORD)            /* Safety */
     dynamic_element(&hash->array, *current_record, HASH_LINK*)->data= new_row;
@@ -886,8 +886,8 @@ my_bool my_hash_check(HASH *hash)
 
 #define RECORDS 1000
 
-const uchar *test_get_key(const void *data, size_t *length,
-                          my_bool not_used __attribute__((unused)))
+const void *test_get_key(const void *data, size_t *length,
+                         my_bool not_used __attribute__((unused)))
 {
   *length= 2;
   return data;

--- a/mysys/lf_hash.cc
+++ b/mysys/lf_hash.cc
@@ -309,7 +309,7 @@ static inline const uchar* hash_key(const LF_HASH *hash,
                                     const uchar *record, size_t *length)
 {
   if (hash->get_key)
-    return (*hash->get_key)(record, length, 0);
+    return static_cast<const uchar*>((*hash->get_key)(record, length, 0));
   *length= hash->key_length;
   return record + hash->key_offset;
 }

--- a/mysys/my_likely.c
+++ b/mysys/my_likely.c
@@ -35,12 +35,12 @@ typedef struct st_likely_entry
   ulonglong ok,fail;
 } LIKELY_ENTRY;
 
-static const uchar *get_likely_key(const void *part_, size_t *length,
-                                   my_bool not_used __attribute__((unused)))
+static const void *get_likely_key(const void *part_, size_t *length,
+                                  my_bool not_used __attribute__((unused)))
 {
   const LIKELY_ENTRY *part= (const LIKELY_ENTRY *) part_;
   *length= part->key_length;
-  return (const uchar *) part->key;
+  return part->key;
 }
 
 pthread_mutex_t likely_mutex;

--- a/mysys/my_safehash.c
+++ b/mysys/my_safehash.c
@@ -71,9 +71,9 @@ static void safe_hash_entry_free(void *entry_)
     #  reference on the key
 */
 
-static const uchar *safe_hash_entry_get(const void *entry_, size_t *length,
-                                        my_bool not_used
-                                        __attribute__((unused)))
+static const void *safe_hash_entry_get(const void *entry_, size_t *length,
+                                       my_bool not_used
+                                       __attribute__((unused)))
 {
   const SAFE_HASH_ENTRY *entry= entry_;
   *length= entry->length;

--- a/plugin/qc_info/qc_info.cc
+++ b/plugin/qc_info/qc_info.cc
@@ -137,7 +137,7 @@ static int qc_info_fill_table(THD *thd, TABLE_LIST *tables,
   /* loop through all queries in the query cache */
   for (uint i= 0; i < queries->records; i++)
   {
-    const uchar *query_cache_block_raw;
+    const void *query_cache_block_raw;
     Query_cache_block* query_cache_block;
     Query_cache_query* query_cache_query;
     Query_cache_query_flags flags;

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -3906,13 +3906,13 @@ mysql_options(MYSQL *mysql,enum mysql_option option, const void *arg)
 /**
   A function to return the key from a connection attribute
 */
-const uchar *
+const void *
 get_attr_key(const void *part_, size_t *length,
              my_bool not_used __attribute__((unused)))
 {
   const LEX_STRING *part= part_;
   *length= part[0].length;
-  return (const uchar *) part[0].str;
+  return part[0].str;
 }
 
 int STDCALL

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -105,11 +105,11 @@ struct st_debug_sync_globals
   }
 
   /* Hash key function for ds_signal_set. */
-  static const uchar *signal_key(const void *str_, size_t *klen, my_bool)
+  static const void *signal_key(const void *str_, size_t *klen, my_bool)
   {
     const LEX_CSTRING *str= static_cast<const LEX_CSTRING*>(str_);
     *klen= str->length;
-    return reinterpret_cast<const uchar*>(str->str);
+    return str->str;
   }
 
   /**

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -3515,7 +3515,7 @@ bool ha_partition::re_create_par_file(const char *name)
   @return Partition name
 */
 
-static const uchar *get_part_name(const void *part_, size_t *length, my_bool)
+static const void *get_part_name(const void *part_, size_t *length, my_bool)
 {
   auto part= reinterpret_cast<const PART_NAME_DEF *>(part_);
   *length= part->length;

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -39,12 +39,12 @@
 #include <mysql/plugin_function.h>
 
 
-extern "C" const uchar *get_native_fct_hash_key(const void *buff,
-                                                size_t *length, my_bool)
+extern "C" const void *get_native_fct_hash_key(const void *buff,
+                                               size_t *length, my_bool)
 {
   auto func= static_cast<const Native_func_registry *>(buff);
   *length= func->name.length;
-  return reinterpret_cast<const uchar *>(func->name.str);
+  return func->name.str;
 }
 
 

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4180,7 +4180,7 @@ public:
 
 /** Extract a hash key from User_level_lock. */
 
-const uchar *ull_get_key(const void *ptr, size_t *length, my_bool)
+const void *ull_get_key(const void *ptr, size_t *length, my_bool)
 {
   User_level_lock *ull = (User_level_lock*) ptr;
   MDL_key *key = ull->lock->get_key();

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -703,7 +703,7 @@ static MDL_map mdl_locks;
 
 extern "C"
 {
-static const uchar *mdl_locks_key(const void *record, size_t *length,
+static const void *mdl_locks_key(const void *record, size_t *length,
                                   my_bool)
 {
   const MDL_lock *lock= static_cast<const MDL_lock *>(record);

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -672,11 +672,11 @@ partition_element *partition_info::get_part_elem(const char *partition_name,
   Helper function to find_duplicate_name.
 */
 
-static const uchar *get_part_name_from_elem(const void *name, size_t *length,
-                                            my_bool)
+static const void *get_part_name_from_elem(const void *name, size_t *length,
+                                           my_bool)
 {
   *length= strlen(static_cast<const char *>(name));
-  return static_cast<const uchar *>(name);
+  return name;
 }
 
 /*

--- a/sql/rpl_filter.cc
+++ b/sql/rpl_filter.cc
@@ -652,14 +652,14 @@ Rpl_filter::set_ignore_db(const char* db_spec)
 }
 
 
-extern "C" const uchar *get_table_key(const void *, size_t *, my_bool);
+extern "C" const void *get_table_key(const void *, size_t *, my_bool);
 extern "C" void free_table_ent(void* a);
 
-const uchar *get_table_key(const void *a, size_t *len, my_bool)
+const void *get_table_key(const void *a, size_t *len, my_bool)
 {
   auto e= static_cast<const TABLE_RULE_ENT *>(a);
   *len= e->key_len;
-  return reinterpret_cast<const uchar *>(e->db);
+  return e->db;
 }
 
 

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -1133,7 +1133,7 @@ rpl_slave_state::iterate(int (*cb)(rpl_gtid *, void *), void *data,
 {
   uint32 i;
   HASH gtid_hash;
-  uchar *rec;
+  void *rec;
   rpl_gtid *gtid;
   int res= 1;
   bool locked= false;
@@ -2435,8 +2435,8 @@ int
 slave_connection_state::update(const rpl_gtid *in_gtid)
 {
   entry *e;
-  uchar *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
-                             sizeof(in_gtid->domain_id));
+  void *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
+                            sizeof(in_gtid->domain_id));
   if (rec)
   {
     e= (entry *)rec;
@@ -2461,8 +2461,8 @@ slave_connection_state::update(const rpl_gtid *in_gtid)
 void
 slave_connection_state::remove(const rpl_gtid *in_gtid)
 {
-  uchar *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
-                             sizeof(in_gtid->domain_id));
+  void *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
+                            sizeof(in_gtid->domain_id));
 #ifdef DBUG_ASSERT_EXISTS
   bool err;
   rpl_gtid *slave_gtid= &((entry *)rec)->gtid;
@@ -2479,8 +2479,8 @@ slave_connection_state::remove(const rpl_gtid *in_gtid)
 void
 slave_connection_state::remove_if_present(const rpl_gtid *in_gtid)
 {
-  uchar *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
-                             sizeof(in_gtid->domain_id));
+  void *rec= my_hash_search(&hash, (const uchar *)(&in_gtid->domain_id),
+                            sizeof(in_gtid->domain_id));
   if (rec)
     my_hash_delete(&hash, rec);
 }

--- a/sql/rpl_mi.cc
+++ b/sql/rpl_mi.cc
@@ -872,12 +872,12 @@ void end_master_info(Master_info* mi)
 }
 
 /* Multi-Master By P.Linux */
-const uchar *get_key_master_info(const void *mi_, size_t *length, my_bool)
+const void *get_key_master_info(const void *mi_, size_t *length, my_bool)
 {
   auto mi= static_cast<const Master_info *>(mi_);
   /* Return lower case name */
   *length= mi->cmp_connection_name.length;
-  return reinterpret_cast<const uchar *>(mi->cmp_connection_name.str);
+  return mi->cmp_connection_name.str;
 }
 
 /*

--- a/sql/rpl_mi.h
+++ b/sql/rpl_mi.h
@@ -481,8 +481,8 @@ void create_logfile_name_with_suffix(char *res_file_name, size_t length,
                              bool append,
                              LEX_CSTRING *suffix);
 
-uchar *get_key_master_info(Master_info *mi, size_t *length,
-                           my_bool not_used __attribute__((unused)));
+const void *get_key_master_info(const void *mi, size_t *length,
+                                my_bool not_used __attribute__((unused)));
 void free_key_master_info(Master_info *mi);
 uint any_slave_sql_running(bool already_locked);
 bool give_error_if_slave_running(bool already_lock);

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -1602,7 +1602,7 @@ scan_one_gtid_slave_pos_table(THD *thd, HASH *hash, DYNAMIC_ARRAY *array,
   {
     uint32 domain_id, server_id;
     uint64 sub_id, seq_no;
-    uchar *rec;
+    void *rec;
 
     if ((err= table->file->ha_rnd_next(table->record[0])))
     {

--- a/sql/session_tracker.cc
+++ b/sql/session_tracker.cc
@@ -558,12 +558,11 @@ void Session_sysvars_tracker::mark_as_changed(THD *thd, const sys_var *var)
   @return Pointer to the key buffer.
 */
 
-const uchar *Session_sysvars_tracker::sysvars_get_key(const void *entry,
-                                                      size_t *length, my_bool)
+const void *Session_sysvars_tracker::sysvars_get_key(const void *entry,
+                                                     size_t *length, my_bool)
 {
   *length= sizeof(sys_var *);
-  return reinterpret_cast<const uchar *>(
-      &((static_cast<const sysvar_node_st *>(entry))->m_svar));
+  return &((static_cast<const sysvar_node_st *>(entry))->m_svar);
 }
 
 

--- a/sql/session_tracker.h
+++ b/sql/session_tracker.h
@@ -217,8 +217,8 @@ public:
   void mark_as_changed(THD *thd, const sys_var *var);
   void deinit() { orig_list.deinit(); }
   /* callback */
-  static const uchar *sysvars_get_key(const void *entry, size_t *length,
-                                      my_bool);
+  static const void *sysvars_get_key(const void *entry, size_t *length,
+                                     my_bool);
 
   friend bool sysvartrack_global_update(THD *thd, char *str, size_t len);
 };

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -48,12 +48,12 @@ static ulonglong system_variable_hash_version= 0;
   Return variable name and length for hashing of variables.
 */
 
-static const uchar *get_sys_var_length(const void *var_, size_t *length,
-                                       my_bool)
+static const void *get_sys_var_length(const void *var_, size_t *length,
+                                      my_bool)
 {
   auto var= static_cast<const sys_var *>(var_);
   *length= var->name.length;
-  return reinterpret_cast<const uchar *>(var->name.str);
+  return var->name.str;
 }
 
 sys_var_chain all_sys_vars = { NULL, NULL };

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2278,7 +2278,7 @@ Sp_handler::sp_exist_routines(THD *thd, TABLE_LIST *routines) const
 }
 
 
-extern "C" const uchar *sp_sroutine_key(const void *ptr, size_t *plen, my_bool)
+extern "C" const void *sp_sroutine_key(const void *ptr, size_t *plen, my_bool)
 {
   auto rn= static_cast<const Sroutine_hash_entry *>(ptr);
   *plen= rn->mdl_request.key.length();

--- a/sql/sp.h
+++ b/sql/sp.h
@@ -648,8 +648,8 @@ void sp_update_stmt_used_routines(THD *thd, Query_tables_list *prelocking_ctx,
                                   SQL_I_List<Sroutine_hash_entry> *src,
                                   TABLE_LIST *belong_to_view);
 
-extern "C" const uchar *sp_sroutine_key(const void *ptr, size_t *plen,
-                                        my_bool);
+extern "C" const void *sp_sroutine_key(const void *ptr, size_t *plen,
+                                       my_bool);
 
 /*
   Routines which allow open/lock and close mysql.proc table even when

--- a/sql/sp_cache.cc
+++ b/sql/sp_cache.cc
@@ -266,15 +266,15 @@ sp_cache_enforce_limit(sp_cache *c, ulong upper_limit_for_elements)
   Internal functions
  *************************************************************************/
 
-extern "C" const uchar *hash_get_key_for_sp_head(const void *ptr, size_t *plen,
-                                                 my_bool);
+extern "C" const void *hash_get_key_for_sp_head(const void *ptr, size_t *plen,
+                                                my_bool);
 extern "C" void hash_free_sp_head(void *p);
 
-const uchar *hash_get_key_for_sp_head(const void *ptr, size_t *plen, my_bool)
+const void *hash_get_key_for_sp_head(const void *ptr, size_t *plen, my_bool)
 {
   auto sp= static_cast<const sp_head *>(ptr);
   *plen= sp->m_qname.length;
-  return reinterpret_cast<const uchar *>(sp->m_qname.str);
+  return sp->m_qname.str;
 }
 
 

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -102,7 +102,7 @@ void init_sp_psi_keys()
 #define MYSQL_RUN_SP(SP, CODE) do { CODE; } while(0)
 #endif
 
-extern "C" const uchar *sp_table_key(const void *ptr, size_t *plen, my_bool);
+extern "C" const void *sp_table_key(const void *ptr, size_t *plen, my_bool);
 
 /**
   Helper function which operates on a THD object to set the query start_time to
@@ -5082,7 +5082,7 @@ typedef struct st_sp_table
 } SP_TABLE;
 
 
-const uchar *sp_table_key(const void *ptr, size_t *plen, my_bool)
+const void *sp_table_key(const void *ptr, size_t *plen, my_bool)
 {
   auto tab= static_cast<const SP_TABLE *>(ptr);
   *plen= tab->qname.length;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -574,20 +574,20 @@ public:
 };
 
 
-static const uchar *acl_entry_get_key(const void *entry_, size_t *length,
-                                      my_bool)
+static const void *acl_entry_get_key(const void *entry_, size_t *length,
+                                     my_bool)
 {
   auto entry= static_cast<const acl_entry *>(entry_);
   *length=(uint) entry->length;
-  return reinterpret_cast<const uchar *>(entry->key);
+  return entry->key;
 }
 
-static const uchar *acl_role_get_key(const void *entry_, size_t *length,
-                                     my_bool)
+static const void *acl_role_get_key(const void *entry_, size_t *length,
+                                    my_bool)
 {
   auto entry= static_cast<const ACL_ROLE *>(entry_);
   *length=(uint) entry->user.length;
-  return reinterpret_cast<const uchar *>(entry->user.str);
+  return entry->user.str;
 }
 
 struct ROLE_GRANT_PAIR : public Sql_alloc
@@ -602,12 +602,12 @@ struct ROLE_GRANT_PAIR : public Sql_alloc
             const char *rolename, bool with_admin_option);
 };
 
-static const uchar *acl_role_map_get_key(const void *entry_, size_t *length,
-                                         my_bool)
+static const void *acl_role_map_get_key(const void *entry_, size_t *length,
+                                        my_bool)
 {
   auto entry= static_cast<const ROLE_GRANT_PAIR *>(entry_);
   *length=(uint) entry->hashkey.length;
-  return reinterpret_cast<const uchar *>(entry->hashkey.str);
+  return entry->hashkey.str;
 }
 
 bool ROLE_GRANT_PAIR::init(MEM_ROOT *mem, const char *username,
@@ -3550,11 +3550,11 @@ int acl_setrole(THD *thd, const char *rolename, privilege_t access)
   return 0;
 }
 
-static const uchar *check_get_key(const void *buff_, size_t *length, my_bool)
+static const void *check_get_key(const void *buff_, size_t *length, my_bool)
 {
   auto buff= static_cast<const ACL_USER *>(buff_);
   *length=buff->hostname_length;
-  return reinterpret_cast<const uchar *>(buff->host.hostname);
+  return buff->host.hostname;
 }
 
 
@@ -5501,12 +5501,12 @@ public:
 };
 
 
-static const uchar *get_key_column(const void *buff_, size_t *length, my_bool)
+static const void *get_key_column(const void *buff_, size_t *length, my_bool)
 {
   auto buff=
       static_cast<const GRANT_COLUMN *>(buff_);
   *length=buff->key_length;
-  return reinterpret_cast<const uchar *>(buff->column);
+  return buff->column;
 }
 
 class GRANT_NAME :public Sql_alloc
@@ -5735,11 +5735,11 @@ GRANT_TABLE::~GRANT_TABLE()
 }
 
 
-static const uchar *get_grant_table(const void *buff_, size_t *length, my_bool)
+static const void *get_grant_table(const void *buff_, size_t *length, my_bool)
 {
   auto buff= static_cast<const GRANT_NAME *>(buff_);
   *length=buff->key_length;
-  return reinterpret_cast<const uchar *>(buff->hash_key);
+  return buff->hash_key;
 }
 
 
@@ -6670,11 +6670,11 @@ static int traverse_role_graph_down(ACL_USER_BASE *user, void *context,
   entries using the role hash. We put all these "interesting"
   entries in a (suposedly small) dynamic array and them use it for merging.
 */
-static const uchar *role_key(const void *role_, size_t *klen, my_bool)
+static const void *role_key(const void *role_, size_t *klen, my_bool)
 {
   auto role= static_cast<const ACL_ROLE *>(role_);
   *klen= role->user.length;
-  return reinterpret_cast<const uchar *>(role->user.str);
+  return role->user.str;
 }
 typedef Hash_set<ACL_ROLE> role_hash_t;
 

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -893,14 +893,13 @@ Query_cache_block_table * Query_cache_block::table(TABLE_COUNTER_TYPE n)
 
 extern "C"
 {
-const uchar *query_cache_table_get_key(const void *record, size_t *length,
-                                       my_bool)
+const void *query_cache_table_get_key(const void *record, size_t *length,
+                                      my_bool)
 {
   auto table_block= static_cast<const Query_cache_block *>(record);
   *length= (table_block->used - table_block->headers_len() -
             ALIGN_SIZE(sizeof(Query_cache_table)));
-  return reinterpret_cast<const uchar *>(
-      ((table_block->data()) + ALIGN_SIZE(sizeof(Query_cache_table))));
+  return (table_block->data()) + ALIGN_SIZE(sizeof(Query_cache_table));
 }
 }
 
@@ -991,14 +990,13 @@ void Query_cache_query::unlock_n_destroy()
 
 extern "C"
 {
-const uchar *query_cache_query_get_key(const void *record, size_t *length,
-                                       my_bool)
+const void *query_cache_query_get_key(const void *record, size_t *length,
+                                      my_bool)
 {
   auto query_block= static_cast<const Query_cache_block *>(record);
   *length= (query_block->used - query_block->headers_len() -
             ALIGN_SIZE(sizeof(Query_cache_query)));
-  return reinterpret_cast<const uchar *>
-      (((query_block->data()) + ALIGN_SIZE(sizeof(Query_cache_query))));
+  return (query_block->data()) + ALIGN_SIZE(sizeof(Query_cache_query));
 }
 }
 
@@ -4332,10 +4330,9 @@ my_bool Query_cache::move_by_type(uchar **border,
 		      *new_block =(Query_cache_block *) *border;
     size_t tablename_offset = block->table()->table() - block->table()->db();
     char *data = (char*) block->data();
-    const uchar *key;
     size_t key_length;
-    key=query_cache_table_get_key( block, &key_length, 0);
-    my_hash_first(&tables, key, key_length, &record_idx);
+    const void *key= query_cache_table_get_key(block, &key_length, 0);
+    my_hash_first(&tables, static_cast<const uchar*>(key), key_length, &record_idx);
 
     block->destroy();
     new_block->init(len);
@@ -4393,10 +4390,9 @@ my_bool Query_cache::move_by_type(uchar **border,
     char *data = (char*) block->data();
     Query_cache_block *first_result_block = ((Query_cache_query *)
 					     block->data())->result();
-    const uchar *key;
     size_t key_length;
-    key=query_cache_query_get_key( block, &key_length, 0);
-    my_hash_first(&queries, key, key_length, &record_idx);
+    const void *key= query_cache_query_get_key(block, &key_length, 0);
+    my_hash_first(&queries, static_cast<const uchar*>(key), key_length, &record_idx);
     block->query()->unlock_n_destroy();
     block->destroy();
     const Query_cache_block_table *table_0= block->table(0),
@@ -5067,9 +5063,9 @@ my_bool Query_cache::check_integrity(bool locked)
       DBUG_PRINT("qcache", ("block %p, type %u...", 
 			    block, (uint) block->type));
       size_t length;
-      const uchar *key= query_cache_query_get_key(block, &length, 0);
-      uchar* val = my_hash_search(&queries, key, length);
-      if ((reinterpret_cast<uchar *>(block)) != val)
+      const void *key= query_cache_query_get_key(block, &length, 0);
+      void* val = my_hash_search(&queries, static_cast<const uchar*>(key), length);
+      if (block != val)
       {
 	DBUG_PRINT("error", ("block %p found in queries hash like %p",
 			     block, val));
@@ -5102,9 +5098,9 @@ my_bool Query_cache::check_integrity(bool locked)
       DBUG_PRINT("qcache", ("block %p, type %u...", 
 			    block, (uint) block->type));
       size_t length;
-      const uchar *key= query_cache_table_get_key(block, &length, 0);
-      uchar* val = my_hash_search(&tables, key, length);
-      if (reinterpret_cast<uchar *>(block) != val)
+      const void *key= query_cache_table_get_key(block, &length, 0);
+      void* val = my_hash_search(&tables, static_cast<const uchar*>(key), length);
+      if (block != val)
       {
 	DBUG_PRINT("error", ("block %p found in tables hash like %p",
 			     block, val));

--- a/sql/sql_cache.h
+++ b/sql/sql_cache.h
@@ -256,10 +256,10 @@ struct Query_cache_result
 
 extern "C"
 {
-  const uchar *query_cache_query_get_key(const void *record, size_t *length,
-                                         my_bool);
-  const uchar *query_cache_table_get_key(const void *record, size_t *length,
-                                         my_bool);
+  const void *query_cache_query_get_key(const void *record, size_t *length,
+                                        my_bool);
+  const void *query_cache_table_get_key(const void *record, size_t *length,
+                                        my_bool);
 }
 extern "C" void query_cache_invalidate_by_MyISAM_filename(const char* filename);
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -89,12 +89,12 @@ char empty_c_string[1]= {0};    /* used for not defined db */
 ** User variables
 ****************************************************************************/
 
-extern "C" const uchar *get_var_key(const void *entry_, size_t *length,
-                                    my_bool)
+extern "C" const void *get_var_key(const void *entry_, size_t *length,
+                                   my_bool)
 {
   const user_var_entry *entry= static_cast<const user_var_entry *>(entry_);
   *length= entry->name.length;
-  return reinterpret_cast<const uchar *>(entry->name.str);
+  return entry->name.str;
 }
 
 extern "C" void free_user_var(void *entry_)
@@ -108,8 +108,8 @@ extern "C" void free_user_var(void *entry_)
 
 /* Functions for last-value-from-sequence hash */
 
-extern "C" const uchar *get_sequence_last_key(const void *entry_,
-                                              size_t *length, my_bool)
+extern "C" const void *get_sequence_last_key(const void *entry_,
+                                             size_t *length, my_bool)
 {
   const SEQUENCE_LAST_VALUE *entry= static_cast<const SEQUENCE_LAST_VALUE *>(entry_);
   *length= entry->length;
@@ -4156,12 +4156,12 @@ Statement::~Statement() = default;
 
 C_MODE_START
 
-static const uchar *get_statement_id_as_hash_key(const void *record,
-                                                 size_t *key_length, my_bool)
+static const void *get_statement_id_as_hash_key(const void *record,
+                                                size_t *key_length, my_bool)
 {
   const Statement *statement= static_cast<const Statement *>(record);
   *key_length= sizeof(statement->id);
-  return reinterpret_cast<const uchar *>(&(statement)->id);
+  return &(statement)->id;
 }
 
 static void delete_statement_as_hash_key(void *key)
@@ -4169,12 +4169,12 @@ static void delete_statement_as_hash_key(void *key)
   delete (Statement *) key;
 }
 
-static const uchar *get_stmt_name_hash_key(const void *entry_, size_t *length,
-                                           my_bool)
+static const void *get_stmt_name_hash_key(const void *entry_, size_t *length,
+                                          my_bool)
 {
   const Statement *entry= static_cast<const Statement *>(entry_);
   *length= entry->name.length;
-  return reinterpret_cast<const uchar *>(entry->name.str);
+  return entry->name.str;
 }
 
 C_MODE_END

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -305,12 +305,12 @@ end:
   started with corresponding variable that is greater then 0.
 */
 
-extern "C" const uchar *get_key_conn(const void *buff_, size_t *length,
-                                     my_bool)
+extern "C" const void *get_key_conn(const void *buff_, size_t *length,
+                                    my_bool)
 {
   auto buff= static_cast<const user_conn *>(buff_);
   *length= buff->len;
-  return reinterpret_cast<const uchar *>(buff->user);
+  return buff->user;
 }
 
 
@@ -398,12 +398,12 @@ static const char *get_client_host(THD *client)
     client->security_ctx->host ? client->security_ctx->host : "";
 }
 
-extern "C" const uchar *get_key_user_stats(const void *user_stats_,
-                                           size_t *length, my_bool)
+extern "C" const void *get_key_user_stats(const void *user_stats_,
+                                          size_t *length, my_bool)
 {
   auto user_stats= static_cast<const USER_STATS *>(user_stats_);
   *length= user_stats->user_name_length;
-  return reinterpret_cast<const uchar *>(user_stats->user);
+  return user_stats->user;
 }
 
 void init_user_stats(USER_STATS *user_stats,
@@ -484,12 +484,12 @@ void init_global_client_stats(void)
                max_connections, 0, 0, get_key_user_stats, my_free, 0);
 }
 
-extern "C" const uchar *get_key_table_stats(const void *table_stats_,
-                                            size_t *length, my_bool)
+extern "C" const void *get_key_table_stats(const void *table_stats_,
+                                           size_t *length, my_bool)
 {
   auto table_stats= static_cast<const TABLE_STATS *>(table_stats_);
   *length= table_stats->table_name_length;
-  return reinterpret_cast<const uchar *>(table_stats->table);
+  return table_stats->table;
 }
 
 void init_global_table_stats(void)
@@ -499,12 +499,12 @@ void init_global_table_stats(void)
                get_key_table_stats, my_free, 0);
 }
 
-extern "C" const uchar *get_key_index_stats(const void *index_stats_,
-                                            size_t *length, my_bool)
+extern "C" const void *get_key_index_stats(const void *index_stats_,
+                                           size_t *length, my_bool)
 {
   auto index_stats= static_cast<const INDEX_STATS *>(index_stats_);
   *length= index_stats->index_name_length;
-  return reinterpret_cast<const uchar *>(index_stats->index);
+  return index_stats->index;
 }
 
 void init_global_index_stats(void)

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -146,11 +146,11 @@ private:
   Hash_set<LEX_STRING> m_set;
   mysql_rwlock_t m_lock;
 
-  static const uchar *get_key(const void *ls_, size_t *sz, my_bool)
+  static const void *get_key(const void *ls_, size_t *sz, my_bool)
   {
     const LEX_STRING *ls= static_cast<const LEX_STRING*>(ls_);
     *sz= ls->length;
-    return reinterpret_cast<const uchar*>(ls->str);
+    return ls->str;
   }
 
 public:
@@ -240,14 +240,14 @@ static int my_rmdir(const char *dir)
   Function we use in the creation of our hash to get key.
 */
 
-extern "C" const uchar *dboptions_get_key(const void *opt, size_t *length,
-                                          my_bool);
+extern "C" const void *dboptions_get_key(const void *opt, size_t *length,
+                                         my_bool);
 
-const uchar *dboptions_get_key(const void *opt_, size_t *length, my_bool)
+const void *dboptions_get_key(const void *opt_, size_t *length, my_bool)
 {
   auto opt= static_cast<const my_dbopt_t *>(opt_);
   *length= opt->name_length;
-  return reinterpret_cast<const uchar *>(opt->name);
+  return opt->name;
 }
 
 

--- a/sql/sql_handler.cc
+++ b/sql/sql_handler.cc
@@ -112,12 +112,12 @@ SQL_HANDLER::~SQL_HANDLER()
     Pointer to the TABLE_LIST struct.
 */
 
-static const uchar *mysql_ha_hash_get_key(const void *table_, size_t *key_len,
-                                          my_bool)
+static const void *mysql_ha_hash_get_key(const void *table_, size_t *key_len,
+                                         my_bool)
 {
   auto table= static_cast<const SQL_HANDLER *>(table_);
   *key_len= table->handler_name.length + 1 ; /* include '\0' in comparisons */
-  return reinterpret_cast<const uchar *>(table->handler_name.str);
+  return table->handler_name.str;
 }
 
 

--- a/sql/sql_hset.h
+++ b/sql/sql_hset.h
@@ -32,7 +32,7 @@ public:
     Constructs an empty unique hash.
   */
   Hash_set(PSI_memory_key psi_key,
-           const uchar *(*K)(const void *, size_t *, my_bool),
+           const void *(*K)(const void *, size_t *, my_bool),
            CHARSET_INFO *cs= &my_charset_bin)
   {
     my_hash_init(psi_key, &m_hash, cs, START_SIZE, 0, 0, K, 0, HASH_UNIQUE);

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1520,23 +1520,23 @@ static int plugin_initialize(MEM_ROOT *tmp_root, struct st_plugin_int *plugin,
 }
 
 
-extern "C" const uchar *get_plugin_hash_key(const void *, size_t *, my_bool);
-extern "C" const uchar *get_bookmark_hash_key(const void *, size_t *, my_bool);
+extern "C" const void *get_plugin_hash_key(const void *, size_t *, my_bool);
+extern "C" const void *get_bookmark_hash_key(const void *, size_t *, my_bool);
 
 
-const uchar *get_plugin_hash_key(const void *buff, size_t *length, my_bool)
+const void *get_plugin_hash_key(const void *buff, size_t *length, my_bool)
 {
   auto plugin= static_cast<const st_plugin_int *>(buff);
   *length= plugin->name.length;
-  return reinterpret_cast<const uchar *>(plugin->name.str);
+  return plugin->name.str;
 }
 
 
-const uchar *get_bookmark_hash_key(const void *buff, size_t *length, my_bool)
+const void *get_bookmark_hash_key(const void *buff, size_t *length, my_bool)
 {
   auto var= static_cast<const st_bookmark *>(buff);
   *length= var->name_len + 1;
-  return reinterpret_cast<const uchar *>(var->key);
+  return var->key;
 }
 
 static inline void convert_dash_to_underscore(char *str, size_t len)

--- a/sql/sql_servers.cc
+++ b/sql/sql_servers.cc
@@ -86,8 +86,8 @@ static int update_server_record_in_cache(FOREIGN_SERVER *existing,
 /* utility functions */
 static void merge_server_struct(FOREIGN_SERVER *from, FOREIGN_SERVER *to);
 
-static const uchar *servers_cache_get_key(const void *server_, size_t *length,
-                                          my_bool)
+static const void *servers_cache_get_key(const void *server_, size_t *length,
+                                         my_bool)
 {
   auto server= static_cast<const FOREIGN_SERVER *>(server_);
   DBUG_ENTER("servers_cache_get_key");
@@ -96,7 +96,7 @@ static const uchar *servers_cache_get_key(const void *server_, size_t *length,
                       server->server_name));
 
   *length= server->server_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(server->server_name));
+  DBUG_RETURN(server->server_name);
 }
 
 static PSI_memory_key key_memory_servers;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -638,13 +638,13 @@ ignore_db_dirs_init()
   @return                 a pointer to the key
 */
 
-static const uchar *db_dirs_hash_get_key(const void *data, size_t *len_ret,
-                                         my_bool)
+static const void *db_dirs_hash_get_key(const void *data, size_t *len_ret,
+                                        my_bool)
 {
   auto e= static_cast<const LEX_CSTRING *>(data);
 
   *len_ret= e->length;
-  return reinterpret_cast<const uchar *>(e->str);
+  return e->str;
 }
 
 

--- a/sql/sql_udf.cc
+++ b/sql/sql_udf.cc
@@ -104,11 +104,11 @@ static const char *init_syms(udf_func *tmp, char *nm)
 }
 
 
-extern "C" const uchar *get_hash_key(const void *buff, size_t *length, my_bool)
+extern "C" const void *get_hash_key(const void *buff, size_t *length, my_bool)
 {
   auto udf= static_cast<const udf_func *>(buff);
   *length= udf->name.length;
-  return reinterpret_cast<const uchar *>(udf->name.str);
+  return udf->name.str;
 }
 
 static PSI_memory_key key_memory_udf_mem;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -246,11 +246,11 @@ View_creation_ctx * View_creation_ctx::create(THD *thd,
 
 /* Get column name from column hash */
 
-static const uchar *get_field_name(const void *buff_, size_t *length, my_bool)
+static const void *get_field_name(const void *buff_, size_t *length, my_bool)
 {
   auto buff= static_cast<const Field *const *>(buff_);
   *length= (*buff)->field_name.length;
-  return reinterpret_cast<const uchar *>((*buff)->field_name.str);
+  return (*buff)->field_name.str;
 }
 
 

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -588,11 +588,11 @@ static void tdc_hash_initializer(LF_HASH *,
 }
 
 
-static const uchar *tdc_hash_key(const void *element_, size_t *length, my_bool)
+static const void *tdc_hash_key(const void *element_, size_t *length, my_bool)
 {
   auto element= static_cast<const TDC_element *>(element_);
   *length= element->m_key_length;
-  return reinterpret_cast<const uchar *>(element->m_key);
+  return element->m_key;
 }
 
 
@@ -1142,12 +1142,12 @@ struct eliminate_duplicates_arg
 };
 
 
-static const uchar *eliminate_duplicates_get_key(const void *element,
-                                                 size_t *length, my_bool)
+static const void *eliminate_duplicates_get_key(const void *element,
+                                                size_t *length, my_bool)
 {
   auto key= static_cast<const LEX_STRING *>(element);
   *length= key->length;
-  return reinterpret_cast<const uchar *>(key->str);
+  return key->str;
 }
 
 

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1498,20 +1498,20 @@ public:
   they should obey C calling conventions.
 */
 
-static const uchar *my_tz_names_get_key(const void *entry_, size_t *length,
-                                            my_bool)
+static const void *my_tz_names_get_key(const void *entry_, size_t *length,
+                                           my_bool)
 {
   auto entry= static_cast<const Tz_names_entry *>(entry_);
   *length= entry->name.length();
-  return reinterpret_cast<const uchar *>(entry->name.ptr());
+  return entry->name.ptr();
 }
 
-static const uchar *my_offset_tzs_get_key(const void *entry_,
-                                             size_t *length, my_bool)
+static const void *my_offset_tzs_get_key(const void *entry_,
+                                            size_t *length, my_bool)
 {
   auto entry= static_cast<const Time_zone_offset *>(entry_);
   *length= sizeof(long);
-  return reinterpret_cast<const uchar *>(&entry->offset);
+  return &entry->offset;
 }
 
 

--- a/sql/xa.cc
+++ b/sql/xa.cc
@@ -147,7 +147,7 @@ public:
     DBUG_ASSERT(!reinterpret_cast<XID_cache_element*>(ptr + LF_HASH_OVERHEAD)
 		->is_set(ACQUIRED));
   }
-  static const uchar *key(const void *el, size_t *length, my_bool)
+  static const void *key(const void *el, size_t *length, my_bool)
   {
     const XID &xid= reinterpret_cast<const XID_cache_element*>(el)->xid;
     *length= xid.key_length();

--- a/storage/blackhole/ha_blackhole.cc
+++ b/storage/blackhole/ha_blackhole.cc
@@ -360,12 +360,12 @@ static void blackhole_free_key(void *share)
   my_free(share);
 }
 
-static const uchar *blackhole_get_key(const void *share_, size_t *length,
-                                      my_bool)
+static const void *blackhole_get_key(const void *share_, size_t *length,
+                                     my_bool)
 {
   auto share= static_cast<const st_blackhole_share *>(share_);
   *length= share->table_name_length;
-  return reinterpret_cast<const uchar *>(share->table_name);
+  return share->table_name;
 }
 
 #ifdef HAVE_PSI_INTERFACE

--- a/storage/csv/ha_tina.cc
+++ b/storage/csv/ha_tina.cc
@@ -107,11 +107,11 @@ int sort_set (const void *a_, const void *b_)
   return ( a->begin > b->begin ? 1 : ( a->begin < b->begin ? -1 : 0 ) );
 }
 
-static const uchar *tina_get_key(const void *share_, size_t *length, my_bool)
+static const void *tina_get_key(const void *share_, size_t *length, my_bool)
 {
   const TINA_SHARE *share= static_cast<const TINA_SHARE *>(share_);
   *length=share->table_name_length;
-  return reinterpret_cast<const uchar *>(share->table_name);
+  return share->table_name;
 }
 
 static PSI_memory_key csv_key_memory_tina_share;

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -430,12 +430,12 @@ static handler *federated_create_handler(handlerton *hton,
 
 /* Function we use in the creation of our hash to get key */
 
-static const uchar *federated_get_key(const void *share_, size_t *length,
-                                      my_bool)
+static const void *federated_get_key(const void *share_, size_t *length,
+                                     my_bool)
 {
   auto share= static_cast<const FEDERATED_SHARE *>(share_);
   *length= share->share_key_length;
-  return reinterpret_cast<const uchar *>(share->share_key);
+  return share->share_key;
 }
 
 #ifdef HAVE_PSI_INTERFACE

--- a/storage/federatedx/ha_federatedx.cc
+++ b/storage/federatedx/ha_federatedx.cc
@@ -363,20 +363,20 @@ static handler *federatedx_create_handler(handlerton *hton,
 
 /* Function we use in the creation of our hash to get key */
 
-static const uchar *federatedx_share_get_key(const void *share_,
-                                             size_t *length, my_bool)
+static const void *federatedx_share_get_key(const void *share_,
+                                            size_t *length, my_bool)
 {
   auto share= static_cast<const FEDERATEDX_SHARE *>(share_);
   *length= share->share_key_length;
-  return reinterpret_cast<const uchar *>(share->share_key);
+  return share->share_key;
 }
 
-static const uchar *federatedx_server_get_key(const void *server_,
-                                              size_t *length, my_bool)
+static const void *federatedx_server_get_key(const void *server_,
+                                             size_t *length, my_bool)
 {
   auto server= static_cast<const FEDERATEDX_SERVER *>(server_);
   *length= server->key_length;
-  return reinterpret_cast<const uchar *>(server->key);
+  return server->key;
 }
 
 #ifdef HAVE_PSI_INTERFACE

--- a/storage/maria/aria_read_log.c
+++ b/storage/maria/aria_read_log.c
@@ -334,8 +334,8 @@ static void usage(void)
 }
 
 
-static const uchar *my_hash_get_string(const void *record_, size_t *length,
-                                       my_bool first __attribute__((unused)))
+static const void *my_hash_get_string(const void *record_, size_t *length,
+                                      my_bool first __attribute__((unused)))
 {
   const char *record= record_;
   *length= (strcend(record, ',') - record);

--- a/storage/maria/trnman.c
+++ b/storage/maria/trnman.c
@@ -126,12 +126,12 @@ default_trnman_end_trans_hook(TRN *trn __attribute__ ((unused)),
 }
 
 
-static const uchar *trn_get_hash_key(const void *trn_, size_t *len,
-                                     my_bool unused __attribute__((unused)))
+static const void *trn_get_hash_key(const void *trn_, size_t *len,
+                                    my_bool unused __attribute__((unused)))
 {
   const TRN *const *trn= trn_;
   *len= sizeof(TrID);
-  return (const uchar *) &((*trn)->trid);
+  return &((*trn)->trid);
 }
 
 

--- a/storage/mroonga/ha_mroonga.cpp
+++ b/storage/mroonga/ha_mroonga.cpp
@@ -614,22 +614,22 @@ static const char *mrn_inspect_extra_function(enum ha_extra_function operation)
 }
 #endif
 
-static const uchar *mrn_open_tables_get_key(const void *record, size_t *length,
-                                            my_bool)
+static const void *mrn_open_tables_get_key(const void *record, size_t *length,
+                                           my_bool)
 {
   MRN_DBUG_ENTER_FUNCTION();
   auto share = static_cast<const MRN_SHARE *>(record);
   *length = share->table_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(share->table_name));
+  DBUG_RETURN(share->table_name);
 }
 
-static const uchar *mrn_long_term_share_get_key(const void *record,
-                                                size_t *length, my_bool)
+static const void *mrn_long_term_share_get_key(const void *record,
+                                               size_t *length, my_bool)
 {
   MRN_DBUG_ENTER_FUNCTION();
   auto long_term_share= static_cast<const MRN_LONG_TERM_SHARE *>(record);
   *length = long_term_share->table_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(long_term_share->table_name));
+  DBUG_RETURN(long_term_share->table_name);
 }
 
 /* status */
@@ -707,12 +707,12 @@ static grn_logger mrn_logger = {
   NULL
 };
 
-static const uchar *mrn_allocated_thds_get_key(const void *record,
-                                               size_t *length, my_bool)
+static const void *mrn_allocated_thds_get_key(const void *record,
+                                              size_t *length, my_bool)
 {
   MRN_DBUG_ENTER_FUNCTION();
   *length = sizeof(THD *);
-  DBUG_RETURN(static_cast<const uchar *>(record));
+  DBUG_RETURN(record);
 }
 
 /* system functions */

--- a/storage/perfschema/pfs_account.cc
+++ b/storage/perfschema/pfs_account.cc
@@ -67,8 +67,8 @@ void cleanup_account(void)
 }
 
 C_MODE_START
-static const uchar *account_hash_get_key(const void *entry, size_t *length,
-                                         my_bool)
+static const void *account_hash_get_key(const void *entry, size_t *length,
+                                        my_bool)
 {
   const PFS_account * const *typed_entry;
   const PFS_account *account;
@@ -79,7 +79,7 @@ static const uchar *account_hash_get_key(const void *entry, size_t *length,
   assert(account != NULL);
   *length= account->m_key.m_key_length;
   result= account->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_digest.cc
+++ b/storage/perfschema/pfs_digest.cc
@@ -146,8 +146,8 @@ void cleanup_digest(void)
 }
 
 C_MODE_START
-static const uchar *digest_hash_get_key(const void *entry, size_t *length,
-                                        my_bool)
+static const void *digest_hash_get_key(const void *entry, size_t *length,
+                                       my_bool)
 {
   const PFS_statements_digest_stat * const *typed_entry;
   const PFS_statements_digest_stat *digest;
@@ -158,7 +158,7 @@ static const uchar *digest_hash_get_key(const void *entry, size_t *length,
   assert(digest != NULL);
   *length= sizeof (PFS_digest_key);
   result= & digest->m_digest_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_host.cc
+++ b/storage/perfschema/pfs_host.cc
@@ -65,8 +65,8 @@ void cleanup_host(void)
 }
 
 C_MODE_START
-static const uchar *host_hash_get_key(const void *entry, size_t *length,
-                                      my_bool)
+static const void *host_hash_get_key(const void *entry, size_t *length,
+                                     my_bool)
 {
   const PFS_host * const *typed_entry;
   const PFS_host *host;
@@ -77,7 +77,7 @@ static const uchar *host_hash_get_key(const void *entry, size_t *length,
   assert(host != NULL);
   *length= host->m_key.m_key_length;
   result= host->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_instr.cc
+++ b/storage/perfschema/pfs_instr.cc
@@ -253,8 +253,8 @@ void cleanup_instruments(void)
 
 C_MODE_START
 /** Get hash table key for instrumented files. */
-static const uchar *filename_hash_get_key(const void *entry, size_t *length,
-                                          my_bool)
+static const void *filename_hash_get_key(const void *entry, size_t *length,
+                                         my_bool)
 {
   const PFS_file * const *typed_entry;
   const PFS_file *file;
@@ -265,7 +265,7 @@ static const uchar *filename_hash_get_key(const void *entry, size_t *length,
   assert(file != NULL);
   *length= file->m_filename_length;
   result= file->m_filename;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_instr_class.cc
+++ b/storage/perfschema/pfs_instr_class.cc
@@ -403,8 +403,8 @@ void cleanup_table_share(void)
 
 C_MODE_START
 /** get_key function for @c table_share_hash. */
-static const uchar *table_share_hash_get_key(const void *entry, size_t *length,
-                                             my_bool)
+static const void *table_share_hash_get_key(const void *entry, size_t *length,
+                                            my_bool)
 {
   const PFS_table_share * const *typed_entry;
   const PFS_table_share *share;
@@ -415,7 +415,7 @@ static const uchar *table_share_hash_get_key(const void *entry, size_t *length,
   assert(share != NULL);
   *length= share->m_key.m_key_length;
   result= &share->m_key.m_hash_key[0];
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_program.cc
+++ b/storage/perfschema/pfs_program.cc
@@ -63,8 +63,8 @@ void cleanup_program(void)
 }
 
 C_MODE_START
-static const uchar *program_hash_get_key(const void *entry, size_t *length,
-                                         my_bool)
+static const void *program_hash_get_key(const void *entry, size_t *length,
+                                        my_bool)
 {
   const PFS_program * const *typed_entry;
   const PFS_program *program;
@@ -75,7 +75,7 @@ static const uchar *program_hash_get_key(const void *entry, size_t *length,
   assert(program != NULL);
   *length= program->m_key.m_key_length;
   result= program->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_setup_actor.cc
+++ b/storage/perfschema/pfs_setup_actor.cc
@@ -63,7 +63,7 @@ void cleanup_setup_actor(void)
 }
 
 C_MODE_START
-static const uchar *setup_actor_hash_get_key(const void *entry, size_t *length,
+static const void *setup_actor_hash_get_key(const void *entry, size_t *length,
                                             my_bool)
 {
   const PFS_setup_actor * const *typed_entry;
@@ -75,7 +75,7 @@ static const uchar *setup_actor_hash_get_key(const void *entry, size_t *length,
   assert(setup_actor != NULL);
   *length= setup_actor->m_key.m_key_length;
   result= setup_actor->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_setup_object.cc
+++ b/storage/perfschema/pfs_setup_object.cc
@@ -63,8 +63,8 @@ void cleanup_setup_object(void)
 }
 
 C_MODE_START
-static const uchar *setup_object_hash_get_key(const void *entry,
-                                              size_t *length, my_bool)
+static const void *setup_object_hash_get_key(const void *entry,
+                                             size_t *length, my_bool)
 {
   const PFS_setup_object * const *typed_entry;
   const PFS_setup_object *setup_object;
@@ -75,7 +75,7 @@ static const uchar *setup_object_hash_get_key(const void *entry,
   assert(setup_object != NULL);
   *length= setup_object->m_key.m_key_length;
   result= setup_object->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/perfschema/pfs_user.cc
+++ b/storage/perfschema/pfs_user.cc
@@ -64,8 +64,8 @@ void cleanup_user(void)
 }
 
 C_MODE_START
-static const uchar *user_hash_get_key(const void *entry, size_t *length,
-                                      my_bool)
+static const void *user_hash_get_key(const void *entry, size_t *length,
+                                     my_bool)
 {
   const PFS_user * const *typed_entry;
   const PFS_user *user;
@@ -76,7 +76,7 @@ static const uchar *user_hash_get_key(const void *entry, size_t *length,
   assert(user != NULL);
   *length= user->m_key.m_key_length;
   result= user->m_key.m_hash_key;
-  return reinterpret_cast<const uchar *>(result);
+  return result;
 }
 C_MODE_END
 

--- a/storage/sphinx/ha_sphinx.cc
+++ b/storage/sphinx/ha_sphinx.cc
@@ -720,12 +720,12 @@ typedef size_t GetKeyLength_t;
 typedef uint GetKeyLength_t;
 #endif
 
-static const uchar *sphinx_get_key(const void *pSharePtr,
-                                   GetKeyLength_t *pLength, my_bool)
+static const void *sphinx_get_key(const void *pSharePtr,
+                                  GetKeyLength_t *pLength, my_bool)
 {
   const CSphSEShare *pShare= static_cast<const CSphSEShare *>(pSharePtr);
   *pLength= pShare->m_iTableNameLen;
-  return reinterpret_cast<const uchar *>(pShare->m_sTable);
+  return pShare->m_sTable;
 }
 
 #if MYSQL_VERSION_ID<50100

--- a/storage/spider/spd_conn.cc
+++ b/storage/spider/spd_conn.cc
@@ -100,7 +100,7 @@ ulong spider_open_connections_line_no;
 pthread_mutex_t spider_conn_mutex;
 
 /* for spider_open_connections and trx_conn_hash */
-const uchar *spider_conn_get_key(
+const void *spider_conn_get_key(
   const void *conn_,
   size_t *length,
   my_bool
@@ -111,10 +111,10 @@ const uchar *spider_conn_get_key(
 #ifdef DBUG_TRACE
   spider_print_keys(conn->conn_key, conn->conn_key_length);
 #endif
-  DBUG_RETURN(reinterpret_cast<const uchar *>(conn->conn_key));
+  DBUG_RETURN(conn->conn_key);
 }
 
-const uchar *spider_ipport_conn_get_key(
+const void *spider_ipport_conn_get_key(
    const void *ip_port_,
    size_t *length,
    my_bool
@@ -123,10 +123,10 @@ const uchar *spider_ipport_conn_get_key(
   auto ip_port= static_cast<const SPIDER_IP_PORT_CONN *>(ip_port_);
   DBUG_ENTER("spider_ipport_conn_get_key");
   *length = ip_port->key_len;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(ip_port->key));
+  DBUG_RETURN(ip_port->key);
 }
 
-static const uchar *spider_loop_check_full_get_key(
+static const void *spider_loop_check_full_get_key(
   const void *ptr_,
   size_t *length,
   my_bool
@@ -134,10 +134,10 @@ static const uchar *spider_loop_check_full_get_key(
   auto ptr= static_cast<const SPIDER_CONN_LOOP_CHECK *>(ptr_);
   DBUG_ENTER("spider_loop_check_full_get_key");
   *length = ptr->full_name.length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(ptr->full_name.str));
+  DBUG_RETURN(ptr->full_name.str);
 }
 
-static const uchar *spider_loop_check_to_get_key(
+static const void *spider_loop_check_to_get_key(
   const void *ptr_,
   size_t *length,
   my_bool
@@ -145,7 +145,7 @@ static const uchar *spider_loop_check_to_get_key(
   auto ptr= static_cast<const SPIDER_CONN_LOOP_CHECK *>(ptr_);
   DBUG_ENTER("spider_loop_check_to_get_key");
   *length = ptr->to_name.length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(ptr->to_name.str));
+  DBUG_RETURN(ptr->to_name.str);
 }
 
 int spider_conn_init(

--- a/storage/spider/spd_conn.h
+++ b/storage/spider/spd_conn.h
@@ -82,13 +82,13 @@ typedef struct st_spider_conn_loop_check
   LEX_CSTRING        merged_value;
 } SPIDER_CONN_LOOP_CHECK;
 
-const uchar *spider_conn_get_key(
+const void *spider_conn_get_key(
   const void *conn,
   size_t *length,
   my_bool
 );
 
-const uchar *spider_ipport_conn_get_key(
+const void *spider_ipport_conn_get_key(
   const void *ip_port,
   size_t *length,
   my_bool

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -347,7 +347,7 @@ static char spider_unique_id_buf[1 + 12 + 1 + (16 * 2) + 1 + 1];
 LEX_CSTRING spider_unique_id;
 
 // for spider_open_tables
-const uchar *spider_tbl_get_key(
+const void *spider_tbl_get_key(
   const void *share_,
   size_t *length,
   my_bool
@@ -355,10 +355,10 @@ const uchar *spider_tbl_get_key(
   auto share= static_cast<const SPIDER_SHARE *>(share_);
   DBUG_ENTER("spider_tbl_get_key");
   *length = share->table_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(share->table_name));
+  DBUG_RETURN(share->table_name);
 }
 
-const uchar *spider_wide_share_get_key(
+const void *spider_wide_share_get_key(
   const void *share_,
   size_t *length,
   my_bool
@@ -366,10 +366,10 @@ const uchar *spider_wide_share_get_key(
   auto share= static_cast<const SPIDER_WIDE_SHARE *>(share_);
   DBUG_ENTER("spider_wide_share_get_key");
   *length = share->table_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(share->table_name));
+  DBUG_RETURN(share->table_name);
 }
 
-const uchar *spider_lgtm_tblhnd_share_hash_get_key(
+const void *spider_lgtm_tblhnd_share_hash_get_key(
   const void *share_,
   size_t *length,
   my_bool
@@ -377,10 +377,10 @@ const uchar *spider_lgtm_tblhnd_share_hash_get_key(
   auto share= static_cast<const SPIDER_LGTM_TBLHND_SHARE *>(share_);
   DBUG_ENTER("spider_lgtm_tblhnd_share_hash_get_key");
   *length = share->table_name_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(share->table_name));
+  DBUG_RETURN(share->table_name);
 }
 
-const uchar *spider_link_get_key(
+const void *spider_link_get_key(
   const void *link_for_hash_,
   size_t *length,
   my_bool
@@ -389,10 +389,10 @@ const uchar *spider_link_get_key(
       static_cast<const SPIDER_LINK_FOR_HASH *>(link_for_hash_);
   DBUG_ENTER("spider_link_get_key");
   *length = link_for_hash->db_table_str->length();
-  DBUG_RETURN(reinterpret_cast<const uchar *>(link_for_hash->db_table_str->ptr()));
+  DBUG_RETURN(link_for_hash->db_table_str->ptr());
 }
 
-const uchar *spider_udf_tbl_mon_list_key(
+const void *spider_udf_tbl_mon_list_key(
   const void *table_mon_list_,
   size_t *length,
   my_bool
@@ -403,17 +403,17 @@ const uchar *spider_udf_tbl_mon_list_key(
   DBUG_PRINT("info",("spider hash key=%s", table_mon_list->key));
   DBUG_PRINT("info",("spider hash key length=%u", table_mon_list->key_length));
   *length = table_mon_list->key_length;
-  DBUG_RETURN(reinterpret_cast<const uchar *>(table_mon_list->key));
+  DBUG_RETURN(table_mon_list->key);
 }
 
-const uchar *spider_allocated_thds_get_key(
+const void *spider_allocated_thds_get_key(
   const void *thd,
   size_t *length,
   my_bool
 ) {
   DBUG_ENTER("spider_allocated_thds_get_key");
   *length = sizeof(THD *);
-  DBUG_RETURN(reinterpret_cast<const uchar *>(thd));
+  DBUG_RETURN(thd);
 }
 
 #ifdef HAVE_PSI_INTERFACE

--- a/storage/spider/spd_table.h
+++ b/storage/spider/spd_table.h
@@ -47,19 +47,19 @@ typedef struct st_spider_param_string_parse
   bool locate_param_def(char*& start_param);
 } SPIDER_PARAM_STRING_PARSE;
 
-const uchar *spider_tbl_get_key(
+const void *spider_tbl_get_key(
   const void *share,
   size_t *length,
   my_bool
 );
 
-const uchar *spider_wide_share_get_key(
+const void *spider_wide_share_get_key(
   const void *share,
   size_t *length,
   my_bool
 );
 
-const uchar *spider_link_get_key(
+const void *spider_link_get_key(
   const void *link_for_hash,
   size_t *length,
   my_bool

--- a/storage/spider/spd_trx.cc
+++ b/storage/spider/spd_trx.cc
@@ -58,7 +58,7 @@ extern ulong spider_allocated_thds_line_no;
 extern pthread_mutex_t spider_allocated_thds_mutex;
 
 // for spider_alter_tables
-const uchar *spider_alter_tbl_get_key(
+const void *spider_alter_tbl_get_key(
   const void *alter_table_,
   size_t *length,
   my_bool
@@ -68,11 +68,11 @@ const uchar *spider_alter_tbl_get_key(
   *length = alter_table->table_name_length;
   DBUG_PRINT("info",("spider table_name_length=%zu", *length));
   DBUG_PRINT("info",("spider table_name=%s", alter_table->table_name));
-  DBUG_RETURN(reinterpret_cast<const uchar *>(alter_table->table_name));
+  DBUG_RETURN(alter_table->table_name);
 }
 
 // for SPIDER_TRX_HA
-const uchar *spider_trx_ha_get_key(
+const void *spider_trx_ha_get_key(
   const void *trx_ha_,
   size_t *length,
   my_bool
@@ -82,7 +82,7 @@ const uchar *spider_trx_ha_get_key(
   *length = trx_ha->table_name_length;
   DBUG_PRINT("info",("spider table_name_length=%zu", *length));
   DBUG_PRINT("info",("spider table_name=%s", trx_ha->table_name));
-  DBUG_RETURN(reinterpret_cast<const uchar *>(trx_ha->table_name));
+  DBUG_RETURN(trx_ha->table_name);
 }
 
 /*


### PR DESCRIPTION
## Summary

  - Change `my_hash_get_key` typedef return type from `const uchar *` to `const void *`
  - Change `HASH_LINK.data` from `uchar *` to `void *`
  - Change record pointer parameters and return types in `my_hash_insert`, `my_hash_delete`, `my_hash_update`, `my_hash_replace`, `my_hash_element`,
  `my_hash_search`, `my_hash_first`, `my_hash_first_from_hash_value`, and `my_hash_next` to use `void *`
  - Update all ~50 get_key callback implementations across 67 files to return `const void *`
  - Remove unnecessary `reinterpret_cast<const uchar *>` casts at callback return sites and caller insert/delete sites

  ## Motivation

  The HASH interface used `uchar *` as a generic pointer type for storing and retrieving arbitrary record types. This forced every caller to cast through
  `(uchar *)` or `reinterpret_cast<const uchar *>` when inserting, deleting, or implementing get_key callbacks — adding noise with no type safety benefit.
  Converting to `void *` leverages implicit pointer conversion in C and well-defined static_cast in C++, making the intent clearer at every call site.

  Key byte-buffer parameters (`const uchar *key` in `my_hash_search`, `my_hash_first`, `my_hash_next`, and the `my_hash_function` typedef) are left
  unchanged since they represent actual byte data used for hashing and comparison.

## How can this PR be tested?

No new MTR tests are added since this is a refactor and we only need to make sure all functionalities are unchanged.

MTR test run with these cmd (Need to run as a non-root user as test `roles.set_default_role_invalid_skip_name_resolve` would fail when running as root user):

```bash
useradd -m mtruser
chown -R mtruser:mtruser /quick-rebuilds/build/mysql-test/var
su - mtruser -c "cd /quick-rebuilds && ./build/mysql-test/mysql-test-run.pl --force --parallel=auto \
    --suite=main,rpl,roles,plugins,json,handler,csv,federated,maria,perfschema,client,spider,mroonga"
```

### Before rebasing to 10.11

```bash
The servers were restarted 908 times
Spent 2775.394 of 486 seconds executing testcases

Completed: All 2952 tests were successful.

524 tests were skipped, 133 by the test itself.
```

### After rebasing to 10.11

I got some tests on main failed due to `mysql_old_password` not found or TLS/SSL error. This is probably due to my Docker env using `OpenSSL 3.6.2 7 Apr 2026 (Library: OpenSSL 3.6.2 7 Apr 2026)` (which disables legacy TLS), and these shouldn't be caused by my hash changes

```bash
The servers were restarted 243 times
Spent 730.695 of 176 seconds executing testcases

Completed: Failed 9/1106 tests, 99.19% were successful.

Failing test(s): main.connect main.ssl_7937 main.ssl_system_ca main.tls_version1 main.tls_version main.change_user main.set_password main.socket_conflict
```

## Basing the PR against the correct MariaDB version

- [x] This is a refactoring change, and the PR is based against the main MariaDB development branch.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.