### PR TITLE
MDEV-37602: Phase 1 & 2 - Session-scoped rgi and Master_info registration in index

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -177,6 +177,13 @@ static bool opt_skip_annotate_row_events= 0;
 
 static my_bool opt_flashback;
 static bool opt_print_table_metadata;
+/*
+  By default (MDEV-37602) mariadb-binlog emits Query_log_events as
+  BINLOG '<base64>' statements so that replay takes the same code path as the
+  slave applier. --query-events-as-sql restores the historical behavior of
+  printing Query_log_events as their original SQL text.
+*/
+static my_bool opt_query_events_as_sql;
 #ifdef WHEN_FLASHBACK_REVIEW_READY
 static my_bool opt_flashback_review;
 static char *flashback_review_dbname, *flashback_review_tablename;
@@ -1152,6 +1159,7 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
       print_event_info->hexdump_from= pos;
 
     print_event_info->base64_output_mode= opt_base64_output_mode;
+    print_event_info->binlog_query_events= !opt_query_events_as_sql;
     print_event_info->print_table_metadata= opt_print_table_metadata;
 
     DBUG_PRINT("debug", ("event_type: %s", ev->get_type_str()));
@@ -1174,6 +1182,12 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
         */
         qe->flags|= LOG_EVENT_SUPPRESS_USE_F;
       }
+      /*
+        MDEV-37602: whether the query is emitted as raw SQL or as a
+        BINLOG '<base64>' statement is decided inside Query_log_event::print()
+        (see print_event_info->binlog_query_events), the same level at which
+        row events decide their own base64 output.
+      */
       print_use_stmt(print_event_info, qe);
       print_skip_replication_statement(print_event_info, ev);
       if (ev->print(result_file, print_event_info))
@@ -1651,6 +1665,13 @@ static struct my_option my_options[] =
    "statements. Output files named after server logs.",
    &opt_raw_mode, &opt_raw_mode, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
+  {"query-events-as-sql", 0, "Print Query_log_events as their original SQL "
+   "text instead of as BINLOG '<base64>' statements. By default (MDEV-37602) "
+   "Query_log_events are emitted as BINLOG statements so that replay uses the "
+   "same applier code path as row events. Transaction-control queries "
+   "(BEGIN/COMMIT/...) are always printed as plain SQL.",
+   &opt_query_events_as_sql, &opt_query_events_as_sql, 0, GET_BOOL, NO_ARG,
+   0, 0, 0, 0, 0, 0},
   {"result-file", 'r', "Direct output to a given file. With --raw this is a "
    "prefix for the file names.",
    &result_file_name, &result_file_name, 0, GET_STR, REQUIRED_ARG,

--- a/mysql-test/main/mysql_binary_mode.test
+++ b/mysql-test/main/mysql_binary_mode.test
@@ -41,7 +41,7 @@ eval DROP TABLE `$table_name_right`;
 
 --echo
 let $MYSQLD_DATADIR= `SELECT @@datadir`;
---exec $MYSQL_BINLOG $MYSQLD_DATADIR/$binlog_file > $MYSQLTEST_VARDIR/tmp/my.sql
+--exec $MYSQL_BINLOG --query-events-as-sql $MYSQLD_DATADIR/$binlog_file > $MYSQLTEST_VARDIR/tmp/my.sql
 RESET MASTER;
 
 --echo # '--exec mysql ...' without --binary-mode option
@@ -109,7 +109,7 @@ FLUSH LOGS;
 --copy_file $MYSQLD_DATADIR/$binlog_file $binlog_uuid_filename
 RESET MASTER;
 
---exec $MYSQL_BINLOG $binlog_uuid_filename  | $MYSQL
+--exec $MYSQL_BINLOG --query-events-as-sql $binlog_uuid_filename  | $MYSQL
 
 --let $table_name=`SELECT table_name FROM information_schema.tables WHERE table_schema='test'`
 --let $tbl1= `SELECT hex(table_name) FROM information_schema.tables WHERE table_schema='test'`
@@ -121,7 +121,7 @@ RESET MASTER;
 #### Replay through regular mysql client non-interactive mode and with binary mode set
 
 RESET MASTER;
---exec $MYSQL_BINLOG $binlog_uuid_filename  | $MYSQL --binary-mode
+--exec $MYSQL_BINLOG --query-events-as-sql $binlog_uuid_filename  | $MYSQL --binary-mode
 
 --let $table_name=`SELECT table_name FROM information_schema.tables WHERE table_schema='test'`
 --let $tbl2= `SELECT hex(table_name) FROM information_schema.tables WHERE table_schema='test'`

--- a/mysql-test/main/mysql_binary_zero_insert.result
+++ b/mysql-test/main/mysql_binary_zero_insert.result
@@ -38,7 +38,7 @@ FOUND 8 /\([0-9]+,0x([1-9][0-9])*00([1-9][0-9])*\)/ in dump.sql
 # Ensure data consistency on mysqlbinlog replay
 #
 FLUSH LOGS;
-# MYSQL_BINLOG MYSQLD_DATADIR/binlog_file > MYSQL_TMP_DIR/binlog_zeros.sql
+# MYSQL_BINLOG --query-events-as-sql MYSQLD_DATADIR/binlog_file > MYSQL_TMP_DIR/binlog_zeros.sql
 FOUND 10 /\x5c\x00/ in binlog_zeros.sql
 # MYSQL --binary-mode test < MYSQL_TMP_DIR/binlog_zeros.sql
 # Table checksum is equivalent before and after binlog replay

--- a/mysql-test/main/mysql_binary_zero_insert.test
+++ b/mysql-test/main/mysql_binary_zero_insert.test
@@ -127,8 +127,10 @@ SELECT COUNT(*)=8 from tb;
 let $MYSQLD_DATADIR= `SELECT @@datadir`;
 let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1);
 FLUSH LOGS;
---echo # MYSQL_BINLOG MYSQLD_DATADIR/binlog_file > MYSQL_TMP_DIR/binlog_zeros.sql
---exec $MYSQL_BINLOG $MYSQLD_DATADIR/$binlog_file > $MYSQL_TMP_DIR/binlog_zeros.sql
+--echo # MYSQL_BINLOG --query-events-as-sql MYSQLD_DATADIR/binlog_file > MYSQL_TMP_DIR/binlog_zeros.sql
+# This test checks that binary-zero data survives a mysqlbinlog dump/replay as
+# plain SQL text, so ask for the legacy SQL output of Query_log_events.
+--exec $MYSQL_BINLOG --query-events-as-sql $MYSQLD_DATADIR/$binlog_file > $MYSQL_TMP_DIR/binlog_zeros.sql
 --let SEARCH_PATTERN= \x5c\x00
 --let SEARCH_FILE= $MYSQL_TMP_DIR/binlog_zeros.sql
 --source include/search_pattern_in_file.inc

