### PR TITLE
MDEV-24646/MDEV-39711: Fix System-Versioned UPDATE with VIRTUAL columns

### DIFF
--- a/mysql-test/suite/rpl/r/versioning_row_virtual_text_blob.result
+++ b/mysql-test/suite/rpl/r/versioning_row_virtual_text_blob.result
@@ -1,0 +1,15 @@
+include/master-slave.inc
+[connection master]
+CREATE OR REPLACE TABLE t (a TEXT, v BLOB AS (a) VIRTUAL)
+WITH SYSTEM VERSIONING AS SELECT 'foo' AS a;
+UPDATE t SET a='bar';
+CREATE OR REPLACE TABLE t (a TEXT, v TEXT AS (RIGHT(a, 1)) VIRTUAL)
+WITH SYSTEM VERSIONING AS SELECT 'before' AS a;
+UPDATE t SET a='after';
+connection slave;
+SELECT * FROM t;
+v	a
+r	after
+connection master;
+DROP TABLE t;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/versioning_row_virtual_text_blob.test
+++ b/mysql-test/suite/rpl/t/versioning_row_virtual_text_blob.test
@@ -1,0 +1,30 @@
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+
+# MDEV-24646 ASAN heap-use-after-free in Field_blob::pack /
+#   THD::binlog_update_row upon DML on table with virtual column
+
+CREATE OR REPLACE TABLE t (a TEXT, v BLOB AS (a) VIRTUAL)
+  WITH SYSTEM VERSIONING AS SELECT 'foo' AS a;
+
+UPDATE t SET a='bar';
+
+
+# MDEV-39711 UPDATE on System-Versioned Tables uses the after-value in Row-
+#  format Binlog's before-image for non-trivial Text/Blob Virtual Columns
+
+CREATE OR REPLACE TABLE t (a TEXT, v TEXT AS (RIGHT(a, 1)) VIRTUAL)
+  WITH SYSTEM VERSIONING AS SELECT 'before' AS a;
+
+UPDATE t SET a='after';
+
+--sync_slave_with_master
+  SELECT * FROM t;
+--connection master
+
+
+# Cleanup
+DROP TABLE t;
+
+--source include/rpl_end.inc

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -9422,7 +9422,7 @@ bool TABLE::vers_update_fields()
   }
 
   if (vfield)
-    update_virtual_fields(file, VCOL_UPDATE_FOR_READ);
+    update_virtual_fields(file, VCOL_UPDATE_FOR_WRITE);
   return res;
 }
 


### PR DESCRIPTION
UPDATEs on System-Versioned Tables used stale data for Row Format Binary Logging’s after-image, which may be the before-value (MDEV-39711) or even invalidated memory (MDEV-24646).

This is outside of my domain/expertise, so can someöne (human or bot) please explain why this 1-liner patch works and is the new mode appropriate?