### PR TITLE
MDEV-36025 Parallel slave concurrent BACKUP MDL locking with ongoing …

### DIFF
--- a/mysql-test/suite/rpl/r/parallel_backup.result
+++ b/mysql-test/suite/rpl/r/parallel_backup.result
@@ -29,9 +29,9 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection slave;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/diff_tables.inc [master:t1,slave:t1]
 # MDEV-30423: dealock XA COMMIT vs BACKUP
 #
@@ -64,6 +64,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -99,6 +100,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -140,8 +142,8 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
@@ -183,13 +185,112 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
 include/start_slave.inc
 include/sync_with_master_gtid.inc
+# Normal XA COMMIT
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (110);
+connection master1;
+INSERT INTO t1 VALUES (110);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (109);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (110 + 1);
+connection master;
+XA COMMIT '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+select @@global.gtid_slave_pos = "0-1-17";
+@@global.gtid_slave_pos = "0-1-17"
+1
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
+# Normal XA ROLLBACK
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (113);
+connection master1;
+INSERT INTO t1 VALUES (113);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (112);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (113 + 1);
+connection master;
+XA ROLLBACK '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+select @@global.gtid_slave_pos = "0-1-21";
+@@global.gtid_slave_pos = "0-1-21"
+1
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= 3;
+include/start_slave.inc
 connection slave;
 include/stop_slave.inc
 SET @@global.slave_parallel_threads= @old_parallel_threads;

--- a/mysql-test/suite/rpl/r/parallel_backup_lsu_off.result
+++ b/mysql-test/suite/rpl/r/parallel_backup_lsu_off.result
@@ -32,9 +32,9 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection slave;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/diff_tables.inc [master:t1,slave:t1]
 # MDEV-30423: dealock XA COMMIT vs BACKUP
 #
@@ -67,6 +67,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -102,6 +103,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -143,8 +145,8 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
@@ -186,13 +188,108 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
 include/start_slave.inc
 include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= 3;
+include/start_slave.inc
+# Normal XA COMMIT
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (110);
+connection master1;
+INSERT INTO t1 VALUES (110);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (109);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (110 + 1);
+connection master;
+XA COMMIT '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+include/sync_with_master_gtid.inc
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
+# Normal XA ROLLBACK
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (113);
+connection master1;
+INSERT INTO t1 VALUES (113);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (112);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (113 + 1);
+connection master;
+XA ROLLBACK '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+include/sync_with_master_gtid.inc
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
 include/stop_slave.inc
 SET @@global.slave_parallel_threads= @old_parallel_threads;

--- a/mysql-test/suite/rpl/r/parallel_backup_slave_binlog_off.result
+++ b/mysql-test/suite/rpl/r/parallel_backup_slave_binlog_off.result
@@ -32,9 +32,9 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection slave;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/diff_tables.inc [master:t1,slave:t1]
 # MDEV-30423: dealock XA COMMIT vs BACKUP
 #
@@ -67,6 +67,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -102,6 +103,7 @@ BACKUP STAGE START;
 BACKUP STAGE BLOCK_COMMIT;
 connection aux_slave;
 ROLLBACK;
+connection aux_slave;
 connection backup_slave;
 BACKUP STAGE END;
 connection slave;
@@ -143,8 +145,8 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
@@ -186,13 +188,108 @@ connection aux_slave;
 ROLLBACK;
 connection backup_slave;
 BACKUP STAGE END;
-connection slave;
 include/stop_slave.inc
+connection slave;
 SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
 SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
 include/start_slave.inc
 include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= 3;
+include/start_slave.inc
+# Normal XA COMMIT
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (110);
+connection master1;
+INSERT INTO t1 VALUES (110);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (109);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (110 + 1);
+connection master;
+XA COMMIT '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+include/sync_with_master_gtid.inc
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
+# Normal XA ROLLBACK
+connection slave;
+include/stop_slave.inc
+connection master;
+connection aux_slave;
+BEGIN;
+INSERT INTO t1 VALUES (113);
+connection master1;
+INSERT INTO t1 VALUES (113);
+include/save_master_gtid.inc
+connection master;
+XA START '1';
+INSERT INTO  t1 VALUES (112);
+XA END '1';
+XA PREPARE '1';
+connection master1;
+include/save_master_gtid.inc
+INSERT INTO t1 VALUES (113 + 1);
+connection master;
+XA ROLLBACK '1';
+include/save_master_gtid.inc
+connection slave;
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+include/start_slave.inc
+connection aux_slave;
+# Xid '1' must be *not* yet in the output:
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+include/sync_with_master_gtid.inc
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 connection slave;
 include/stop_slave.inc
 SET @@global.slave_parallel_threads= @old_parallel_threads;

--- a/mysql-test/suite/rpl/r/parallel_backup_xa_debug.result
+++ b/mysql-test/suite/rpl/r/parallel_backup_xa_debug.result
@@ -26,6 +26,12 @@ backup stage start;
 backup stage block_commit;
 connection slave;
 SET debug_sync = 'now SIGNAL continue_worker';
+select * from t where a=1;
+a
+1
+xa recover;
+formatID	gtrid_length	bqual_length	data
+1	1	0	x
 SET debug_sync = RESET;
 connection slave1;
 backup stage end;

--- a/mysql-test/suite/rpl/r/rpl_parallel_backup_waits_worker_retry.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_backup_waits_worker_retry.result
@@ -1,0 +1,154 @@
+include/master-slave.inc
+[connection master]
+#
+# MDEV-36025 backup taken from parallel replica may contain prepared transactions
+#
+connection master;
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE = innodb;
+INSERT INTO  t1 VALUES (1, 0);
+INSERT INTO  t1 VALUES (2, 0);
+connection slave;
+include/stop_slave.inc
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+SET @old_parallel_threads  = @@GLOBAL.slave_parallel_threads;
+SET @old_parallel_mode     = @@GLOBAL.slave_parallel_mode;
+SET @@global.slave_parallel_threads= 2;
+SET @@global.slave_parallel_mode   = 'optimistic';
+connection master;
+begin /* trx1/L1 */;
+delete from t1 where a = 1;
+update t1 set b = 1 where a = 2;
+commit;
+begin /* trx2/F2 */;
+delete from t1 where a = 2;
+commit;
+connect  aux_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,;
+BEGIN;
+DELETE FROM t1 WHERE a = 1;
+connection slave;
+include/start_slave.inc
+connection aux_slave;
+connect  backup_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+connection aux_slave;
+connection backup_slave;
+BACKUP STAGE END;
+connection slave;
+include/diff_tables.inc [master:t1,slave:t1]
+connection slave;
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= 3;
+include/start_slave.inc
+connection master;
+INSERT INTO t1 VALUES (11,0), (12,0), (13,0), (14,0);
+connection master;
+connection slave;
+include/stop_slave.inc
+connection aux_slave;
+BEGIN;
+DELETE FROM t1 WHERE a = 11;
+connection master;
+begin /* trx1/L1 */;
+delete from t1 where a = 11;
+update t1 set b = 1 where a = 12;
+commit;
+begin /* trx2/F2 */;
+delete from t1 where a = 12;
+update t1 set b=2 where a=14;
+commit;
+begin /* trx3/F3  */;
+delete from t1 where a = 13;
+commit;
+connection slave;
+include/start_slave.inc
+connection aux_slave;
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+connect  aux_slave2,127.0.0.1,root,,test,$SLAVE_MYPORT,;
+BEGIN;
+UPDATE t1 SET b=2 WHERE a=14;
+connection slave;
+connection aux_slave;
+ROLLBACK;
+connection aux_slave;
+connection aux_slave2;
+ROLLBACK;
+connection backup_slave;
+BACKUP STAGE END;
+connection master;
+connection slave;
+include/diff_tables.inc [master:t1,slave:t1]
+connection slave;
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= 4;
+include/start_slave.inc
+connection master;
+INSERT INTO t1 VALUES (21,0), (22,0), (23,0), (24,0);
+connection master;
+connection slave;
+include/stop_slave.inc
+connection aux_slave;
+BEGIN;
+DELETE FROM t1 WHERE a = 21;
+connection master;
+begin /* trx1/L1 */;
+delete from t1 where a = 21;
+update t1 set b = 1 where a = 22;
+commit;
+begin /* trx2/F2 */;
+delete from t1 where a = 22;
+update t1 set b=2 where a=24;
+commit;
+begin /* trx3/F3  */;
+delete from t1 where a = 23;
+commit;
+connection slave;
+include/start_slave.inc
+connection aux_slave;
+connection backup_slave;
+BACKUP STAGE START;
+BACKUP STAGE BLOCK_COMMIT;
+connection aux_slave;
+connection aux_slave2;
+BEGIN;
+UPDATE t1 SET b=1 WHERE a=24;
+connection slave;
+connection aux_slave;
+ROLLBACK;
+# prove the MDL lock state is about to become /*granted*/ S2,S5(F2); /* waitng */ X3
+connection aux_slave;
+connection master;
+INSERT INTO t1 VALUES (25,0) /* L4 third slave group commit leader */;
+connection slave;
+connection aux_slave2;
+ROLLBACK;
+connection backup_slave;
+L4's S6 is waiting
+connection slave;
+INSERT(25) is backup-locked out
+select * from t1 where a = 25;
+a	b
+connection backup_slave;
+BACKUP STAGE END;
+connection master;
+connection slave;
+INSERT(25) is done
+select * from t1 where a = 25;
+a	b
+25	0
+include/diff_tables.inc [master:t1,slave:t1]
+connection slave;
+include/stop_slave.inc
+SET @@global.slave_parallel_threads= @old_parallel_threads;
+SET @@global.slave_parallel_mode   = @old_parallel_mode;
+include/start_slave.inc
+connection server_1;
+DROP TABLE t1;
+include/rpl_end.inc
+# End of the tests

