### PR TITLE
MDEV-39804 : Galera test failure on GCF-360

### DIFF
--- a/mysql-test/suite/galera/t/GCF-360.cnf
+++ b/mysql-test/suite/galera/t/GCF-360.cnf
@@ -2,3 +2,5 @@
 
 [mysqld]
 wsrep_ignore_apply_errors=0
+loose-gcf-360=1
+

--- a/mysql-test/suite/galera/t/GCF-360.test
+++ b/mysql-test/suite/galera/t/GCF-360.test
@@ -28,19 +28,19 @@ while ($count)
         --send DROP TABLE nonexisting_table;
 
         --connection node_1
-        --error ER_BAD_TABLE_ERROR
+        --error ER_BAD_TABLE_ERROR,ER_QUERY_INTERRUPTED
         --reap
 
         --connection node_2
-        --error ER_BAD_TABLE_ERROR
+        --error ER_BAD_TABLE_ERROR,ER_QUERY_INTERRUPTED
         --reap
 
         --connection node_3
-        --error ER_BAD_TABLE_ERROR
+        --error ER_BAD_TABLE_ERROR,ER_QUERY_INTERRUPTED
         --reap
 
         --connection node_4
-        --error ER_BAD_TABLE_ERROR
+        --error ER_BAD_TABLE_ERROR,ER_QUERY_INTERRUPTED
         --reap
 
         --dec $count


### PR DESCRIPTION
Allow error ER_QUERY_INTERRUPTED because TOI for DROP starts before table is actually even opened, thus every node could start it concurrently.