### PR TITLE
MDEV-39675 mariadb_upgrade utility failed when path=nonexist

### DIFF
--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -2470,3 +2470,24 @@ SELECT CHARACTER_SET_CLIENT, COLLATION_CONNECTION FROM INFORMATION_SCHEMA.VIEWS
 WHERE TABLE_SCHEMA='mysql' AND TABLE_NAME='user';
 CHARACTER_SET_CLIENT	COLLATION_CONNECTION
 latin1	latin1_swedish_ci
+# End of 11.4 tests
+#
+# MDEV-39675 mariadb_upgrade utility failed when path=nonexist
+#
+set @old_path=@@global.path;
+set path 'non-existent';
+create or replace function sys.extract_schema_from_file_name()
+RETURNS TEXT RETURN "nothetruth";
+show create function sys.extract_schema_from_file_name;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+extract_schema_from_file_name		CREATE DEFINER=`mariadb.sys`@`localhost` FUNCTION `extract_schema_from_file_name`(path VARCHAR(512)
+    ) RETURNS varchar(64) CHARSET utf8mb3 COLLATE utf8mb3_general_ci
+    NO SQL
+    DETERMINISTIC
+    SQL SECURITY INVOKER
+    COMMENT '\n             Description\n             Takes a raw file path, and attempts to extract the schema name from it.\n             Useful for when interacting with Performance Schema data\n             concerning IO statistics, for example.\n             Currently relies on the fact that a table data file will be within a\n             specified database directory (will not work with partitions or tables\n             that specify an individual DATA_DIRECTORY).\n             Parameters\n             path (VARCHAR(512)):\n               The full file path to a data file to extract the schema name from.\n             Returns\n             VARCHAR(64)\n             Example\n             mysql> SELECT sys.extract_schema_from_file_name(''/var/lib/mysql/employees/employee.ibd'');\n             +----------------------------------------------------------------------------+\n             | sys.extract_schema_from_file_name(''/var/lib/mysql/employees/employee.ibd'') |\n             +----------------------------------------------------------------------------+\n             | employees                                                                  |\n             +----------------------------------------------------------------------------+\n             1 row in set (0.00 sec)\n            '
+BEGIN
+    RETURN LEFT(SUBSTRING_INDEX(SUBSTRING_INDEX(REPLACE(path, '\\', '/'), '/', -2), '/', 1), 64);
+END	utf8mb3	utf8mb3_general_ci	utf8mb3_general_ci
+set path @old_path;
+# End of 12.3 tests

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -599,3 +599,21 @@ FLUSH TABLES mysql.user;
 FLUSH PRIVILEGES;
 SELECT CHARACTER_SET_CLIENT, COLLATION_CONNECTION FROM INFORMATION_SCHEMA.VIEWS
 WHERE TABLE_SCHEMA='mysql' AND TABLE_NAME='user';
+
+--echo # End of 11.4 tests
+
+--echo #
+--echo # MDEV-39675 mariadb_upgrade utility failed when path=nonexist
+--echo #
+
+set @old_path=@@global.path;
+set path 'non-existent';
+
+create or replace function sys.extract_schema_from_file_name()
+RETURNS TEXT RETURN "nothetruth";
+--exec $MYSQL_UPGRADE --force --silent 2>&1
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
+show create function sys.extract_schema_from_file_name;
+set path @old_path;
+
+--echo # End of 12.3 tests

--- a/scripts/mariadb_system_tables_fix.sql
+++ b/scripts/mariadb_system_tables_fix.sql
@@ -30,7 +30,7 @@ set default_storage_engine=Aria;
 set enforce_storage_engine=NULL;
 set alter_algorithm='DEFAULT';
 set use_stat_tables='NEVER';
-
+set path 'CURRENT_SCHEMA';
 
 --
 -- Upgrade mysql.column_stats table early because its quite noisy otherwise


### PR DESCRIPTION
The upgrade SQL assumes the functions will resolve.

With a non-default path this isn't true and results in:

ERROR 1305 (42000) at line 3211: FUNCTION extract_schema_from_file_name does not exist

Resolve by setting PATH = 'CURRENT_SCHEMA' for the upgrade.

Idea thanks to Sergei Golubchik