### PR TITLE
MDEV-31209 Queries with window functions do not obey KILL / max_statement_time

### DIFF
--- a/mysql-test/main/set_statement_notembedded.result
+++ b/mysql-test/main/set_statement_notembedded.result
@@ -15,3 +15,12 @@ Max_statement_time_exceeded	1
 SELECT @@MAX_STATEMENT_TIME;
 @@MAX_STATEMENT_TIME
 0.000000
+#
+# MDEV-31209 Queries with window functions do not obey KILL / max_statement_time
+#
+create table t (i int);
+insert into t values(1),(2),(3);
+set statement max_statement_time=0.03 for select max(sleep(0.1)) over( ) from t;
+ERROR 70100: Query execution was interrupted (max_statement_time exceeded)
+drop table t;
+# End of 10.11 tests

--- a/mysql-test/main/set_statement_notembedded.test
+++ b/mysql-test/main/set_statement_notembedded.test
@@ -11,4 +11,14 @@ SET STATEMENT MAX_STATEMENT_TIME=1 FOR SELECT SLEEP(10);
 SHOW STATUS LIKE "max_statement_time_exceeded";
 SELECT @@MAX_STATEMENT_TIME;
 
+--echo #
+--echo # MDEV-31209 Queries with window functions do not obey KILL / max_statement_time
+--echo #
 
+create table t (i int);
+insert into t values(1),(2),(3);
+--error ER_STATEMENT_TIMEOUT
+set statement max_statement_time=0.03 for select max(sleep(0.1)) over( ) from t;
+drop table t;
+
+--echo # End of 10.11 tests

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -2255,6 +2255,7 @@ private:
      between them, top bound row  and bottom bound row inclusive. */
   void compute_values_for_current_row()
   {
+    THD *thd= current_thd;
     if (top_bound.is_outside_computation_bounds() ||
         bottom_bound.is_outside_computation_bounds())
       return;
@@ -2265,7 +2266,8 @@ private:
 
     cursor.move_to(start_rownum);
 
-    for (ha_rows idx= start_rownum; idx <= bottom_rownum; idx++)
+    for (ha_rows idx= start_rownum; idx <= bottom_rownum
+         && ((idx & 0xFF) || !thd->check_killed(true)); idx++)
     {
       if (cursor.fetch()) //EOF
         break;


### PR DESCRIPTION
Window functions run in a loop in
Frame_cursor::compute_values_for_current_row which can include a large number of rows.

Adjust this function to check for the current thd being killed.