--- a/mysql-test/main/mysqlbinlog.test
+++ b/mysql-test/main/mysqlbinlog.test
@@ -285,7 +285,7 @@ DROP TABLE t1;
 
 --disable_query_log
 CREATE TABLE patch (a BLOB);
---exec $MYSQL_BINLOG --hexdump --local-load=$MYSQLTEST_VARDIR/tmp/ $MYSQLD_DATADIR/master-bin.000012 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_tmp.dat
+--exec $MYSQL_BINLOG --query-events-as-sql --hexdump --local-load=$MYSQLTEST_VARDIR/tmp/ $MYSQLD_DATADIR/master-bin.000012 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_tmp.dat
 ### Starting master-bin.000014
 eval LOAD DATA LOCAL INFILE '$MYSQLTEST_VARDIR/tmp/mysqlbinlog_tmp.dat'
      INTO TABLE patch FIELDS TERMINATED BY '';
@@ -403,7 +403,7 @@ query_vertical SELECT * FROM t1;
 DROP TABLE t1;
 
 echo >> mysqlbinlog var/log/master-bin.000020 > var/tmp/bug32580.sql;
-exec $MYSQL_BINLOG $MYSQLD_DATADIR/master-bin.000020 > $MYSQLTEST_VARDIR/tmp/bug32580.sql;
+exec $MYSQL_BINLOG --query-events-as-sql $MYSQLD_DATADIR/master-bin.000020 > $MYSQLTEST_VARDIR/tmp/bug32580.sql;
 echo >> mysql test < var/tmp/bug32580.sql;
 exec $MYSQL test < $MYSQLTEST_VARDIR/tmp/bug32580.sql;
 remove_file $MYSQLTEST_VARDIR/tmp/bug32580.sql;
@@ -606,10 +606,12 @@ eval SET GLOBAL SERVER_ID = $old_server_id;
 --echo # FDE corrupted in relay log
 --echo #
 --let TZ=GMT
---exec $MYSQL_BINLOG --hexdump std_data/mdev-4645-binlog_checksum.binlog
---exec $MYSQL_BINLOG --hexdump std_data/mdev-4645-binlog_group_id.binlog
---exec $MYSQL_BINLOG --hexdump std_data/mdev-4645-binlog_group_id_checksum.binlog
---exec $MYSQL_BINLOG --hexdump std_data/mdev-4645-binlog_none.binlog
+# This section checks the decoded SQL text of the events, so keep the legacy
+# SQL output of Query_log_events (MDEV-37602).
+--exec $MYSQL_BINLOG --query-events-as-sql --hexdump std_data/mdev-4645-binlog_checksum.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --hexdump std_data/mdev-4645-binlog_group_id.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --hexdump std_data/mdev-4645-binlog_group_id_checksum.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --hexdump std_data/mdev-4645-binlog_none.binlog
 
 #
 # MDEV-12372 mysqlbinlog --version output is the same on 10.x as on 5.5.x, and contains not only version

--- a/mysql-test/main/mysqlbinlog_query_events.result
+++ b/mysql-test/main/mysqlbinlog_query_events.result
@@ -1,0 +1,71 @@
+RESET MASTER;
+#
+# A workload mixing DDL, autocommit DML and an explicit transaction.
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,'one');
+BEGIN;
+INSERT INTO t1 VALUES (2,'two');
+UPDATE t1 SET b='ONE' WHERE a=1;
+COMMIT;
+FLUSH LOGS;
+#
+# 1. Default: Query_log_events are emitted as BINLOG '<base64>'.
+#    The DDL/DML statement text must NOT appear as executable SQL.
+#
+NOT FOUND /\nCREATE TABLE t1/ in default.sql
+NOT FOUND /\nINSERT INTO t1/ in default.sql
+NOT FOUND /\nUPDATE t1/ in default.sql
+#
+# ... but transaction control still arrives as plain SQL, because that
+# cleanup must run through dispatch_command() rather than the applier.
+#
+FOUND 2 /\nSTART TRANSACTION/ in default.sql
+FOUND 2 /\nCOMMIT/ in default.sql
+#
+# 2. --query-events-as-sql restores the historical raw SQL for the same
+#    events.  The only BINLOG statement left is the format-description
+#    event, which is emitted regardless.
+#
+FOUND 1 /\nCREATE TABLE t1/ in sql.sql
+FOUND 2 /\nINSERT INTO t1/ in sql.sql
+FOUND 1 /\nUPDATE t1/ in sql.sql
+FOUND 1 /BINLOG '/ in sql.sql
+#
+# 3. Modes that suppress base64 output keep the raw SQL, exactly as they
+#    already do for row events.  Without this, --base64-output=NEVER
+#    would silently produce a dump with no statements in it at all.
+#
+FOUND 1 /\nCREATE TABLE t1/ in never.sql
+NOT FOUND /BINLOG '/ in never.sql
+FOUND 1 /\nCREATE TABLE t1/ in decode.sql
+NOT FOUND /BINLOG '/ in decode.sql
+FOUND 1 /\nCREATE TABLE t1/ in short.sql
+NOT FOUND /BINLOG '/ in short.sql
+#
+# 4. Round trip: replaying the default (BINLOG) dump into an empty
+#    database must reproduce the original table definition and contents.
+#
+DROP TABLE t1;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) NOT NULL,
+  `b` varchar(20) DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+SELECT * FROM t1 ORDER BY a;
+a	b
+1	ONE
+2	two
+# Checksum matches the pre-replay value.
+#
+# 5. The --query-events-as-sql dump must replay to the same state.
+#
+DROP TABLE t1;
+SELECT * FROM t1 ORDER BY a;
+a	b
+1	ONE
+2	two
+# Checksum matches the pre-replay value.
+DROP TABLE t1;

