### PR TITLE
MDEV-38796 Refactor: clean up THD::decide_logging_format() checks

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_close_during_commit.result
+++ b/mysql-test/suite/binlog/r/binlog_close_during_commit.result
@@ -1,0 +1,183 @@
+call mtr.add_suppression("\\[ERROR\\] Error writing file '.*master-bin.*' .*errno: 9");
+call mtr.add_suppression("\\[ERROR\\] Error writing file");
+call mtr.add_suppression("\\[ERROR\\] Could not use");
+#
+# Sub-case 1: DML on a transactional table
+#
+connection default;
+create table t_trans (id int primary key) engine=innodb;
+create table t2 (id int primary key) engine=innodb;
+connect  con1,localhost,root,,test;
+connect  con3,localhost,root,,test;
+connection con1;
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+SET DEBUG_DBUG= '+d,commit_after_binlog_ready_before_LOCK_log';
+insert into t_trans values (1);
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+# Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+FLUSH LOGS;
+ERROR HY000: Can't open file: 'master-bin' (errno: 2 "No such file or directory")
+# Ensure binary logging disables for the rest of the server lifespan
+NOT FOUND matches in mysqld.1.err
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con1;
+connection default;
+# con1's statement must have committed in the engine
+select * from t_trans;
+id
+1
+# A follow-up commit on a third connection must also succeed without
+# logging another ER_ERROR_ON_WRITE
+connection con3;
+insert into t2 values (102);
+select * from t2 order by id;
+id
+102
+disconnect con1;
+disconnect con3;
+connection default;
+drop table t_trans, t2;
+# restart
+#
+# Sub-case 2: DML on a non-transactional table
+#
+connection default;
+create table t_myisam (id int primary key) engine=myisam;
+create table t2 (id int primary key) engine=innodb;
+connect  con1,localhost,root,,test;
+connect  con3,localhost,root,,test;
+connection con1;
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+insert into t_myisam values (1);
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+# Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+FLUSH LOGS;
+ERROR HY000: Can't open file: 'master-bin' (errno: 2 "No such file or directory")
+# Ensure binary logging disables for the rest of the server lifespan
+NOT FOUND matches in mysqld.1.err
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con1;
+connection default;
+# con1's statement must have committed in the engine
+select * from t_myisam;
+id
+1
+connection con3;
+insert into t2 values (202);
+select * from t2 order by id;
+id
+202
+disconnect con1;
+disconnect con3;
+connection default;
+drop table t_myisam, t2;
+# restart
+#
+# Sub-case 3: Multi-table UPDATE on trans + non-trans
+#
+connection default;
+create table t_trans (id int primary key, v int) engine=innodb;
+create table t_myisam (id int primary key, v int) engine=myisam;
+create table t2 (id int primary key) engine=innodb;
+insert into t_trans values (1, 0), (2, 0);
+insert into t_myisam values (1, 0), (2, 0);
+connect  con1,localhost,root,,test;
+connect  con3,localhost,root,,test;
+connection con1;
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+update t_trans, t_myisam set t_trans.v = 1, t_myisam.v = 1 where t_trans.id = t_myisam.id;
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+# Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+FLUSH LOGS;
+ERROR HY000: Can't open file: 'master-bin' (errno: 2 "No such file or directory")
+# Ensure binary logging disables for the rest of the server lifespan
+NOT FOUND matches in mysqld.1.err
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con1;
+connection default;
+# con1's statement must have committed in the engine
+select * from t_trans order by id;
+id	v
+1	1
+2	1
+select * from t_myisam order by id;
+id	v
+1	1
+2	1
+# con2's (default conn's) statement must have committed in the engine
+select * from t2;
+id
+connection con3;
+insert into t2 values (302);
+select * from t2 order by id;
+id
+302
+disconnect con1;
+disconnect con3;
+connection default;
+drop table t_trans, t_myisam, t2;
+# restart
+#
+# Sub-case 4: DML selecting from a temporary table
+#
+connection default;
+create table t_trans (id int primary key) engine=innodb;
+create table t2 (id int primary key) engine=innodb;
+connect  con1,localhost,root,,test;
+connect  con3,localhost,root,,test;
+connection con1;
+create temporary table t_tmp (id int primary key) engine=innodb;
+insert into t_tmp values (1);
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+insert into t_trans (id) select id from t_tmp;
+connection default;
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+# Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+FLUSH LOGS;
+ERROR HY000: Can't open file: 'master-bin' (errno: 2 "No such file or directory")
+# Ensure binary logging disables for the rest of the server lifespan
+NOT FOUND matches in mysqld.1.err
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+connection con1;
+# con1's statement must have committed in the engine
+select * from t_tmp;
+id
+1
+select * from t_trans;
+id
+1
+drop temporary table t_tmp;
+connection default;
+# con2's (default conn's) statement must have committed in the engine
+select * from t2;
+id
+connection con3;
+insert into t2 values (402);
+select * from t2 order by id;
+id
+402
+disconnect con1;
+disconnect con3;
+connection default;
+drop table t_trans, t2;
+# restart
+#
+# Sub-case 5: DDL (CREATE TABLE)
+# TODO: Fill in this test case with MDEV-40171
+#
+#
+# Cleanup
+#
+SET DEBUG_SYNC= 'RESET';
+# End of binlog_close_during_commit.test

--- a/mysql-test/suite/binlog/r/binlog_spurious_ddl_errors.result
+++ b/mysql-test/suite/binlog/r/binlog_spurious_ddl_errors.result
@@ -1,25 +1,28 @@
 SET @old_binlog_format= @@global.binlog_format;
 INSTALL PLUGIN example SONAME 'ha_example';
 ################################################################################
-# Verifies if ER_BINLOG_STMT_MODE_AND_ROW_ENGINE happens by setting the binlog
-# format to STATEMENT and the transaction isolation level to READ COMMITTED as
-# such changes force Innodb to accept changes in the row format.
-#
-# When CREATE TABLE, ALTER TABLE, CREATE INDEX and CREATE TRIGGER are executed
-# any error should be triggered.
-# 
-# In contrast, CREATE TABLE ... SELECT should trigger the following error:
-# ER_BINLOG_STMT_MODE_AND_ROW_ENGINE.
+# If the binlog format is set to STATEMENT and the transaction isolation
+# level to READ COMMITTED, InnoDB must override the STATEMENT format
+# configuration and write using ROW format.
 ################################################################################
 SET binlog_format = STATEMENT;
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 CREATE TABLE t_row (a VARCHAR(100)) ENGINE = InnoDB;
+SET statement binlog_format = row for insert into t_row values ('a'), ('b'), ('c');
 ALTER TABLE t_row ADD COLUMN b INT;
 CREATE TRIGGER trig_row BEFORE INSERT ON t_row FOR EACH ROW INSERT INTO t_stmt VALUES (1);
 CREATE INDEX i ON t_row(a);
+# Flush binlogs to ensure the next statement can be analyzed alone
+FLUSH BINARY LOGS;
 CREATE TABLE t_row_new ENGINE = InnoDB SELECT * FROM t_row;
