### PR TITLE
MDEV-38405 Assertion `tbl->trn == 0' failed in _ma_set_trn_for_table

### DIFF
--- a/sql/sql_test.cc
+++ b/sql/sql_test.cc
@@ -633,10 +633,6 @@ Next alarm time: %lu\n",
 #elif defined(HAVE_MALLINFO)
   struct mallinfo info= mallinfo();
 #endif
-#if __has_feature(memory_sanitizer)
-  /* Work around missing MSAN instrumentation */
-  MEM_MAKE_DEFINED(&info, sizeof info);
-#endif
 #if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
   char llbuff[10][22];
   printf("\nMemory status:\n\

--- a/storage/maria/ma_trnman.h
+++ b/storage/maria/ma_trnman.h
@@ -32,7 +32,7 @@ static inline void _ma_set_trn_for_table(MARIA_HA *tbl, TRN *newtrn)
   /* check that we are not calling this twice in a row */
   DBUG_ASSERT(newtrn->used_instances != (void*) tbl);
   DBUG_ASSERT(newtrn != &dummy_transaction_object);
-  DBUG_ASSERT(tbl->trn == 0);
+  DBUG_ASSERT(tbl->trn == 0 || tbl->trn == &dummy_transaction_object);
   DBUG_ASSERT(tbl->trn_next == 0);
   DBUG_ASSERT(tbl->trn_prev == 0);
 

--- a/storage/rocksdb/rdb_mariadb_server_port.cc
+++ b/storage/rocksdb/rdb_mariadb_server_port.cc
@@ -12,6 +12,7 @@
 //#include <mysql/thread_pool_priv.h>
 
 #include <string>
+#include <algorithm>
 
 /* MyRocks includes */
 #include "./rdb_threads.h"


### PR DESCRIPTION
Aria bulk insert operations disables share->now_transaction meaning a concurrent open of the stable table will have
tbl->trn == &dummy_transaction_object for its handler object during opening.

As the _ma_set_trn_for_table is setting the trn, its harmless if the current trn is the dummy_transaction_object.

Relax the assert to allow for this state.