--- a/mysql-test/main/mysqlbinlog_query_events.test
+++ b/mysql-test/main/mysqlbinlog_query_events.test
@@ -1,0 +1,146 @@
+# MDEV-37602: Query_log_events replayed through the slave applier
+#
+# mariadb-binlog emits Query_log_events as BINLOG '<base64>' statements so that
+# replay drives the same applier entry point as row events, instead of being
+# re-parsed as ordinary client SQL.  --query-events-as-sql restores the
+# historical raw-SQL output.
+#
+# This test covers the *client-side emission contract*:
+#   1. which events become BINLOG statements and which stay plain SQL
+#   2. how the choice interacts with --short-form and --base64-output
+#   3. that a default (BINLOG) dump still replays to identical table contents
+#
+# The server-side applier context is covered by main.mysqlbinlog_replay_context.
+
+--source include/have_log_bin.inc
+--source include/have_binlog_format_statement.inc
+--source include/have_innodb.inc
+
+RESET MASTER;
+
+--echo #
+--echo # A workload mixing DDL, autocommit DML and an explicit transaction.
+--echo #
+CREATE TABLE t1 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,'one');
+BEGIN;
+INSERT INTO t1 VALUES (2,'two');
+UPDATE t1 SET b='ONE' WHERE a=1;
+COMMIT;
+
+let $datadir= `SELECT @@datadir`;
+let $binlog= query_get_value(SHOW MASTER STATUS, File, 1);
+FLUSH LOGS;
+
+--let $checksum_before= `CHECKSUM TABLE t1`
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # 1. Default: Query_log_events are emitted as BINLOG '<base64>'.
+--echo #    The DDL/DML statement text must NOT appear as executable SQL.
+--echo #
+--exec $MYSQL_BINLOG $datadir/$binlog > $MYSQL_TMP_DIR/default.sql
+
+--let SEARCH_FILE= $MYSQL_TMP_DIR/default.sql
+--let SEARCH_PATTERN= \nCREATE TABLE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \nINSERT INTO t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \nUPDATE t1
+--source include/search_pattern_in_file.inc
+
+--echo #
+--echo # ... but transaction control still arrives as plain SQL, because that
+--echo # cleanup must run through dispatch_command() rather than the applier.
+--echo #
+--let SEARCH_PATTERN= \nSTART TRANSACTION
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \nCOMMIT
+--source include/search_pattern_in_file.inc
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # 2. --query-events-as-sql restores the historical raw SQL for the same
+--echo #    events.  The only BINLOG statement left is the format-description
+--echo #    event, which is emitted regardless.
+--echo #
+--exec $MYSQL_BINLOG --query-events-as-sql $datadir/$binlog > $MYSQL_TMP_DIR/sql.sql
+
+--let SEARCH_FILE= $MYSQL_TMP_DIR/sql.sql
+--let SEARCH_PATTERN= \nCREATE TABLE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \nINSERT INTO t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \nUPDATE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= BINLOG '
+--source include/search_pattern_in_file.inc
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # 3. Modes that suppress base64 output keep the raw SQL, exactly as they
+--echo #    already do for row events.  Without this, --base64-output=NEVER
+--echo #    would silently produce a dump with no statements in it at all.
+--echo #
+--exec $MYSQL_BINLOG --base64-output=NEVER $datadir/$binlog > $MYSQL_TMP_DIR/never.sql
+--let SEARCH_FILE= $MYSQL_TMP_DIR/never.sql
+--let SEARCH_PATTERN= \nCREATE TABLE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= BINLOG '
+--source include/search_pattern_in_file.inc
+
+--exec $MYSQL_BINLOG --base64-output=DECODE-ROWS --verbose $datadir/$binlog > $MYSQL_TMP_DIR/decode.sql
+--let SEARCH_FILE= $MYSQL_TMP_DIR/decode.sql
+--let SEARCH_PATTERN= \nCREATE TABLE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= BINLOG '
+--source include/search_pattern_in_file.inc
+
+--exec $MYSQL_BINLOG --short-form $datadir/$binlog > $MYSQL_TMP_DIR/short.sql
+--let SEARCH_FILE= $MYSQL_TMP_DIR/short.sql
+--let SEARCH_PATTERN= \nCREATE TABLE t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= BINLOG '
+--source include/search_pattern_in_file.inc
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # 4. Round trip: replaying the default (BINLOG) dump into an empty
+--echo #    database must reproduce the original table definition and contents.
+--echo #
+DROP TABLE t1;
+--exec $MYSQL test < $MYSQL_TMP_DIR/default.sql
+
+SHOW CREATE TABLE t1;
+SELECT * FROM t1 ORDER BY a;
+
+--let $checksum_after= `CHECKSUM TABLE t1`
+if ($checksum_before != $checksum_after)
+{
+  --echo # checksum before replay: $checksum_before
+  --echo # checksum after  replay: $checksum_after
+  --die Replay through BINLOG statements did not reproduce the table contents
+}
+--echo # Checksum matches the pre-replay value.
+
+--echo #
+--echo # 5. The --query-events-as-sql dump must replay to the same state.
+--echo #
+DROP TABLE t1;
+--exec $MYSQL test < $MYSQL_TMP_DIR/sql.sql
+SELECT * FROM t1 ORDER BY a;
+
+--let $checksum_sql= `CHECKSUM TABLE t1`
+if ($checksum_before != $checksum_sql)
+{
+  --die --query-events-as-sql replay diverged from the default replay
+}
+--echo # Checksum matches the pre-replay value.
+
+# cleanup
+DROP TABLE t1;
+--remove_file $MYSQL_TMP_DIR/default.sql
+--remove_file $MYSQL_TMP_DIR/sql.sql
+--remove_file $MYSQL_TMP_DIR/never.sql
+--remove_file $MYSQL_TMP_DIR/decode.sql
+--remove_file $MYSQL_TMP_DIR/short.sql

