### PR TITLE
MDEV-39692 innodb intrinsics fail to compile on ARMv8.3-A and later (…

### DIFF
--- a/storage/innobase/sync/cache.cc
+++ b/storage/innobase/sync/cache.cc
@@ -82,11 +82,8 @@ static void pmem_cvap(const void* buf, size_t size)
   for (uintptr_t u= uintptr_t(buf) & ~(CPU_LEVEL1_DCACHE_LINESIZE),
          end= uintptr_t(buf) + size;
        u < end; u+= CPU_LEVEL1_DCACHE_LINESIZE)
-#if defined __ARM_ARCH && __ARM_ARCH == 9
-    __asm__ __volatile__(".arch armv9.4-a\n dc cvap, %0" :: "r"(u) : "memory");
-#else
-    __asm__ __volatile__(".arch armv8.2-a\n dc cvap, %0" :: "r"(u) : "memory");
-#endif
+    __asm__ __volatile__(/* dc cvap, %0 */ "sys #3, c7, c12, 1, %0" ::
+                         "r"(u) : "memory");
 
   __asm__ __volatile__("dmb ishst" ::: "memory");
 }


### PR DESCRIPTION
…but not ARMv9.x)

fails with:

Assembler messages:
{standard input}:169: Error: selected processor does not support `retaa' {standard input}:271: Error: selected processor does not support `retaa'

It happens because the pmem_cvap() funciton manually inserts the `.arch armv8-2.a` clause, making GAS believe that retaa instruction (inserted by GCC) is invalid. Bump the manually inserted clause to armv8.3-a, to prevent GAS from choking on the retaa instructions.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>

Ported from https://lore.kernel.org/openembedded-devel/20260520113418.2523208-1-dmitry.baryshkov@oss.qualcomm.com/ by Daniel Black.


from #3677