### PR TITLE
MDEV-39861 innodb_log_recovery_target wrongly opens log in read-write mode

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3768,7 +3768,8 @@ bool log_t::archived_switch_recovery_prepare(lsn_t lsn) noexcept
   static_assert(int{READ_WRITE} == 0, "");
   static_assert(int{READ_ONLY} == 1, "");
   resize_log.m_file= os_file_create_func(fn, OS_FILE_OPEN, OS_LOG_FILE,
-                                         int{i->second.access} > 0, &success);
+                                         int{i->second.access > 0} ||
+                                         recv_sys.rpo, &success);
   ut_ad(success == (resize_log.m_file != OS_FILE_CLOSED));
   if (resize_log.m_file == OS_FILE_CLOSED)
   {


### PR DESCRIPTION
`log_t::archived_switch_recovery_prepare()`: Observe `recv_sys.rpo` similar to what `recv_sys_t::find_checkpoint()` does.

This is based on b98be034347bc81c7fcf2b4622c2ce05dd5be4f4 from #4817 which fixed an intermittent failure of the test `backup.backup_innodb` on Microsoft Windows.