### PR TITLE
MDEV-38389: Galera test failure on galera_3nodes.galera_vote_majority_dml

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_vote_majority_dml.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_vote_majority_dml.result
@@ -1,7 +1,11 @@
 connection node_2;
 connection node_1;
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 BLOB) ENGINE=InnoDB;
 connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 BLOB) ENGINE=InnoDB;
 connection node_3;
 SET GLOBAL wsrep_on=OFF;
 ALTER TABLE t1 MODIFY f2 LONGTEXT;
@@ -61,10 +65,10 @@ f1	f2
 DROP TABLE t1;
 connection node_1;
 CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
-CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: .*, seqno");
 connection node_2;
 CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
-CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: .*, seqno");
 connection node_3;
 CALL mtr.add_suppression("Vote 0 \\(success\\) on (.*) is inconsistent with group. Leaving cluster.");
 CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");

--- a/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_vote_majority_dml.test
@@ -6,10 +6,23 @@
 --source include/galera_cluster.inc
 --source include/have_perfschema.inc
 
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 BLOB) ENGINE=InnoDB;
 
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
+# Wait until the CREATE TABLE has been applied on node_3 before turning
+# wsrep off, otherwise the ALTER below can race ahead of replication and
+# fail with ER_NO_SUCH_TABLE.
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = 'test' AND table_name = 't1'
+--source include/wait_condition.inc
 SET GLOBAL wsrep_on=OFF;
 ALTER TABLE t1 MODIFY f2 LONGTEXT; # Introducing schema inconsistency
 SET GLOBAL wsrep_on=ON;
@@ -57,12 +70,15 @@ DROP TABLE t1;
 
 --connection node_1
 CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
-CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: .*, seqno");
 
 --connection node_2
 CALL mtr.add_suppression("Replica SQL: Column 1 of table 'test.t1' cannot be converted from type 'longblob' to type 'blob', Error_code: MY-013146");
-CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: 3, seqno");
+CALL mtr.add_suppression("Event 3 Write_rows_v1 apply failed: .*, seqno");
 
 --connection node_3
 CALL mtr.add_suppression("Vote 0 \\(success\\) on (.*) is inconsistent with group. Leaving cluster.");
 CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc


### PR DESCRIPTION
Fix the broken Galera MTR test `galera_3nodes.galera_vote_majority_dml`
by restoring the value of the AUTO_INCREMENT_OFFSET at the end of the
test.
