### PR TITLE
MDEV-37214: CREATE OR REPLACE USER must not drop user if auth plugin is not loaded

### DIFF
--- a/mysql-test/main/create_drop_role.result
+++ b/mysql-test/main/create_drop_role.result
@@ -85,4 +85,5 @@ GRANT r TO foo;
 CREATE OR REPLACE USER foo IDENTIFIED WITH non_existing_plugin;
 ERROR HY000: Plugin 'non_existing_plugin' is not loaded
 DROP ROLE r;
+DROP USER foo;
 DROP USER bar;

--- a/mysql-test/main/create_drop_role.test
+++ b/mysql-test/main/create_drop_role.test
@@ -65,4 +65,5 @@ GRANT r TO foo;
 --error ER_PLUGIN_IS_NOT_LOADED
 CREATE OR REPLACE USER foo IDENTIFIED WITH non_existing_plugin;
 DROP ROLE r;
+DROP USER foo;
 DROP USER bar;

--- a/mysql-test/main/create_drop_user.result
+++ b/mysql-test/main/create_drop_user.result
@@ -41,3 +41,66 @@ Warnings:
 Note	1974	Can't drop user 'u1'@'%'; it doesn't exist
 DROP USER u2;
 ERROR HY000: Operation DROP USER failed for 'u2'@'%'
+CREATE USER u3@localhost;
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+ERROR HY000: Plugin 'no_such_plugin' is not loaded
+SELECT User FROM mysql.user WHERE user='u3';
+User
+u3
+DROP USER u3@localhost;
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT SELECT ON test.* TO u3@localhost;
+CREATE TABLE test.t1 (id INT);
+GRANT SELECT ON test.t1 TO u3@localhost;
+SELECT user,db FROM mysql.db WHERE user='u3';
+user	db
+u3	test
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+db	table_name
+test	t1
+CREATE OR REPLACE USER u3@localhost IDENTIFIED BY 'pw2';
+SELECT plugin,authentication_string FROM mysql.user WHERE user='u3';
+plugin	authentication_string
+mysql_native_password	*B27918D2D9402882CEADA0EF687D35FBDC137D72
+SELECT user,db FROM mysql.db WHERE user='u3';
+user	db
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+db	table_name
+DROP TABLE test.t1;
+DROP USER u3@localhost;
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+SELECT password_expired FROM mysql.user WHERE user='u3';
+password_expired
+N
+CREATE OR REPLACE USER u3@localhost;
+SELECT password_expired FROM mysql.user WHERE user='u3';
+password_expired
+N
+DROP USER u3@localhost;
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT SELECT ON test.* TO u3@localhost;
+CREATE TABLE test.t1 (id INT);
+GRANT SELECT ON test.t1 TO u3@localhost;
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+ERROR HY000: Plugin 'no_such_plugin' is not loaded
+SELECT User FROM mysql.user WHERE user='u3';
+User
+u3
+SELECT user,db FROM mysql.db WHERE user='u3';
+user	db
+u3	test
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+db	table_name
+test	t1
+DROP TABLE test.t1;
+DROP USER u3@localhost;
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT RELOAD ON *.* TO u3@localhost;
+SHOW GRANTS FOR u3@localhost;
+Grants for u3@localhost
+GRANT RELOAD ON *.* TO `u3`@`localhost` IDENTIFIED BY PASSWORD '*2B602296A79E0A8784ACC5C88D92E46588CCA3C3'
+CREATE OR REPLACE USER u3@localhost IDENTIFIED BY 'pw2';
+SHOW GRANTS FOR u3@localhost;
+Grants for u3@localhost
+GRANT USAGE ON *.* TO `u3`@`localhost` IDENTIFIED BY PASSWORD '*B27918D2D9402882CEADA0EF687D35FBDC137D72'
+DROP USER u3@localhost;

--- a/mysql-test/main/create_drop_user.test
+++ b/mysql-test/main/create_drop_user.test
@@ -44,3 +44,64 @@ DROP USER IF EXISTS u1, u2;
 
 --error ER_CANNOT_USER
 DROP USER u2;