--- a/mysql-test/suite/rpl/r/rpl_parallel_backup_worker_retry.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_backup_worker_retry.result
@@ -35,6 +35,8 @@ connection aux_slave;
 ROLLBACK;
 connection aux_slave;
 connection backup_slave;
+connection aux_slave;
+connection backup_slave;
 BACKUP STAGE END;
 connection slave;
 include/diff_tables.inc [master:t1,slave:t1]

--- a/mysql-test/suite/rpl/t/parallel_backup.test
+++ b/mysql-test/suite/rpl/t/parallel_backup.test
@@ -3,6 +3,13 @@
 --source include/have_binlog_format_mixed.inc
 --source include/master-slave.inc
 
+#
+# The test for MDEV-21953 is adapted to MDEV-36025 fixes including
+# some comments.
+# Find in rpl.rpl_parallel_backup_worker_retry more
+# of the parallel slave concurrent with BACKUP scenarios.
+#
+
 --echo #
 --echo # MDEV-21953: deadlock between BACKUP STAGE BLOCK_COMMIT and parallel
 --echo # replication
@@ -45,24 +52,30 @@ INSERT INTO t1 VALUES (1);
 
 --connection aux_slave
 --let $wait_condition= SELECT COUNT(*) > 0 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
---source include/wait_condition.inc
+source include/wait_condition.inc;
 
 # While the 1st worker is locked out run backup
 --connect (backup_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,)
 BACKUP STAGE START;
 --send BACKUP STAGE BLOCK_COMMIT
 
-# release the 1st work
 --connection aux_slave
---sleep 1
+# BACKUP is waiting
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+source include/wait_condition.inc;
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Update"
+source include/wait_condition.inc;
+# go trx1,trx2
 ROLLBACK;
+
+# .. so the group of two will commit. This proves MDEV-36025 efficacy.
+--connection slave
+--sync_with_master
 
 --connection backup_slave
 --reap
 BACKUP STAGE END;
 
---connection slave
---sync_with_master
 
 --let $diff_tables= master:t1,slave:t1
 --source include/diff_tables.inc
@@ -93,6 +106,28 @@ BACKUP STAGE END;
 --source include/start_slave.inc
 --source include/sync_with_master_gtid.inc
 
+if (!$parallel_backup_without_binlog)
+{
+# Test with optimistic retry.
+--let $complete = COMMIT
+--source parallel_backup_xa2.inc
+--let $complete = ROLLBACK
+--source parallel_backup_xa2.inc
+}
+
+source include/stop_slave.inc;
+SET @@global.slave_parallel_threads= 3;
+source include/start_slave.inc;
+
+if ($parallel_backup_without_binlog)
+{
+# Test with optimistic retry.
+# --skip-log-bin and --log-slave-updates=0 tests have a bit different scenario.
+--let $complete = COMMIT
+--source parallel_backup_xa3.inc
+--let $complete = ROLLBACK
+--source parallel_backup_xa3.inc
+}
 
 # Clean up.
 --connection slave

--- a/mysql-test/suite/rpl/t/parallel_backup_lsu_off.test
+++ b/mysql-test/suite/rpl/t/parallel_backup_lsu_off.test
@@ -4,4 +4,5 @@
 --echo # MDEV-21953: deadlock between BACKUP STAGE BLOCK_COMMIT and parallel
 --echo # MDEV-30423: dealock XA COMMIT vs BACKUP
 --let $rpl_skip_reset_master_and_slave = 1
+--let $parallel_backup_without_binlog=1
 --source parallel_backup.test

--- a/mysql-test/suite/rpl/t/parallel_backup_slave_binlog_off.test
+++ b/mysql-test/suite/rpl/t/parallel_backup_slave_binlog_off.test
@@ -4,4 +4,5 @@
 --echo # MDEV-21953: deadlock between BACKUP STAGE BLOCK_COMMIT and parallel
 --echo # MDEV-30423: dealock XA COMMIT vs BACKUP
 --let $rpl_server_skip_log_bin= 1
+--let $parallel_backup_without_binlog=1
 --source parallel_backup.test

--- a/mysql-test/suite/rpl/t/parallel_backup_xa.inc
+++ b/mysql-test/suite/rpl/t/parallel_backup_xa.inc
@@ -62,20 +62,28 @@ XA RECOVER;
     --let $rpl_allow_error=1
   }
   ROLLBACK;
---let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
---source include/wait_condition.inc
---connection backup_slave
-  --reap
-  BACKUP STAGE END;
---connection slave
+
 if (!$slave_ooo_error)
 {
+  --connection aux_slave
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and command = "Slave_worker"
+  source include/wait_condition.inc;
+}
+  --connection backup_slave
+  --reap
+  BACKUP STAGE END;
+
+if (!$slave_ooo_error)
+{
+  --connection slave
   --source include/sync_with_master_gtid.inc
 }  
+
 --let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 if ($slave_ooo_error)
 {
+  --connection slave
   SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
   SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;
 }

--- a/mysql-test/suite/rpl/t/parallel_backup_xa2.inc
+++ b/mysql-test/suite/rpl/t/parallel_backup_xa2.inc
@@ -1,0 +1,103 @@
+# Invoked from parallel_backup.test
+# Parameters:
+# $complete        = COMMIT or ROLLBACK
+
+# This test conducts T1,XAP2,T3,XAC4 parallel execution with retries
+# having a BACKUP command interjecting with its BLOCK_COMMIT prior to
+# T1 gets out of its retry and T3 reaches its commit stage.
+--let $kind = Normal
+--echo # $kind XA $complete
+
+--connection slave
+--source include/stop_slave.inc
+
+--connection master
+# val_0 is the first value to insert on master in prepared xa
+# val_1 is the next one to insert which is the value to block on slave
+--let $val_0 = `SELECT max(a)+1 FROM t1`
+--let $val_1 = $val_0
+--inc $val_1
+
+--connection aux_slave
+BEGIN;
+--eval INSERT INTO t1 VALUES ($val_1)
+
+# the slave group commit leader transaction will be harassed by above into retry
+connection master1;
+# conflicting value
+ --eval INSERT INTO t1 VALUES ($val_1)
+--source include/save_master_gtid.inc
+--let $save_gtid_1=$master_pos
+
+--connection master
+XA START '1';
+--eval INSERT INTO  t1 VALUES ($val_0)
+XA END '1';
+XA PREPARE '1';
+
+--connection master1
+--source include/save_master_gtid.inc
+--let $save_gtid_2=$master_pos
+--eval INSERT INTO t1 VALUES ($val_1 + 1)
+
+--connection master
+--eval XA $complete '1'
+--source include/save_master_gtid.inc
+--let $save_gtid_all=$master_pos
+
+--connection slave
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+
+--source include/start_slave.inc
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+--echo # Xid '1' must be *not* yet in the output:
+XA RECOVER;
+
+--connection backup_slave
+  BACKUP STAGE START;
+--send BACKUP STAGE BLOCK_COMMIT
+
+--connection aux_slave
+  let $status_var= Slave_retried_transactions;
+  let $status_var_value= query_get_value(SHOW STATUS LIKE '$status_var', Value, 1);
+  # wait for T1's re-try get stuck in repeating wait-for-lock..
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Update"
+  source include/wait_condition.inc;
+
+  let $status_var_comparsion= >;
+  source include/wait_for_status_var.inc;
+  # Note T3 is not yet scheduled as each worker is busy, and BLOCK_COMMIT is
+  # being waited.
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and command = "Query"
+  
+  ROLLBACK;
+
+  --connection aux_slave
+  --let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and command = "Slave_worker"
+  source include/wait_condition.inc;
+  # This is MDEV-21469 XA recovery related. The XAP has a post-prepare
+  # action to insert its gtid and that is blocked. The two waiters for Backup
+  # are the XAP and its follower INSERT($val_1 + 1) trx. So instead of
+    #--let $master_pos=$save_gtid_2
+    #--source include/sync_with_master_gtid.inc
+  # the check must hold
+  --eval select @@global.gtid_slave_pos = "$save_gtid_1"
+
+  --connection backup_slave
+  --reap
+  BACKUP STAGE END;
+
+  --connection slave
+  --let $master_pos=$save_gtid_all
+  --source include/sync_with_master_gtid.inc
+
+--source include/stop_slave.inc
+
+  --connection slave
+  SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+  SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;

