### PR TITLE
MDEV-39925: Fix error reporting in create_libaio

### DIFF
--- a/tpool/aio_libaio.cc
+++ b/tpool/aio_libaio.cc
@@ -198,8 +198,8 @@ aio *create_libaio(thread_pool *pool, int max_io)
   memset(&ctx, 0, sizeof ctx);
   if (int ret= io_setup(max_io, &ctx))
   {
-    fprintf(stderr, "Warning: io_setup(%d) returned %s. See man 2 io_setup.\n",
-            max_io, strerror(ret));
+    fprintf(stderr, "Warning: io_setup(%d) returned %s (errno: %d). See man 3 io_setup.\n",
+            max_io, strerror(-ret), -ret);
     return nullptr;
   }
   return new aio_libaio(ctx, pool);


### PR DESCRIPTION
The io_setup function in libaio returns a negated errno value on error,
but strerror expects a normal errno value.
