### PR TITLE
MDEV-37664: main.lotofstack fails with MSAN+Debug

### DIFF
--- a/mysql-test/main/lotofstack.test
+++ b/mysql-test/main/lotofstack.test
@@ -8,6 +8,8 @@
 source include/not_asan.inc;
 source include/not_embedded.inc;
 source include/not_ubsan.inc;
+# MSAN with debug exceeds the stack early.
+source include/not_msan_with_debug.inc;
 
 #
 # Bug#10100 function (and stored procedure?) recursivity problem


### PR DESCRIPTION
Under MSAN+Debug this test case exceeds the stack
early without the stack detection mechanism to
identify that it passed its limit.