### PR TITLE
MDEV-39783 : Galera test failure on MDEV-35018

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-35018.result
+++ b/mysql-test/suite/galera/r/MDEV-35018.result
@@ -22,7 +22,6 @@ DROP TABLE t2;
 connection node_2;
 SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
 SET SESSION wsrep_sync_wait = 0;
-1
 connection node_1;
 UPDATE t1 SET f2 = 1 WHERE id=2;
 connection node_2;

--- a/mysql-test/suite/galera/t/MDEV-35018.test
+++ b/mysql-test/suite/galera/t/MDEV-35018.test
@@ -43,7 +43,6 @@ SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
 
 SET SESSION wsrep_sync_wait = 0;
 --let $expected_apply_waits = `SELECT VARIABLE_VALUE+1 FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
---echo $expected_apply_waits
 
 #
 # Issue a UPDATE to table that references t1
@@ -53,7 +52,6 @@ SET SESSION wsrep_sync_wait = 0;
 #
 --connection node_1
 UPDATE t1 SET f2 = 1 WHERE id=2;
-
 
 #
 # Expect the UPDATE to depend on the DROP,


### PR DESCRIPTION
Test did echo wsrep_apply_waits+1 value, but this value is dependent what was value of the wsrep_apply_waits when test started. If previous test run by same worker
increased the value of wsrep_apply_waits, expected value 1 in result file would be different than current value. Removed output as it does not give any real value, because test already has wait_condition for expected increase of wsrep_apply_waits value.