### PR TITLE
MDEV-28610 : Assertion `marked_for_read()' failed upon range select with virtual column in index

### DIFF
--- a/mysql-test/suite/vcol/r/vcol_misc.result
+++ b/mysql-test/suite/vcol/r/vcol_misc.result
@@ -600,4 +600,22 @@ SELECT (SELECT 1 FROM foo) FROM t1;
 ERROR 42S02: Table 'test.foo' doesn't exist
 INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
+#
+# MDEV-28610 Assertion `marked_for_read()' failed upon range select with virtual column in index
+#
+CREATE TABLE t (
+a INT UNSIGNED NOT NULL DEFAULT 0,
+b INT AS (a) VIRTUAL,
+c TIME,
+d INT,
+e DATE,
+f VARCHAR(1024),
+PRIMARY KEY(c),
+KEY(c,b,d,f(64))
+);
+INSERT INTO t (c) VALUES ('00:00:00'),('00:00:04');
+SELECT c FROM t WHERE c BETWEEN '00:00:00' AND '00:00:00' ORDER BY d;
+c
+00:00:00
+DROP TABLE t;
 # End of 10.11 tests

--- a/mysql-test/suite/vcol/t/vcol_misc.test
+++ b/mysql-test/suite/vcol/t/vcol_misc.test
@@ -576,4 +576,24 @@ SELECT (SELECT 1 FROM foo) FROM t1;
 INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-28610 Assertion `marked_for_read()' failed upon range select with virtual column in index
+--echo #
+
+CREATE TABLE t (
+  a INT UNSIGNED NOT NULL DEFAULT 0,
+  b INT AS (a) VIRTUAL,
+  c TIME,
+  d INT,
+  e DATE,
+  f VARCHAR(1024),
+  PRIMARY KEY(c),
+  KEY(c,b,d,f(64))
+);
+INSERT INTO t (c) VALUES ('00:00:00'),('00:00:04');
+SELECT c FROM t WHERE c BETWEEN '00:00:00' AND '00:00:00' ORDER BY d;
+
+# Cleanup
+DROP TABLE t;
+
 --echo # End of 10.11 tests

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -32827,9 +32827,9 @@ void JOIN::init_join_cache_and_keyread()
           depends on are automatically added to the read_set - because they're
           needed to calculate the vcol.
           But if we're doing keyread, vcol is taken
-          from the index, not calculated, and base columns do not need to  be
-          in the read set. To ensure this we try to set the read_set to only
-          the key-parts of the indexes.
+          from the index, not calculated. The below call adds the key-parts
+          to the read_set, and for virtual columns also adds any base columns
+          they depend on.
 
           Another side effect of this is
             Lets say you have a query
@@ -32841,7 +32841,7 @@ void JOIN::init_join_cache_and_keyread()
           tuple.
       */
       if (!(table->file->index_flags(table->file->keyread, 0, 1) & HA_CLUSTERED_INDEX))
-        table->mark_index_columns(table->file->keyread, table->read_set);
+        table->mark_index_columns_for_read(table->file->keyread);
     }
     bool init_for_explain= false;
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -7665,7 +7665,7 @@ inline void TABLE::mark_index_columns_no_reset(uint index, MY_BITMAP *bitmap)
 }
 
 
-inline void TABLE::mark_index_columns_for_read(uint index)
+void TABLE::mark_index_columns_for_read(uint index)
 {
   do_mark_index_columns(this, index, read_set, true);
 }


### PR DESCRIPTION
fixes [MDEV-28610](https://jira.mariadb.org/browse/MDEV-28610)

### Problem:
Executing a range select using an index that includes virtual/generated columns
(e.g. SELECT ... WHERE c BETWEEN ... ORDER BY d) could trigger:

Assertion 'marked_for_read()' failed in Field access during execution.

### Cause:
The keyread initialization path was populating table->read_set using
mark_index_columns(), which follows the non-recursive index marking path.
This only marks direct index fields and does not resolve dependencies of
virtual/generated columns.

As a result, when an index contained virtual columns, their dependent base
columns were not included in read_set, leading to invalid access during
later evaluation of virtual columns.

### Fix:
Replace mark_index_columns() with mark_index_columns_for_read() in the
keyread initialization path. This ensures the recursive read-marking logic is
used, so virtual/generated column dependencies are correctly propagated into
read_set before execution.