--- a/mysql-test/suite/rpl/t/parallel_backup_xa3.inc
+++ b/mysql-test/suite/rpl/t/parallel_backup_xa3.inc
@@ -1,0 +1,108 @@
+# Invoked from parallel_backup.test
+# Parameters:
+# $complete        = COMMIT or ROLLBACK
+
+# This test conducts T1,XAP2,T3,XAC4 parallel execution with retries
+# having a BACKUP command interjecting with its BLOCK_COMMIT prior to
+# T1 gets out of its retry and T3 has acquire MDL lock.
+# We prove the BACKUP command would not prevent 1,2,3 seq-no team group-commit
+# as well as itself complete leaving the 4th seq-no transaction waiting.
+--let $kind = Normal
+--echo # $kind XA $complete
+
+--connection slave
+--source include/stop_slave.inc
+
+--connection master
+# val_0 is the first value to insert on master in prepared xa
+# val_1 is the next one to insert which is the value to block on slave
+--let $val_0 = `SELECT max(a)+1 FROM t1`
+--let $val_1 = $val_0
+--inc $val_1
+
+--connection aux_slave
+BEGIN;
+--eval INSERT INTO t1 VALUES ($val_1)
+
+# the slave group commit leader transaction will be harassed by above into retry
+connection master1;
+# conflicting value
+ --eval INSERT INTO t1 VALUES ($val_1)
+--source include/save_master_gtid.inc
+--let $save_gtid_1=$master_pos
+
+--connection master
+XA START '1';
+--eval INSERT INTO  t1 VALUES ($val_0)
+XA END '1';
+XA PREPARE '1';
+
+--connection master1
+--source include/save_master_gtid.inc
+--let $save_gtid_2=$master_pos
+--eval INSERT INTO t1 VALUES ($val_1 + 1)
+
+--connection master
+--eval XA $complete '1'
+--source include/save_master_gtid.inc
+--let $save_gtid_all=$master_pos
+
+--connection slave
+SET @sav_innodb_lock_wait_timeout  = @@global.innodb_lock_wait_timeout;
+SET @sav_slave_transaction_retries = @@global.slave_transaction_retries;
+SET @@global.innodb_lock_wait_timeout =2;
+SET @@global.slave_transaction_retries=100;
+
+--source include/start_slave.inc
+# XAP has not acquired BACKUP MDL at waiting
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+--echo # Xid '1' must be *not* yet in the output:
+XA RECOVER;
+
+--connection backup_slave
+  BACKUP STAGE START;
+--send BACKUP STAGE BLOCK_COMMIT
+
+--connection aux_slave
+  let $status_var= Slave_retried_transactions;
+  let $status_var_value= query_get_value(SHOW STATUS LIKE '$status_var', Value, 1);
+  # wait for T1's re-try get stuck in repeating wait-for-lock..
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Update"
+  source include/wait_condition.inc;
+
+  let $status_var_comparsion= >;
+  source include/wait_for_status_var.inc;
+  # T3 does not let the backup's BLOCK_COMMIT, so the latter is waiting
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and command = "Query"
+
+  # release T1 which is going to
+  # - leapfrog the backup thread waiting strong lock at retry
+  # - commit itself, notify XAP2 and T3 that both will share MDL and
+  #   group-commit.
+  ROLLBACK;
+
+  # Backup will finally get the lock; XAC4 is waiting
+  --connection aux_slave
+  --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and command = "Slave_worker"
+  source include/wait_condition.inc;
+  # Unlike --log-bin setup, thanks to T3 timeing to thake the shared MD,
+  # XAP2 will also acquire the BACKUP MDL and complete with its gtid_seq_no
+  # insertion part.
+  --let $master_pos=$save_gtid_2
+  --source include/sync_with_master_gtid.inc
+
+  --connection backup_slave
+  --reap
+  BACKUP STAGE END;
+
+  --connection slave
+  --let $master_pos=$save_gtid_all
+  --source include/sync_with_master_gtid.inc
+
+--source include/stop_slave.inc
+
+  --connection slave
+  SET @@global.innodb_lock_wait_timeout = @sav_innodb_lock_wait_timeout;
+  SET @@global.slave_transaction_retries= @sav_slave_transaction_retries;

--- a/mysql-test/suite/rpl/t/parallel_backup_xa_debug.test
+++ b/mysql-test/suite/rpl/t/parallel_backup_xa_debug.test
@@ -26,7 +26,27 @@ xa start 'x';
 xa end 'x';
 xa prepare 'x';
 
+# Affects of MDEV-36025 to the user XA and backup.
+# In the following master logs two trx:s the 1st is Leader which will be
+# delayed into the group commmit and the 2nd is XA PREPAREd Follower that will
+# acquire BACKUP MDL share lock before a backup thread will make a stronger
+# request it. It will wait.
+# Here we prove that the delayed arrival of the Leader to the group commit
+# will pass throuh the wating backup X.
+# The gtid 100,101 group will complete and the backup thread will be unhang
+# upon that.
+# HOWEVER, the XAP completion in the slave group commit can't be full.
+# Becose of MDEV-21469 specific slave's sub-case that incorporates
+# gtid_slave_pos to the user XA prepared replicated trx the XAP might not
+# be able to acquire an S BACKUP MDL on this extra statement. That's why
+# we prove the group commit with showing data affects
+# by Leader and XAP state rather than syncing with master.
+#
+# Despite of the necessary workaround, we prove the delayed Leader leapfrogs
+# a stronger waiting request, the same as it happens in the normal trx case.
+
 --connection slave
+# Leader is delayed, Follower awaits it.
 SET @@global.debug_dbug="+d,hold_worker_on_schedule";
 start slave;
 SET debug_sync = 'now WAIT_FOR reached_pause';
@@ -35,15 +55,33 @@ SET debug_sync = 'now WAIT_FOR reached_pause';
 
 --connection slave1
 backup stage start;
-backup stage block_commit;
+--send backup stage block_commit
 
 --connection slave
+
+# Backup is waiting which means the MDL query: S(g101); X(backup)
 --let $wait_condition= SELECT count(*) = 1 FROM information_schema.processlist WHERE state LIKE "Waiting for backup lock"
-SET debug_sync = 'now SIGNAL continue_worker';
 --source include/wait_condition.inc
+
+# Leader is released to group commit with g101
+SET debug_sync = 'now SIGNAL continue_worker';
+
+#--connection slave
+# This is a workaround MDEV-21469 relate issue.
+let $show_statement = xa recover;
+let $field = data;
+let $condition = = 'x';
+let $wait_timeout = 30;
+--source include/wait_show_condition.inc
+select * from t where a=1;
+--eval $show_statement
+# :sweat-smile:
 SET debug_sync = RESET;
 
+#--sync_slave_with_master
+
 --connection slave1
+--reap
 backup stage end;
 
 --connection master

