### PR TITLE
MDEV-39770 log_t::persist(): Assertion is_opened() == archive failed

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1544,13 +1544,14 @@ void log_t::persist(lsn_t lsn) noexcept
   ut_ad(!write_lock.is_owner());
   ut_ad(!flush_lock.is_owner());
   ut_ad(latch_have_wr());
-  ut_ad(is_opened() == archive);
 
   lsn_t old= flushed_to_disk_lsn.load(std::memory_order_relaxed);
 
   if (old > lsn)
     return;
 
+  ut_ad(is_mmap_writeable());
+  ut_ad(is_opened() == archive);
   const size_t start(calc_lsn_offset(old));
   const size_t end(calc_lsn_offset(lsn));
 


### PR DESCRIPTION
`log_t::persist()`: Move a debug assertion after the point that we are actually about to write to the log. For crash recovery, this function may be invoked in such a way that `log_sys.archive` disagrees with the format of the log file.

This fixes a regression that was introduced in #4405.