-ERROR HY000: Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging.
+Warnings:
+Note	1665	Statement cannot be logged as STATEMENT as at least one table is limited to row-based logging. Switching temporarly to row format
+FLUSH BINARY LOGS;
+# MYSQL_BINLOG binlog_file --result-file=binlog_out --base64-output=never --verbose
+include/assert_grep.inc [Ensure CREATE TABLE ... SELECT in STATEMENT uses ROW binlogging when InnoDB cannot log using STATEMENT format]
+include/assert_grep.inc [Ensure CREATE TABLE ... SELECT in STATEMENT writes all rows when InnoDB cannot log using STATEMENT format]
 DROP TABLE t_row;
+DROP TABLE t_row_new;
 
 
 ################################################################################

--- a/mysql-test/suite/binlog/t/binlog_close_during_commit.test
+++ b/mysql-test/suite/binlog/t/binlog_close_during_commit.test
@@ -1,0 +1,273 @@
+#
+# Purpose:
+#   Exercise the race where a statement passes the per-THD
+# thd->binlog_ready() check, then the global binary log is closed by
+# another connection before the statement acquires LOCK_log to commit
+# into the binlog. The statement must still commit in the storage
+# engine, and the error log must contain exactly one ER_ERROR_ON_WRITE
+# entry per binlog-close event (not one per affected transaction).
+# After the close, the binary log remains closed and subsequent
+# transactions continue to be processed in engines but are not
+# binlogged, with no further ER_ERROR_ON_WRITE entries logged.
+#
+# Methodology:
+#   DEBUG_SYNC point 'commit_after_binlog_ready_before_LOCK_log'
+# pauses the statement in MYSQL_BIN_LOG::write_transaction_to_binlog
+# immediately after the thd->binlog_ready() check, but before the
+# transaction is queued for group commit (and before LOCK_log is
+# taken). From a second connection, the binlog is closed by setting
+# DBUG injection 'fault_injection_new_file_rotate_event' and running
+# FLUSH LOGS. The fault makes the rotation fail, which leaves the
+# binlog in a closed state (see the "Binlog could be closed if
+# rotation fails" comment in trx_group_commit_with_engines). The
+# first connection, still paused at the sync point, is then resumed
+# and reaches LOCK_log to find the binlog closed.
+#
+#   Five statement types are covered:
+#     1) DML on a transactional table (InnoDB)
+#     2) DML on a non-transactional table (MyISAM)
+#     3) Multi-table UPDATE targeting both a trans and a non-trans
+#        table
+#     4) DML selecting from a temporary table
+#     5) DDL: CREATE TABLE (InnoDB) - Currently broken and commented out
+#        (MDEV-40171)
+#
+# References:
+#   MDEV-38796: branch context for the binlog_ready() refactor
+#
+
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/have_innodb.inc
+--source include/have_binlog_format_row.inc
+
+call mtr.add_suppression("\\[ERROR\\] Error writing file '.*master-bin.*' .*errno: 9");
+call mtr.add_suppression("\\[ERROR\\] Error writing file");
+call mtr.add_suppression("\\[ERROR\\] Could not use");
+
+# Setup for search_pattern_in_file.inc error checking
+--let $error_log= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_FILE= $error_log
+--let SEARCH_OUTPUT= count
+--let SEARCH_PATTERN= Could not use .* Turning off logging
+
+
+--echo #
+--echo # Sub-case 1: DML on a transactional table
+--echo #
+--connection default
+create table t_trans (id int primary key) engine=innodb;
+create table t2 (id int primary key) engine=innodb;
+
+--connect (con1,localhost,root,,test)
+--connect (con3,localhost,root,,test)
+
+--connection con1
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+SET DEBUG_DBUG= '+d,commit_after_binlog_ready_before_LOCK_log';
+--send insert into t_trans values (1)
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+
+--echo # Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+--error ER_ERROR_ON_WRITE
+FLUSH LOGS;
+
+--echo # Ensure binary logging disables for the rest of the server lifespan
+--source include/search_pattern_in_file.inc
+
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+
+--connection con1
+--reap
+
+--connection default
+--echo # con1's statement must have committed in the engine
+select * from t_trans;
+
+--echo # A follow-up commit on a third connection must also succeed without
+--echo # logging another ER_ERROR_ON_WRITE
+--connection con3
+insert into t2 values (102);
+select * from t2 order by id;
+
+
+--disconnect con1
+--disconnect con3
+
+--connection default
+drop table t_trans, t2;
+--source include/restart_mysqld.inc
+
+
+--echo #
+--echo # Sub-case 2: DML on a non-transactional table
+--echo #
+--connection default
+create table t_myisam (id int primary key) engine=myisam;
+create table t2 (id int primary key) engine=innodb;
+
+--connect (con1,localhost,root,,test)
+--connect (con3,localhost,root,,test)
+
+--connection con1
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+--send insert into t_myisam values (1)
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+
+--echo # Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+--error ER_ERROR_ON_WRITE
+FLUSH LOGS;
+
+--echo # Ensure binary logging disables for the rest of the server lifespan
+--source include/search_pattern_in_file.inc
+
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+
+--connection con1
+--reap
+
+--connection default
+--echo # con1's statement must have committed in the engine
+select * from t_myisam;
+
+--connection con3
+insert into t2 values (202);
+select * from t2 order by id;
+
+--disconnect con1
+--disconnect con3
+
+--connection default
+drop table t_myisam, t2;
+--source include/restart_mysqld.inc
+
+--echo #
+--echo # Sub-case 3: Multi-table UPDATE on trans + non-trans
+--echo #
+--connection default
+create table t_trans (id int primary key, v int) engine=innodb;
+create table t_myisam (id int primary key, v int) engine=myisam;
+create table t2 (id int primary key) engine=innodb;
+insert into t_trans values (1, 0), (2, 0);
+insert into t_myisam values (1, 0), (2, 0);
+
+--connect (con1,localhost,root,,test)
+--connect (con3,localhost,root,,test)
+
+--connection con1
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+--send update t_trans, t_myisam set t_trans.v = 1, t_myisam.v = 1 where t_trans.id = t_myisam.id
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+
+--echo # Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+--error ER_ERROR_ON_WRITE
+FLUSH LOGS;
+
+--echo # Ensure binary logging disables for the rest of the server lifespan
+--source include/search_pattern_in_file.inc
+
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+
+--connection con1
+--reap
+
+--connection default
+--echo # con1's statement must have committed in the engine
+select * from t_trans order by id;
+select * from t_myisam order by id;
+--echo # con2's (default conn's) statement must have committed in the engine
+select * from t2;
+
+--connection con3
+insert into t2 values (302);
+select * from t2 order by id;
+
+--disconnect con1
+--disconnect con3
+
+--connection default
+drop table t_trans, t_myisam, t2;
+--source include/restart_mysqld.inc
+
+
+--echo #
+--echo # Sub-case 4: DML selecting from a temporary table
+--echo #
+# Temporary table DML still funnels through the same commit path as
+# regular DML; the binlog cache is statement-cached but the commit
+# goes through write_transaction_to_binlog.
+--connection default
+create table t_trans (id int primary key) engine=innodb;
+create table t2 (id int primary key) engine=innodb;
+
+--connect (con1,localhost,root,,test)
+--connect (con3,localhost,root,,test)
+
+--connection con1
+create temporary table t_tmp (id int primary key) engine=innodb;
+insert into t_tmp values (1);
+SET DEBUG_SYNC= 'commit_after_binlog_ready_before_LOCK_log SIGNAL paused WAIT_FOR go';
+--send insert into t_trans (id) select id from t_tmp
+
+--connection default
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+
+--echo # Trigger the binlog error and permanent closure via a failed rotation
+SET DEBUG_DBUG= '+d,fault_injection_new_file_rotate_event';
+--error ER_ERROR_ON_WRITE
+FLUSH LOGS;
+
+--echo # Ensure binary logging disables for the rest of the server lifespan
+--source include/search_pattern_in_file.inc
+
+SET DEBUG_DBUG= '';
+SET DEBUG_SYNC= 'now SIGNAL go';
+
+--connection con1
+--reap
+--echo # con1's statement must have committed in the engine
+select * from t_tmp;
+select * from t_trans;
+drop temporary table t_tmp;
+
+--connection default
+--echo # con2's (default conn's) statement must have committed in the engine
+select * from t2;
+
+--connection con3
+insert into t2 values (402);
+select * from t2 order by id;
+
+--disconnect con1
+--disconnect con3
+
+--connection default
+drop table t_trans, t2;
+--source include/restart_mysqld.inc
+
+
+--echo #
+--echo # Sub-case 5: DDL (CREATE TABLE)
+--echo # TODO: Fill in this test case with MDEV-40171
+--echo #
+
+
+--echo #
+--echo # Cleanup
+--echo #
+SET DEBUG_SYNC= 'RESET';
+
+--echo # End of binlog_close_during_commit.test

