### PR TITLE
MDEV-39708 invalid supplier name for MariaDB's own components

### DIFF
--- a/cmake/generate_sbom.cmake
+++ b/cmake/generate_sbom.cmake
@@ -98,7 +98,7 @@ FUNCTION (sbom_get_supplier repo_name repo_user varname)
   ELSEIF (repo_name MATCHES "boost")
     SET(${varname} "Boost.org" PARENT_SCOPE)
   ELSEIF(repo_user MATCHES "mariadb-corporation|mariadb")
-    SET(${varname} "MariaDB")
+    SET(${varname} "MariaDB" PARENT_SCOPE)
   ELSE()
     # Capitalize just first letter in repo_user
     STRING(SUBSTRING "${repo_user}" 0 1 first_letter)


### PR DESCRIPTION
Fix sbom_get_supplier() to correctly return supplier name to caller in all cases.