### PR TITLE
Fix Lintian flagged spelling in MariaDB Server repository

### DIFF
--- a/extra/mariadb_migrate_config_file.c
+++ b/extra/mariadb_migrate_config_file.c
@@ -2081,7 +2081,7 @@ static int process_defaults(const char *conf_file,
       fprintf(stderr,
               "Cannot execute '%s' to test if the new option files "
               "works (error %d)\n"
-              "Try specifiying the full path for the MariaDB server with "
+              "Try specifying the full path for the MariaDB server with "
               "--mariadbd=...\n",
               used_name, (int) errno);
       finish_updated_files(&ctx, 1);

--- a/storage/connect/odbconn.cpp
+++ b/storage/connect/odbconn.cpp
@@ -281,7 +281,7 @@ static CATPARM *AllocCatInfo(PGLOBAL g, CATINFO fid, PCSZ db,
 		cap->Status = (UWORD *)PlugSubAlloc(g, NULL, m * sizeof(UWORD));
 
 	} catch (int n) {
-		htrc("Exeption %d: %s\n", n, g->Message);
+		htrc("Exception %d: %s\n", n, g->Message);
 		cap = NULL;
 	} catch (const char *msg) {
 		htrc(g->Message, msg);


### PR DESCRIPTION
Fixes following Lintian nags:

    X: mariadb-plugin-connect: spelling-error-in-binary Exeption Exception [usr/lib/mysql/plugin/ha_connect.so]
    X: mariadb-client-core: spelling-error-in-binary specifiying specifying [usr/bin/mariadb-migrate-config-file]