--- a/mysql-test/main/mysqlbinlog_replay_context.result
+++ b/mysql-test/main/mysqlbinlog_replay_context.result
@@ -1,0 +1,107 @@
+RESET MASTER;
+#
+# Two tables, so table-map ids alternate rather than staying constant,
+# and a mix of multi-statement transactions with autocommit statements.
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1,'one');
+INSERT INTO t2 VALUES (1,'uno');
+INSERT INTO t1 VALUES (2,'two');
+UPDATE t2 SET b='UNO' WHERE a=1;
+DELETE FROM t1 WHERE a=2;
+COMMIT;
+INSERT INTO t1 VALUES (3,'three');
+INSERT INTO t1 VALUES (4,'four');
+INSERT INTO t2 VALUES (2,'dos');
+BEGIN;
+UPDATE t1 SET b='THREE' WHERE a=3;
+INSERT INTO t2 VALUES (3,'tres');
+COMMIT;
+FLUSH LOGS;
+#
+# A second binary log, so the replay can drive two pseudo_slave_mode
+# cycles through one connection (each dump brackets itself with
+# PSEUDO_SLAVE_MODE=1 ... =0).
+#
+CREATE TABLE t3 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t3 VALUES (1,'x');
+INSERT INTO t3 VALUES (2,'y');
+COMMIT;
+INSERT INTO t3 VALUES (3,'z');
+FLUSH LOGS;
+FOUND 1 /PSEUDO_SLAVE_MODE=1/ in ctx1.sql
+FOUND 1 /PSEUDO_SLAVE_MODE=0/ in ctx1.sql
+DROP TABLE t1, t2, t3;
+#
+# Replay both dumps over a single connection.  The concatenation drives
+# PSEUDO_SLAVE_MODE 1 -> 0 -> 1 -> 0, so the session Master_info and
+# rpl_group_info are built, torn down and rebuilt without the connection
+# ever being closed.
+#
+SELECT * FROM t1 ORDER BY a;
+a	b
+1	one
+3	THREE
+4	four
+SELECT * FROM t2 ORDER BY a;
+a	b
+1	UNO
+2	dos
+3	tres
+SELECT * FROM t3 ORDER BY a;
+a	b
+1	x
+2	y
+3	z
+# All three tables match their pre-replay checksums.
+#
+# Replaying the same dump twice over one connection, with the tables
+# dropped in between, must give the same result both times: the context
+# rebuilt for the second cycle must not retain table maps from the first,
+# even though the replayed events carry identical table ids.
+#
+DROP TABLE t1, t2, t3;
+SELECT * FROM t1 ORDER BY a;
+a	b
+1	one
+3	THREE
+4	four
+SELECT * FROM t2 ORDER BY a;
+a	b
+1	UNO
+2	dos
+3	tres
+# Both replay cycles produced the same checksums.
+DROP TABLE t1, t2;
+#
+# Compressed query events (QUERY_COMPRESSED_EVENT) must be accepted by
+# the BINLOG statement too, otherwise replay of a compressed binary log
+# fails outright once query events stop being emitted as raw SQL.
+#
+SET @old_compress= @@GLOBAL.log_bin_compress;
+SET @old_min_len= @@GLOBAL.log_bin_compress_min_len;
+SET GLOBAL log_bin_compress= ON;
+SET GLOBAL log_bin_compress_min_len= 10;
+SET SESSION binlog_format= STATEMENT;
+RESET MASTER;
+CREATE TABLE t4 (a INT PRIMARY KEY, b VARCHAR(500)) ENGINE=InnoDB;
+INSERT INTO t4 VALUES (1, REPEAT('compressible payload ', 8));
+BEGIN;
+INSERT INTO t4 VALUES (2, REPEAT('more compressible payload ', 8));
+UPDATE t4 SET b= REPEAT('updated payload ', 8) WHERE a=1;
+COMMIT;
+FLUSH LOGS;
+FOUND 4 /Query_compressed/ in ctx3.sql
+DROP TABLE t4;
+SELECT a, LENGTH(b) FROM t4 ORDER BY a;
+a	LENGTH(b)
+1	128
+2	208
+# Compressed-event replay matches the pre-replay checksum.
+DROP TABLE t4;
+SET GLOBAL log_bin_compress= @old_compress;
+SET GLOBAL log_bin_compress_min_len= @old_min_len;
+SET SESSION binlog_format= ROW;

