### PR TITLE
MDEV-26820 Added vcol info in temp field.

### DIFF
--- a/mysql-test/suite/vcol/r/vcol_misc.result
+++ b/mysql-test/suite/vcol/r/vcol_misc.result
@@ -600,4 +600,22 @@ SELECT (SELECT 1 FROM foo) FROM t1;
 ERROR 42S02: Table 'test.foo' doesn't exist
 INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
+#
+# MDEV-26820 Assertion `marked_for_read()' failed upon SELECT with VALUE(virtual column)
+#
+CREATE TABLE t1 (a VARCHAR(8), b VARCHAR(8) AS (REPEAT(a,1)) VIRTUAL) ENGINE=MyISAM;
+INSERT INTO t1 (a) VALUES ('foo'),('bar');
+SELECT VALUE(b) FROM (SELECT * FROM t1) sq;
+VALUE(b)
+NULL
+NULL
+DROP TABLE t1;
+CREATE TABLE t1 ( id uuid, vid varchar(255) GENERATED always AS (id)) engine=aria;
+INSERT INTO t1 (id) values (uuid()),(uuid()),(uuid());
+SELECT VALUE( vid ) FROM (select * from t1)dt;
+VALUE( vid )
+NULL
+NULL
+NULL
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/suite/vcol/t/vcol_misc.test
+++ b/mysql-test/suite/vcol/t/vcol_misc.test
@@ -576,4 +576,20 @@ SELECT (SELECT 1 FROM foo) FROM t1;
 INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-26820 Assertion `marked_for_read()' failed upon SELECT with VALUE(virtual column)
+--echo #
+
+CREATE TABLE t1 (a VARCHAR(8), b VARCHAR(8) AS (REPEAT(a,1)) VIRTUAL) ENGINE=MyISAM;
+INSERT INTO t1 (a) VALUES ('foo'),('bar');
+SELECT VALUE(b) FROM (SELECT * FROM t1) sq;
+
+DROP TABLE t1;
+
+CREATE TABLE t1 ( id uuid, vid varchar(255) GENERATED always AS (id)) engine=aria;
+INSERT INTO t1 (id) values (uuid()),(uuid()),(uuid());
+SELECT VALUE( vid ) FROM (select * from t1)dt;
+
+DROP TABLE t1;
+
 --echo # End of 10.11 tests

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -10302,6 +10302,7 @@ bool Item_insert_value::fix_fields(THD *thd, Item **items)
       set_field(tmp_field);
       // the index is important when read bits set
       tmp_field->field_index= field_arg->field->field_index;
+      tmp_field->vcol_info= field_arg->field->vcol_info;
     }
   }
   return FALSE;


### PR DESCRIPTION
fixes [MDEV-26820](https://jira.mariadb.org/browse/MDEV-26820)

### Problem:
Item_insert_value::fix_fields() created a temporary field
without preserving vcol_info. As a result, VALUE()/VALUES()
on virtual columns lost dependency metadata and could trigger:

Assertion `marked_for_read()' failed during virtual column evaluation.

### Cause:
The temporary Field_string copied field_index but did not copy virtual column metadata from the original field.

### Fix:
Preserve vcol_info when creating temporary fields in Item_insert_value::fix_fields() so virtual column dependency
tracking remains intact.