+
+# MDEV-37214: CREATE OR REPLACE USER with invalid plugin must not drop
+# the existing user and must not leave master/replica in diverged state.
+CREATE USER u3@localhost;
+--error ER_PLUGIN_IS_NOT_LOADED
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+SELECT User FROM mysql.user WHERE user='u3';
+DROP USER u3@localhost;
+
+# MDEV-37214: CREATE OR REPLACE USER must wipe old privileges from other
+# grant tables (mysql.db, mysql.tables_priv, etc.) before updating mysql.user.
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT SELECT ON test.* TO u3@localhost;
+CREATE TABLE test.t1 (id INT);
+GRANT SELECT ON test.t1 TO u3@localhost;
+SELECT user,db FROM mysql.db WHERE user='u3';
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+CREATE OR REPLACE USER u3@localhost IDENTIFIED BY 'pw2';
+SELECT plugin,authentication_string FROM mysql.user WHERE user='u3';
+SELECT user,db FROM mysql.db WHERE user='u3';
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+DROP TABLE test.t1;
+DROP USER u3@localhost;
+
+# MDEV-37214 follow-up: CREATE OR REPLACE USER with no IDENTIFIED clause must
+# not lose/expire the existing password_last_changed. Since the OR REPLACE
+# path now UPDATEs the existing mysql.user/global_priv row in place (instead
+# of DROP+recreate), password_last_changed must be explicitly carried over
+# when auth isn't being changed, otherwise a restored/replaced account can
+# read back with password_last_changed unset, which is indistinguishable
+# from "manually expired".
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+SELECT password_expired FROM mysql.user WHERE user='u3';
+CREATE OR REPLACE USER u3@localhost;
+SELECT password_expired FROM mysql.user WHERE user='u3';
+DROP USER u3@localhost;
+
+# Failed OR REPLACE must not touch privileges either (all-or-nothing per account).
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT SELECT ON test.* TO u3@localhost;
+CREATE TABLE test.t1 (id INT);
+GRANT SELECT ON test.t1 TO u3@localhost;
+--error ER_PLUGIN_IS_NOT_LOADED
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+SELECT User FROM mysql.user WHERE user='u3';
+SELECT user,db FROM mysql.db WHERE user='u3';
+SELECT db,table_name FROM mysql.tables_priv WHERE user='u3';
+DROP TABLE test.t1;
+DROP USER u3@localhost;
+
+# MDEV-37214 follow-up: CREATE OR REPLACE USER must not let the replaced
+# account keep its old GLOBAL privileges. Since OR REPLACE now UPDATEs the
+# existing mysql.global_priv row in place, User_table::set_access()'s additive
+# merge (access |= rights) would otherwise leave old global privilege bits
+# set even though the OR REPLACE statement itself grants nothing.
+CREATE USER u3@localhost IDENTIFIED BY 'pw1';
+GRANT RELOAD ON *.* TO u3@localhost;
+SHOW GRANTS FOR u3@localhost;
+CREATE OR REPLACE USER u3@localhost IDENTIFIED BY 'pw2';
+SHOW GRANTS FOR u3@localhost;
+DROP USER u3@localhost;

--- a/mysql-test/main/mysqldump-system.result
+++ b/mysql-test/main/mysqldump-system.result
@@ -1888,7 +1888,7 @@ DROP USER mariadb_test_restore;
 SELECT * FROM mysql.global_priv ORDER BY User,Host;
 Host	User	Priv
 %	foobar	{"access":0,"version_id":VERSION,"plugin":"test_plugin_server","authentication_string":"plug_dest","password_last_changed":NOW,"default_role":"role_2"}
-localhost	mariadb.sys	{"access":0,"version_id":VERSION,"plugin":"mysql_native_password","authentication_string":"","password_last_changed":NOW,"password_lifetime":-1,"default_role":""}
+localhost	mariadb.sys	{"access":0,"plugin":"mysql_native_password","authentication_string":"","account_locked":false,"password_last_changed":NOW,"version_id":VERSION,"password_lifetime":-1,"default_role":""}
 	role_1	{"access":16384,"version_id":VERSION,"is_role":true}
 	role_2	{"access":0,"version_id":VERSION,"is_role":true}
 localhost	root	{"access":549755813887,"version_id":VERSION,"plugin":"mysql_native_password","authentication_string":"","password_last_changed":NOW,"default_role":""}

--- a/mysql-test/suite/rpl/r/rpl_create_drop_user.result
+++ b/mysql-test/suite/rpl/r/rpl_create_drop_user.result
@@ -63,4 +63,35 @@ Note	1974	Can't drop user 'u3'@'localhost'; it doesn't exist
 connection slave;
 SELECT user,password,plugin,authentication_string FROM mysql.user WHERE user LIKE 'u%' ;
 User	Password	plugin	authentication_string