--- a/mysql-test/suite/rpl/t/rpl_parallel_backup_waits_worker_retry.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_backup_waits_worker_retry.test
@@ -1,0 +1,387 @@
+--source include/have_innodb.inc
+--source include/have_binlog_format_mixed.inc
+--source include/master-slave.inc
+
+--echo #
+--echo # MDEV-36025 backup taken from parallel replica may contain prepared transactions
+--echo #
+
+# The tests proves the following.
+#
+# 1. The patch replaces MDEV-21953/MDEV-23586 W2(S1),B(X2),W1(S3) deadlock
+#     and its post-fixes MDEV-37453.
+# 2. Applies "ignore-priority" requesting and scheduling of BACKUP MDL
+#    by parallel slave worker threads.
+#    A. demonstrate a shared lock request by a parallel worker which
+#       is being waited for (prior-commit) is granted immediately even
+#       though there exists a waiting X lock in the way.
+#    B. show fainess of MDL acquision, that is a waiting X by
+#       BLOCK_COMMIT of backup thread is granted in due time
+#       that is all slave workers have gathered a group-committable "team".
+
+
+# Legends
+# -------
+#
+# Threads notations.
+# L or Li, F,F1,F2 - Leader and Follower slave group commit transactions,
+#   the number index indicates binlog ordering (read as gtid seq_no).
+# T are utility transaction to help building trx dependencies on slave and
+# W are worker threads/transactions when their F/L role is irrelevant.
+#
+# Locks notations.
+# Si, Xi - typical MDL:s that are acquired by the slave worker and the
+#   backup thread; i stands for ordering of acquiring the BACKUP MDL;
+#   Si(Fj or Lk) describes the owner of the MDL lock or request.
+#   Note a parallel slave thread can re-request S lock to advance the index.
+# To present the MDL queue we use `;' to separate the granted head from
+# waiters that are ordered by `k` index as below.
+#   Si,... ; Xk, ...
+# E,g S1(F2); X2(B) - reads a shared BACKUP MDL is granted to the slave thread
+# and there is a backup thread waiter for X.
+
+# PROOF 1.
+# --------
+# The plot.
+# It's about having the MDL requests order as
+#
+#   S1(F2); X2(B), S3(L1)
+#
+# where the Follower will be waiting for (prior commit of)  L leader (2 > 1),
+# while the latter is delayed.
+# Also F -depends-> L in data part and therefore  L is going to kill it.
+# Upon retry F2 will find X2 lock in the way of its S4 (one more request at its
+# retry) which it won't be allowed to bypass. After L1 has committed
+# the MDL queue settles into
+#
+#   /* granted */ X2(B); /* waiting*/ S4(F2).
+#
+# T auxiliary slave local trx orchestrates necessary timings to conduct the plot.
+#
+# This all proves the safety of concurrent execution of the parallel slave and
+# backup thread in a simple setup, reported in the referreced bugs.
+# The most importantly we prove the state of the waiting queue of
+#         ...; X2,S3(L)
+# is resolved into
+#       /* granted */ S3(L); X2.
+
+
+--connection master
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE = innodb;
+INSERT INTO  t1 VALUES (1, 0);
+INSERT INTO  t1 VALUES (2, 0);
+--sync_slave_with_master
+--source include/stop_slave.inc
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+SET @old_parallel_threads  = @@GLOBAL.slave_parallel_threads;
+SET @old_parallel_mode     = @@GLOBAL.slave_parallel_mode;
+SET @@global.slave_parallel_threads= 2;
+SET @@global.slave_parallel_mode   = 'optimistic';
+
+# Proof 1
+
+--connection master
+begin /* trx1/L1 */;
+  delete from t1 where a = 1;
+  update t1 set b = 1 where a = 2;
+commit;
+begin /* trx2/F2 */;
+  delete from t1 where a = 2;
+commit;
+
+--save_master_pos
+
+--connect (aux_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,)
+BEGIN;
+# block the 1st worker and wait for the 2nd ready to commit
+  DELETE FROM t1 WHERE a = 1;
+
+--connection slave
+--source include/start_slave.inc
+
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+
+# While the 1st worker is locked out run backup
+--connect (backup_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,)
+BACKUP STAGE START;
+--send BACKUP STAGE BLOCK_COMMIT
+
+--connection aux_slave
+# Make sure BACKUP lock is waiting
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+# release the 1st work
+let $status_var= Slave_retried_transactions;
+let $status_var_value= query_get_value(SHOW STATUS LIKE '$status_var', Value, 1);
+--sleep 1
+ROLLBACK;
+
+# that will kick the 2nd out of the current WfPTtC into next retry one
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+
+let $status_var_comparsion= >;
+--source include/wait_for_status_var.inc
+
+--connection aux_slave
+# Make sure trx1 is waiting for MDL
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+--connection backup_slave
+reap;
+BACKUP STAGE END;
+
+--connection slave
+--sync_with_master
+
+--let $diff_tables= master:t1,slave:t1
+--source include/diff_tables.inc
+
+# PROOF 2.A
+# The plot.
+# It's about initially having the MDL requests shape the lock as
+#   /* granted */ S1(F3),S3(F2); /* waiting */ X3(B)
+# by time of S4(L1) request. It must bypass X3 and
+# in transaction non-dependent case that would end up with
+#   /* granted */ S1,S3,S4(L); /* waiting*/ X3
+# However here we complicate the matter with the Proof 1's kind of
+# the data dependency of F2 -> L1.
+# L1 commits alone and in that process killes F2 into retry,
+# the latter's S5 (its 2nd that is) request will see the BACKUP MDL state as
+#   S1(F3); X3, S5(F2)
+# so it will be allowed (3 > 2) to leapfrog X3. The state now
+#   /* granted*/ S1,S5(F2); /* waiting */ X3
+# and immediately, as F2 will turn into the leader role, L2 and F3 commit
+# to leave
+#   X3(granted).
+#
+# This all futher validates the safety of Proof 1 under more stringent
+# condtion of the paralle slave retry and effective functionality of
+# jumping over "ignoring" incompatible BACKUP MDL request in the way.
+
+--connection slave
+--source include/stop_slave.inc
+SET @@global.slave_parallel_threads= 3;
+--source include/start_slave.inc
+
+--connection master
+# Insert new, non-conflicting rows for the 3 workers.
+INSERT INTO t1 VALUES (11,0), (12,0), (13,0), (14,0);
+
+--connection master
+--sync_slave_with_master
+--source include/stop_slave.inc
+
+--connection aux_slave
+BEGIN;
+# block L1
+  DELETE FROM t1 WHERE a = 11;
+
+--connection master
+begin /* trx1/L1 */;
+  delete from t1 where a = 11;
+  update t1 set b = 1 where a = 12;
+commit;
+begin /* trx2/F2 */; ## TODO: delay F2
+  delete from t1 where a = 12;
+  update t1 set b=2 where a=14;
+commit;
+begin /* trx3/F3  */;
+  delete from t1 where a = 13;
+commit;
+
+--connection slave
+--source include/start_slave.inc
+
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+
+# While the 1st worker is locked out run backup
+--connection backup_slave
+BACKUP STAGE START;
+--send BACKUP STAGE BLOCK_COMMIT
+
+--connection aux_slave
+# Make sure BACKUP lock is waiting
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+# Prepare to hang again F2 now at its retry
+--connect (aux_slave2,127.0.0.1,root,,test,$SLAVE_MYPORT,)
+BEGIN;
+  send UPDATE t1 SET b=2 WHERE a=14;
+
+--connection slave
+# wait the aux_slave2 spoiler starts waiting for F2 lock, and then..
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.INNODB_LOCK_WAITS;
+--source include/wait_condition.inc
+
+# .. release L
+ROLLBACK;
+
+# prove the MDL lock state is now  /* granted */  S1(F3); /* waiting */ X3
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and Command = "Query"
+--source include/wait_condition.inc
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Updating" and Command = "Slave_worker"
+--source include/wait_condition.inc
+
+# Finish L2=F2,F3 group
+--connection aux_slave2
+--reap
+ROLLBACK;
+
+--connection backup_slave
+reap;
+BACKUP STAGE END;
+
+# Correctness proof
+--connection master
+--sync_slave_with_master
+
+--let $diff_tables= master:t1,slave:t1
+--source include/diff_tables.inc
+
+# PROOF 2.B.
+# The plot further extends the scenario of the Proof 2.A to introduce
+# one more replicated transaction which can't leapfrog the X of backup.
+# It's about initally having the MDL queue state as
+#   /* granted */ S1(F2),S2(F3); /* waiting */ X3(B),
+# Along the way to commit L1 kills F2 and bypasses X3. Past F2 retry
+# the BACKUP MDL queue state gets about
+#   S3(F3),S5(F2); X3
+# Before the 2nd group commits S6(by L4) is requested and it won't be able
+# to make to the grantees 'cos 4 > 3 and 2.
+# In the following the plot 2.A is largely repeated, and in the end
+# the BACKUP MDL will have
+#     /*granted*/ X3; /*waiting*/ S6
+# which proves the ignore-priority scheduler's fairness.
+
+--connection slave
+--source include/stop_slave.inc
+SET @@global.slave_parallel_threads= 4;
+--source include/start_slave.inc
+
+--connection master
+# Insert new, non-conflicting rows for the 3 workers.
+INSERT INTO t1 VALUES (21,0), (22,0), (23,0), (24,0);
+
+--connection master
+--sync_slave_with_master
+--source include/stop_slave.inc
+
+--connection aux_slave
+BEGIN;
+# block the 1st follower
+  DELETE FROM t1 WHERE a = 21;
+
+--connection master
+begin /* trx1/L1 */;
+  delete from t1 where a = 21;
+  update t1 set b = 1 where a = 22;
+commit;
+begin /* trx2/F2 */;
+  delete from t1 where a = 22;
+  update t1 set b=2 where a=24;
+commit;
+begin /* trx3/F3  */;
+  delete from t1 where a = 23;
+commit;
+
+--connection slave
+--source include/start_slave.inc
+
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+
+# While the 1st worker is locked out run backup
+--connection backup_slave
+BACKUP STAGE START;
+--send BACKUP STAGE BLOCK_COMMIT
+
+--connection aux_slave
+# Make sure BACKUP lock is waiting
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+# Prepare to hang F2 at its retry
+connection aux_slave2;
+BEGIN;
+  --send UPDATE t1 SET b=1 WHERE a=24
+
+--connection slave
+# wait the aux_slave2 spoiler starts waiting for F2 lock, and then..
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.INNODB_LOCK_WAITS;
+--source include/wait_condition.inc
+
+# .. release L
+ROLLBACK;
+
+--echo # prove the MDL lock state is about to become /*granted*/ S2,S5(F2); /* waitng */ X3
+--connection aux_slave
+# F3 is waiting for the innodb lock waiting F2
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock" and Command = "Query"
+--source include/wait_condition.inc
+
+# Before to finish F2/L2,F3 group conduct Proof 3 specfic actions
+connection master;
+INSERT INTO t1 VALUES (25,0) /* L4 third slave group commit leader */;
+
+# L4 can't leapfrog
+connection slave;
+--let $wait_condition= SELECT COUNT(*) = 2 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+# Complete L2,F3
+connection aux_slave2;
+--reap
+ROLLBACK;
+
+connection backup_slave;
+reap;
+
+--echo L4's S6 is waiting
+connection slave;
+--echo INSERT(25) is backup-locked out
+select * from t1 where a = 25;
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+--source include/wait_condition.inc
+
+connection backup_slave;
+BACKUP STAGE END;
+
+# Correctness proof
+connection master;
+sync_slave_with_master;
+--echo INSERT(25) is done
+select * from t1 where a = 25;
+
+--let $diff_tables= master:t1,slave:t1
+--source include/diff_tables.inc
+
+
+# Clean up.
+--connection slave
+--source include/stop_slave.inc
+SET @@global.slave_parallel_threads= @old_parallel_threads;
+SET @@global.slave_parallel_mode   = @old_parallel_mode;
+--source include/start_slave.inc
+
+--connection server_1
+DROP TABLE t1;
+
+--source include/rpl_end.inc
+--echo # End of the tests

--- a/mysql-test/suite/rpl/t/rpl_parallel_backup_worker_retry.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_backup_worker_retry.test
@@ -2,6 +2,11 @@
 --source include/have_binlog_format_mixed.inc
 --source include/master-slave.inc
 
+#
+# The test for MDEV-37453 is adapted to MDEV-36025 fixes including
+# some comments. The latter bug-fixes extends the current scenario into few,
+# find rpl.rpl_parallel_backup_worker_retry.
+#
 --echo #
 --echo # MDEV-37453 Parallel Replication Crash During Backup
 --echo #
@@ -17,8 +22,9 @@
 # 2. At this point issue BACKUP commands of which BLOCK_COMMIT will
 #    later force the 2nd transaction to wait for the BACKUP MDL lock.
 # 3. Release locks to the 1st transaction which would kick the 2nd out
-#    of waiting-for-prior-commit only to return negative from the
-#    BACKUP MDL acquisition attempt (found itself killed).
+#    of waiting-for-prior-commit.
+#    MDEV-36025: it won't do
+#      BACKUP MDL re-acquisition attempt along the way to retry.
 # 4. Finally, prove of safety: the 2nd transaction retries successfully.
 
 --connection master
@@ -59,7 +65,9 @@ BEGIN;
 # While the 1st worker is locked out run backup
 --connect (backup_slave,127.0.0.1,root,,test,$SLAVE_MYPORT,)
 BACKUP STAGE START;
-BACKUP STAGE BLOCK_COMMIT;
+# MDEV-36025 changes the slave worker not to release BACKUP MDL which it
+# is holding see $wait_condition above.
+--send BACKUP STAGE BLOCK_COMMIT
 
 # release the 1st work
 --connection aux_slave
@@ -71,14 +79,29 @@ ROLLBACK;
 # that will kick the 2nd out of the current WfPTtC into next retry one
 --connection aux_slave
 --let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for prior transaction to commit"
---source include/wait_condition.inc
+source include/wait_condition.inc;
+
+# at same time BACKUP's request is still waiting
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+source include/wait_condition.inc;
 
 let $status_var_comparsion= >;
 --source include/wait_for_status_var.inc
 
+# BACKUP gets its lock granted by trx1
+--connection backup_slave
+reap;
+
+# which makes the retrying trx2 wait for it
+--connection aux_slave
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state = "Waiting for backup lock"
+source include/wait_condition.inc;
+
+# release BACKUP MDL
 --connection backup_slave
 BACKUP STAGE END;
 
