### PR TITLE
MDEV-6589: Remove `have_debug_sync` requirement

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_parallel_mdev6589.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_mdev6589.result
@@ -150,8 +150,6 @@ connection server_2;
 include/stop_slave.inc
 SET GLOBAL slave_parallel_threads=@old_parallel_threads;
 include/start_slave.inc
-SET DEBUG_SYNC= 'RESET';
 connection server_1;
 DROP TABLE t1,t2;
-SET DEBUG_SYNC= 'RESET';
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_parallel_mdev6589.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_mdev6589.test
@@ -1,6 +1,5 @@
 --source include/have_innodb.inc
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 --source include/master-slave.inc
 
 --connection server_2
@@ -123,10 +122,8 @@ SELECT * FROM t2 ORDER BY a;
 --source include/stop_slave.inc
 SET GLOBAL slave_parallel_threads=@old_parallel_threads;
 --source include/start_slave.inc
-SET DEBUG_SYNC= 'RESET';
 
 --connection server_1
 DROP TABLE t1,t2;
-SET DEBUG_SYNC= 'RESET';
 
 --source include/rpl_end.inc


### PR DESCRIPTION
The test for `rpl.rpl_parallel_mdev6589` required `include/have_debug_sync.inc` but did not use `@@debug_sync` (besides RESETting it during cleanup).
It uses `MASTER_GTID_WAIT()`.