+connection master;
+CREATE USER u3@localhost IDENTIFIED BY 'abcdefghijk';
+CREATE USER u4@localhost IDENTIFIED BY 'abcdefghijk';
+connection slave;
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+User
+u3
+u4
+connection master;
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+ERROR HY000: Plugin 'no_such_plugin' is not loaded
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin, u4@localhost IDENTIFIED BY 'newpw12345678';
+ERROR HY000: Plugin 'no_such_plugin' is not loaded
+CREATE OR REPLACE USER u4@localhost IDENTIFIED BY 'newpw12345678', u3@localhost IDENTIFIED VIA no_such_plugin;
+ERROR HY000: Plugin 'no_such_plugin' is not loaded
+connection slave;
+include/check_slave_no_error.inc
+connection master;
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+User
+u3
+u4
+connection slave;
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+User
+u3
+u4
+connection master;
+DROP USER u3@localhost;
+DROP USER u4@localhost;
+connection slave;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_create_drop_user.test
+++ b/mysql-test/suite/rpl/t/rpl_create_drop_user.test
@@ -54,4 +54,40 @@ sync_slave_with_master;
 --sorted_result
 SELECT user,password,plugin,authentication_string FROM mysql.user WHERE user LIKE 'u%' ;
 
+# MDEV-37214: failing CREATE OR REPLACE USER must not write to binlog
+# and must not leave master/replica in diverged state.
+connection master;
+CREATE USER u3@localhost IDENTIFIED BY 'abcdefghijk';
+CREATE USER u4@localhost IDENTIFIED BY 'abcdefghijk';
+sync_slave_with_master;
+--sorted_result
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+
+connection master;
+# Single-account: bad plugin -> statement fails, u3 unchanged on both sides
+--error ER_PLUGIN_IS_NOT_LOADED
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin;
+# Multi-account: bad plugin on first account -> u3 fails (unchanged),
+# u4 is recreated (partial success is documented behavior)
+--error ER_PLUGIN_IS_NOT_LOADED
+CREATE OR REPLACE USER u3@localhost IDENTIFIED VIA no_such_plugin, u4@localhost IDENTIFIED BY 'newpw12345678';
+# Multi-account: bad plugin on second account -> u4 is recreated first,
+# then u3 fails (partial success)
+--error ER_PLUGIN_IS_NOT_LOADED
+CREATE OR REPLACE USER u4@localhost IDENTIFIED BY 'newpw12345678', u3@localhost IDENTIFIED VIA no_such_plugin;
+sync_slave_with_master;
+# Verify slave did not stop with a replication error
+--source include/check_slave_no_error.inc
+connection master;
+--sorted_result
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+connection slave;
+--sorted_result
+SELECT user FROM mysql.user WHERE user IN ('u3','u4');
+
+connection master;
+DROP USER u3@localhost;
+DROP USER u4@localhost;
+sync_slave_with_master;
+
 --source include/rpl_end.inc

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -4815,11 +4815,25 @@ static bool test_if_create_new_users(THD *thd)
 ****************************************************************************/
 static USER_AUTH auth_no_password;
 
