### PR TITLE
MDEV-39712: gcc 16 error with error=parentheses on mysql/service_encr…

### DIFF
--- a/cmake/do_abi_check.cmake
+++ b/cmake/do_abi_check.cmake
@@ -46,8 +46,8 @@
 # leave a <build directory>/abi_check.out file.
 #
 # A developer with a justified API change will then do a
-# mv <build directory>/abi_check.out include/mysql/plugin.pp 
-# to replace the old canons with the new ones.
+# build of the target abi_update and verify the API change
+# in the git difference is as intended.
 #
 
 SET(abi_check_out ${BINARY_DIR}/abi_check.out)
@@ -65,7 +65,7 @@ FOREACH(file ${ABI_HEADERS})
       ERROR_QUIET OUTPUT_FILE ${tmpfile})
   EXECUTE_PROCESS(
     COMMAND sed -e "/^# /d"
-                -e "/^[	]*$/d"
+                -e "/^[ 	;]*$/d"
                 -e "/^#pragma GCC set_debug_pwd/d"
                 -e "/^#ident/d"
     RESULT_VARIABLE result OUTPUT_FILE ${abi_check_out} INPUT_FILE ${tmpfile})

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_data_type.h.pp
+++ b/include/mysql/plugin_data_type.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_function.h.pp
+++ b/include/mysql/plugin_function.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -59,7 +59,6 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
   if (src < dst)
     assert(src + slen <= dst);
   else

--- a/include/mysql/service_encryption.h
+++ b/include/mysql/service_encryption.h
@@ -26,11 +26,21 @@
 
 #ifndef MYSQL_ABI_CHECK
 #include <my_alloca.h>
+#ifdef __has_include
+#if __has_include(<my_valgrind.h>)
+#include <my_valgrind.h>
+#endif
+#endif
 #ifdef _WIN32
 #ifndef __cplusplus
 #define inline __inline
 #endif
 #endif
+#endif
+
+#ifndef MEM_UNDEFINED
+#define MEM_UNDEFINED(addr, length)
+#define MEM_CHECK_ADDRESSABLE(addr, length)
 #endif
 
 #ifdef __cplusplus
@@ -119,10 +129,16 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   int res1, res2;
   unsigned int d1, d2= *dlen;
 
-  // Verify dlen is initialized properly. See MDEV-30389
+  /* Verify dlen is initialized properly. */
   assert(*dlen >= slen);
-  assert((dst[*dlen - 1]= 1) == 1);
-  // Verify buffers do not overlap
+  /* ensure we're not leaking output */
+  MEM_UNDEFINED(dst, *dlen);
+  /* inputs should be accessible */
+  MEM_CHECK_ADDRESSABLE(src, slen);
+  MEM_CHECK_ADDRESSABLE(dst, *dlen);
+  MEM_CHECK_ADDRESSABLE(key, klen);
+  MEM_CHECK_ADDRESSABLE(iv, ivlen);
+  /* Verify buffers do not overlap */
   if (src < dst)
     assert(src + slen <= dst);
   else


### PR DESCRIPTION
…yption.h

The assertion on assignment failed on gcc16.

The assertion added in MDEV-30389 seems intent on testing boundaries.

Re-use the my_valgrind.h header to approve a bunch of assertions around the contents of the output buffer, and the addressibility of the pointer and lengths passed to the encryption function.

note:
very much a test at the moment. Using my_valgrind.h as a header may by appropriate on headers. Having the boundary testing is useful however. The __has_include may not be as portable as desirable.

this is very much a test