+# and we're done
 --connection slave
 --sync_with_master
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1791,7 +1791,7 @@ int ha_commit_trans(THD *thd, bool all)
                                                         &no_rollback);
   /* rw_trans is TRUE when we in a transaction changing data */
   bool rw_trans= is_real_trans && rw_ha_count > 0;
-  MDL_request mdl_request, *mdl_ptr= nullptr;
+  MDL_request mdl_request, *mdl_ptr= &mdl_request;
   DBUG_PRINT("info", ("is_real_trans: %d  rw_trans:  %d  rw_ha_count: %d",
                       is_real_trans, rw_trans, rw_ha_count));
 
@@ -1813,17 +1813,24 @@ int ha_commit_trans(THD *thd, bool all)
     */
     if (!WSREP(thd))
     {
+      auto lock_type= MDL_BACKUP_COMMIT;
+      rpl_group_info *rgi= thd->rgi_slave;
+      bool is_parallel_slave= rgi && rgi->is_parallel_exec;
+
+      if (is_parallel_slave)
+      {
+	mdl_ptr= new (&thd->transaction->mem_root) MDL_request();
+      }
       /*
         Allocate slave's lock in greater scope mem-root due to MDEV-7458
         requirements, see error case's rollback comments further down.
       */
-      mdl_ptr= (thd->rgi_slave && thd->rgi_slave->is_parallel_exec) ?
-	       new (&thd->transaction->mem_root) MDL_request() : &mdl_request;
-      MDL_REQUEST_INIT(mdl_ptr, MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
+      MDL_REQUEST_INIT(mdl_ptr, MDL_key::BACKUP, "", "", lock_type,
                        MDL_EXPLICIT);
-      if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec)
+      if (is_parallel_slave)
 	mdl_ptr->is_teammate_callback=
 	  &rpl_group_info::ignore_mdl_priority;
+
       if (thd->mdl_context.acquire_lock(mdl_ptr,
                                         thd->variables.lock_wait_timeout))
       {

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1791,7 +1791,7 @@ int ha_commit_trans(THD *thd, bool all)
                                                         &no_rollback);
   /* rw_trans is TRUE when we in a transaction changing data */
   bool rw_trans= is_real_trans && rw_ha_count > 0;
-  MDL_request mdl_backup;
+  MDL_request mdl_request, *mdl_ptr= nullptr;
   DBUG_PRINT("info", ("is_real_trans: %d  rw_trans:  %d  rw_ha_count: %d",
                       is_real_trans, rw_trans, rw_ha_count));
 
@@ -1811,19 +1811,27 @@ int ha_commit_trans(THD *thd, bool all)
       We allow the owner of FTWRL to COMMIT; we assume that it knows
       what it does.
     */
-    MDL_REQUEST_INIT(&mdl_backup, MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
-                     MDL_EXPLICIT);
-
     if (!WSREP(thd))
     {
-      if (thd->mdl_context.acquire_lock(&mdl_backup,
+      /*
+        Allocate slave's lock in greater scope mem-root due to MDEV-7458
+        requirements, see error case's rollback comments further down.
+      */
+      mdl_ptr= (thd->rgi_slave && thd->rgi_slave->is_parallel_exec) ?
+	       new (&thd->transaction->mem_root) MDL_request() : &mdl_request;
+      MDL_REQUEST_INIT(mdl_ptr, MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
+                       MDL_EXPLICIT);
+      if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec)
+	mdl_ptr->is_teammate_callback=
+	  &rpl_group_info::ignore_mdl_priority;
+      if (thd->mdl_context.acquire_lock(mdl_ptr,
                                         thd->variables.lock_wait_timeout))
       {
         my_error(ER_ERROR_DURING_COMMIT, MYF(0), 1);
         ha_rollback_trans(thd, all);
         DBUG_RETURN(1);
       }
-      thd->backup_commit_lock= &mdl_backup;
+      thd->backup_commit_lock= mdl_ptr;
     }
     DEBUG_SYNC(thd, "ha_commit_trans_after_acquire_commit_lock");
   }
@@ -2073,18 +2081,20 @@ err:
                 thd->rgi_slave->is_parallel_exec);
   }
 end:
-  // reset the pointer to the ticket when it's stack instantiated
-  if (thd->backup_commit_lock == &mdl_backup)
+  if (!(thd->rgi_slave && thd->rgi_slave->is_parallel_exec && error) &&
+      (mdl_ptr && thd->backup_commit_lock == mdl_ptr))
   {
     /*
       We do not always immediately release transactional locks
       after ha_commit_trans() (see uses of ha_enable_transaction()),
       thus we release the commit blocker lock as soon as it's
       not needed.
+      Errored-out slave parallel worker needs to keep it BACKUP lock
+      to be released at its cleanup before the MDEV-7458 deferred rollback.
      */
-    if (mdl_backup.ticket)
-      thd->mdl_context.release_lock(mdl_backup.ticket);
-    thd->backup_commit_lock= 0;
+    if (mdl_ptr->ticket)
+      thd->mdl_context.release_lock(mdl_ptr->ticket);
+    thd->backup_commit_lock= nullptr;
   }
 #ifdef WITH_WSREP
   if (wsrep_is_active(thd) && is_real_trans && !error &&
@@ -2238,6 +2248,18 @@ commit_one_phase_2(THD *thd, bool all, THD_TRANS *trans, bool is_real_trans)
   if (is_real_trans)
   {
     thd->has_waiter= false;
+    if (!error && (thd->rgi_slave && thd->rgi_slave->is_parallel_exec) &&
+	thd->backup_commit_lock)
+    {
+      DBUG_ASSERT(thd->backup_commit_lock->ticket);
+      /*
+        As parallel slave allocates its BACKUP lock in transaction mem-root
+        the successful commit by slave must be followed with the lock release
+        before the mem-root is cleaned.
+      */
+      thd->mdl_context.release_lock(thd->backup_commit_lock->ticket);
+      thd->backup_commit_lock= nullptr;
+    }
     thd->transaction->cleanup();
     if (count >= 2)
       statistic_increment(transactions_multi_engine, LOCK_status);
@@ -2403,6 +2425,18 @@ int ha_rollback_trans(THD *thd, bool all)
       thd->transaction->xid_state.set_error(thd->get_stmt_da()->sql_errno());
 
     thd->has_waiter= false;
+    if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec &&
+	thd->backup_commit_lock)
+    {
+      /*
+        MDL BACKUP unlocking by parallel slave is done after the transaction
+        rolls back. The MDL lock must be released before its memory allocatioon
+        in transaction root is cleaned.
+      */
+      thd->mdl_context.release_lock(thd->backup_commit_lock->ticket);
+      thd->backup_commit_lock= nullptr;
+    }
+
     thd->transaction->cleanup();
   }
   if (all)

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8204,7 +8204,6 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
   group_commit_entry *entry, *orig_queue, *last;
   wait_for_commit *cur;
   wait_for_commit *wfc;
-  bool backup_lock_released= 0;
   int result= 0;
   THD *thd= orig_entry->thd;
   DBUG_ENTER("MYSQL_BIN_LOG::queue_for_group_commit");
