### PR TITLE
MDEV-38988 : Assertion failure in Protocol::end_statement or lack of warning upon query with INTERSECT and LIMIT ROWS EXAMINED

### DIFF
--- a/mysql-test/main/except.result
+++ b/mysql-test/main/except.result
@@ -656,3 +656,35 @@ SELECT * FROM t WHERE i != ANY ( SELECT 3 EXCEPT SELECT 3 );
 i
 drop table t;
 # End of 10.3 tests
+#
+# MDEV-38988: Assertion failure in Protocol::end_statement or
+# lack of warning upon query with INTERSECT and LIMIT ROWS EXAMINED
+#
+CREATE TABLE t (a INT PRIMARY KEY, b INT);
+INSERT INTO t SELECT seq, seq FROM seq_1_to_30;
+(SELECT a FROM t LIMIT ROWS EXAMINED 100) EXCEPT ALL (SELECT a FROM t);
+a
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+Warnings:
+Warning	1931	Query execution was interrupted. The query exceeded LIMIT ROWS EXAMINED 100. The query result may be incomplete
+DROP TABLE t;
+CREATE TABLE t (id INT PRIMARY KEY, f VARCHAR(16));
+INSERT INTO t SELECT seq, '' FROM seq_1_to_8650;
+(SELECT f FROM t WHERE id BETWEEN 7000 AND 9000 LIMIT ROWS EXAMINED 8000)
+INTERSECT
+(SELECT f FROM t WHERE id BETWEEN 7000 AND 9000 LIMIT ROWS EXAMINED 8000);
+f
+
+Warnings:
+Warning	1931	Query execution was interrupted. The query exceeded LIMIT ROWS EXAMINED 8000. The query result may be incomplete
+DROP TABLE t;
+# End of 10.11 tests

--- a/mysql-test/main/except.test
+++ b/mysql-test/main/except.test
@@ -1,5 +1,6 @@
 # For explain
 --source include/default_optimizer_switch.inc
+--source include/have_sequence.inc
 set @@join_buffer_size=256*1024;
 
 create table t1 (a int, b int) engine=MyISAM;
@@ -97,3 +98,24 @@ drop table t;
 
 
 --echo # End of 10.3 tests
+
+--echo #
+--echo # MDEV-38988: Assertion failure in Protocol::end_statement or
+--echo # lack of warning upon query with INTERSECT and LIMIT ROWS EXAMINED
+--echo #
+
+CREATE TABLE t (a INT PRIMARY KEY, b INT);
+INSERT INTO t SELECT seq, seq FROM seq_1_to_30;
+(SELECT a FROM t LIMIT ROWS EXAMINED 100) EXCEPT ALL (SELECT a FROM t);
+
+DROP TABLE t;
+
+CREATE TABLE t (id INT PRIMARY KEY, f VARCHAR(16));
+INSERT INTO t SELECT seq, '' FROM seq_1_to_8650;
+(SELECT f FROM t WHERE id BETWEEN 7000 AND 9000 LIMIT ROWS EXAMINED 8000)
+INTERSECT
+(SELECT f FROM t WHERE id BETWEEN 7000 AND 9000 LIMIT ROWS EXAMINED 8000);
+
+DROP TABLE t;
+
+--echo # End of 10.11 tests

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -2306,7 +2306,7 @@ bool st_select_lex_unit::exec()
 	  }
 	}
       }
-      if (unlikely(saved_error))
+      if (thd->killed != ABORT_QUERY && unlikely(saved_error))
       {
 	DBUG_RETURN(saved_error);
       }


### PR DESCRIPTION
fixes [MDEV-38988](https://jira.mariadb.org/browse/MDEV-38988)

### Problem:
  LIMIT ROWS EXAMINED sets ABORT_QUERY, but in set operations (EXCEPT ALL / INTERSECT) this was incorrectly treated as a fatal saved_error, causing early exit from exec_inner(). This skipped fake_select and left Diagnostics_area uninitialized, leading to Protocol::end_statement() assertion failure.

### Cause:
saved_error triggered goto err without considering that ABORT_QUERY is a recoverable stop condition intended to return partial results with a warning.

### Fix:
 Treat ABORT_QUERY as non-fatal in set-operation execution, allowing normal completion path (fake_select, DA finalization, protocol end) to run and return partial results correctly.