--- a/mysql-test/suite/binlog/t/binlog_spurious_ddl_errors.test
+++ b/mysql-test/suite/binlog/t/binlog_spurious_ddl_errors.test
@@ -29,19 +29,14 @@ SET @old_binlog_format= @@global.binlog_format;
 INSTALL PLUGIN example SONAME 'ha_example';
 
 --echo ################################################################################
---echo # Verifies if ER_BINLOG_STMT_MODE_AND_ROW_ENGINE happens by setting the binlog
---echo # format to STATEMENT and the transaction isolation level to READ COMMITTED as
---echo # such changes force Innodb to accept changes in the row format.
---echo #
---echo # When CREATE TABLE, ALTER TABLE, CREATE INDEX and CREATE TRIGGER are executed
---echo # any error should be triggered.
---echo # 
---echo # In contrast, CREATE TABLE ... SELECT should trigger the following error:
---echo # ER_BINLOG_STMT_MODE_AND_ROW_ENGINE.
+--echo # If the binlog format is set to STATEMENT and the transaction isolation
+--echo # level to READ COMMITTED, InnoDB must override the STATEMENT format
+--echo # configuration and write using ROW format.
 --echo ################################################################################
 SET binlog_format = STATEMENT;
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 CREATE TABLE t_row (a VARCHAR(100)) ENGINE = InnoDB;
+SET statement binlog_format = row for insert into t_row values ('a'), ('b'), ('c');
 
 ALTER TABLE t_row ADD COLUMN b INT;
 
@@ -49,10 +44,33 @@ CREATE TRIGGER trig_row BEFORE INSERT ON t_row FOR EACH ROW INSERT INTO t_stmt V
 
 CREATE INDEX i ON t_row(a);
 
---error ER_BINLOG_STMT_MODE_AND_ROW_ENGINE
+--echo # Flush binlogs to ensure the next statement can be analyzed alone
+FLUSH BINARY LOGS;
+
 CREATE TABLE t_row_new ENGINE = InnoDB SELECT * FROM t_row;
 
+--let $mysqld_datadir= `SELECT @@datadir`
+--let $binlog_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_file= $mysqld_datadir/$binlog_filename
+FLUSH BINARY LOGS;
+
+--let $binlog_out= $MYSQLTEST_VARDIR/tmp/rpl_spurious_ddl_errors.out
+--echo # MYSQL_BINLOG binlog_file --result-file=binlog_out --base64-output=never --verbose
+--exec $MYSQL_BINLOG $binlog_file --result-file=$binlog_out --base64-output=never  --verbose
+
+--let $assert_file= $binlog_out
+--let $assert_text= Ensure CREATE TABLE ... SELECT in STATEMENT uses ROW binlogging when InnoDB cannot log using STATEMENT format
+--let $assert_select= Write_rows
+--let $assert_count= 1
+--source include/assert_grep.inc
+
+--let $assert_text= Ensure CREATE TABLE ... SELECT in STATEMENT writes all rows when InnoDB cannot log using STATEMENT format
+--let $assert_select= INSERT INTO
+--let $assert_count= 3
+--source include/assert_grep.inc
+
 DROP TABLE t_row;
+DROP TABLE t_row_new;
 
 --echo
 --echo

--- a/mysql-test/suite/rpl/r/rpl_lsu_binlog_filter.result
+++ b/mysql-test/suite/rpl/r/rpl_lsu_binlog_filter.result
@@ -1,0 +1,40 @@
+include/rpl_init.inc [topology=1->2, 2->3]
+#
+# Initialize test data
+connection server_1;
+create database db_not_filtered;
+create database db_filtered;
+use db_not_filtered;
+create table t1 (a int) engine=innodb;
+insert into t1 values (10);
+use db_filtered;
+create table t2 (a int) engine=innodb;
+insert into t2 values (20);
+connection server_1;
+include/save_master_gtid.inc
+connection server_2;
+include/sync_with_master_gtid.inc
+# Server_2 should have both db_not_filtered.t1 and db_filtered.t2 data
+select count(*) from db_not_filtered.t1;
+count(*)
+1
+select count(*) from db_filtered.t2;
+count(*)
+1
+include/save_master_gtid.inc
+connection server_3;
+include/sync_with_master_gtid.inc
+# Server_3 should only have db_not_filtered.t1
+select count(*) from db_not_filtered.t1;
+count(*)
+1
+# Server_3 should err when trying to access db_filtered.t2
+select count(*) from db_filtered.t2;
+ERROR 42S02: Table 'db_filtered.t2' doesn't exist
+#
+# Cleanup
+connection server_1;
+drop database db_not_filtered;
+drop database db_filtered;
+include/rpl_end.inc
+# End of rpl_lsu_binlog_filter.test

--- a/mysql-test/suite/rpl/t/rpl_lsu_binlog_filter.cnf
+++ b/mysql-test/suite/rpl/t/rpl_lsu_binlog_filter.cnf
@@ -1,0 +1,17 @@
+!include ../my.cnf
+
+[mysqld.1]
+server_id=1
+
+[mysqld.2]
+server_id=2
+binlog_ignore_db=db_filtered
+log_slave_updates
+
+[mysqld.3]
+server_id=3
+log_slave_updates
+
+[ENV]
+SERVER_MYPORT_3=		@mysqld.3.port
+SERVER_MYSOCK_3=		@mysqld.3.socket