--- a/mysql-test/main/mysqlbinlog_replay_context.test
+++ b/mysql-test/main/mysqlbinlog_replay_context.test
@@ -1,0 +1,208 @@
+# MDEV-37602: session-scoped applier context for BINLOG replay
+#
+# Once Query_log_events are replayed through the applier, a BINLOG statement is
+# no longer a self-contained unit of work: consecutive BINLOG statements in one
+# connection belong to the same event stream and must share applier state.
+# The connection -- not the individual BINLOG statement -- therefore owns the
+# rpl_group_info and the Master_info/Relay_log_info that back it.
+#
+# This test pins the observable consequences of that ownership rule:
+#   1. tables opened by one BINLOG statement stay usable by the next one in the
+#      same transaction (a transaction spans several BINLOG statements)
+#   2. table-map ids are still released between autocommit BINLOG statements,
+#      so a reused table id cannot collide with a stale mapping
+#   3. the per-connection context survives interleaved tables and transactions
+#   4. resetting pseudo_slave_mode tears the context down and a later BINLOG
+#      statement rebuilds it, within a single connection
+#
+# The client-side emission contract is covered by main.mysqlbinlog_query_events.
+
+--source include/have_log_bin.inc
+--source include/have_binlog_format_row.inc
+--source include/have_innodb.inc
+
+RESET MASTER;
+
+--echo #
+--echo # Two tables, so table-map ids alternate rather than staying constant,
+--echo # and a mix of multi-statement transactions with autocommit statements.
+--echo #
+CREATE TABLE t1 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+
+# A transaction spanning several row-event BINLOG statements, touching both
+# tables.  Under the connection-scoped rgi the tables opened by the first
+# statement must remain open for the rest of the transaction.
+BEGIN;
+INSERT INTO t1 VALUES (1,'one');
+INSERT INTO t2 VALUES (1,'uno');
+INSERT INTO t1 VALUES (2,'two');
+UPDATE t2 SET b='UNO' WHERE a=1;
+DELETE FROM t1 WHERE a=2;
+COMMIT;
+
+# Autocommit statements: each is its own event group, so the table-map context
+# must be dropped between them even though the table id is reused.
+INSERT INTO t1 VALUES (3,'three');
+INSERT INTO t1 VALUES (4,'four');
+INSERT INTO t2 VALUES (2,'dos');
+
+# A second transaction after the autocommit run.
+BEGIN;
+UPDATE t1 SET b='THREE' WHERE a=3;
+INSERT INTO t2 VALUES (3,'tres');
+COMMIT;
+
+let $datadir= `SELECT @@datadir`;
+let $binlog1= query_get_value(SHOW MASTER STATUS, File, 1);
+FLUSH LOGS;
+
+--let $sum_t1= `CHECKSUM TABLE t1`
+--let $sum_t2= `CHECKSUM TABLE t2`
+
+--echo #
+--echo # A second binary log, so the replay can drive two pseudo_slave_mode
+--echo # cycles through one connection (each dump brackets itself with
+--echo # PSEUDO_SLAVE_MODE=1 ... =0).
+--echo #
+CREATE TABLE t3 (a INT PRIMARY KEY, b VARCHAR(20)) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t3 VALUES (1,'x');
+INSERT INTO t3 VALUES (2,'y');
+COMMIT;
+INSERT INTO t3 VALUES (3,'z');
+
+let $binlog2= query_get_value(SHOW MASTER STATUS, File, 1);
+FLUSH LOGS;
+
+--let $sum_t3= `CHECKSUM TABLE t3`
+
+--exec $MYSQL_BINLOG $datadir/$binlog1 > $MYSQL_TMP_DIR/ctx1.sql
+--exec $MYSQL_BINLOG $datadir/$binlog2 > $MYSQL_TMP_DIR/ctx2.sql
+
+# Each dump must bracket itself with PSEUDO_SLAVE_MODE 1 ... 0, otherwise
+# concatenating the two does not exercise teardown and rebuild at all.
+--let SEARCH_FILE= $MYSQL_TMP_DIR/ctx1.sql
+--let SEARCH_PATTERN= PSEUDO_SLAVE_MODE=1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= PSEUDO_SLAVE_MODE=0
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t1, t2, t3;
+
+--echo #
+--echo # Replay both dumps over a single connection.  The concatenation drives
+--echo # PSEUDO_SLAVE_MODE 1 -> 0 -> 1 -> 0, so the session Master_info and
+--echo # rpl_group_info are built, torn down and rebuilt without the connection
+--echo # ever being closed.
+--echo #
+--exec cat $MYSQL_TMP_DIR/ctx1.sql $MYSQL_TMP_DIR/ctx2.sql | $MYSQL test
+
+SELECT * FROM t1 ORDER BY a;
+SELECT * FROM t2 ORDER BY a;
+SELECT * FROM t3 ORDER BY a;
+
+--let $sum_t1_after= `CHECKSUM TABLE t1`
+--let $sum_t2_after= `CHECKSUM TABLE t2`
+--let $sum_t3_after= `CHECKSUM TABLE t3`
+
+if ($sum_t1 != $sum_t1_after)
+{
+  --die t1 diverged after BINLOG replay
+}
+if ($sum_t2 != $sum_t2_after)
+{
+  --die t2 diverged after BINLOG replay
+}
+if ($sum_t3 != $sum_t3_after)
+{
+  --die t3 diverged after BINLOG replay
+}
+--echo # All three tables match their pre-replay checksums.
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # Replaying the same dump twice over one connection, with the tables
+--echo # dropped in between, must give the same result both times: the context
+--echo # rebuilt for the second cycle must not retain table maps from the first,
+--echo # even though the replayed events carry identical table ids.
+--echo #
+DROP TABLE t1, t2, t3;
+
+--write_file $MYSQL_TMP_DIR/dropall.sql
+DROP TABLE t1, t2;
+EOF
+
+--exec cat $MYSQL_TMP_DIR/ctx1.sql $MYSQL_TMP_DIR/dropall.sql $MYSQL_TMP_DIR/ctx1.sql | $MYSQL test
+
+SELECT * FROM t1 ORDER BY a;
+SELECT * FROM t2 ORDER BY a;
+
+--let $sum_t1_twice= `CHECKSUM TABLE t1`
+--let $sum_t2_twice= `CHECKSUM TABLE t2`
+if ($sum_t1 != $sum_t1_twice)
+{
+  --die Second replay of the same dump diverged for t1
+}
+if ($sum_t2 != $sum_t2_twice)
+{
+  --die Second replay of the same dump diverged for t2
+}
+--echo # Both replay cycles produced the same checksums.
+
+DROP TABLE t1, t2;
+--remove_file $MYSQL_TMP_DIR/ctx1.sql
+--remove_file $MYSQL_TMP_DIR/ctx2.sql
+--remove_file $MYSQL_TMP_DIR/dropall.sql
+
+# ----------------------------------------------------------------------------
+--echo #
+--echo # Compressed query events (QUERY_COMPRESSED_EVENT) must be accepted by
+--echo # the BINLOG statement too, otherwise replay of a compressed binary log
+--echo # fails outright once query events stop being emitted as raw SQL.
+--echo #
+SET @old_compress= @@GLOBAL.log_bin_compress;
+SET @old_min_len= @@GLOBAL.log_bin_compress_min_len;
+SET GLOBAL log_bin_compress= ON;
+SET GLOBAL log_bin_compress_min_len= 10;
+
+# Statement format, so the DML is logged as (compressed) Query events rather
+# than row events -- that is the case the BINLOG statement had to learn.
+SET SESSION binlog_format= STATEMENT;
+
+RESET MASTER;
+CREATE TABLE t4 (a INT PRIMARY KEY, b VARCHAR(500)) ENGINE=InnoDB;
+INSERT INTO t4 VALUES (1, REPEAT('compressible payload ', 8));
+BEGIN;
+INSERT INTO t4 VALUES (2, REPEAT('more compressible payload ', 8));
+UPDATE t4 SET b= REPEAT('updated payload ', 8) WHERE a=1;
+COMMIT;
+
+let $binlog3= query_get_value(SHOW MASTER STATUS, File, 1);
+FLUSH LOGS;
+--let $sum_t4= `CHECKSUM TABLE t4`
+
+--exec $MYSQL_BINLOG $datadir/$binlog3 > $MYSQL_TMP_DIR/ctx3.sql
+
+# Guard against this section silently becoming vacuous: if the workload stops
+# producing compressed query events, the replay below proves nothing.
+--let SEARCH_FILE= $MYSQL_TMP_DIR/ctx3.sql
+--let SEARCH_PATTERN= Query_compressed
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t4;
+--exec $MYSQL test < $MYSQL_TMP_DIR/ctx3.sql
+
+SELECT a, LENGTH(b) FROM t4 ORDER BY a;
+--let $sum_t4_after= `CHECKSUM TABLE t4`
+if ($sum_t4 != $sum_t4_after)
+{
+  --die Compressed-event replay diverged
+}
+--echo # Compressed-event replay matches the pre-replay checksum.
+
+DROP TABLE t4;
+--remove_file $MYSQL_TMP_DIR/ctx3.sql
+SET GLOBAL log_bin_compress= @old_compress;
+SET GLOBAL log_bin_compress_min_len= @old_min_len;
+SET SESSION binlog_format= ROW;

--- a/mysql-test/suite/binlog/t/binlog_admin_cmd_kill.test
+++ b/mysql-test/suite/binlog/t/binlog_admin_cmd_kill.test
@@ -89,7 +89,9 @@ let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1);
 FLUSH LOGS;
 
 --let $MYSQLD_DATADIR= `select @@datadir`
