### PR TITLE
MDEV-36896 - Assertion `marked_for_read()' failed in virtual String *Field_varstring::val_str(String *, String *)

### DIFF
--- a/mysql-test/suite/vcol/r/vcol_keys_innodb.result
+++ b/mysql-test/suite/vcol/r/vcol_keys_innodb.result
@@ -303,3 +303,31 @@ IF(@@innodb_sort_buffer_size < count(*)*200, 'GOOD', 'WRONG SIZE')
 GOOD
 alter table t1 drop column va;
 drop table t1;
+#
+# MDEV-36896 Assertion `marked_for_read()' failed in virtual String *Field_varstring::val_str(String *, String *)
+#
+SET @old_isolation_level= @@session.tx_isolation;
+SET @@session.tx_isolation= 'READ-UNCOMMITTED';
+CREATE TABLE t (a VARCHAR(10),b INT,c CHAR(10) GENERATED ALWAYS AS (a) VIRTUAL,KEY(b,c)) ENGINE=InnoDB;
+INSERT INTO t (a) VALUES ('A');
+SELECT * FROM t WHERE b IS NULL ORDER BY a;
+a	b	c
+A	NULL	A
+DROP TABLE t;
+CREATE TABLE t (
+a VARCHAR(10),
+b INT,
+c CHAR(10) GENERATED ALWAYS AS (a) VIRTUAL,
+d INT GENERATED ALWAYS AS (IF(a = c, 1, 0)) VIRTUAL,
+KEY(b, c)
+) ENGINE=InnoDB;
+INSERT INTO t (a) VALUES ('A');
+INSERT INTO t (a, b) VALUES ('B', 1);
+SELECT * FROM t WHERE b IS NULL ORDER BY a;
+a	b	c	d
+A	NULL	A	1
+DROP TABLE t;
+SET @@session.tx_isolation= @old_isolation_level;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/suite/vcol/t/vcol_keys_innodb.test
+++ b/mysql-test/suite/vcol/t/vcol_keys_innodb.test
@@ -135,3 +135,36 @@ insert t1 (id,a,c) select seq,seq,seq from seq_1_to_330;
 select IF(@@innodb_sort_buffer_size < count(*)*200, 'GOOD', 'WRONG SIZE') from t1;
 alter table t1 drop column va;
 drop table t1;
+
+
+--echo #
+--echo # MDEV-36896 Assertion `marked_for_read()' failed in virtual String *Field_varstring::val_str(String *, String *)
+--echo #
+
+SET @old_isolation_level= @@session.tx_isolation;
+
+SET @@session.tx_isolation= 'READ-UNCOMMITTED';
+CREATE TABLE t (a VARCHAR(10),b INT,c CHAR(10) GENERATED ALWAYS AS (a) VIRTUAL,KEY(b,c)) ENGINE=InnoDB;
+INSERT INTO t (a) VALUES ('A');
+SELECT * FROM t WHERE b IS NULL ORDER BY a;
+
+DROP TABLE t;
+
+CREATE TABLE t (
+  a VARCHAR(10),
+  b INT,
+  c CHAR(10) GENERATED ALWAYS AS (a) VIRTUAL,
+  d INT GENERATED ALWAYS AS (IF(a = c, 1, 0)) VIRTUAL,
+  KEY(b, c)
+) ENGINE=InnoDB;
+
+INSERT INTO t (a) VALUES ('A');
+INSERT INTO t (a, b) VALUES ('B', 1);
+SELECT * FROM t WHERE b IS NULL ORDER BY a;
+DROP TABLE t;
+
+SET @@session.tx_isolation= @old_isolation_level;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -980,12 +980,13 @@ bool Item_field::check_field_expression_processor(void *arg)
 bool Item_field::update_vcol_processor(void *arg)
 {
   MY_BITMAP *map= (MY_BITMAP *) arg;
-  if (field->vcol_info &&
-      !bitmap_fast_test_and_set(map, field->field_index))
+
+  if (!bitmap_fast_test_and_set(map, field->field_index) && field->vcol_info)
   {
     field->vcol_info->expr->walk(&Item::update_vcol_processor, 0, arg);
     field->vcol_info->expr->save_in_field(field, 0);
   }
+
   return 0;
 }
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -9187,11 +9187,21 @@ int TABLE::update_virtual_field(Field *vf, bool ignore_warnings)
           TABLE::update_virtual_fields(handler *, enum_vcol_update_mode).
   */
   in_use->set_n_backup_active_arena(expr_arena, &backup_arena);
+  MY_BITMAP saved_tmp_set;
+  uint bitmap_size= bitmap_buffer_size(s->fields);
+  my_bitmap_map *saved_buf= (my_bitmap_map *) my_safe_alloca(bitmap_size);
+  my_bitmap_init(&saved_tmp_set, saved_buf, s->fields);
+  bitmap_copy(&saved_tmp_set, &tmp_set);
+
   bitmap_clear_all(&tmp_set);
   vf->vcol_info->expr->walk(&Item::update_vcol_processor, 0, &tmp_set);
   DBUG_FIX_WRITE_SET(vf);
   vf->vcol_info->expr->save_in_field(vf, 0);
   DBUG_RESTORE_WRITE_SET(vf);
+
+  bitmap_copy(&tmp_set, &saved_tmp_set);          /* restore original state */
+  my_safe_afree(saved_buf, bitmap_size);
+
   in_use->restore_active_arena(expr_arena, &backup_arena);
   in_use->pop_internal_handler();
   if (ignore_warnings)


### PR DESCRIPTION
fixes [MDEV-36896](https://jira.mariadb.org/browse/MDEV-36896)

### Problem:
Executing queries that require virtual/generated column evaluation during filesort trigger debug assertions due to missing columns in read_set.

### Cause:
find_all_keys() temporarily assigns TABLE::tmp_set as both read_set and write_set. Later, TABLE::update_virtual_field() calls bitmap_clear_all(&tmp_set) before evaluating virtual column dependencies. Since all three pointers share the same underlying bitmap buffer, clearing tmp_set also clears the active read_set/write_set, causing required columns to appear missing during execution and triggering the assertion.

### Fix:
Before clearing tmp_set in TABLE::update_virtual_field(), save its current state into a stack-allocated bitmap clone using my_safe_alloca + bitmap_copy. After virtual column evaluation is complete, restore tmp_set to its original state before returning. This preserves whatever bits were live in the shared buffer (i.e. the active read_set/write_set) across the call, while still allowing the dependency walk to use tmp_set as scratch space as before. my_safe_alloca is used instead of heap allocation to keep this save/restore overhead minimal on what is a per-row hot path.