@@ -8239,22 +8238,6 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
         !loc_waitee->commit_started)
     {
       PSI_stage_info old_stage;
-
-        /*
-          Release MDL_BACKUP_COMMIT LOCK while waiting for other threads to
-          commit.
-          This is needed to avoid deadlock between the other threads (which not
-          yet have the MDL_BACKUP_COMMIT_LOCK) and any threads using
-          BACKUP LOCK BLOCK_COMMIT.
-        */
-      if (thd->backup_commit_lock && thd->backup_commit_lock->ticket &&
-          !backup_lock_released)
-      {
-        backup_lock_released= 1;
-        thd->mdl_context.release_lock(thd->backup_commit_lock->ticket);
-        thd->backup_commit_lock->ticket= 0;
-      }
-
       /*
         By setting wfc->opaque_pointer to our own entry, we mark that we are
         ready to commit, but waiting for another transaction to commit before
@@ -8515,9 +8498,6 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
                       (orig_queue == NULL) ? "leader" : "participant"));
 
 end:
-  if (backup_lock_released)
-    thd->mdl_context.acquire_lock(thd->backup_commit_lock,
-                                  thd->variables.lock_wait_timeout);
   DBUG_RETURN(result);
 }
 

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -139,7 +139,8 @@ static const LEX_STRING backup_lock_types[]=
   { C_STRING_WITH_LEN("MDL_BACKUP_DDL") },
   { C_STRING_WITH_LEN("MDL_BACKUP_BLOCK_DDL") },
   { C_STRING_WITH_LEN("MDL_BACKUP_ALTER_COPY") },
-  { C_STRING_WITH_LEN("MDL_BACKUP_COMMIT") }
+  { C_STRING_WITH_LEN("MDL_BACKUP_COMMIT") },
+  { C_STRING_WITH_LEN("MDL_BACKUP_COMMIT_RPL") }
 };
 
 
@@ -1615,45 +1616,47 @@ MDL_lock::MDL_object_lock::m_waiting_incompatible[MDL_TYPE_END]=
   The first array specifies if particular type of request can be satisfied
   if there is granted backup lock of certain type.
 
-     Request  |           Type of active backup lock                    |
-      type    | S0  S1  S2  S3  S4  F1  F2   D  TD  SD   DD  BL  AC  C  |
-    ----------+---------------------------------------------------------+
-    S0        |  -   -   -   -   -   +   +   +   +   +   +   +   +   +  |
-    S1        |  -   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    S2        |  -   +   +   +   +   +   +   -   +   +   +   +   +   +  |
-    S3        |  -   +   +   +   +   +   +   -   +   +   -   +   +   +  |
-    S4        |  -   +   +   +   +   +   +   -   +   -   -   +   +   -  |
-    FTWRL1    |  +   +   +   +   +   +   +   -   -   -   -   +   -   +  |
-    FTWRL2    |  +   +   +   +   +   +   +   -   -   -   -   +   -   -  |
-    D         |  +   -   -   -   -   -   -   +   +   +   +   +   +   +  |
-    TD        |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  |
-    SD        |  +   +   +   +   -   -   -   +   +   +   +   +   +   +  |
-    DDL       |  +   +   +   -   -   -   -   +   +   +   +   -   +   +  |
-    BLOCK_DDL |  -   +   +   +   +   +   +   +   +   +   -   +   +   +  |
-    ALTER_COP |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  |
-    COMMIT    |  +   +   +   +   -   +   -   +   +   +   +   +   +   +  |
+     Request  |           Type of active backup lock                       |
+      type    | S0  S1  S2  S3  S4  F1  F2   D  TD  SD   DD  BL  AC  C  R  |
+    ----------+------------------------------------------------------------+
+    S0        |  -   -   -   -   -   +   +   +   +   +   +   +   +   +  +  |
+    S1        |  -   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    S2        |  -   +   +   +   +   +   +   -   +   +   +   +   +   +  +  |
+    S3        |  -   +   +   +   +   +   +   -   +   +   -   +   +   +  +  |
+    S4        |  -   +   +   +   +   +   +   -   +   -   -   +   +   -  +  |
+    FTWRL1    |  +   +   +   +   +   +   +   -   -   -   -   +   -   +  +  |
+    FTWRL2    |  +   +   +   +   +   +   +   -   -   -   -   +   -   -  +  |
+    D         |  +   -   -   -   -   -   -   +   +   +   +   +   +   +  +  |
+    TD        |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  +  |
+    SD        |  +   +   +   +   -   -   -   +   +   +   +   +   +   +  +  |
+    DDL       |  +   +   +   -   -   -   -   +   +   +   +   -   +   +  +  |
+    BLOCK_DDL |  -   +   +   +   +   +   +   +   +   +   -   +   +   +  +  |
+    ALTER_COP |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  +  |
+    COMMIT    |  +   +   +   +   -   +   -   +   +   +   +   +   +   +  +  |
+    COMMIT_RPL|  +   +   +   +   -   +   -   +   +   +   +   +   +   +  +  |
 
   The second array specifies if particular type of request can be satisfied
   if there is already waiting request for the backup lock of certain type.
   I.e. it specifies what is the priority of different lock types.
 
-     Request  |               Pending backup lock                       |
-      type    | S0  S1  S2  S3  S4  F1  F2   D  TD  SD   DD  BL  AC  C  |
-    ----------+---------------------------------------------------------+
-    S0        |  +   -   -   -   -   +   +   +   +   +   +   +   +   +  |
-    S1        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    S2        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    S3        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    S4        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    FTWRL1    |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    FTWRL2    |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    D         |  +   -   -   -   -   -   -   +   +   +   +   +   +   +  |
-    TD        |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  |
-    SD        |  +   +   +   +   -   -   -   +   +   +   +   +   +   +  |
-    DDL       |  +   +   +   -   -   -   -   +   +   +   +   -   +   +  |
-    BLOCK_DDL |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  |
-    ALTER_COP |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  |
-    COMMIT    |  +   +   +   +   -   +   -   +   +   +   +   +   +   +  |
+     Request  |               Pending backup lock                          |
+      type    | S0  S1  S2  S3  S4  F1  F2   D  TD  SD   DD  BL  AC  C  R  |
+    ----------+------------------------------------------------------------+
+    S0        |  +   -   -   -   -   +   +   +   +   +   +   +   +   +  +  |
+    S1        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    S2        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    S3        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    S4        |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    FTWRL1    |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    FTWRL2    |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    D         |  +   -   -   -   -   -   -   +   +   +   +   +   +   +  +  |
+    TD        |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  +  |
+    SD        |  +   +   +   +   -   -   -   +   +   +   +   +   +   +  +  |
+    DDL       |  +   +   +   -   -   -   -   +   +   +   +   -   +   +  +  |
+    BLOCK_DDL |  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
+    ALTER_COP |  +   +   +   +   +   -   -   +   +   +   +   +   +   +  +  |
+    COMMIT    |  +   +   +   +   -   +   -   +   +   +   +   +   +   +  +  |
+    COMMIT_RPL|  +   +   +   +   +   +   +   +   +   +   +   +   +   +  +  |
 
   Here: "+" -- means that request can be satisfied
         "-" -- means that request can't be satisfied and should wait
@@ -1687,6 +1690,8 @@ MDL_lock::MDL_backup_lock::m_granted_incompatible[MDL_BACKUP_END]=
   MDL_BIT(MDL_BACKUP_START) | MDL_BIT(MDL_BACKUP_FLUSH) | MDL_BIT(MDL_BACKUP_WAIT_FLUSH) | MDL_BIT(MDL_BACKUP_WAIT_DDL) | MDL_BIT(MDL_BACKUP_WAIT_COMMIT) | MDL_BIT(MDL_BACKUP_BLOCK_DDL) | MDL_BIT(MDL_BACKUP_DDL),
   MDL_BIT(MDL_BACKUP_FTWRL1) | MDL_BIT(MDL_BACKUP_FTWRL2),
   /* MDL_BACKUP_COMMIT */
+  MDL_BIT(MDL_BACKUP_WAIT_COMMIT) | MDL_BIT(MDL_BACKUP_FTWRL2),
+  /* MDL_BACKUP_COMMIT_RPL */
   MDL_BIT(MDL_BACKUP_WAIT_COMMIT) | MDL_BIT(MDL_BACKUP_FTWRL2)
 };
 
@@ -1714,7 +1719,9 @@ MDL_lock::MDL_backup_lock::m_waiting_incompatible[MDL_BACKUP_END]=
   MDL_BIT(MDL_BACKUP_START),
   MDL_BIT(MDL_BACKUP_FTWRL1) | MDL_BIT(MDL_BACKUP_FTWRL2),
   /* MDL_BACKUP_COMMIT */
-  MDL_BIT(MDL_BACKUP_WAIT_COMMIT) | MDL_BIT(MDL_BACKUP_FTWRL2)
+  MDL_BIT(MDL_BACKUP_WAIT_COMMIT) | MDL_BIT(MDL_BACKUP_FTWRL2),
+ /* MDL_BACKUP_COMMIT_RPL: is highest priority allowing to bypass any waiter */
+  0
 };
 
 
@@ -2128,36 +2135,8 @@ MDL_context::try_acquire_lock_impl(MDL_request *mdl_request,
                                   mdl_request->m_src_line);
 
   ticket->m_lock= lock;
-  /*
-    When so specified in mdl_request, compute the grant lock decision
-    basing on whether there is a grantee which is a member of
-    requestor's "team" that logically share the lock. The requestor
-    provides with a method to identify the teamship.
-  */
-  bool do_grant_lock= false;
-  if (mdl_request->is_teammate_callback)
-  {
-    // known locks that can be granted on the basis of team membership
-    DBUG_ASSERT(mdl_request->key.mdl_namespace() == MDL_key::BACKUP);
 
-    const THD *requestor_thd= this->get_thd();
-    /*
-      Scan the granted list to find any one holder which
-      the current requestor can team up with.
-    */
-    for (const auto &ticket : lock->m_granted)
-    {
-      THD *holder_thd= ticket.get_ctx()->get_thd();
-      if (holder_thd &&
-	  ticket.get_type() == MDL_BACKUP_COMMIT &&
-	  mdl_request->is_teammate_callback(holder_thd, requestor_thd))
-      {
-        do_grant_lock= true;
-        break; // Found one teammate that is enough to ignore priority
-      }
-    }
-  }
-  if (do_grant_lock || lock->can_grant_lock(mdl_request->type, this, false))
+  if (lock->can_grant_lock(mdl_request->type, this, false))
   {
     if (metadata_lock_info_plugin_loaded)
       ticket->m_time= microsecond_interval_timer();
@@ -2340,6 +2319,58 @@ MDL_context::acquire_lock(MDL_request *mdl_request, double lock_wait_timeout)
     DBUG_PRINT("mdl", ("Seized:   %s", dbug_print_mdl(mdl_request->ticket)));
     DBUG_RETURN(FALSE);
   }
+  /*
+    Teammate-Aware Escalation Check:
+    If this request failed due to a waiting lock, inspect if there is an
+    active parallel teammate already granted in the matrix. If a teammate
+    is found, mutate type to MDL_BACKUP_COMMIT_RPL to leapfrog natively.
+    This search might be designe with maintaining by slave the max sub-id
+    grantee.
+  */
+  lock= ticket->m_lock;
+  if (mdl_request->is_teammate_callback &&
+      mdl_request->type == MDL_BACKUP_COMMIT)
+  {
+    const THD *requestor_thd= this->get_thd();
+    bool has_teammate= false;
+
+    for (const auto &granted_ticket : lock->m_granted)
+    {
+      THD *holder_thd= granted_ticket.get_ctx()->get_thd();
+      if (holder_thd &&
+          granted_ticket.get_type() == MDL_BACKUP_COMMIT &&
+          mdl_request->is_teammate_callback(holder_thd, requestor_thd))
+      {
+        has_teammate= true;
+        break;
+      }
+    }
+
+    if (has_teammate)
+    {
+      mdl_request->type= MDL_BACKUP_COMMIT_RPL;
+
+      /* Unlock and dispose of the failed standard ticket before retrying */
+      mysql_prlock_unlock(&lock->m_rwlock);
+      MDL_ticket::destroy(ticket);
+
+      if (try_acquire_lock_impl(mdl_request, &ticket))
+      {
+        DBUG_PRINT("mdl", ("OOM during lock type upgrade"));
+        DBUG_RETURN(TRUE);
+      }
+
+      if (mdl_request->ticket)
+      {
+        DBUG_PRINT("info", ("Got upgraded RPL lock without waiting"));
+        DBUG_RETURN(FALSE);
+      }
+
+      /* If still blocked (e.g., by an active FTWRL), preserve lock pointer */
+      lock= ticket->m_lock;
+    }
+  }
+
 
 #ifdef DBUG_TRACE
     const char *ticket_msg= dbug_print_mdl(ticket);

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -1022,6 +1022,7 @@ void MDL_request::init_with_source(MDL_key::enum_mdl_namespace mdl_namespace,
   ticket= NULL;
   m_src_file= src_file;
   m_src_line= src_line;
+  is_teammate_callback= nullptr;
 }
 
 
