### PR TITLE
MDEV-20122: Remove `Master_info::is_demotion`

### DIFF
--- a/sql/rpl_mi.h
+++ b/sql/rpl_mi.h
@@ -373,14 +373,6 @@ class Master_info: public Master_info_file, public Slave_reporting_capability
     Cache the value so future RESET SLAVE commands don't revert to Slave_Pos.
   */
   bool &master_supports_gtid= master_use_gtid.gtid_supported;
-
-  /*
-    When TRUE, transition this server from being an active master to a slave.
-    This updates the replication state to account for any transactions which
-    were committed into the binary log. In particular, it merges
-    gtid_binlog_pos into gtid_slave_pos.
-  */
-  bool is_demotion= false;
 };
 
 struct start_alter_thd_args

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -370,6 +370,12 @@ struct LEX_MASTER_INFO
   ulong server_id;
   uint port;
   int sql_delay;
+  /**
+    When `true`, transition this connection from an active master to a slave.
+    This updates the replication state to account for any transactions which
+    were committed into the binary log. In particular, it merges
+    `gtid_binlog_pos` into `gtid_slave_pos`.
+  */
   bool is_demotion_opt;
   bool is_until_before_gtids;
   bool show_all_slaves;


### PR DESCRIPTION
MDEV-20122 introduced this field, but it was never actually used.
`CHANGE MASTER TO master_demote_to_slave=…` only uses the parser field `LEX_MASTER_INFO::is_demotion_opt` and is not recorded in either `@@master_info_file` or `@@relay_log_info_file`, as it takes effect during CHANGE MASTER rather than during replication.