---exec $MYSQL_BINLOG $MYSQLD_DATADIR/$binlog_file > $MYSQLTEST_VARDIR/tmp/mysqlbinlog.out
+# This checks the decoded SQL text of a Query_log_event, so keep the legacy
+# SQL output of Query_log_events (MDEV-37602).
+--exec $MYSQL_BINLOG --query-events-as-sql $MYSQLD_DATADIR/$binlog_file > $MYSQLTEST_VARDIR/tmp/mysqlbinlog.out
 
 --let SEARCH_PATTERN= OPTIMIZE TABLE t1,t2
 --let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/mysqlbinlog.out

--- a/mysql-test/suite/binlog/t/binlog_killed.test
+++ b/mysql-test/suite/binlog/t/binlog_killed.test
@@ -68,7 +68,7 @@ let $rows= `select count(*) from t2  /* must be 2 or 0 */`;
 let $MYSQLD_DATADIR= `select @@datadir`;
 --let $binlog_killed_pos=query_get_value(SHOW BINLOG EVENTS, Pos, 6)
 --let $binlog_killed_end_log_pos=query_get_value(SHOW BINLOG EVENTS, Pos, 7)
---exec $MYSQL_BINLOG --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/kill_query_calling_sp.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/kill_query_calling_sp.binlog
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --disable_result_log
 eval select
@@ -282,7 +282,7 @@ source include/show_binlog_events.inc;
 
 --echo *** a proof the query is binlogged with an error ***
 
---exec $MYSQL_BINLOG --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 eval select
 (@a:=load_file("$MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog"))
@@ -330,7 +330,7 @@ source include/show_binlog_events.inc;
 
 # a proof the query is binlogged with an error
 
---exec $MYSQL_BINLOG --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog
+--exec $MYSQL_BINLOG --query-events-as-sql --force-if-open --start-position=$binlog_killed_pos --stop-position=$binlog_killed_end_log_pos $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 eval select
 (@a:=load_file("$MYSQLTEST_VARDIR/tmp/binlog_killed_bug27571.binlog"))

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -904,6 +904,14 @@ typedef struct st_print_event_info
   uint32 domain_id;
   uint8 common_header_len;
   enum_base64_output_mode base64_output_mode;
