### PR TITLE
MDEV-39685 : galera multi table update crash

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-39685.result
+++ b/mysql-test/suite/galera/r/MDEV-39685.result
@@ -1,0 +1,13 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (
+pk int PRIMARY KEY,
+c varchar(8),
+i int
+) ENGINE=InnoDB;
+CREATE TABLE t2 (f int) ENGINE=InnoDB;
+CREATE TABLE t3 (x int,
+FOREIGN KEY (x) REFERENCES t1 (pk)
+) ENGINE=InnoDB;
+UPDATE t1 JOIN t2 ON t1.i = t2.f SET t1.c = 'foo';
+DROP TABLE t3, t2, t1;

--- a/mysql-test/suite/galera/t/MDEV-39685.test
+++ b/mysql-test/suite/galera/t/MDEV-39685.test
@@ -1,0 +1,18 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (
+  pk int PRIMARY KEY,
+  c varchar(8),
+  i int
+) ENGINE=InnoDB;
+
+CREATE TABLE t2 (f int) ENGINE=InnoDB;
+
+CREATE TABLE t3 (x int,
+  FOREIGN KEY (x) REFERENCES t1 (pk)
+) ENGINE=InnoDB;
+
+UPDATE t1 JOIN t2 ON t1.i = t2.f SET t1.c = 'foo';
+
+DROP TABLE t3, t2, t1;

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -2037,29 +2037,43 @@ bool mysql_multi_update(THD *thd, TABLE_LIST *table_list, List<Item> *fields,
 #ifdef WITH_WSREP
   if (WSREP(thd))
   {
-    bool transactional= false;
-    bool non_trans= false;
-    for (TABLE_LIST *tablel= table_list; tablel; tablel= tablel->next_global)
+    const bool limited = (wsrep_max_ws_rows ||
+                         (wsrep_max_ws_size != WSREP_MAX_WS_SIZE));
+
+    if (limited)
     {
-      TABLE *table= tablel->table;
-      if (table->file->has_transactions_and_rollback())
-	transactional= true;
-      else
-	non_trans= true;
-    }
-    /* In multi-table update Galera does not support update to both
-       transactional and non-transactional engines if write-set
-       size is limited. */
-    bool limited = (wsrep_max_ws_rows || wsrep_max_ws_size != WSREP_MAX_WS_SIZE);
-    if (transactional && non_trans && limited)
-    {
-      my_error(ER_GALERA_REPLICATION_NOT_SUPPORTED, MYF(0));
-      push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                          ER_GALERA_REPLICATION_NOT_SUPPORTED,
-                          "Galera does not support multi-table update",
-                          " to both transactional and non-transactional engines"
-                          " if write-set size is limited.");
-      DBUG_RETURN(1);
+      /* Write set size is limited, check if this update contains
+         updates to both transactional and non-transactional table. */
+      bool transactional= false;
+      bool non_trans= false;
+      for (TABLE_LIST *tablel= table_list; tablel; tablel= tablel->next_global)
+      {
+        TABLE *table= tablel->table;
+        /* This can happen on multi-table update if one of the
+           tables updated is referenced by foreign key from other not
+           updated table. Not updated table is not yet opened, thus
+           there is item on table list but actual table is NULL. */
+        if (!table)
+          continue;
+        /* Table has been opened, check is SE transactional or not. */
+        if (table->file->has_transactions_and_rollback())
+          transactional= true;
+        else
+          non_trans= true;
+      }
+      /* In multi-table update Galera does not support update to both
+         transactional and non-transactional engines if write-set
+         size is limited. */
+      if (transactional && non_trans)
+      {
+        my_error(ER_GALERA_REPLICATION_NOT_SUPPORTED, MYF(0));
+        push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                            ER_GALERA_REPLICATION_NOT_SUPPORTED,
+                            "Galera does not support multi-table update",
+                            " to both transactional and non-transactional engines"
+                            " if write-set size is limited.");
+        DBUG_RETURN(1);
+      }
     }
   }
 #endif /* WITH_WSREP */


### PR DESCRIPTION
This is regression caused by MDEV-28750 commit 1f349968.

In multi-table update table list could contain tables that are not yet opened because update does not really change them. This can happen e.g. when update changes table that is referenced by foreign key by table that is not part of multi-table update.

Fixed by first checking is wsrep write set size limited. If it is not multi-table update can continue normally. If write set size is limited then check has update updated both transactional and non-transactional tables and those tables that have not yet been opened can be safely skipped as they are not updated.