--- a/mysql-test/suite/rpl/t/rpl_lsu_binlog_filter.test
+++ b/mysql-test/suite/rpl/t/rpl_lsu_binlog_filter.test
@@ -1,0 +1,64 @@
+#
+# This test ensures that a slave respects binlog_do/ignore_db filters. That is,
+# if a slave is configured with log_slave_updates and binlog filters, if it is
+# applying transactions that are targeted by this filter, the data should not
+# be binlogged. This is verified by using a chain replication setup, where the
+# middle server in the chain is configured with a database filter. The test
+# runs a workload consisting of filtered and non-filtered statements. After
+# replicating all statements, the final state of the topology should be that
+# the middle server has all transactions applied, and the last server in the
+# chain only has transactions not targeted by the middle server's binlog
+# filters. The test creates two databases, db_not_filtered (not filtered) and
+# db_filtered (filtered).
+#
+#
+# References:
+#   MDEV-38796: Refactor: clean up THD::decide_logging_format() checks
+#
+
+--source include/have_innodb.inc
+--let $rpl_topology=1->2, 2->3
+--source include/rpl_init.inc
+
+--echo #
+--echo # Initialize test data
+--connection server_1
+create database db_not_filtered;
+create database db_filtered;
+
+use db_not_filtered;
+create table t1 (a int) engine=innodb;
+insert into t1 values (10);
+
+use db_filtered;
+create table t2 (a int) engine=innodb;
+insert into t2 values (20);
+
+--connection server_1
+--source include/save_master_gtid.inc
+--connection server_2
+--source include/sync_with_master_gtid.inc
+
+--echo # Server_2 should have both db_not_filtered.t1 and db_filtered.t2 data
+select count(*) from db_not_filtered.t1;
+select count(*) from db_filtered.t2;
+
+--source include/save_master_gtid.inc
+--connection server_3
+--source include/sync_with_master_gtid.inc
+
+--echo # Server_3 should only have db_not_filtered.t1
+select count(*) from db_not_filtered.t1;
+--echo # Server_3 should err when trying to access db_filtered.t2
+--error ER_NO_SUCH_TABLE
+select count(*) from db_filtered.t2;
+
+
+--echo #
+--echo # Cleanup
+--connection server_1
+drop database db_not_filtered;
+drop database db_filtered;
+
+--source include/rpl_end.inc
+--echo # End of rpl_lsu_binlog_filter.test

--- a/mysql-test/suite/sql_sequence/gtid.result
+++ b/mysql-test/suite/sql_sequence/gtid.result
@@ -605,11 +605,14 @@ select @@session.binlog_format;
 STATEMENT
 create sequence s1 cache 2;
 select next value for s1;
-ERROR HY000: Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging.
+next value for s1
+1
+Warnings:
+Note	1665	Statement cannot be logged as STATEMENT as at least one table is limited to row-based logging. Switching temporarly to row format
 set session binlog_format=row;
 select next value for s1;
 next value for s1
-1
+2
 select * from s1;
 next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
 3	1	9223372036854775806	1	1	2	0	0

--- a/mysql-test/suite/sql_sequence/gtid.test
+++ b/mysql-test/suite/sql_sequence/gtid.test
@@ -506,7 +506,6 @@ connection master;
 set session binlog_format=statement;
 select @@session.binlog_format;
 create sequence s1 cache 2;
---error ER_BINLOG_STMT_MODE_AND_ROW_ENGINE
 select next value for s1;
 
 set session binlog_format=row;

--- a/mysql-test/suite/sql_sequence/replication.result
+++ b/mysql-test/suite/sql_sequence/replication.result
@@ -701,11 +701,14 @@ select @@session.binlog_format;
 STATEMENT
 create sequence s1 cache 2;
 select next value for s1;
-ERROR HY000: Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging.
+next value for s1
+1
+Warnings:
+Note	1665	Statement cannot be logged as STATEMENT as at least one table is limited to row-based logging. Switching temporarly to row format
 set session binlog_format=row;
 select next value for s1;
 next value for s1
-1
+2
 select * from s1;
 next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
 3	1	9223372036854775806	1	1	2	0	0

--- a/mysql-test/suite/sql_sequence/replication.test
+++ b/mysql-test/suite/sql_sequence/replication.test
@@ -585,7 +585,6 @@ connection master;
 set session binlog_format=statement;
 select @@session.binlog_format;
 create sequence s1 cache 2;
---error ER_BINLOG_STMT_MODE_AND_ROW_ENGINE
 select next value for s1;
 
 set session binlog_format=row;

--- a/sql/backup.cc
+++ b/sql/backup.cc
@@ -406,7 +406,7 @@ static bool backup_block_commit(THD *thd)
   /* We can ignore errors from flush_tables () */
   (void) flush_tables(thd, FLUSH_SYS_TABLES);
 