+  /*
+    MDEV-37602: when true (the default), Query_log_events are printed as
+    BINLOG '<base64>' statements so they replay through the applier like row
+    events. Transaction-control queries (BEGIN/COMMIT/...) are always printed
+    as plain SQL regardless of this flag. Set to false by --query-events-as-sql
+    to restore the historical raw-SQL output for Query_log_events.
+  */
+  bool binlog_query_events;
   my_off_t hexdump_from;
 
   /*

--- a/sql/log_event_client.cc
+++ b/sql/log_event_client.cc
@@ -2173,35 +2173,55 @@ bool Query_log_event::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
     goto err;
   if (!is_flashback)
   {
-    if (gtid_flags_extra & (Gtid_log_event::FL_START_ALTER_E1 |
-                            Gtid_log_event::FL_COMMIT_ALTER_E1 |
-                            Gtid_log_event::FL_ROLLBACK_ALTER_E1))
+    bool do_print_encoded=
+      print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
+      print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS &&
+      !print_event_info->short_form;
+    bool is_alter=
+      gtid_flags_extra & (Gtid_log_event::FL_START_ALTER_E1 |
+                          Gtid_log_event::FL_COMMIT_ALTER_E1 |
+                          Gtid_log_event::FL_ROLLBACK_ALTER_E1);
+    /*
+      MDEV-37602: by default emit the query as a BINLOG '<base64>' statement so
+      it is replayed through the applier, the same path used by row events (and,
+      already, by ALTER Start/Commit/Rollback events). Transaction-control
+      queries (BEGIN/COMMIT/...) are kept as plain SQL so their transaction
+      cleanup goes through dispatch_command(), matching how GTID events emit
+      START TRANSACTION as plain SQL.
+    */
+    bool emit_base64= do_print_encoded &&
+      (is_alter ||
+       (print_event_info->binlog_query_events &&
+        !is_trans_keyword(print_event_info->is_xa_trans())));
+
+    if (emit_base64)
     {
-      bool do_print_encoded=
-        print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
-        print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS &&
-        !print_event_info->short_form;
-      bool comment_mode= do_print_encoded &&
+      bool comment_mode=
         gtid_flags_extra & (Gtid_log_event::FL_START_ALTER_E1 |
                             Gtid_log_event::FL_ROLLBACK_ALTER_E1);
 
-      if(comment_mode)
+      if (comment_mode)
         my_b_printf(&cache, "/*!100600 ");
-      if (do_print_encoded)
-        my_b_printf(&cache, "BINLOG '\n");
-      if (print_base64(&cache, print_event_info, do_print_encoded))
+      my_b_printf(&cache, "BINLOG '\n");
+      if (print_base64(&cache, print_event_info, true))
         goto err;
-      if (do_print_encoded)
-      {
-        if(comment_mode)
-           my_b_printf(&cache, "' */%s\n", print_event_info->delimiter);
-        else
-           my_b_printf(&cache, "'%s\n", print_event_info->delimiter);
-      }
+      if (comment_mode)
+        my_b_printf(&cache, "' */%s\n", print_event_info->delimiter);
+      else
+        my_b_printf(&cache, "'%s\n", print_event_info->delimiter);
       if (print_event_info->verbose && print_verbose(&cache, print_event_info))
-      {
         goto err;
-      }
+    }
+    else if (is_alter)
+    {
+      /*
+        base64 disabled (--short-form / --base64-output=NEVER|DECODE-ROWS):
+        keep the historical ALTER behavior of only printing the decoded form.
+      */
+      if (print_base64(&cache, print_event_info, false))
+        goto err;
+      if (print_event_info->verbose && print_verbose(&cache, print_event_info))
+        goto err;
     }
     else
     {
@@ -3861,6 +3881,7 @@ st_print_event_info::st_print_event_info()
   printed_fd_event=FALSE;
   file= 0;
   base64_output_mode=BASE64_OUTPUT_UNSPEC;
+  binlog_query_events= true;
   m_is_event_group_active= TRUE;
   m_is_event_group_filtering_enabled= FALSE;
   m_is_partial_rows_ev_group_active= TRUE;

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -1897,7 +1897,8 @@ int Query_log_event::do_apply_event(rpl_group_info *rgi,
             ::do_apply_event(), then the companion SET also have so
             we don't need to reset_one_shot_variables().
   */
-  if (rpl_filter->is_db_empty() ||
+  if (!thd->slave_thread /* filtering is for slave only (MDEV-37602) */ ||
+      rpl_filter->is_db_empty() ||
       is_trans_keyword(
           (rgi->gtid_ev_flags2 & (Gtid_log_event::FL_PREPARED_XA |
                                   Gtid_log_event::FL_COMPLETED_XA))) ||

--- a/sql/rpl_mi.cc
+++ b/sql/rpl_mi.cc
@@ -35,10 +35,12 @@ static void init_connection_config(Master_info* mi);
 static void init_group_counters(Master_info* mi);
 
 Master_info::Master_info(LEX_CSTRING *connection_name_arg,
-                         bool is_slave_recovery):
+                         bool is_slave_recovery,
+                         const char *rli_thread_name):
    Master_info_file(ignore_server_ids, domain_id_filter.m_domain_ids[0],
                                        domain_id_filter.m_domain_ids[1]),
-   Slave_reporting_capability("I/O"), fd(-1), io_thd(0), rli(is_slave_recovery),
+   Slave_reporting_capability("I/O"), fd(-1), io_thd(0),
+   rli(is_slave_recovery, rli_thread_name),
    checksum_alg_before_fd(BINLOG_CHECKSUM_ALG_UNDEF),
    connects_tried(0), binlog_storage_engine(0), inited(0), abort_slave(0),
    slave_running(MYSQL_SLAVE_NOT_RUN), slave_run_id(0),

--- a/sql/rpl_mi.h
+++ b/sql/rpl_mi.h
@@ -158,7 +158,8 @@ class Master_info: public Master_info_file, public Slave_reporting_capability
     USE_GTID_CURRENT_POS= enum_master_use_gtid::CURRENT_POS,
     USE_GTID_SLAVE_POS  = enum_master_use_gtid::SLAVE_POS;
 
-  Master_info(LEX_CSTRING *connection_name, bool is_slave_recovery);
+  Master_info(LEX_CSTRING *connection_name, bool is_slave_recovery,
+              const char *rli_thread_name= "SQL");
   ~Master_info();
   bool shall_ignore_server_id(ulong s_id);
   void clear_in_memory_info(bool all);

--- a/sql/sql_binlog.cc
+++ b/sql/sql_binlog.cc
@@ -58,6 +58,7 @@ static int check_event_type(int type, Relay_log_info *rli)
   case START_EVENT_V3:
   case FORMAT_DESCRIPTION_EVENT:
   case QUERY_EVENT:
+  case QUERY_COMPRESSED_EVENT:
   case TABLE_MAP_EVENT:
   case WRITE_ROWS_EVENT_V1:
   case UPDATE_ROWS_EVENT_V1:
@@ -158,19 +159,17 @@ int binlog_defragment(THD *thd)
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
 int save_restore_context_apply_event(Log_event *ev, rpl_group_info *rgi)
 {
-  if (ev->get_type_code() != QUERY_EVENT)
+  if (!LOG_EVENT_IS_QUERY(ev->get_type_code()))
     return ev->apply_event(rgi);
 
   THD *thd= rgi->thd;
   Relay_log_info *rli= thd->rli_fake;
-  DBUG_ASSERT(!rli->mi);
-  LEX_CSTRING connection_name= { STRING_WITH_LEN("BINLOG_BASE64_EVENT") };
-
-  if (!(rli->mi= new Master_info(&connection_name, false)))
-  {
-    my_error(ER_OUT_OF_RESOURCES, MYF(0));
-    return -1;
-  }
+  /*
+    The Master_info is created once per connection together with rli_fake (see
+    mysql_client_binlog_statement()) and persists for the session, so unlike
+    before we neither create nor delete it here.
+  */
+  DBUG_ASSERT(rli->mi);
 
   sql_digest_state *m_digest= thd->m_digest;
   PSI_statement_locker *m_statement_psi= thd->m_statement_psi;;
@@ -189,8 +188,6 @@ int save_restore_context_apply_event(Log_event *ev, rpl_group_info *rgi)
   thd->m_statement_psi= m_statement_psi;
   thd->variables.pseudo_thread_id= m_thread_id;
   thd->reset_db(&save_db);
-  delete rli->mi;
-  rli->mi= NULL;
 
   return err;
 }
@@ -234,28 +231,61 @@ void mysql_client_binlog_statement(THD* thd)
 
   int err;
   Relay_log_info *rli;
-  rpl_group_info *rgi;
+  rpl_group_info *rgi= thd->rgi_fake;
   uchar *buf= NULL;
   size_t coded_len= 0, decoded_len= 0;
+  const char *error= 0;
+  Log_event *ev= 0;
+  my_bool is_fragmented= FALSE;
 
   rli= thd->rli_fake;
-  if (!rli && (rli= thd->rli_fake= new Relay_log_info(FALSE, "BINLOG_BASE64_EVENT")))
-    rli->sql_driver_thd= thd;
-  if (!(rgi= thd->rgi_fake))
-    rgi= thd->rgi_fake= new rpl_group_info(rli);
-  rgi->thd= thd;
-  const char *error= 0;
-  Log_event *ev = 0;
-  my_bool is_fragmented= FALSE;
-  my_bool keep_rgi= false;
-  /*
-    Out of memory check
-  */
-  if (!(rli))
+  if (!rli)
   {
-    my_error(ER_OUTOFMEMORY, MYF(ME_FATAL), 1);  /* needed 1 bytes */
-    goto end;
+    /*
+      Create a session-scoped Master_info whose embedded Relay_log_info serves
+      as rli_fake for this connection. Having a stable Master_info/Relay_log_info
+      pair for the lifetime of the connection means Query_log_events replayed via
+      BINLOG statements get a valid execution context without recreating a
+      throwaway Master_info for every event (see save_restore_context_apply_event).
+
+      Note: it is intentionally NOT registered in master_info_index; surfacing
+      replay connections in SHOW SLAVE STATUS is left as future work.
+    */
+    LEX_CSTRING connection_name= { STRING_WITH_LEN("BINLOG_BASE64_EVENT") };
+    /*
+      Name the embedded Relay_log_info "BINLOG_BASE64_EVENT" (rather than the
+      default "SQL") so replay error messages keep their historical identity.
+    */
+    Master_info *mi= new Master_info(&connection_name, false,
+                                     "BINLOG_BASE64_EVENT");
+    if (!mi || mi->error())
+    {
+      delete mi;
+      my_error(ER_OUTOFMEMORY, MYF(ME_FATAL), 1);  /* needed 1 bytes */
+      goto end;
+    }
+    mi->rli.mi= mi;
+    mi->rli.sql_driver_thd= thd;
+    thd->mi_fake= mi;
+    thd->rli_fake= rli= &mi->rli;
   }
+
+  /*
+    The rpl_group_info is created once per connection and persists across
+    BINLOG statements (it is freed in THD::free_connection). Keeping it alive
+    preserves cross-event context (table maps, deferred events, partial-row
+    assembly) between consecutive BINLOG statements, matching the slave SQL
+    thread which keeps a single rgi for the lifetime of the thread.
+  */
+  if (!rgi)
+  {
+    if (!(rgi= thd->rgi_fake= new rpl_group_info(rli)))
+    {
+      my_error(ER_OUTOFMEMORY, MYF(ME_FATAL), 1);
+      goto end;
+    }
+  }
+  rgi->thd= thd;
 
   DBUG_ASSERT(rli->belongs_to_client());
 
@@ -412,16 +442,6 @@ void mysql_client_binlog_statement(THD* thd)
         */
         LEX *backup_lex;
 
-        /*
-          If we are re-assembling a Rows_log_event from a group of
-          Partial_rows_log_events, the rgi houses the assembler, so we need
-          it around while we are re-constructing the event.
-        */
-        if (ev->get_type_code() == PARTIAL_ROW_DATA_EVENT &&
-            (((Partial_rows_log_event *) ev)->seq_no <
-             ((Partial_rows_log_event *) ev)->total_fragments))
-          keep_rgi= true;
-
         thd->backup_and_reset_current_lex(&backup_lex);
         err= save_restore_context_apply_event(ev, rgi);
         thd->restore_current_lex(backup_lex);
@@ -462,13 +482,19 @@ end:
   if (unlikely(is_fragmented))
     my_free(const_cast<char*>(thd->lex->comment.str));
   thd->variables.option_bits= thd_options;
-  rgi->slave_close_thread_tables(thd);
+  /*
+    Close the tables and drop the rgi's table-map / tables_to_lock context at
+    the end of a BINLOG statement only when we are NOT inside an explicit
+    transaction. Within a transaction the rgi must persist across BINLOG
+    statements (so tables opened by one event group stay usable by the next),
+    and cleanup happens when the transaction-ending COMMIT -- which mysqlbinlog
+    now emits as plain SQL -- runs through dispatch_command(). For autocommit
+    BINLOG statements there is no such COMMIT, and dispatch_command() closes
+    thd tables but does not clear the rgi table maps, so we must do it here;
+    otherwise a stale table id would clash with a later Table_map (MDEV-37602).
+  */
+  if (rgi && !thd->in_active_multi_stmt_transaction())
+    rgi->slave_close_thread_tables(thd);
   my_free(buf);
-
-  if (!keep_rgi)
-  {
-    delete rgi;
-    rgi= thd->rgi_fake= NULL;
-  }
   DBUG_VOID_RETURN;
 }

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -36,6 +36,7 @@
 #include "sql_base.h"
 #include "sql_handler.h"                      // mysql_ha_cleanup
 #include "rpl_rli.h"
+#include "rpl_mi.h"
 #include "rpl_filter.h"
 #include "rpl_record.h"
 #include "slave.h"
@@ -714,7 +715,7 @@ const char *thd_where(THD *thd)
 THD::THD(my_thread_id id, bool is_wsrep_applier)
   :Statement(&main_lex, &main_mem_root, STMT_CONVENTIONAL_EXECUTION,
              /* statement id */ 0),
-   rli_fake(0), rgi_fake(0), rgi_slave(NULL),
+   mi_fake(0), rli_fake(0), rgi_fake(0), rgi_slave(NULL),
    protocol_text(this), protocol_binary(this), initial_status_var(0),
    m_current_stage_key(0), m_psi(0), start_time(0), start_time_sec_part(0),
    in_sub_stmt(0), log_all_errors(0),
@@ -1792,8 +1793,22 @@ void THD::free_connection()
   net_end(&net);
   delete(rgi_fake);
   rgi_fake= NULL;
-  delete(rli_fake);
-  rli_fake= NULL;
+  if (mi_fake)
+  {
+    /*
+      The session-scoped Master_info owns its embedded Relay_log_info, which is
+      what rli_fake points at, so deleting mi_fake frees the rli too. It is not
+      registered in master_info_index, so no deregistration is needed here.
+    */
+    delete mi_fake;
+    mi_fake= NULL;
+    rli_fake= NULL;
+  }
+  else
+  {
+    delete(rli_fake);
+    rli_fake= NULL;
+  }
 #endif
  if (!cleanup_done)
    cleanup();

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -96,6 +96,7 @@ enum wsrep_consistency_check_mode {
 
 class Reprepare_observer;
 class Relay_log_info;
+class Master_info;
 struct rpl_group_info;
 struct rpl_parallel_thread;
 class Rpl_filter;
@@ -3195,6 +3196,15 @@ public:
   MDL_context mdl_context;
 
   /* Used to execute base64 coded binlog events in MySQL server */
+  /*
+    Session-scoped Master_info backing rli_fake for BINLOG statement replay.
+    It is NOT registered in master_info_index (that is future work); it merely
+    provides a stable Relay_log_info / Master_info pair so that Query_log_events
+    replayed via BINLOG statements have the execution context they require
+    without recreating a throwaway Master_info per event. NULL until the first
+    BINLOG statement on the connection; freed in THD::free_connection().
+  */
+  Master_info* mi_fake;
   Relay_log_info* rli_fake;
   rpl_group_info* rgi_fake;
   /* Slave applier execution context */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7322,10 +7322,24 @@ static bool check_pseudo_slave_mode(sys_var *self, THD *thd, set_var *var)
     if (!val)
     {
 #ifndef EMBEDDED_LIBRARY
-      delete thd->rli_fake;
-      thd->rli_fake= NULL;
       delete thd->rgi_fake;
       thd->rgi_fake= NULL;
+      if (thd->mi_fake)
+      {
+        /*
+          rli_fake is the Relay_log_info embedded in the session-scoped
+          Master_info, so it must not be freed on its own; deleting mi_fake
+          frees it. mi_fake is not registered in master_info_index.
+        */
+        delete thd->mi_fake;
+        thd->mi_fake= NULL;
+        thd->rli_fake= NULL;
+      }
+      else
+      {
+        delete thd->rli_fake;
+        thd->rli_fake= NULL;
+      }
 #endif
     }
     else if (previous_val && val)


### PR DESCRIPTION
Phase 1: Persist rpl_group_info per connection instead of per BINLOG statement
Phase 2: Create session Master_info and register in master_info_index with unique names