### PR TITLE
MDEV-39911:  Crash in ST_SIMPLIFY of a collection geometry

### DIFF
--- a/mysql-test/main/spatial_utility_function_simplify.result
+++ b/mysql-test/main/spatial_utility_function_simplify.result
@@ -557,6 +557,26 @@ SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0
 ERROR HY000: Incorrect arguments to st_simplify
 SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0 0,0 0,0 0))'), a));
 ERROR 42S22: Unknown column 'a' in 'SELECT'
+#
+# MDEV-39911 Crash in ST_SIMPLIFY of a collection geometry
+#
+# ST_SIMPLIFY of a collection reserved less space than the WKB header it
+# writes, so the element count overran a small buffer.  CONCAT_WS
+# builds its separator in a ten byte stack buffer and COLUMN_GET builds its
+# column name in an eleven byte stack buffer.  Each query below crashed
+# before the fix.
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTILINESTRING((0 0,5 5,0 10),(0 0,-5 5,0 10))'), 5), 7, 5) IS NOT NULL AS ok;
+ok
+1
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,10 0,15 5,10 10,0 10,-5 5,0 0))'), 0.0001), 7, 5) IS NOT NULL AS ok;
+ok
+1
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTIPOLYGON(((0 0,10 0,15 5,10 10,0 10,-5 5,0 0)))'), 0.0001), 7, 5) IS NOT NULL AS ok;
+ok
+1
+SELECT COLUMN_GET(COLUMN_CREATE('a', 1), ST_SIMPLIFY(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(MULTILINESTRING((0 0,5 5,0 10),(0 0,-5 5,0 10)))'), 5) AS CHAR) IS NULL AS ok;
+ok
+1
 # Clean up
 DROP TABLE gis_geometrycollection;
 #

--- a/mysql-test/main/spatial_utility_function_simplify.test
+++ b/mysql-test/main/spatial_utility_function_simplify.test
@@ -497,6 +497,20 @@ SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0
 --error ER_BAD_FIELD_ERROR
 SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0 0,0 0,0 0))'), a));
 
+--echo #
+--echo # MDEV-39911 Crash in ST_SIMPLIFY of a collection geometry
+--echo #
+
+--echo # ST_SIMPLIFY of a collection reserved less space than the WKB header it
+--echo # writes, so the element count overran a small buffer.  CONCAT_WS
+--echo # builds its separator in a ten byte stack buffer and COLUMN_GET builds its
+--echo # column name in an eleven byte stack buffer.  Each query below crashed
+--echo # before the fix.
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTILINESTRING((0 0,5 5,0 10),(0 0,-5 5,0 10))'), 5), 7, 5) IS NOT NULL AS ok;
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,10 0,15 5,10 10,0 10,-5 5,0 0))'), 0.0001), 7, 5) IS NOT NULL AS ok;
+SELECT CONCAT_WS(ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTIPOLYGON(((0 0,10 0,15 5,10 10,0 10,-5 5,0 0)))'), 0.0001), 7, 5) IS NOT NULL AS ok;
+SELECT COLUMN_GET(COLUMN_CREATE('a', 1), ST_SIMPLIFY(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(MULTILINESTRING((0 0,5 5,0 10),(0 0,-5 5,0 10)))'), 5) AS CHAR) IS NULL AS ok;
+
 --echo # Clean up
 DROP TABLE gis_geometrycollection;
 

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -2395,7 +2395,9 @@ int Gis_polygon::simplify(String *result, double max_distance) const
     return 1;
 
   result->length(0);
-  result->reserve(SRID_SIZE + WKB_HEADER_SIZE);
+  // Reserve room for the SRID, byte order, type, and ring count.
+  if (result->reserve(SRID_SIZE + WKB_HEADER_SIZE + sizeof(uint32)))
+    return 1;
   result->q_append(SRID_PLACEHOLDER);
   result->q_append((char) wkb_ndr);
   result->q_append((uint32) wkb_polygon);
@@ -3500,7 +3502,9 @@ int Gis_multi_line_string::simplify(String *result, double max_distance) const
     return 1;
 
   result->length(0);
-  result->reserve(SRID_SIZE + WKB_HEADER_SIZE);
+  // Reserve room for the SRID, byte order, type, and line count.
+  if (result->reserve(SRID_SIZE + WKB_HEADER_SIZE + sizeof(uint32)))
+    return 1;
   result->q_append(SRID_PLACEHOLDER);
   result->q_append((char) wkb_ndr);
   result->q_append((uint32) wkb_multilinestring);
@@ -4107,7 +4111,9 @@ int Gis_multi_polygon::simplify(String *result, double max_distance) const
     return 1;
 
   result->length(0);
-  result->reserve(SRID_SIZE + WKB_HEADER_SIZE);
+  // Reserve room for the SRID, byte order, type, and polygon count.
+  if (result->reserve(SRID_SIZE + WKB_HEADER_SIZE + sizeof(uint32)))
+    return 1;
   result->q_append(SRID_PLACEHOLDER);
   result->q_append((char) wkb_ndr);
   result->q_append((uint32) wkb_multipolygon);
@@ -4702,7 +4708,9 @@ int Gis_geometry_collection::simplify(String *result,
     return 1;
 
   result->length(0);
-  result->reserve(SRID_SIZE + BYTE_ORDER_SIZE + WKB_HEADER_SIZE);
+  // Reserve room for the SRID, byte order, type, and geometry count.
+  if (result->reserve(SRID_SIZE + WKB_HEADER_SIZE + sizeof(uint32)))
+    return 1;
   result->q_append(SRID_PLACEHOLDER);
   result->q_append((char) wkb_ndr);
   result->q_append((uint32) wkb_geometrycollection);


### PR DESCRIPTION
ST_SIMPLIFY of a multilinestring, polygon, multipolygon, or geometry collection reserved space for the result header but omitted the four byte element count that it then appends.  This resulted in a buffer overrun.

Reserve the full header size, including the count, in each of the four collection simplify functions, the same fix applied for MDEV-35062 and MDEV-36042.