### PR TITLE
bound datetime/time stmt param reads to the declared length

### DIFF
--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -578,7 +578,7 @@ void Item_param::set_param_time(uchar **pos, ulong len)
     tm.hour=   (uint) to[5] + day * 24;
     tm.minute= (uint) to[6];
     tm.second= (uint) to[7];
-    tm.second_part= (length > 8) ? (ulong) sint4korr(to+8) : 0;
+    tm.second_part= (length >= 12) ? (ulong) sint4korr(to+8) : 0;
     if (tm.hour > 838)
     {
       /* TODO: add warning 'Data truncated' here */
@@ -607,7 +607,7 @@ void Item_param::set_param_datetime(uchar **pos, ulong len)
     tm.year=   (uint) sint2korr(to);
     tm.month=  (uint) to[2];
     tm.day=    (uint) to[3];
-    if (length > 4)
+    if (length >= 7)
     {
       tm.hour=   (uint) to[4];
       tm.minute= (uint) to[5];
@@ -616,7 +616,7 @@ void Item_param::set_param_datetime(uchar **pos, ulong len)
     else
       tm.hour= tm.minute= tm.second= 0;
 
-    tm.second_part= (length > 7) ? (ulong) sint4korr(to+7) : 0;
+    tm.second_part= (length >= 11) ? (ulong) sint4korr(to+7) : 0;
   }
   else
     set_zero_time(&tm, MYSQL_TIMESTAMP_DATETIME);


### PR DESCRIPTION
get_param_length() validates only `length` bytes for a parameter value, but the binary-protocol datetime reader reads to[4..6] when length>4 (needs 7) and to[7..10] when length>7 (needs 11), and the time reader reads to[8..11] when length>8 (needs 12). A client sending an off-spec datetime length of 5/6/8/9/10 or a time length of 9/10/11 makes the server read past the value, out of bounds when it ends at the packet boundary. Gate the optional time and microsecond reads on the canonical encoding lengths (7/11 for datetime, 12 for time).