### PR TITLE
MDEV-39784 test plugins.feedback_os_release fails

### DIFF
--- a/mysql-test/suite/plugins/t/feedback_os_release.test
+++ b/mysql-test/suite/plugins/t/feedback_os_release.test
@@ -47,17 +47,17 @@ let $plugin_val= `select variable_value from information_schema.feedback
                   where variable_name = 'Uname_distribution'`;
 
 # Skip if plugin returned empty (e.g. FreeBSD with MTR_FEEDBACK_PLUGIN=0)
-if (`select '$plugin_val' = ''`)
+if (`select "$plugin_val" = ''`)
 {
   --skip Uname_distribution not available on this platform
 }
 
 let $expected_val= `select TRIM(LOAD_FILE('$MYSQLTEST_VARDIR/tmp/mdev39126_pretty_name'))`;
 
-if (`select '$plugin_val' != '$expected_val'`)
+if (`select "$plugin_val" != "$expected_val"`)
 {
-  --echo Mismatch! Plugin: '$plugin_val'
-  --echo Expected:         '$expected_val'
+  --echo Mismatch! Plugin: "$plugin_val"
+  --echo Expected:         "$expected_val"
   --die Uname_distribution does not match /etc/os-release PRETTY_NAME
 }
 


### PR DESCRIPTION
The use of un-interpolated quotes resulted in no
bash expansion of the variables of the test causing test failure.

Review: Daniel Black

```
worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
plugins.feedback_os_release              [ pass ]    112
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 0.112 of 18 seconds executing testcases

Completed: All 1 tests were successful.

(base) 
~/repos/build-mariadb-server-10.11-debug 
$ cat /etc/os-release
NAME='Gentoo'
ID='gentoo'
PRETTY_NAME='Gentoo Linux'
VERSION='2.18'
VERSION_ID='2.18'
HOME_URL='https://www.gentoo.org/'
SUPPORT_URL='https://www.gentoo.org/support/'
BUG_REPORT_URL='https://bugs.gentoo.org/'
ANSI_COLOR='1;32'
```

Thanks @hydrapolic