+static int handle_grant_data(THD *thd, Grant_tables& tables, bool drop,
+                             LEX_USER *user_from, LEX_USER *user_to,
+                             bool skip_user_table= false);
+
 static int replace_user_table(THD *thd, const User_table &user_table,
                               LEX_USER * const combo, privilege_t rights,
                               const bool revoke_grant,
                               const bool can_create_user,
-                              const bool no_auto_create)
+                              const bool no_auto_create,
+                              bool or_replace= false,
+                              Grant_tables *grant_tables= nullptr);
+
+static int replace_user_table(THD *thd, const User_table &user_table,
+                              LEX_USER * const combo, privilege_t rights,
+                              const bool revoke_grant,
+                              const bool can_create_user,
+                              const bool no_auto_create,
+                              bool or_replace,
+                              Grant_tables *grant_tables)
 {
   int error = -1;
   uint nauth= 0;
@@ -4903,6 +4917,16 @@ static int replace_user_table(THD *thd, const User_table &user_table,
     else
       auth->plugin= guess_auth_plugin(thd, auth->auth_str.length);
   }
+
+  /*
+    CREATE OR REPLACE USER now updates the existing mysql.global_priv row
+    in place instead of DROP + fresh INSERT, so set_access()'s additive
+    merge (access |= rights) would otherwise let the replaced account keep
+    its old global privileges. Clear them first so OR REPLACE starts from
+    a clean slate, matching the old DROP + recreate behavior.
+  */
+  if (or_replace && old_row_exists)
+    user_table.set_access(ALL_KNOWN_ACL, true);
 
   /* Update table columns with new privileges */
   user_table.set_access(rights, revoke_grant);
@@ -4994,12 +5018,29 @@ static int replace_user_table(THD *thd, const User_table &user_table,
     if (lex->account_options.account_locked != ACCOUNTLOCK_UNSPECIFIED)
       user_table.set_account_locked(new_acl_user.account_locked);
 
-    if (nauth)
+    if (nauth || (or_replace && old_row_exists))
+      /*
+        Even when OR REPLACE doesn't specify new auth (nauth == 0), the
+        on-disk row is being freshly rewritten from the in-memory
+        new_acl_user (which carries over the old password_last_changed).
+        Persist it explicitly so it isn't lost or read back as the
+        "manually expired" sentinel (0) if it's absent from the row we
+        just read off disk -- see MDEV-37214 follow-up.
+      */
       user_table.set_password_last_changed(new_acl_user.password_last_changed);
     if (lex->account_options.password_expire != PASSWORD_EXPIRE_UNSPECIFIED)
     {
       user_table.set_password_lifetime(new_acl_user.password_lifetime);
       user_table.set_password_expired(new_acl_user.password_expired);
+    }
+  }
+
+  if (or_replace && old_row_exists && grant_tables)
+  {
+    if (handle_grant_data(thd, *grant_tables, true, combo, NULL, true) < 0)
+    {
+      error= -1;
+      goto end;
     }
   }
 
@@ -10955,7 +10996,8 @@ static int handle_grant_struct(enum enum_acl_lists struct_no, bool drop,
 */
 
 static int handle_grant_data(THD *thd, Grant_tables& tables, bool drop,
-                             LEX_USER *user_from, LEX_USER *user_to)
+                             LEX_USER *user_from, LEX_USER *user_to,
+                             bool skip_user_table)
 {
   int result= 0;
   int found;
@@ -11124,20 +11166,23 @@ static int handle_grant_data(THD *thd, Grant_tables& tables, bool drop,
       goto end;
   }
 
-  /* Handle user table. */
-  if ((found= handle_grant_table(thd, tables.user_table(), USER_TABLE,
-                                 drop, user_from, user_to)) < 0)
+  if (!skip_user_table)
   {
-    /* Handle of table failed, don't touch the in-memory array. */
-    result= -1;
-  }
-  else
-  {
-    enum enum_acl_lists what= handle_as_role ? ROLE_ACL : USER_ACL;
-    if (((handle_grant_struct(what, drop, user_from, user_to)) || found) && !result)
+    /* Handle user table. */
+    if ((found= handle_grant_table(thd, tables.user_table(), USER_TABLE,
+                                   drop, user_from, user_to)) < 0)
     {
-      result= 1; /* At least one record/element found. */
-      DBUG_ASSERT(! search_only);
+      /* Handle of table failed, don't touch the in-memory array. */
+      result= -1;
+    }
+    else
+    {
+      enum enum_acl_lists what= handle_as_role ? ROLE_ACL : USER_ACL;
+      if (((handle_grant_struct(what, drop, user_from, user_to)) || found) && !result)
+      {
+        result= 1; /* At least one record/element found. */
+        DBUG_ASSERT(! search_only);
+      }
     }
   }
 
@@ -11219,17 +11264,7 @@ bool mysql_create_user(THD *thd, List <LEX_USER> &list, bool handle_as_role)
     {
       if (thd->lex->create_info.or_replace())
       {
-        // Drop the existing user
-        if (handle_grant_data(thd, tables, 1, user_name, NULL) <= 0)
-        {
-          // DROP failed
-          append_user(thd, &wrong_users, user_name);
-          result= true;
-          continue;
-        }
-        else
-          some_users_dropped= true;
-        // Proceed with the creation
+        some_users_dropped= true;
       }
       else if (thd->lex->create_info.if_not_exists())
       {
@@ -11256,7 +11291,8 @@ bool mysql_create_user(THD *thd, List <LEX_USER> &list, bool handle_as_role)
     }
 
     if (replace_user_table(thd, tables.user_table(), user_name,
-                           NO_ACL, 0, 1, 0))
+                           NO_ACL, 0, 1, 0,
+                           thd->lex->create_info.or_replace(), &tables))
     {
       append_user(thd, &wrong_users, user_name);
       result= TRUE;
@@ -11296,6 +11332,18 @@ bool mysql_create_user(THD *thd, List <LEX_USER> &list, bool handle_as_role)
                                  &thd->lex->definer->host,
                                  &user_name->user, true, NULL, false);
     }
+  }
+
+  if (handle_as_role && some_users_dropped)
+  {
+    /*
+      CREATE OR REPLACE ROLE re-adds a creator-admin role mapping onto a role
+      whose old mapping entries were only removed from roles_mappings_hash
+      (see the delayed drop in replace_user_table()), not from the
+      ACL_ROLE/ACL_USER_BASE cross-reference arrays. Rebuild those arrays now
+      so no stale/duplicate entries survive to crash a later DROP ROLE.
+    */
+    rebuild_role_grants();
   }
 
   if (result && some_users_dropped && !handle_as_role)


### PR DESCRIPTION
validated the plugin in "CREATE OR REPLACE UESR" before dropping the user. 