### PR TITLE
MDEV-39832 mhnsw: skip non-dirty nodes when invalidating the shared cache on commit

### DIFF
--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -439,7 +439,7 @@ public:
   const FVector *vec= nullptr;
   Neighborhood *neighbors= nullptr;
   uint8_t max_layer;
-  bool stored:1, deleted:1;
+  bool stored:1, deleted:1, dirty:1;
 
   FVectorNode(MHNSW_Share *ctx_, const void *gref_);
   FVectorNode(MHNSW_Share *ctx_, const void *tref_, uint8_t layer,
@@ -790,10 +790,13 @@ int MHNSW_Trx::do_commit(THD *thd, bool all)
           {
             // consider copying nodes from trx to shared cache when it makes
             // sense. for ann_benchmarks it does not.
-            // also, consider flushing only changed nodes (a flag in the node)
             for (FVectorNode &from : trx->get_cache())
+            {
+              if (!from.dirty)
+                continue;
               if (FVectorNode *node= ctx->find_node(from.gref()))
                 node->vec= nullptr;
+            }
             ctx->start= nullptr;
           }
           ctx->release(true, share);
@@ -927,14 +930,14 @@ const FVector *FVectorNode::make_vec(const void *v)
 }
 
 FVectorNode::FVectorNode(MHNSW_Share *ctx_, const void *gref_)
-  : ctx(ctx_), stored(true), deleted(false)
+  : ctx(ctx_), stored(true), deleted(false), dirty(false)
 {
   memcpy(gref(), gref_, gref_len());
 }
 
 FVectorNode::FVectorNode(MHNSW_Share *ctx_, const void *tref_, uint8_t layer,
                          const void *vec_)
-  : ctx(ctx_), stored(false), deleted(false)
+  : ctx(ctx_), stored(false), deleted(false), dirty(false)
 {
   DBUG_ASSERT(tref_);
   memset(gref(), 0xff, gref_len()); // important: larger than any real gref
@@ -1203,6 +1206,14 @@ int FVectorNode::save(TABLE *graph)
 {
   DBUG_ASSERT(vec);
   DBUG_ASSERT(neighbors);
+
+  // Mark as dirty BEFORE touching disk: any path that calls save()
+  // is mutating this node. do_commit's partial invalidation
+  // uses this flag to skip read-only trx-cache entries and only
+  // invalidate the share-cache copies that are now actually stale.
+  // Set even on save() error paths so a partially-written node still
+  // forces share to reload.
+  dirty= true;
 
   restore_record(graph, s->default_values);
   graph->field[FIELD_LAYER]->store(max_layer, false);
@@ -1697,6 +1708,7 @@ int mhnsw_invalidate(TABLE *table, const uchar *rec, KEY *keyinfo)
   graph->file->position(graph->record[0]);
   FVectorNode *node= ctx->get_node(graph->file->ref);
   node->deleted= true;
+  node->dirty= true;     // forces share-cache invalidation on commit
 
   return 0;
 }


### PR DESCRIPTION
### Description

While benchmarking MariaDB's vector index against pgvector with VectorDBBench (https://github.com/zilliztech/VectorDBBench), I observed that MariaDB's query latency under read/write concurrency is significantly higher than pgvector's, and grows with the volume of data already inserted.

Benchmark: an HNSW index is created at table-creation time, vectors are then inserted continuously, and read bursts are issued at 20% / 50% / 80% of the total insert progress so that reads and writes run concurrently. 

### Root cause

In `MHNSW_Trx::do_commit()` (sql/vector_mhnsw.cc), the partial-invalidation path walks every entry in the committing transaction's node cache and clears the shared-cache copy's `vec` pointer:

```cpp
for (FVectorNode &from : trx->get_cache())
  if (FVectorNode *node= ctx->find_node(from.gref()))
    node->vec= nullptr;
ctx->start= nullptr;
```

The trx-local cache, however, contains every node the transaction touched, including the many nodes traversed by `search_layer` and evaluated by `select_neighbors` during the insert that were never actually modified. The shared-cache copies of those read-only nodes are still consistent with on-disk data, but they get invalidated anyway, forcing concurrent and subsequent readers to reload them through `FVectorNode::load()`.

There is in fact a pre-existing TODO at the same location:

```cpp
// also, consider flushing only changed nodes (a flag in the node)
```

### Proposed fix

Add a `dirty` bit to `FVectorNode` and set it on the two paths that actually mutate the node:

- in `FVectorNode::save()` (covers both the newly-inserted target and every neighbor rewritten by `update_second_degree_neighbors`);
- in `mhnsw_invalidate()` alongside `deleted = true`.

The partial-invalidation loop in `do_commit` then skips entries whose `dirty` is false. The flag fits in the existing trailing byte alongside `stored` and `deleted`, so `FVectorNode`'s footprint is unchanged. The flag is set before any storage-engine call inside `save()`, so that a write path failing mid-flight still forces the shared cache to reload.

### Results

On the 1536D-50K VectorDBBench Streaming run (with an HNSW index created at table-creation time):

- Search latency p95 at 80% insert progress: ~100 ms → ~10 ms
- recall and QPS are unchanged

The fix is local to `sql/vector_mhnsw.cc` and small (≈10 lines).

### Attatchments

1. Search latency p95 (under read/write concurrency) MariaDB vs pgvector
<img width="1814" height="1156" alt="image" src="https://github.com/user-attachments/assets/e2522e0c-4f34-46db-aa5a-dfd5b7fc91e1" />

2. Search latency p95 (under read/write concurrency) after this fix
<img width="1866" height="1150" alt="image" src="https://github.com/user-attachments/assets/8ba3d664-42e3-4176-824a-35618e8c8378" />