-  if (mysql_bin_log.is_open())
+  if (thd->binlog_ready_no_wsrep())
   {
     mysql_mutex_lock(mysql_bin_log.get_log_lock());
     mysql_file_sync(mysql_bin_log.get_log_file()->file, MYF(MY_WME));

--- a/sql/ddl_log.cc
+++ b/sql/ddl_log.cc
@@ -70,7 +70,7 @@
   After the final recovery phase is done, the file is truncated.
 
   Note that in this file we test for mysql_bin_log.is_open() instead of
-  using thd->binlog_is_read(). This is because during recovery binlog
+  using thd->binlog_ready(). This is because during recovery binlog
   cannot be disabled for some particular commands.
 
   History:

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -3343,7 +3343,7 @@ Item*
 Create_func_binlog_gtid_pos::create_2_arg(THD *thd, Item *arg1, Item *arg2)
 {
 #ifdef HAVE_REPLICATION
-  if (unlikely(!mysql_bin_log.is_open()))
+  if (unlikely(!(thd->binlog_state & BINLOG_STATE_OPEN)))
 #endif
   {
     my_error(ER_NO_BINARY_LOGGING, MYF(0));

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8539,6 +8539,14 @@ MYSQL_BIN_LOG::write_transaction_to_binlog(THD *thd,
     DBUG_RETURN(0);
   }
 
+  /*
+    Pause point between the per-THD binlog_ready() check and acquisition of
+    LOCK_log. Used by binlog.binlog_close_during_commit to inject a global
+    binlog close from a second connection and exercise the race where the
+    cached state says "ready" but the global binlog is no longer open.
+  */
+  DEBUG_SYNC(thd, "commit_after_binlog_ready_before_LOCK_log");
+
   entry.thd= thd;
   entry.cache_mngr= cache_mngr;
   entry.error= 0;

--- a/sql/log.h
+++ b/sql/log.h
@@ -1408,8 +1408,16 @@ enum enum_binlog_state
     of the following bits set
   */
   BINLOG_STATE_BYPASS=          (1<<4),
-  // Database filtering used. Note that this does not set the BYPASS bit
-  BINLOG_STATE_FILTER=          (1<<5),
+  /*
+    Set when the thread's current default database is rejected by the
+    binlog_do_db/binlog_ignore_db filters. The flag is updated only on a
+    change of default database (see update_binlog_filter_state()), which
+    avoids repeating the filter check for every statement. Note that the
+    flag applies only to statement format logging. In row format the same
+    filters are applied to the database of each modified table instead,
+    through can_do_row_logging (see open_table_from_share()).
+  */
+  BINLOG_STATE_FILTER_DB=       (1<<5),
   // set by tmp_disable_binlog(). Previously using OPTION_BIN_TMP_LOG_OFF
   BINLOG_STATE_TMP_DISABLED=    (1<<6),
   // sql_bin_log == 0, set in set_binlog_bit()

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -693,6 +693,7 @@ int Log_event_writer::write_internal(const uchar *pos, size_t len)
   DBUG_ASSERT(!ctx || encrypt_or_write == &Log_event_writer::encrypt_and_write);
   if (cache_data &&
 #ifdef WITH_WSREP
+    /* TODO: MDEV-38865 */
       mysql_bin_log.is_open() &&
 #endif
       cache_data->write_prepare(len))

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -1467,7 +1467,7 @@ Sp_handler::sp_create_routine(THD *thd, const sp_head *sp) const
     }
 
     if (type() == SP_TYPE_FUNCTION &&
-        !trust_function_creators && mysql_bin_log.is_open())
+        !trust_function_creators && thd->binlog_ready_no_wsrep())
     {
       if (!sp->detistic())
       {
@@ -1715,7 +1715,7 @@ Sp_handler::sp_update_routine(THD *thd, const Database_qualified_name *name,
   if ((ret= db_find_routine_aux(thd, name, table)) == SP_OK)
   {
     if (type() == SP_TYPE_FUNCTION && ! trust_function_creators &&
-        mysql_bin_log.is_open() &&
+        thd->binlog_ready_no_wsrep() &&
         (chistics->daccess == SP_CONTAINS_SQL ||
          chistics->daccess == SP_MODIFIES_SQL_DATA))
     {

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -4423,6 +4423,9 @@ int acl_set_default_role(THD *thd,
   if (!strcasecmp(rolename.str, none.str))
     clear_role= TRUE;
 
+  /*
+    TODO: MDEV-38865
+  */
   if (mysql_bin_log.is_open() ||
       (WSREP(thd) && !IF_WSREP(thd->wsrep_applier, 0)))
   {
@@ -11664,7 +11667,7 @@ bool mysql_rename_user(THD *thd, List <LEX_USER> &list)
   if (result)
     my_error(ER_CANNOT_USER, MYF(0), "RENAME USER", wrong_users.c_ptr_safe());
 
-  if (some_users_renamed && mysql_bin_log.is_open())
+  if (some_users_renamed && thd->binlog_ready_no_wsrep())
     result |= write_bin_log(thd, FALSE, thd->query(), thd->query_length());
 
   mysql_rwlock_unlock(&LOCK_grant);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1384,7 +1384,6 @@ void THD::init()
   tx_isolation= (enum_tx_isolation) variables.tx_isolation;
   tx_read_only= variables.tx_read_only;
   update_charset();             // plugin_thd_var() changed character sets
-  reset_binlog_local_stmt_filter();
 
   binlog_state= BINLOG_STATE_NONE;
   sync_binlog_state_with_binlog_open_force();
@@ -1642,6 +1641,20 @@ void THD::change_user(void)
 #endif /* WITH_WSREP */
 }
 
+/*
+  Update binlog_state's BINLOG_STATE_FILTER value based on the thread's current
+  default database. I.e. if the default database is to be filtered by option
+  binlog_do_db/binlog_ignore_db options, then BINLOG_STATE_FILTER is set;
+  otherwise, the option is negated.
+*/
+inline void update_binlog_filter_state(THD *thd)
+{
+  thd->binlog_state= (thd->binlog_ready_precheck() && binlog_filter &&
+                      !binlog_filter->db_ok(thd->db.str)) ?
+                         (thd->binlog_state | BINLOG_STATE_FILTER_DB) :
+                         (thd->binlog_state & ~BINLOG_STATE_FILTER_DB);
+}
+
 /**
    Change default database
 
@@ -1683,6 +1696,7 @@ bool THD::set_db(const LEX_CSTRING *new_db)
     my_free((char*) org_db);
   }
   PSI_CALL_set_thread_db(db.str, (int) db.length);
+  update_binlog_filter_state(this);
   return result;
 }
 
@@ -1710,6 +1724,7 @@ void THD::reset_db(const LEX_CSTRING *new_db)
     mysql_mutex_unlock(&LOCK_thd_data);
     PSI_CALL_set_thread_db(db.str, (int) db.length);
   }
+  update_binlog_filter_state(this);
 }
 
 
@@ -2528,13 +2543,12 @@ void THD::cleanup_after_query()
 #endif
   }
   /*
-    Forget the binlog stmt filter for the next query.
+    Forget READONLY for the next query.
     There are some code paths that:
     - do not call THD::decide_logging_format()
     - do call THD::binlog_query(),
     making this reset necessary.
   */
-  reset_binlog_local_stmt_filter();
   binlog_state= binlog_state & ~BINLOG_STATE_READONLY;
   if (first_successful_insert_id_in_cur_stmt > 0)
   {
@@ -6006,11 +6020,7 @@ extern "C" void thd_mark_transaction_to_rollback(MYSQL_THD thd, bool all)
 
 extern "C" bool thd_binlog_filter_ok(const MYSQL_THD thd)
 {
-  /*
-    TODO: Replace by binlog_state & BINLOG_FILTER) when BINLOG_FILTER
-    is set when thd->db.str changes value.
-  */
-  return binlog_filter->db_ok(thd->db.str);
+  return !(thd->binlog_state & BINLOG_STATE_FILTER_DB);
 }
 
 /*
@@ -6934,7 +6944,7 @@ int THD::decide_logging_format(TABLE_LIST *tables)
     Strip the binlogging restrictions from the state that are calculated
     later in this function
   */
-  binlog_state= (binlog_state & ~(BINLOG_STATE_FILTER | BINLOG_STATE_READONLY));
+  binlog_state= (binlog_state & ~BINLOG_STATE_READONLY);
   /* We should have either binlog or wsrep_emulate_binlog active */
   DBUG_ASSERT((binlog_state & BINLOG_STATE_ACTIVE) &&
               binlog_state & (BINLOG_STATE_OPEN | BINLOG_STATE_WSREP));
@@ -7004,12 +7014,46 @@ int THD::decide_logging_format(TABLE_LIST *tables)
                 (BINLOG_STATE_WSREP | BINLOG_STATE_ACTIVE));
 #endif /* WITH_WSREP */
 
-  if (binlog_format == BINLOG_FORMAT_STMT && !binlog_filter->db_ok(db.str))
-    binlog_state= binlog_state | BINLOG_STATE_FILTER;
+  /*
+    Before actually deciding the logging format, ensure that binlogging is
+    enabled/active. Also, as part of this pre-check, if the pre-configured
+    binlog_format is statement mode, ensure that the default database passes
+    the binlog_do_db/binlog_ignore_db filters. Statement mode logs the query
+    text as a single unit: the databases it modifies may be fully qualified
+    in the query itself, yet the query cannot be split the way row events
+    can, so the filters consider the default database alone. That outcome is
+    independent of the statement and is maintained in BINLOG_STATE_FILTER_DB
+    at each change of default database.
 
+    This pre-check must precede the format decision rather than be left to
+    a write time filter, because the decision enforces the obligations that
+    come with being binlogged. A statement that will never reach the binlog
+    must be exempt from those obligations, not merely have its events
+    discarded once generated. For statement mode, the pre-check separates
+    two cases:
+
+     1) If the default database is filtered: the entire query is always
+        ignored, exempt from the obligations and producing no events, even
+        when the decision would have forced row format over a table limited
+        to row logging (ER_BINLOG_STMT_MODE_AND_ROW_ENGINE). The
+        pre-configured format, not the format the decision would have chosen,
+        selects the filtering semantics.
+
+     2) If the default database is not filtered: the query proceeds to the
+        obligations. That is, the later-decisions may, for example, fail it
+        (ER_BINLOG_ROW_ENGINE_AND_STMT_ENGINE), or force it to row format
+        (ER_BINLOG_STMT_MODE_AND_ROW_ENGINE).
+  */
   if (WSREP_EMULATE_BINLOG_NNULL(this) ||
-      (binlog_ready_no_wsrep() && !(binlog_state & BINLOG_STATE_FILTER)))
+      (binlog_ready_no_wsrep() && !(binlog_format == BINLOG_FORMAT_STMT &&
+                                    (binlog_state & BINLOG_STATE_FILTER_DB))))
   {
+    /*
+      Binary logging is used.
+      In case of WSREP (galera) all changes are logged.
+      We are not coming here in case of statement base logging together with
+      an active database filtering on the current database.
+    */
     if (is_bulk_op())
     {
       if (binlog_format == BINLOG_FORMAT_STMT)
@@ -7020,7 +7064,6 @@ int THD::decide_logging_format(TABLE_LIST *tables)
         DBUG_RETURN(-1);
       }
     }
-    reset_binlog_local_stmt_filter();
 
     /*
       Compute one bit field with the union of all the engine
@@ -7420,7 +7463,6 @@ int THD::decide_logging_format(TABLE_LIST *tables)
       if ((replicated_tables_count == 0) || ! is_write)
       {
         DBUG_PRINT("info", ("decision: no logging, no replicated table affected"));
-        set_binlog_local_stmt_filter();
         binlog_state|= BINLOG_STATE_READONLY;
       }
       else
@@ -7429,15 +7471,7 @@ int THD::decide_logging_format(TABLE_LIST *tables)
         {
           my_error((error= ER_BINLOG_STMT_MODE_AND_NO_REPL_TABLES), MYF(0));
         }
-        else
-        {
-          clear_binlog_local_stmt_filter();
-        }
       }
-    }
-    else
-    {
-      clear_binlog_local_stmt_filter();
     }
 
     if (unlikely(error))
@@ -7494,12 +7528,12 @@ int THD::decide_logging_format(TABLE_LIST *tables)
                         "mysql_bin_log.is_open(): %d   "
                         "(options & OPTION_BIN_LOG): 0x%llx  "
                         "binlog_format: %u  "
-                        "binlog_filter->db_ok(db): %d  "
+                        "BINLOG_STATE_FILTER_DB: %d  "
                         "binlog_status: %x",
                         mysql_bin_log.is_open(),
                         (variables.option_bits & OPTION_BIN_LOG),
                         (uint) binlog_format,
-                        binlog_filter->db_ok(db.str),
+                        MY_TEST(binlog_state & BINLOG_STATE_FILTER_DB),
                         binlog_state));
 
     /* TODO: Check if the following is really needed */
@@ -8261,15 +8295,6 @@ int THD::binlog_query(THD::enum_binlog_query_type qtype, char const *query_arg,
   DBUG_ASSERT(query_arg);
   DBUG_ASSERT(binlog_state & BINLOG_STATE_ACTIVE_WSREP);
 
-  if (get_binlog_local_stmt_filter() == BINLOG_FILTER_SET)
-  {
-    /*
-      The current statement is to be ignored, and not written to
-      the binlog. Do not call issue_unsafe_warnings().
-    */
-    DBUG_RETURN(-1);
-  }
-
   /* If this is withing a BEGIN ... COMMIT group, don't log it */
   if (variables.option_bits & OPTION_GTID_BEGIN)
   {
@@ -8407,11 +8432,9 @@ int THD::binlog_query(THD::enum_binlog_query_type qtype, char const *query_arg,
 
 bool THD::binlog_current_query_unfiltered()
 {
-  if (!mysql_bin_log.is_open())
+  if (!binlog_ready_no_wsrep())
     return 0;
 
-  reset_binlog_local_stmt_filter();
-  clear_binlog_local_stmt_filter();
   binlog_state= binlog_state & ~BINLOG_STATE_READONLY;
   return binlog_query(THD::STMT_QUERY_TYPE, query(), query_length(),
                       /* is_trans */     FALSE,

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3548,35 +3548,6 @@ public:
     return !binlog_ready_no_wsrep();
   }
 
-  enum binlog_filter_state
-  {
-    BINLOG_FILTER_UNKNOWN,
-    BINLOG_FILTER_CLEAR,
-    BINLOG_FILTER_SET
-  };
-
-  inline void reset_binlog_local_stmt_filter()
-  {
-    m_binlog_filter_state= BINLOG_FILTER_UNKNOWN;
-  }
-
-  inline void clear_binlog_local_stmt_filter()
-  {
-    DBUG_ASSERT(m_binlog_filter_state == BINLOG_FILTER_UNKNOWN);
-    m_binlog_filter_state= BINLOG_FILTER_CLEAR;
-  }
-
-  inline void set_binlog_local_stmt_filter()
-  {
-    DBUG_ASSERT(m_binlog_filter_state == BINLOG_FILTER_UNKNOWN);
-    m_binlog_filter_state= BINLOG_FILTER_SET;
-  }
-
-  inline binlog_filter_state get_binlog_local_stmt_filter()
-  {
-    return m_binlog_filter_state;
-  }
-
   bool binlog_renamed_tmp_tables(TABLE_LIST *table_list);
 
   /**
@@ -3593,14 +3564,6 @@ public:
   }
 
 private:
-  /**
-    Indicate if the current statement should be discarded
-    instead of written to the binlog.
-    This is used to discard special statements, such as
-    DML or DDL that affects only 'local' (non replicated)
-    tables, such as performance_schema.*
-  */
-  binlog_filter_state m_binlog_filter_state;
 
   /**
     Indicates the format in which the current statement will be
@@ -3992,7 +3955,7 @@ public:
   /* We come here if binlog open state has changed */
   inline void sync_binlog_state_with_binlog_open()
   {
-    if (mysql_bin_log.is_open() != (binlog_state & BINLOG_STATE_OPEN))
+    if (mysql_bin_log.is_open() != MY_TEST(binlog_state & BINLOG_STATE_OPEN))
       sync_binlog_state_with_binlog_open_force();
   }
   void sync_binlog_state_with_binlog_open_force();

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -730,14 +730,13 @@ CHARSET_INFO *get_default_db_collation(THD *thd, const char *db_name)
 		Function assumes that this is already validated.
   options       DDL options, e.g. IF NOT EXISTS
   create_info	Database create options (like character set)
-  silent	Used by replication when internally creating a database.
-		In this case the entry should not be logged.
 
   SIDE-EFFECTS
    1. Report back to client that command succeeded (my_ok)
    2. Report errors to client
    3. Log event to binary log
-   (The 'silent' flags turns off 1 and 3.)
+   (If THD->binlog_state has BINLOG_STATE_TMP_DISABLED flag, 1 and 3 won't
+    happen)
 
   RETURN VALUES
   FALSE ok
@@ -748,8 +747,7 @@ CHARSET_INFO *get_default_db_collation(THD *thd, const char *db_name)
 static int
 mysql_create_db_internal(THD *thd, const Lex_ident_db &db,
                          const DDL_options_st &options,
-                         Schema_specification_st *create_info,
-                         bool silent)
+                         Schema_specification_st *create_info)
 {
   char	 path[FN_REFLEN+16];
   MY_STAT stat_info;
@@ -842,7 +840,7 @@ mysql_create_db_internal(THD *thd, const Lex_ident_db &db,
   backup_log_ddl(&ddl_log);
 
 not_silent:
-  if (!silent)
+  if (!(thd->binlog_state & BINLOG_STATE_TMP_DISABLED))
   {
     char *query;
     uint query_length;
@@ -974,7 +972,7 @@ int mysql_create_db(THD *thd, const Lex_ident_db &db, DDL_options_st options,
   if (thd->slave_thread &&
       slave_ddl_exec_mode_options == SLAVE_EXEC_MODE_IDEMPOTENT)
     options.add(DDL_options::OPT_IF_NOT_EXISTS);
-  return mysql_create_db_internal(thd, db, options, &tmp, false);
+  return mysql_create_db_internal(thd, db, options, &tmp);
 }
 
 
@@ -1932,6 +1930,7 @@ bool mysql_upgrade_db(THD *thd, const Lex_ident_db &old_db)
   TABLE_LIST *table_list;
   SELECT_LEX *sl= thd->lex->current_select;
   Lex_ident_db new_db;
+  BINLOG_STATE binlog_state_save;
   DBUG_ENTER("mysql_upgrade_db");
 
   if ((old_db.length <= MYSQL50_TABLE_NAME_PREFIX_LENGTH) ||
@@ -1978,9 +1977,10 @@ bool mysql_upgrade_db(THD *thd, const Lex_ident_db &old_db)
   }
 
   /* Step1: Create the new database */
-  if (unlikely((error= mysql_create_db_internal(thd, new_db,
-                                                DDL_options(), &create_info,
-                                                1))))
+  thd->tmp_disable_binlog(&binlog_state_save, BINLOG_STATE_TMP_DISABLED);
+  error= mysql_create_db_internal(thd, new_db, DDL_options(), &create_info);
+  thd->reenable_binlog(&binlog_state_save);
+  if (unlikely((error)))
     goto exit;
 
   /* Step2: Move tables to the new database */

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -5150,7 +5150,7 @@ select_create::prepare(List<Item> &_values, SELECT_LEX_UNIT *u)
   */
   if (!thd->lex->tmp_table() &&
       thd->is_current_stmt_binlog_format_row() &&
-      mysql_bin_log.is_open())
+      thd->binlog_ready_no_wsrep())
   {
     thd->binlog_start_trans_and_stmt();
   }
@@ -5688,7 +5688,7 @@ void select_create::abort_result_set()
     table=0;                                    // Safety
     if (thd->log_current_statement())
     {
-      if (mysql_bin_log.is_open())
+      if (thd->binlog_ready_no_wsrep())
       {
         /* Remove logging of drop, create + insert rows */
         binlog_reset_cache(thd);

--- a/sql/sql_load.cc
+++ b/sql/sql_load.cc
@@ -163,6 +163,7 @@ class READ_INFO: public Load_data_param
   int	*stack,*stack_pos;
   bool	found_end_of_line,start_of_line,eof;
   int level; /* for load xml */
+  bool use_binlog;
 
   bool getbyte(char *to)
   {
@@ -271,7 +272,7 @@ public:
   void skip_data_till_eof()
   {
 #ifndef EMBEDDED_LIBRARY
-    if (mysql_bin_log.is_open())
+    if (use_binlog)
       cache.read_function= cache.real_read_function;
 #endif
     while (GET != my_b_EOF)
@@ -641,7 +642,7 @@ int mysql_load(THD *thd, const sql_exchange *ex, TABLE_LIST *table_list,
   }
 
 #ifndef EMBEDDED_LIBRARY
-  if (mysql_bin_log.is_open())
+  if (thd->binlog_ready_no_wsrep())
   {
     read_info.cache.thd = thd;
     read_info.cache.wrote_create_file = 0;
@@ -766,7 +767,7 @@ int mysql_load(THD *thd, const sql_exchange *ex, TABLE_LIST *table_list,
       read_info.skip_data_till_eof();
 
 #ifndef EMBEDDED_LIBRARY
-    if (mysql_bin_log.is_open())
+    if (thd->binlog_ready_no_wsrep())
     {
       {
 	/*
@@ -811,7 +812,7 @@ int mysql_load(THD *thd, const sql_exchange *ex, TABLE_LIST *table_list,
   thd->transaction->all.m_unsafe_rollback_flags|=
     (thd->transaction->stmt.m_unsafe_rollback_flags & THD_TRANS::DID_WAIT);
 #ifndef EMBEDDED_LIBRARY
-  if (mysql_bin_log.is_open())
+  if (thd->binlog_ready_no_wsrep())
   {
     /*
       We need to do the job that is normally done inside
@@ -1454,7 +1455,8 @@ READ_INFO::READ_INFO(THD *thd, File file_par,
    file(file_par),
    m_field_term(field_term), m_line_term(line_term), m_line_start(line_start),
    escape_char(escape), found_end_of_line(false), eof(false),
-   error(false), line_cuted(false), found_null(false)
+   use_binlog(thd->binlog_ready_no_wsrep()), error(false), line_cuted(false),
+   found_null(false)
 {
   data.set_thread_specific();
   /*
@@ -1494,7 +1496,7 @@ READ_INFO::READ_INFO(THD *thd, File file_par,
       if (get_it_from_net)
 	cache.read_function = _my_b_net_read;
 
-      if (mysql_bin_log.is_open())
+      if (use_binlog)
       {
         cache.real_read_function= cache.read_function;
         cache.read_function= log_loaded_block;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6374,7 +6374,7 @@ check_rename_table(THD *thd, TABLE_LIST *first_table,
 #ifndef DBUG_OFF
 static bool __attribute__ ((noinline)) generate_incident_event(THD *thd)
 {
-  if (mysql_bin_log.is_open())
+  if (thd->binlog_ready_no_wsrep())
   {
 
     Incident incident= INCIDENT_NONE;
@@ -7501,6 +7501,9 @@ void THD::reset_for_next_command(bool do_clear_error)
   save_prep_leaf_list= false;
 
 #if defined(WITH_WSREP) && !defined(DBUG_OFF)
+/*
+  TODO: MDEV-38865
+*/
   if (mysql_bin_log.is_open())
     DBUG_PRINT("info",
                ("is_current_stmt_binlog_format_row(): %d",

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -3947,7 +3947,8 @@ void Prepared_statement::setup_set_params()
   */
   bool replace_params_with_values= false;
   // binlog
-  replace_params_with_values|= mysql_bin_log.is_open() && is_update_query(lex->sql_command);
+  replace_params_with_values|=
+      thd->binlog_ready_no_wsrep() && is_update_query(lex->sql_command);
   // general or slow log
   replace_params_with_values|= opt_log || thd->variables.sql_log_slow;
   // query cache

--- a/sql/sql_rename.cc
+++ b/sql/sql_rename.cc
@@ -183,7 +183,7 @@ bool mysql_rename_tables(THD *thd, TABLE_LIST *table_list, bool silent,
     */
     thd->binlog_xid= thd->query_id;
     ddl_log_update_xid(&ddl_log_state, thd->binlog_xid);
-    if (mysql_bin_log.is_open())
+    if (thd->binlog_ready_no_wsrep())
     {
       if (not_logged_temporary_tables)
         binlog_error= thd->binlog_renamed_tmp_tables(table_list);

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -655,7 +655,7 @@ bool purge_error_message(THD* thd, int res)
 bool purge_master_logs(THD* thd, const char* to_log)
 {
   char search_file_name[FN_REFLEN];
-  if (!mysql_bin_log.is_open())
+  if (!thd->binlog_ready_no_wsrep())
   {
     my_ok(thd);
     return FALSE;
@@ -681,7 +681,7 @@ bool purge_master_logs(THD* thd, const char* to_log)
 */
 bool purge_master_logs_before_date(THD* thd, time_t purge_time)
 {
-  if (!mysql_bin_log.is_open())
+  if (!thd->binlog_ready_no_wsrep())
   {
     my_ok(thd);
     return 0;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12526,9 +12526,8 @@ end_inplace:
   THD_STAGE_INFO(thd, stage_end);
   DEBUG_SYNC(thd, "alter_table_before_main_binlog");
 
-  DBUG_ASSERT(!(mysql_bin_log.is_open() &&
-                thd->is_binlog_format_row() &&
-                (create_info->tmp_table())));
+  DBUG_ASSERT(!((mysql_bin_log.is_open() && thd->binlog_ready_no_wsrep()) &&
+                thd->is_binlog_format_row() && (create_info->tmp_table())));
 
   if (start_alter_id)
   {

--- a/sql/temporary_tables.cc
+++ b/sql/temporary_tables.cc
@@ -663,7 +663,7 @@ bool THD::close_temporary_tables()
   }
 
   // Write DROP TEMPORARY TABLE query log events to binary log.
-  if (mysql_bin_log.is_open())
+  if (binlog_ready_no_wsrep())
   {
     error= log_events_and_free_tmp_shares();
   }

--- a/storage/maria/ha_maria.cc
+++ b/storage/maria/ha_maria.cc
@@ -3234,7 +3234,7 @@ THR_LOCK_DATA **ha_maria::store_lock(THD *thd,
          sql_command != SQLCOM_ALTER_TABLE &&
          sql_command != SQLCOM_LOCK_TABLES) &&
         (thd->variables.option_bits & OPTION_BIN_LOG) &&
-        mysql_bin_log.is_open())
+         thd->binlog_ready_no_wsrep())
       lock_type= TL_READ_NO_INSERT;
     else if (lock_type == TL_WRITE_CONCURRENT_INSERT)
     {


### PR DESCRIPTION
This PR sits on top of the binlog state refactor (base branch tip:
`MDEV-38865 Simplify testing if binary logging is enabled`). Only the top
six commits are new; everything beneath them is the base work. Each commit
addresses one TODO item from MDEV-38796 and is intended to be reviewed on
its own, in commit order. The first commit contains only test updates, the
middle four change server code, and the last is a small build fix.

## Commit walkthrough

1. **Test updates for forced row logging** (ed7f657f077). Test changes
   only. The base branch changed `ER_BINLOG_STMT_MODE_AND_ROW_ENGINE` from
   an error into a note: when a statement in STATEMENT mode touches a table
   limited to row logging, the server now switches the statement to row
   format temporarily instead of failing it. This commit updates
   `binlog.binlog_spurious_ddl_errors` and the `sql_sequence` tests that
   relied on the old error.

2. **Update BINLOG_STATE_FILTER at DB change time** (ec517d4b242).
   `decide_logging_format()` used to call `binlog_filter->db_ok()` for
   every statement. The result is now cached in `binlog_state` and
   recomputed only when the default database changes (`THD::set_db()` and
   `THD::reset_db()`, via the new `update_binlog_filter_state()`);
   `thd_binlog_filter_ok()` reads the cached bit. The flag is renamed from
   `BINLOG_STATE_FILTER` to `BINLOG_STATE_FILTER_DB`, since it reflects
   only the binlog_do_db/binlog_ignore_db decision on the current default
   database. A new comment block in `decide_logging_format()` documents the
   statement mode filtering semantics. Adds `rpl.rpl_lsu_binlog_filter`, a
   chain replication test (three servers) verifying that a middle server
   configured with `log_slave_updates` and binlog filters keeps filtered
   transactions out of its own binlog.

3. **Remove `*_binlog_local_stmt_filter()`** (7fe6738f169). Deletes
   `THD::m_binlog_filter_state` and its four accessors, since the
   information is fully carried by `binlog_state` (`BINLOG_STATE_FILTER_DB`
   and `BINLOG_STATE_READONLY`). Pure removal, net 52 lines deleted.

4. **Remove `silent` option from `mysql_create_db_internal`**
   (53c847f7da6). Replaces the special `silent` parameter with the standard
   `tmp_disable_binlog()` / `reenable_binlog()` mechanism.
   `mysql_create_db_internal()` now checks `BINLOG_STATE_TMP_DISABLED`, and
   the one internal caller (`mysql_upgrade_db()`) wraps its call
   accordingly.

5. **Replace `mysql_bin_log.is_open` with `binlog_ready()`**
   (f7a90e81d24). The widest commit, touching about fifteen files.
   `mysql_bin_log.is_open()` is read without a mutex on main code paths,
   which makes it unreliable; those sites now use the state cached on the
   THD (`thd->binlog_ready_no_wsrep()`). `is_open()` remains only where it
   is legitimate: at commit time under `LOCK_log`, in ddl_log recovery, and
   at WSREP sites deliberately deferred to MDEV-38865 (each marked with a
   `TODO: MDEV-38865` comment). Adds a DEBUG_SYNC point
   (`commit_after_binlog_ready_before_LOCK_log`) and the new test
   `binlog.binlog_close_during_commit`, which closes the binlog from a
   second connection between a statement's `binlog_ready()` check and its
   acquisition of `LOCK_log`, covering five statement types. The
   transaction must still commit in the engine, and the error log must
   report the closed binlog once per close event rather than once per
   transaction.

6. **Fix Windows compiler error** (423acf79a26). One line: wraps a
   `binlog_state` bit test in `MY_TEST()` so the comparison against `bool`
   compiles on Windows.

## Notes for review

* Commits 2 and 3 form a sequence: commit 2 introduces the cached filter
  state, and commit 3 removes the machinery it replaces. Commits 1, 4, 5,
  and 6 are independent of that sequence and of each other.
* New test coverage lives in commits 2 (`rpl.rpl_lsu_binlog_filter`) and 5
  (`binlog.binlog_close_during_commit`). Commit 1 only adapts existing
  tests to base branch behavior.
* Two items are known and deliberately out of scope: the WSREP related
  `is_open()` sites (tracked as MDEV-38865), and the CREATE TABLE case in
  `binlog_close_during_commit`, which is commented out pending MDEV-40171.