### PR TITLE
MDEV-38260 applier hang due to sequence table access

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-38260.result
+++ b/mysql-test/suite/galera/r/MDEV-38260.result
@@ -1,0 +1,51 @@
+connection node_2;
+connection node_1;
+connection node_1;
+SET global wsrep_slave_threads = 2;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_2;
+START SLAVE;
+connection node_3;
+CREATE SEQUENCE my_seq INCREMENT BY 1 NOCACHE ENGINE=INNODB;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+insert into t1 values (0);
+BEGIN;
+select nextval(my_seq);
+nextval(my_seq)
+1
+select nextval(my_seq);
+nextval(my_seq)
+2
+select nextval(my_seq);
+nextval(my_seq)
+3
+insert into t1 values (1);
+COMMIT;
+insert into t1 values (2);
+delete from t1;
+DROP TABLE t1;
+CREATE TABLE t1(a int not null primary key default nextval(my_seq), b int) engine=innodb;
+BEGIN;
+INSERT INTO t1(b) VALUES(3);
+INSERT INTO t1(a,b) VALUES(10,4);
+COMMIT;
+delete from t1;
+connection node_1;
+SET global wsrep_slave_threads = DEFAULT;
+connection node_3;
+DROP SEQUENCE my_seq;
+DROP TABLE t1;
+connection node_1;
+connection node_2;
+STOP SLAVE;
+RESET SLAVE ALL;
+connection node_1;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_2;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_3;
+reset master;

--- a/mysql-test/suite/galera/t/MDEV-38260.cnf
+++ b/mysql-test/suite/galera/t/MDEV-38260.cnf
@@ -1,0 +1,14 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+log-bin=mysqld-bin
+log-slave-updates
+binlog-format=ROW
+
+gtid_strict_mode=ON
+gtid_domain_id=10
+
+[mysqld.1]
+wsrep_gtid_mode=ON
+[mysqld.2]
+wsrep_gtid_mode=ON

--- a/mysql-test/suite/galera/t/MDEV-38260.test
+++ b/mysql-test/suite/galera/t/MDEV-38260.test
@@ -1,0 +1,97 @@
+#
+# Test Galera as a slave to a MariaDB master using sequence table and GTID mode
+#
+# In the problematic execution scenario, seqence access marks GTID event as DDL
+# and applier makes implicit commit before the actual transaction is even applied.
+# Second commit attempt after the actual payload applying would then wait for
+# commit order eternally, causing total cluster hang
+#
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+--source include/galera_cluster.inc
+
+#
+# node_1 = galera cluster replica node
+# node_2 = galera cluster node, operating as replication slave for node_3
+# node_3 = regular mariadb server operating as replication master
+#
+
+# enable parallel applying in galera cluster replica node
+--connection node_1
+SET global wsrep_slave_threads = 2;
+
+# As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
+# we open the node_3 connection here
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_2
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE;
+
+--connection node_3
+CREATE SEQUENCE my_seq INCREMENT BY 1 NOCACHE ENGINE=INNODB;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+insert into t1 values (0);
+
+BEGIN;
+# spend some sequence values
+select nextval(my_seq);
+select nextval(my_seq);
+select nextval(my_seq);
+
+# regular insert, which may cause duplicate commit in node_1
+insert into t1 values (1);
+COMMIT;
+
+# feed some more DML, which may cause hang in galera replication, node_1
+insert into t1 values (2);
+delete from t1;
+
+#
+# Scenario where seqeunce value is used in a SQL statement
+#
+DROP TABLE t1;
+CREATE TABLE t1(a int not null primary key default nextval(my_seq), b int) engine=innodb;
+
+BEGIN;
+INSERT INTO t1(b) VALUES(3);
+INSERT INTO t1(a,b) VALUES(10,4);
+COMMIT;
+
+delete from t1;
+
+# tear down the replication, force galera nodes to apply all remaining as single threaded
+--connection node_1
+SET global wsrep_slave_threads = DEFAULT;
+
+--connection node_3
+DROP SEQUENCE my_seq;
+DROP TABLE t1;
+
+# wait untill replication channel is flushed and all is applied in node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'my_seq'
+--source include/wait_condition.inc
+
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_1
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_2
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_3
+reset master;

--- a/sql/ha_sequence.cc
+++ b/sql/ha_sequence.cc
@@ -251,6 +251,12 @@ int ha_sequence::write_row(const uchar *buf)
       - Check that the new row is an accurate SEQUENCE object
     */
     /* mark a full binlog image insert to force non-parallel slave */
+#ifdef WITH_WSREP
+    if (WSREP_ON && WSREP(thd) && wsrep_thd_is_applying(thd))
+    {
+      WSREP_DEBUG("skipped to mark trx as DDL due to sequence table insert");
+    } else
+#endif /* WITH_WSREP */
     thd->transaction->stmt.mark_trans_did_ddl();
     if (table->s->tmp_table == NO_TMP_TABLE &&
         thd->mdl_context.upgrade_shared_lock(table->mdl_ticket,

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -238,6 +238,7 @@ int wsrep_apply_events(THD*        thd,
     }
 
     typ= ev->get_type_code();
+    WSREP_DEBUG("applying event %d, type %d, buf_len %zu", event, typ, buf_len);
 
     switch (typ) {
     case FORMAT_DESCRIPTION_EVENT:

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -34,6 +34,7 @@
 #include "log_event.h"
 #include "sql_class.h"
 
+#include <mysql/psi/mysql_transaction.h>
 #include <string>
 #include <sstream>
 
@@ -1663,13 +1664,15 @@ int Wsrep_schema::store_gtid_event(THD* thd,
 
   if (in_ddl)
   {
-    // Commit transaction if this GTID is part of DDL-clause because
-    // DDL causes implicit commit assuming there is no multi statement
-    // transaction ongoing.
-    if((error= trans_commit_stmt(thd)))
-      goto out;
-
-    (void)trans_commit(thd);
+    /* gtid slave state recording above has started a trasaction and called for
+       statemet commit. Resetting here the transaction state for the actual DDL
+       execution to happen by following events
+    */
+    thd->transaction->cleanup();
+    MYSQL_COMMIT_TRANSACTION(thd->m_transaction_psi);
+    thd->m_transaction_psi= NULL;
+    thd->server_status&=
+      ~(SERVER_STATUS_IN_TRANS | SERVER_STATUS_IN_TRANS_READONLY);
   }
 
 out:


### PR DESCRIPTION
Avoiding to mark sequence table write as a DDL transaction for galera applying.

Skipping commit for DDL marked GTID log event in applying as this would lead to double commit, if the transaction has also a real transaction. Such scnenario could happen if transaction has sequence table writes together with other innodb table writes.

The commit contains a new mtr test galera.MDEV-38260 for testing applying of a transaction having sequence table access when using GTID mode