### PR TITLE
MDEV-39870: macOSB Build Warning on Typecast

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3289,7 +3289,16 @@ public:
       void reset(THD *thd)
       {
         tv_sec= thd->query_start();
-        tv_usec= (long) thd->query_start_sec_part();
+
+        /*
+          The type of tv_usec depends on the system and on macOS
+          it is __darwin_suseconds_t.  Using decltype is system
+          agnostic because its result is whatever the underlying
+          type of tv_usec is.  This should be more portable than
+          assuming that the left hand side is (long) (the previous
+          cast value).
+         */
+        tv_usec= static_cast<decltype(tv_usec)>(thd->query_start_sec_part());
       }
     } start_time;
 


### PR DESCRIPTION
On THD::reset, typecast the result of query_start_sec_part() to tv_usec in a more portable way.  Previously, we assumed that the left hand side was always long-compatible but that isn't the case on mac.