@@ -1046,6 +1047,7 @@ void MDL_request::init_by_key_with_source(const MDL_key *key_arg,
   ticket= NULL;
   m_src_file= src_file;
   m_src_line= src_line;
+  is_teammate_callback= nullptr;
 }
 
 
@@ -2126,8 +2128,36 @@ MDL_context::try_acquire_lock_impl(MDL_request *mdl_request,
                                   mdl_request->m_src_line);
 
   ticket->m_lock= lock;
+  /*
+    When so specified in mdl_request, compute the grant lock decision
+    basing on whether there is a grantee which is a member of
+    requestor's "team" that logically share the lock. The requestor
+    provides with a method to identify the teamship.
+  */
+  bool do_grant_lock= false;
+  if (mdl_request->is_teammate_callback)
+  {
+    // known locks that can be granted on the basis of team membership
+    DBUG_ASSERT(mdl_request->key.mdl_namespace() == MDL_key::BACKUP);
 
-  if (lock->can_grant_lock(mdl_request->type, this, false))
+    const THD *requestor_thd= this->get_thd();
+    /*
+      Scan the granted list to find any one holder which
+      the current requestor can team up with.
+    */
+    for (const auto &ticket : lock->m_granted)
+    {
+      THD *holder_thd= ticket.get_ctx()->get_thd();
+      if (holder_thd &&
+	  ticket.get_type() == MDL_BACKUP_COMMIT &&
+	  mdl_request->is_teammate_callback(holder_thd, requestor_thd))
+      {
+        do_grant_lock= true;
+        break; // Found one teammate that is enough to ignore priority
+      }
+    }
+  }
+  if (do_grant_lock || lock->can_grant_lock(mdl_request->type, this, false))
   {
     if (metadata_lock_info_plugin_loaded)
       ticket->m_time= microsecond_interval_timer();

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -324,7 +324,8 @@ enum enum_mdl_type {
   Must be acquired during commit.
 */
 #define MDL_BACKUP_COMMIT enum_mdl_type(13)
-#define MDL_BACKUP_END enum_mdl_type(14)
+#define MDL_BACKUP_COMMIT_RPL enum_mdl_type(14)
+#define MDL_BACKUP_END enum_mdl_type(15)
 
 
 /** Duration of metadata lock. */

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -551,6 +551,12 @@ public:
   const char *m_src_file;
   uint m_src_line;
 
+  /**
+    If set, this callback is used to determine if this request can
+    ignore a waiting higher priority lock.
+  */
+  bool (*is_teammate_callback)(const THD*, const THD*);
+
 public:
 
   static void *operator new(size_t size, MEM_ROOT *mem_root) throw ()
@@ -616,7 +622,8 @@ public:
     return *this;
   }
   /* Another piece of ugliness for TABLE_LIST constructor */
-  MDL_request(): type(MDL_NOT_INITIALIZED), ticket(NULL) {}
+  MDL_request(bool ignore_arg= false):
+    type(MDL_NOT_INITIALIZED), ticket(NULL), is_teammate_callback(nullptr) {}
 
   MDL_request(const MDL_request *rhs)
     :type(rhs->type),

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -700,6 +700,11 @@ rpl_slave_state::record_gtid(THD *thd, const rpl_gtid *gtid, uint64 sub_id,
   suspended_wfc= thd->suspend_subsequent_commits();
   thd->lex->reset_n_backup_query_tables_list(&lex_backup);
   tlist.init_one_table(&MYSQL_SCHEMA_NAME, &gtid_pos_table_name, NULL, TL_WRITE);
+  if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec)
+  {
+    tlist.table_options|= TL_OPTION_GTID_TABLE_SLAVE;
+  }
+
   if ((err= open_and_lock_tables(thd, &tlist, FALSE, 0)))
     goto end;
   table_opened= true;

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2286,6 +2286,8 @@ void rpl_group_info::cleanup_context(THD *thd, bool error, bool keep_domain_owne
     trans_rollback_stmt(thd); // if a "statement transaction"
     /* trans_rollback() also resets OPTION_GTID_BEGIN */
     trans_rollback(thd);      // if a "real transaction"
+
+    DBUG_ASSERT(!thd->backup_commit_lock); // trans_rollback must've taken care
     /*
       Now that we have rolled back the transaction, make sure we do not
       erroneously update the GTID position.
@@ -2437,6 +2439,45 @@ void rpl_group_info::slave_close_thread_tables(THD *thd)
   DBUG_VOID_RETURN;
 }
 
+/*
+  The method computes weather the requestor's replicatated transaction
+  can be grouped with the holder's one to share BACKUP MDL.
+
+  The method returns
+    false
+  when the holder is not parallel slave transaction, or
+  when its (multi-) source or gtid domain are different, or the holder has lesser
+  gtid sequence number. The latter condtion is safe for parallel slave
+  performance. It merely forces such requestors to enqueue its S BACKUP DML
+  after any waiting locks which contributes to fairness
+  of BACKUP MDL acquision.
+
+  Otherwise when
+     rgi_hol->gtid_sub_id > rgi_req->gtid_sub_id
+  it returns
+    true.
+*/
+bool
+rpl_group_info::ignore_mdl_priority(const THD* holder, const THD* requestor)
+{
+  DBUG_ASSERT(requestor->system_thread == SYSTEM_THREAD_SLAVE_SQL);
+  DBUG_ASSERT(requestor->rgi_slave->is_parallel_exec); // func is for parallel
+
+  rpl_group_info *rgi_hol= holder->rgi_slave;
+  rpl_group_info *rgi_req= requestor->rgi_slave;
+
+  if (unlikely(rgi_req->gtid_sub_id == 0))
+    return false; ; // requestor is not a slave worker executing commit
+
+  bool do_ignore=
+    holder->system_thread == SYSTEM_THREAD_SLAVE_SQL &&
+    (rgi_hol->rli == rgi_req->rli &&
+     rgi_hol->current_gtid.domain_id == rgi_req->current_gtid.domain_id &&
+     rgi_hol->gtid_sub_id > 0 &&
+     rgi_hol->gtid_sub_id > rgi_req->gtid_sub_id);
+
+  return do_ignore;
+}
 
 
 static void

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2442,6 +2442,8 @@ void rpl_group_info::slave_close_thread_tables(THD *thd)
 /*
   The method computes weather the requestor's replicatated transaction
   can be grouped with the holder's one to share BACKUP MDL.
+  The requestor must be slave parallel worker or the driver thread
+  having special sub-id == zero.
 
   The method returns
     false
@@ -2463,18 +2465,19 @@ rpl_group_info::ignore_mdl_priority(const THD* holder, const THD* requestor)
   DBUG_ASSERT(requestor->system_thread == SYSTEM_THREAD_SLAVE_SQL);
   DBUG_ASSERT(requestor->rgi_slave->is_parallel_exec); // func is for parallel
 
-  rpl_group_info *rgi_hol= holder->rgi_slave;
-  rpl_group_info *rgi_req= requestor->rgi_slave;
+  rpl_group_info *rgi_holder= holder->rgi_slave;
+  rpl_group_info *rgi_requestor= requestor->rgi_slave;
 
-  if (unlikely(rgi_req->gtid_sub_id == 0))
+  if (unlikely(rgi_requestor->gtid_sub_id == 0))
     return false; ; // requestor is not a slave worker executing commit
 
   bool do_ignore=
     holder->system_thread == SYSTEM_THREAD_SLAVE_SQL &&
-    (rgi_hol->rli == rgi_req->rli &&
-     rgi_hol->current_gtid.domain_id == rgi_req->current_gtid.domain_id &&
-     rgi_hol->gtid_sub_id > 0 &&
-     rgi_hol->gtid_sub_id > rgi_req->gtid_sub_id);
+    (rgi_holder->rli == rgi_requestor->rli &&
+     rgi_holder->current_gtid.domain_id == rgi_requestor->current_gtid.domain_id
+     &&
+     rgi_holder->gtid_sub_id > 0 &&
+     rgi_holder->gtid_sub_id > rgi_requestor->gtid_sub_id);
 
   return do_ignore;
 }

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -1052,7 +1052,11 @@ struct rpl_group_info
   {
     finish_event_group_called= value;
   }
-
+  /*
+    The method helps to determine if a lock request from a parallel worker
+    can ignore BACKUP MDL priority to be granted ahead of any waiting X lock.
+  */
+  static bool ignore_mdl_priority(const THD* holder, const THD* requestor);
 };
 
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -2384,7 +2384,11 @@ retry_share:
 
       MDL_REQUEST_INIT(&protection_request, MDL_key::BACKUP, "", "", mdl_type,
                        MDL_STATEMENT);
-
+      if (table_list->table_options & TL_OPTION_GTID_TABLE_SLAVE)
+      {
+	protection_request.is_teammate_callback=
+	  &rpl_group_info::ignore_mdl_priority;
+      }
       /*
         Install error handler which if possible will convert deadlock error
         into request to back-off and restart process of opening tables.

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -2382,13 +2382,21 @@ retry_share:
         DBUG_RETURN(TRUE);
       }
 
-      MDL_REQUEST_INIT(&protection_request, MDL_key::BACKUP, "", "", mdl_type,
-                       MDL_STATEMENT);
       if (table_list->table_options & TL_OPTION_GTID_TABLE_SLAVE)
       {
-	protection_request.is_teammate_callback=
-	  &rpl_group_info::ignore_mdl_priority;
+	/*
+          This is a request of a committing phase of slave transaction
+          though done on behalf on implicnt gtid table insert statement.
+          It must be able to bypass any waiting lock by backup process
+          even without yet knowking whether the transaction is going to
+          slave group commit leader. When it turns out not the case
+          the strong MDL_STATEMENT requested lock would've been already
+          relinquished.
+        */
+	mdl_type= MDL_BACKUP_COMMIT_RPL;
       }
