### PR TITLE
MDEV-33170: ASAN errors upon CONVERT TABLE TO PARTITION with query cache

### DIFF
--- a/mysql-test/main/query_cache_partition.result
+++ b/mysql-test/main/query_cache_partition.result
@@ -1,0 +1,13 @@
+#
+# MDEV-33170 ASAN errors upon CONVERT TABLE TO PARTITION with query cache
+#
+SET @qcache= @@global.query_cache_type;
+SET GLOBAL query_cache_type= 1;
+CREATE TABLE t (a INT) PARTITION BY LIST (a) (PARTITION p0 VALUES IN (1));
+CREATE TABLE t1 (a INT);
+ALTER TABLE t CONVERT TABLE t1 TO PARTITION pn VALUES IN (2);
+DROP TABLE IF EXISTS t1, t;
+Warnings:
+Note	1051	Unknown table 'test.t1'
+SET GLOBAL query_cache_type= @qcache;
+# End of 10.11 tests

--- a/mysql-test/main/query_cache_partition.test
+++ b/mysql-test/main/query_cache_partition.test
@@ -1,0 +1,19 @@
+--source include/have_partition.inc
+--source include/have_query_cache.inc
+
+--echo #
+--echo # MDEV-33170 ASAN errors upon CONVERT TABLE TO PARTITION with query cache
+--echo #
+
+SET @qcache= @@global.query_cache_type;
+SET GLOBAL query_cache_type= 1;
+
+CREATE TABLE t (a INT) PARTITION BY LIST (a) (PARTITION p0 VALUES IN (1));
+CREATE TABLE t1 (a INT);
+ALTER TABLE t CONVERT TABLE t1 TO PARTITION pn VALUES IN (2);
+
+# Cleanup
+DROP TABLE IF EXISTS t1, t;
+SET GLOBAL query_cache_type= @qcache;
+
+--echo # End of 10.11 tests

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -4631,8 +4631,6 @@ static int fast_end_partition(THD *thd, ulonglong copied,
 
   thd->proc_info="end";
 
-  query_cache_invalidate3(thd, table_list, 0);
-
   my_snprintf(tmp_name, sizeof(tmp_name), ER_THD(thd, ER_INSERT_INFO),
               (ulong) (copied + deleted),
               (ulong) deleted,
@@ -7529,6 +7527,8 @@ uint fast_alter_partition_table(THD *thd, TABLE *table,
   lpt->deleted= 0;
   lpt->pack_frm_data= NULL;
   lpt->pack_frm_len= 0;
+
+  query_cache_invalidate3(thd, table_list, 0);
 
   /* Add IF EXISTS to binlog if shared table */
   if (table->file->partition_ht()->flags & HTON_TABLE_MAY_NOT_EXIST_ON_SLAVE)


### PR DESCRIPTION
With a fast altering partition mechanism, the table cache of the the moved partition is invalided in alter_partition_convert_in.

Let's invalidate the query cache of these table involved in the query early.

This prevents a use after free that was previous there when the query_cache_invalidate was at the end of the function and the references to tables where closed and frred.