### PR TITLE
MDEV-31808 crash upon altering table with NEXTVAL for default under exclusive lock

### DIFF
--- a/mysql-test/main/alter_table_combinations.result
+++ b/mysql-test/main/alter_table_combinations.result
@@ -321,4 +321,13 @@ drop table t1;
 #
 # End of 10.5 tests
 #
+#
+# MDEV-31808 Server crash upon altering table with NEXTVAL for default under exclusive lock
+#
+CREATE SEQUENCE s ENGINE=Aria;
+CREATE TABLE t (a INT DEFAULT(NEXTVAL(s)), b INT);
+ALTER TABLE t FORCE, ALGORITHM=COPY, LOCK=EXCLUSIVE;
+DROP TABLE t;
+DROP SEQUENCE s;
+# End of 10.6 tests
 set @@default_storage_engine= @save_default_engine;

--- a/mysql-test/main/alter_table_combinations.test
+++ b/mysql-test/main/alter_table_combinations.test
@@ -260,4 +260,18 @@ drop table t1;
 --echo # End of 10.5 tests
 --echo #
 
+--echo #
+--echo # MDEV-31808 Server crash upon altering table with NEXTVAL for default under exclusive lock
+--echo #
+
+CREATE SEQUENCE s ENGINE=Aria;
+CREATE TABLE t (a INT DEFAULT(NEXTVAL(s)), b INT);
+ALTER TABLE t FORCE, ALGORITHM=COPY, LOCK=EXCLUSIVE;
+
+# Cleanup
+DROP TABLE t;
+DROP SEQUENCE s;
+
+--echo # End of 10.6 tests
+
 set @@default_storage_engine= @save_default_engine;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -2085,7 +2085,7 @@ retry_share:
       goto retry_share;
     }
 
-    if (thd->open_tables && thd->open_tables->s->tdc->flushed)
+    if (!table_list->sequence && thd->open_tables && thd->open_tables->s->tdc->flushed)
     {
       /*
         If the version changes while we're opening the tables,
@@ -5005,6 +5005,10 @@ bool open_and_lock_internal_tables(TABLE *table, bool lock_table)
     if (lock_tables(thd, table->internal_tables, counter,
                     MYSQL_LOCK_USE_MALLOC))
       goto err;
+
+    /* no existing lock to merge with */
+    if (save_lock == nullptr)
+      DBUG_RETURN(0);
 
     if (!(new_lock= mysql_lock_merge(save_lock, thd->lock)))
     {


### PR DESCRIPTION
A segfault in mysql_lock_merge waa the result of a null argument when called from open_and_lock_internal_tables. As the argument was null there was no lock to merge and thd->lock was already in place, so no futher action is required in open_and_lock_internal_tables.

After passing the previous correctly on open_table of the sequence used in the table, we get to the checking the thd->open_table list where tdc is flushed. This puts the open_table into an error condition to reopen all tables. When we are just opening a sequence, this condition isn't one we want to fail on.