+      MDL_REQUEST_INIT(&protection_request, MDL_key::BACKUP, "", "", mdl_type,
+                       MDL_STATEMENT);
       /*
         Install error handler which if possible will convert deadlock error
         into request to back-off and restart process of opening tables.

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -8298,20 +8298,6 @@ wait_for_commit::wait_for_prior_commit2(THD *thd, bool allow_kill)
 {
   PSI_stage_info old_stage;
   wait_for_commit *loc_waitee;
-  bool backup_lock_released= false;
-
-  /*
-    Release MDL_BACKUP_COMMIT LOCK while waiting for other threads to commit
-    This is needed to avoid deadlock between the other threads (which not
-    yet have the MDL_BACKUP_COMMIT_LOCK) and any threads using
-    BACKUP LOCK BLOCK_COMMIT.
-  */
-  if (thd->backup_commit_lock && thd->backup_commit_lock->ticket)
-  {
-    backup_lock_released= true;
-    thd->mdl_context.release_lock(thd->backup_commit_lock->ticket);
-    thd->backup_commit_lock->ticket= 0;
-  }
 
   mysql_mutex_lock(&LOCK_wait_commit);
   DEBUG_SYNC(thd, "wait_for_prior_commit_waiting");
@@ -8365,16 +8351,10 @@ wait_for_commit::wait_for_prior_commit2(THD *thd, bool allow_kill)
     use within enter_cond/exit_cond.
   */
   DEBUG_SYNC(thd, "wait_for_prior_commit_killed");
-  if (unlikely(backup_lock_released))
-    thd->mdl_context.acquire_lock(thd->backup_commit_lock,
-                                  thd->variables.lock_wait_timeout);
   return wakeup_error;
 
 end:
   thd->EXIT_COND(&old_stage);
-  if (unlikely(backup_lock_released))
-    thd->mdl_context.acquire_lock(thd->backup_commit_lock,
-                                  thd->variables.lock_wait_timeout);
   return wakeup_error;
 }
 

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -465,6 +465,7 @@ enum enum_drop_mode
 #define TL_OPTION_ALIAS         8
 #define TL_OPTION_SEQUENCE      16
 #define TL_OPTION_TABLE_FUNCTION        32
+#define TL_OPTION_GTID_TABLE_SLAVE      64
 
 typedef List<Item> List_item;
 typedef Mem_root_array<ORDER*, true> Group_list_ptrs;

--- a/sql/xa.cc
+++ b/sql/xa.cc
@@ -22,6 +22,7 @@
 #include "my_cpu.h"
 #include <pfs_transaction_provider.h>
 #include <mysql/psi/mysql_transaction.h>
+#include "rpl_rli.h" // rgi->is_parallel_exec
 
 static bool slave_applier_reset_xa_trans(THD *thd);
 
@@ -524,6 +525,8 @@ static bool trans_xa_get_backup_lock(THD *thd, MDL_request *mdl_request)
   DBUG_ASSERT(thd->backup_commit_lock == 0);
   MDL_REQUEST_INIT(mdl_request, MDL_key::BACKUP, "", "", MDL_BACKUP_COMMIT,
                    MDL_EXPLICIT);
+  if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec)
+    mdl_request->is_teammate_callback= rpl_group_info::ignore_mdl_priority;
   if (thd->mdl_context.acquire_lock(mdl_request,
                                     thd->variables.lock_wait_timeout))
     return 1;
@@ -1166,6 +1169,7 @@ static bool slave_applier_reset_xa_trans(THD *thd)
   thd->transaction->all.ha_list= 0;
 
   ha_close_connection(thd);
+  trans_xa_release_backup_lock(thd);
   thd->transaction->cleanup();
   thd->transaction->all.reset();
 


### PR DESCRIPTION
MDEV-36025 Parallel slave concurrent BACKUP MDL locking with ongoing backup..

The problem the patch tackles is that the binlogging parallel slave
can expose prepared state of transactions to the backup process.
That is the latter can enroll such transactions, typically waiting for
prior commits - in other words *undecided* (of whether they are going
to commit at all - sic!), into backup image.

The technical possibility of that owes to earlier deadlocks fixes in this area
that made the parallel slave worker to re-acquire its BACKUP MDL within
the wait-for-prior commit phase (which is post- engine prepare) one.

Note the --skip-log-bin or --log-slave-update=OFF parallel slave is
not vulnerable to the exposure of its prepared transactions.

The fixes this patch provides make sure the backup image contains only
transactions that are (binlog-order) committed, while
parallel slave does not deadlock (MDEV-23586).

The principal part of the fixes implements leapfrogging of a waiting
"high-priority" BACKUP MDL by a slave parallel worker which is
exemplified in the following. First mind about notations:

  here (as elsewhere in the patch) `Fn` group commit followers
  indexed by the gtid seq-no `n`; `F|xyz` indicates the execution
  status (timing) of the MDL request.  `B` - stands for backup
  thread; `Si,Xk` are BACKUP share and exclusive MDL sequenced by
  `i,k` that are logical times of the MDL acquisition; The
  semi-column separates the granted head of the lock queue from the
   waiters.

The queue below is the BACKUP MDL queue.

| which initially is
|
| [Initial Queue State]
| GRANTED            ; WAITING QUEUE
| ----------------------------------
| S1(F2)             ; X2(B)
|
| Next it receives
|                     <- Incoming Request: S3(L1)
| the scheduler having the following context
| [Scheduler Evaluation]
| Requestor: L1 (gtid_sub_id = 1)
| Holder   : F2 (gtid_sub_id = 2)
| Condition: holder->gtid_sub_id > requestor->gtid_sub_id  (2 > 1) -> TRUE!
|  Action   : ignore_mdl_priority = true. L1 bypasses the waiting X2 lock.
|
| decides where to place it
|
| [Final Queue State]
| GRANTED            ; WAITING QUEUE
| ----------------------------------
| S1(F2), S3(L1)     ; X2(B)

| so it chooses to team up L1,F2 correctly. Any next S4(F_n), where n > 2
| won't be granted which means F_n will wait for the backup completion.
| Like this
|
| [Final Queue State]
| GRANTED            ; WAITING QUEUE
| ----------------------------------
| S1(F2), S3(L1)     ; X2(B),S4(F3)

The decision to allow S3 leapfrog X2 requires the current lock holder
F2 to have a greater gtid_sub_id (2 > 1).

To implement this scheduling policy requires the following modifications.

P1 sql/mdl.h
    The new method determines whether a BACKUP lock requester is a teammate
    of a group that can share the MDL lock and that there exists at least
    on granted member of the group.

    +MDL_request::bool (*is_teammate_callback)(const THD*, const THD*);

P2. sql/log.cc
    dismantling of mdl_context.{release,acquire}_lock() in the parallel worker
    wait-for-prior commit

P3. sql/handler.cc

    setting the P1 MDL_request::is_teammate_callback to the slave parallel worker
    as hint to try acquiring the MDL lock by team membership.

P4. sql/rpl_rli.cc
    defines the teammate callback for the parallel slave.

    +rpl_group_info::ignore_mdl_priority

P5. sql/handler.cc
    Logics of "careful" release of the MDL lock could not be streamlined.
    The failed parallel slave worker still has to abide with  [ha_commit_trans] a policy of
>     as there is extra replication
>     book-keeping to be done before rolling back and allowing a conflicting
>     transaction to continue (MDEV-7458).
    For that reason of MDEV-7458 the BACKUP MDL request's memory is now allocated
    for the worker in THD::st_transaction::mem_root. Also guards are deployed to not let
    the mem-root be be cleaned too early, before the lock gets released. It can be
    released fast to follow with transaction->cleanup() for
    not failing trx:s.
    Failing to commit parallel workers defer that to Relay_log_info::cleanup_context()
    from where now ha_rollback_trans() will make it.

Aslo necessary changes are caused by to the gtid implicit statement's design.

1. sql/sql_class.cc
   Removed earlier backup-on-parallel-slave bugfixes of MDEV-23586.
   The parallel worker does not release anymore BACKUP MDL at its wait-for-prior
   commit stage.

2. sql/sql_lex.h, sql/sql_base.cc, sql/rpl_gtid.cc
   Has to be introduced
    +#define TL_OPTION_GTID_TABLE_SLAVE      64

   as a part of a method to find out (see open_table() hunk) at
   executing record_gtid() by implicit GTID statement that its
   BACKUP MDL lock (however it is necessary - it is not challenged
   here) needs the ignore-priority hint. Note this hint applies for granting
   a "special" S' share locked not yet the commit time  ha_commit_trans()'s
   MDL_BACKUP_COMMIT (denoted as S) lock, which is going to be requested later.

   Let's exemplify it on the following diagrams, calling S' a sort of
   shared lock, compatible with with S of the commit time.

   *Without* the teammate hint the request for S'3(F2) at record_gtid() time

         S1(F3|wait_for_prior_commit); X2(B) <- S'3(F2|record_gtid)

   would end up to wait behind X2

         S1; /* waiting */ X2, S'3

   and we'd regress back to hang/deadlock of earlier bugs: F3 would not be
   awaken by F2 who is blocked by B.

Tested with extended set of parallel slave with backup scenarios.

This commit must require more and extensive testing and may cause
followup amendments, through review comments as well.

Co-authored-with: hemant.dangi@mariadb.com.
