### PR TITLE
MDEV-39721: wsrep_notify.cc: reject shell-unsafe characters in joiner-supplied member fields

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_notify_cmd_injection.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_notify_cmd_injection.result
@@ -1,0 +1,10 @@
+connection node_2;
+connection node_1;
+SELECT 1;
+1
+1
+connection node_1;
+call mtr.add_suppression('Process completed with error');
+call mtr.add_suppression('Notification command failed');
+call mtr.add_suppression('Unsafe characters in cluster member');
+FOUND 3 /Unsafe characters in cluster member/ in mysqld.1.err

--- a/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.cnf
+++ b/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.cnf
@@ -1,0 +1,10 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+# Victim: /bin/true exits 0 ignoring argv, so injection happens in sh -c parsing.
+wsrep_notify_cmd=/bin/true
+
+[mysqld.2]
+# Attacker: shell metacharacters in wsrep_node_name; trailing '#' comments
+# out whatever the server appends after the name.
+wsrep_node_name='n;touch PWN;#'

--- a/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.test
@@ -1,0 +1,30 @@
+#
+# Joiner-supplied wsrep_node_name must not inject shell commands into
+# the donor's wsrep_notify_cmd. Fails if "Notification command failed"
+# co-occurs with ";touch" in node_1's error log.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SELECT 1;
+
+--connection node_1
+call mtr.add_suppression('Process completed with error');
+call mtr.add_suppression('Notification command failed');
+call mtr.add_suppression('Unsafe characters in cluster member');
+--let $datadir=`select @@datadir`
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'WSREP_LOCAL_STATE_COMMENT'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--sleep 2
+
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN = Unsafe characters in cluster member
+--source include/search_pattern_in_file.inc
+
+--list_files $datadir PWN

--- a/sql/wsrep_notify.cc
+++ b/sql/wsrep_notify.cc
@@ -14,9 +14,37 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA */
 
 #include "mariadb.h"
+#include <ctype.h>
 #include <mysqld.h>
 #include "wsrep_priv.h"
 #include "wsrep_utils.h"
+
+/* Allow only alnum and -_. */
+static bool is_valid_node_name(const char* s)
+{
+  if (!s) return true;
+  for (; *s; ++s)
+  {
+    unsigned char c= (unsigned char) *s;
+    if (!isalnum(c) && c != '-' && c != '_' && c != '.')
+      return false;
+  }
+  return true;
+}
+
+/* Allow alnum and -_.:[]/ (host:port and [ipv6] forms). */
+static bool is_valid_node_addr(const char* s)
+{
+  if (!s) return true;
+  for (; *s; ++s)
+  {
+    unsigned char c= (unsigned char) *s;
+    if (!isalnum(c) && c != '-' && c != '_' && c != '.' &&
+        c != ':' && c != '[' && c != ']' && c != '/')
+      return false;
+  }
+  return true;
+}
 
 void wsrep_notify_status(enum wsrep::server_state::state status,
                          const wsrep::view* view)
@@ -67,13 +95,22 @@ void wsrep_notify_status(enum wsrep::server_state::state status,
 
       for (unsigned int i= 0; i < members.size(); i++)
       {
+        const char* name=     members[i].name().c_str();
+        const char* incoming= members[i].incoming().c_str();
+        if (!is_valid_node_name(name) || !is_valid_node_addr(incoming))
+        {
+          WSREP_ERROR("Unsafe characters in cluster member %u "
+                      "wsrep_node_name or wsrep_node_incoming_address, "
+                      "aborting notification.", i);
+          my_free(cmd_ptr);
+          return;
+        }
         std::ostringstream id;
         id << members[i].id();
         cmd_off += snprintf(cmd_ptr + cmd_off, cmd_len - cmd_off,
                             "%c%s/%s/%s", i > 0 ? ',' : ' ',
                             id.str().c_str(),
-                            members[i].name().c_str(),
-                            members[i].incoming().c_str());
+                            name, incoming);
       }
     }
   }


### PR DESCRIPTION
Issue:
wsrep_notify_status() interpolated members[i].name() (the peer's wsrep_node_name) and members[i].incoming() verbatim into a command string that is then executed via 'sh -c' by wsp::process. A peer joining the cluster with shell metacharacters in its wsrep_node_name caused arbitrary commands to run on every cluster member that had wsrep_notify_cmd configured.

Solution:
Validate both fields before substitution; reject values containing shell-significant characters.