### PR TITLE
MDEV-39449: Memory corruption (GIS) - test fix

### DIFF
--- a/mysql-test/main/gis-precise.result
+++ b/mysql-test/main/gis-precise.result
@@ -886,6 +886,7 @@ NULL
 # Gcalc_function::count_internal and Assertion `(0)' failed in
 # Item_func_spatial_precise_rel::val_bool
 #
-SELECT ST_COVEREDBY (ST_GEOMFROMTEXT ('POINT(0 0)'),ST_GEOMFROMTEXT ('POLYGON ((0 0,0 0,0 0,0 0,0 0))'));
-ST_COVEREDBY (ST_GEOMFROMTEXT ('POINT(0 0)'),ST_GEOMFROMTEXT ('POLYGON ((0 0,0 0,0 0,0 0,0 0))'))
+SELECT ST_COVEREDBY (ST_GEOMFROMTEXT ('POINT(0 0)'),ST_GEOMFROMTEXT ('POLYGON ((0 0,0 0,0 0,0 0,0 0))')) a;
+a
 0
+# End of 12.3 tests

--- a/mysql-test/main/gis-precise.test
+++ b/mysql-test/main/gis-precise.test
@@ -500,4 +500,6 @@ SELECT ST_CROSSES( ST_GEOMFROMTEXT('POLYGON ((59 18,67 18,67 13,59 13,59 18)) ')
 --echo # Gcalc_function::count_internal and Assertion `(0)' failed in
 --echo # Item_func_spatial_precise_rel::val_bool
 --echo #
-SELECT ST_COVEREDBY (ST_GEOMFROMTEXT ('POINT(0 0)'),ST_GEOMFROMTEXT ('POLYGON ((0 0,0 0,0 0,0 0,0 0))'));
+SELECT ST_COVEREDBY (ST_GEOMFROMTEXT ('POINT(0 0)'),ST_GEOMFROMTEXT ('POLYGON ((0 0,0 0,0 0,0 0,0 0))')) a;
+
+--echo # End of 12.3 tests


### PR DESCRIPTION
Fix the view protocol for the gis-precise.test.