### PR TITLE
Fix operator typo in `||` chain

### DIFF
--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -6742,7 +6742,7 @@ bool Table_map_log_event::write_data_body()
          write_data(cbuf, (size_t) (cbuf_end - cbuf)) ||
          write_data(m_coltype, m_colcnt) ||
          write_data(mbuf, (size_t) (mbuf_end - mbuf)) ||
-         write_data(m_field_metadata, m_field_metadata_size),
+         write_data(m_field_metadata, m_field_metadata_size) ||
          write_data(m_null_bits, (m_colcnt + 7) / 8) ||
          write_data((const uchar*) m_metadata_buf.ptr(),
                                   m_metadata_buf.length());


### PR DESCRIPTION
There is a `,` breaking `Table_map_log_event::write_data_body()`’s `||` chain.
This “comma operator” still connects the expressions, but if a step in the first sub-chain fails, the code will disregard the failure and continue with the second half-chain.

This change was originally **unsolicitedly** suggested by our new spambot [in mariadb-corporation/MariaDBEnterprise#265](https://github.com/mariadb-corporation/MariaDBEnterprise/pull/265#pullrequestreview-4353425584); that is, I did not activate a bot nor provide any prompt, but rather the CI-triggered spambot comment came to me like junk mail.
By verifying the bot output and creating this patch independently *without AI assistance*, I confirm I understand the change and can claim its authorship and responsibility, and *I remain have never provided AI-generated code*.

---

This PR targets 10.6 in the name of stability improvement; I’m happy to retarget 10.11.
(Help me [answer the very same spambot](https://github.com/MariaDB/server/pull/5118#discussion_r3295530650): Do I need to engineer a fault-injection test for *this* triviality as well?)