### PR TITLE
chore: TPC-H automation and packaging section update in README.

### DIFF
--- a/storage/duckdb/README.md
+++ b/storage/duckdb/README.md
@@ -10,14 +10,38 @@ Create a table with `ENGINE=DuckDB` and analytical queries against it are execut
 - **Ad-hoc analytical queries** — complex joins, aggregations, subqueries, and window functions over large datasets without exporting data to a separate system.
 - **Eliminating ETL complexity** — no need for a dedicated analytical cluster or data movement pipelines; the analytical engine runs in-process.
 
+## Roadmap
+
+- **Analytical GIS** — deliver geospatial analytics via DuckDB's Spatial extension.
+- **Faster HTAP over InnoDB-only data** — run queries against InnoDB-only data through DuckDB's vectorized execution.
+- **Partial query pushdown** — implement a derived handler to push parts of complex queries down into DuckDB.
+- **Data lake access** — reach data lake protocols and formats via DuckDB extensions.
+
 ## Performance
 
-TPC-H Scale Factor 10 (~10 GB raw data, ~60M rows in `lineitem`):
+TPC-H Scale Factor 10 (~11 GB raw data, 86.6M rows total, ~60M in `lineitem`).
+
+**Hardware / environment:** Intel Core i7-13700H (14 cores / 20 threads), 64 GB RAM, NVMe SSD (ext4). MariaDB 11.4.13 with embedded DuckDB v1.5.2, `duckdb_memory_limit=8 GiB`, `threads=20`. Warm runs; numbers stable to ~±15%.
 
 | Metric | Result |
 |---|---|
-| Data loading | 250 seconds |
-| All 22 TPC-H queries | **3.7 seconds** total |
+| Data loading (in-engine `COPY`) | 33 seconds |
+| All 22 TPC-H queries | **4.30 seconds** total |
+
+### Per-query latency (seconds, warm)
+
+| Query | Time | Query | Time | Query | Time |
+|---|---:|---|---:|---|---:|
+| q01 | 0.253 | q09 | 0.337 | q17 | 0.116 |
+| q02 | 0.076 | q10 | 0.253 | q18 | 0.318 |
+| q03 | 0.134 | q11 | 0.049 | q19 | 0.207 |
+| q04 | 0.135 | q12 | 0.152 | q20 | 0.166 |
+| q05 | 0.142 | q13 | 0.606 | q21 | 0.486 |
+| q06 | 0.070 | q14 | 0.128 | q22 | 0.113 |
+| q07 | 0.133 | q15 | 0.101 | **Total** | **4.30** |
+| q08 | 0.145 | q16 | 0.178 | | |
+
+Each query also pays a small fixed cost (~40 ms) for client connect and pushdown setup — noticeable on the cheapest queries, negligible on the heavy analytical ones. See [`docs/tpch_sf10_query_benchmark.md`](docs/tpch_sf10_query_benchmark.md) and [`docs/tpch_sf10_ingestion_benchmark.md`](docs/tpch_sf10_ingestion_benchmark.md) for full methodology.
 
 ## How It Works
 

--- a/storage/duckdb/README.md
+++ b/storage/duckdb/README.md
@@ -33,37 +33,44 @@ Tables created with `ENGINE=DuckDB` store data in DuckDB's native format. Querie
 
 The engine is built as part of the MariaDB server tree. It lives under `storage/duckdb/` and uses `ExternalProject_Add` to build DuckDB v1.5.2 from source.
 
-Until the patch is accepted into MariaDB upstream, clone one of the prepared branches from the server fork and then clone the plugin:
+Clone the branch matching your target MariaDB version. The engine is already part of the tree under `storage/duckdb/`:
 
 ```bash
 # Pick the branch matching your target MariaDB version
-git clone -b bb-11.4-duckdb https://github.com/drrtuy/mdb-server.git mariadb-server
-# or: -b 11.8-duckdb
-# or: -b 12.3-duckdb
+git clone --recurse-submodules -b 11.4 https://github.com/MariaDB/server.git mariadb-server
+# or: -b 11.8
+# or: -b 12.3
 cd mariadb-server
 
-# Clone the DuckDB engine plugin
-git clone --recurse-submodules https://github.com/MariaDB/duckdb-engine storage/duckdb/duckdb
-
 # Install build dependencies (requires root)
-./storage/duckdb/duckdb/build.sh -D
+./storage/duckdb/build.sh -D
 
 # Build and install
-./storage/duckdb/duckdb/build.sh
+./storage/duckdb/build.sh
+```
+
+### Build dependencies
+
+Before building packages, install the build dependencies. This is a one-time setup that installs the system packages and toolchain required to compile the server and the DuckDB engine (requires root):
+
+```bash
+./storage/duckdb/build.sh -D
 ```
 
 ### Build packages
 
+With the dependencies installed, build a distributable package for your platform.
+
 **RPM** (Rocky/Fedora/Amazon Linux):
 
 ```bash
-./storage/duckdb/duckdb/build.sh -p
+./storage/duckdb/build.sh -p
 ```
 
 **DEB** (Debian/Ubuntu):
 
 ```bash
-./storage/duckdb/duckdb/build.sh -p
+./storage/duckdb/build.sh -p
 ```
 
 ## Cross-Engine Queries

--- a/storage/duckdb/build.sh
+++ b/storage/duckdb/build.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 SCRIPT_LOCATION=$(dirname "$0")
 source "$SCRIPT_LOCATION/utils.sh"
-MDB_SOURCE_PATH=$(realpath "$SCRIPT_LOCATION"/../../../)
+MDB_SOURCE_PATH=$(realpath "$SCRIPT_LOCATION"/../../)
 DUCKDB_SOURCE_PATH=$(realpath "$SCRIPT_LOCATION")
 BUILD_PATH=$(realpath "$MDB_SOURCE_PATH"/../DuckdbBuildOf_$(basename "$MDB_SOURCE_PATH"))
 CPUS=$(getconf _NPROCESSORS_ONLN)

--- a/storage/duckdb/docs/disabled-tests-plan.md
+++ b/storage/duckdb/docs/disabled-tests-plan.md
@@ -88,7 +88,7 @@ Error code fixes done: `ER_DUCKDB_TABLE_STRUCT_INVALID` for ALTER structural err
 
 | Test | Problem |
 |------|---------|
-| `duckdb_add_backticks` | UDF `duckdb_query_udf` returns `[Rows: 0]` for digit-name schemas (`09898141`) — DuckDB information_schema can't find them because schema names starting with digits need quoting |
+| `duckdb_add_backticks` | UDF `run_in_duckdb` returns `[Rows: 0]` for digit-name schemas (`09898141`) — DuckDB information_schema can't find them because schema names starting with digits need quoting |
 | `duckdb_appender_allocator_flush_threshold` | `appender_allocator_flush_threshold` setting doesn't exist in upstream DuckDB v1.3.2 (AliSQL fork only). May exist as `allocator_flush_threshold` in DuckDB v1.5.2 |
 | `duckdb_bit_string` | `WHERE col = x'41'` returns empty result — hex/binary literal comparison via pushdown is broken, likely `SELECT_LEX::print()` outputs `x'41'` which DuckDB doesn't understand |
 

--- a/storage/duckdb/docs/ingestion-memory-limits.md
+++ b/storage/duckdb/docs/ingestion-memory-limits.md
@@ -1,0 +1,82 @@
+# Limiting DuckDB RAM During Ingestion
+
+This document records what DuckDB settings exist to constrain memory consumption
+during data ingestion (large `COPY` / `INSERT ... SELECT` loads, e.g. via
+`run_in_duckdb()`), and the one configuration gotcha that most often causes
+apparently unbounded RAM growth.
+
+> **Summary:** DuckDB has **no ingestion-specific memory budget**. The only hard
+> ceiling is the instance-wide `memory_limit` (alias `max_memory`), and it can
+> only be enforced if DuckDB has spill space (a `temp_directory`). Without a temp
+> directory, DuckDB **explicitly cannot limit memory** and will grow unbounded.
+
+## 1. Likely root cause: no spill space
+
+DuckDB can only honor `memory_limit` for memory-intensive operators if it can
+offload to a temporary directory. The temporary-memory manager is explicit:
+
+```@/git/mdb-w-duckdb/storage/duckdb/third_parties/duckdb/src/storage/temporary_memory_manager.cpp:134-136
+	} else if (!has_temporary_directory) {
+		// We cannot offload, so we cannot limit memory usage. Set reservation equal to the remaining size
+		SetReservation(temporary_memory_state, temporary_memory_state.GetRemainingSize());
+```
+
+Consequences:
+
+- If the shared instance has **no `temp_directory`** (or no swap space), the
+  memory limit cannot be enforced during heavy ingestion.
+- `memory_limit` set to `-1` / `none` / `null` means **infinite**
+  (`DBConfig::ParseMemoryLimit`, `config.cpp:633-637`).
+
+## 2. Settings that affect ingestion memory
+
+All are real, in-tree settings (registered in `config.cpp`, defined in
+`settings.hpp`):
+
+- **`write_buffer_row_group_count`** (GLOBAL, default `5`) — the most directly
+  relevant. Its description: *"The amount of row groups to buffer in bulk
+  ingestion prior to flushing them together. Reducing this setting can reduce
+  memory consumption."* (`settings.hpp:1609-1618`). Closest thing to an
+  ingestion-specific RAM control.
+- **`memory_limit` / `max_memory`** (GLOBAL) — the instance-wide ceiling
+  (`MaxMemorySetting`, `custom_settings.cpp:1295-1309`). Enforceable only with
+  spill space (see section 1).
+- **`temp_directory`** + **`max_temp_directory_size`** (GLOBAL) — set these so
+  the limit can be enforced by spilling
+  (`custom_settings.cpp:1314-1358`, `1606-1633`).
+- **`preserve_insertion_order`** (GLOBAL, default `true`) — when `false`, the
+  planner enables parallel/streaming insert and may reorder, reducing buffering.
+  Gated in `PlanInsert` via
+  `parallel_streaming_insert = !PreserveInsertionOrder(...)`
+  (`plan_insert.cpp:102`).
+
+For `COPY ... TO ... (PARTITION_BY ...)` (writing partitioned files):
+
+- **`partitioned_write_flush_threshold`** (default `524288` rows) — flush a
+  thread's partition buffer sooner (`settings.hpp:1257-1266`; used in
+  `physical_copy_to_file.cpp:287,317`).
+- **`partitioned_write_max_open_files`** (default `100`) — fewer simultaneously
+  open files = less buffering (`settings.hpp:1268-1277`).
+
+Not relevant: `streaming_buffer_size` controls only result streaming back to the
+client, not ingestion (`client_config.hpp:82-83`).
+
+## 3. Caveat: single shared instance
+
+These are **GLOBAL** settings on the **single shared DuckDB instance** (the same
+instance `run_in_duckdb()` uses — see `security-model.md`). A `SET GLOBAL ...`
+issued through `run_in_duckdb()` changes behavior for **every** session; there is
+no per-call or per-tenant memory isolation, and a caller can also raise
+`memory_limit` or set it to unlimited.
+
+## References
+
+- `src/storage/temporary_memory_manager.cpp` — memory cannot be limited without
+  a temp directory
+- `src/main/config.cpp`, `src/main/settings/custom_settings.cpp`,
+  `src/include/duckdb/main/settings.hpp` — setting definitions
+- `src/execution/physical_plan/plan_insert.cpp` — insertion-order vs. parallel
+  streaming insert
+- `src/execution/operator/persistent/physical_copy_to_file.cpp` — partitioned
+  write buffering
+- `docs/security-model.md` — shared-instance / `run_in_duckdb()` context

--- a/storage/duckdb/docs/security-model.md
+++ b/storage/duckdb/docs/security-model.md
@@ -1,0 +1,146 @@
+# Security Model: DuckDB and the `run_in_duckdb` Function
+
+This document describes the security characteristics of the embedded DuckDB
+instance used by the engine, the limitations of DuckDB's security model, and
+the security side effects of the `run_in_duckdb()` SQL function. It is intended
+for operators deciding whether and where to enable the engine, especially in
+shared or multi-tenant deployments.
+
+> **Summary:** `run_in_duckdb()` executes arbitrary DuckDB SQL, in-process,
+> as the server OS user, on a single shared DuckDB instance, and is **not**
+> gated by any MariaDB privilege or by DuckDB access control. Treat the ability
+> to call it as equivalent to granting `FILE` plus arbitrary code-adjacent
+> access on the server host. Do not expose it in untrusted or multi-tenant
+> environments.
+
+## 1. DuckDB's security model and its limitations
+
+DuckDB is an *embedded* analytical database. Its threat model assumes the
+embedding application is trusted and is responsible for access control. As a
+result:
+
+- **No users, roles, or object privileges.** DuckDB has no `GRANT`/`REVOKE`
+  system comparable to a server DBMS. There is no per-table, per-column, or
+  per-row authorization inside DuckDB. Any SQL that reaches the DuckDB
+  connection runs with full rights over the whole DuckDB catalog.
+- **Filesystem and network access are SQL-level features.** DuckDB SQL can read
+  and write local files (`COPY ... TO`, `read_csv`, `read_parquet`,
+  `read_text`, `ATTACH`) and — once the relevant extensions are present — reach
+  the network (e.g. `httpfs`). These are normal SQL functions, not privileged
+  operations.
+- **Security is configuration-driven and must be locked.** DuckDB's intended
+  hardening mechanism is instance-creation configuration that is then frozen:
+  `enable_external_access`, `allowed_directories` / `allowed_paths`,
+  `autoinstall_known_extensions`, `autoload_known_extensions`,
+  `allow_community_extensions`, `allow_unsigned_extensions`, and
+  `lock_configuration`. If these are not set (and locked), the full SQL surface
+  is available.
+
+See the upstream guidance: <https://duckdb.org/docs/operations_manual/securing_duckdb/overview>.
+
+## 2. How `run_in_duckdb()` works
+
+`run_in_duckdb(sql_string)` is registered as a `MariaDB_FUNCTION_PLUGIN`
+alongside the storage engine (`duckdb_udf.cc`, `ha_duckdb.cc`). When called:
+
+1. It takes the single string argument **verbatim** (the only transformation is
+   that backticks are rewritten to double quotes for identifier quoting).
+2. It opens a connection to the **single, server-wide** DuckDB instance
+   (`DuckdbManager::CreateConnection()`), backed by `duckdb.db` in the data
+   directory.
+3. It executes the string with `connection.Query()` and returns the rendered
+   result (or the DuckDB error text) as a binary string.
+
+Two properties matter for security:
+
+- **No privilege check.** The function implementation performs no authorization
+  check of any kind. There is no dedicated MariaDB privilege for it; any account
+  that can evaluate a `SELECT` expression can call it.
+- **No schema scoping.** Unlike normal engine query paths, the function does
+  **not** call `config_duckdb_env()`/`config_duckdb_session()`, so the statement
+  is not confined to the caller's current database — it runs against the entire
+  shared DuckDB catalog.
+
+## 3. Current instance configuration
+
+The shared instance is created in `DuckdbManager::Initialize()` with
+performance-oriented settings (memory limit, threads, temp directory,
+checkpoint threshold). Relevant to security:
+
+- `enable_external_access` is **left at its default (enabled)** — filesystem
+  access is permitted.
+- `autoload_known_extensions=true` and `autoinstall_known_extensions=true` are
+  **explicitly enabled**, so known extensions can be fetched and loaded on
+  demand.
+- No `allowed_directories`, `allow_community_extensions=false`, or
+  `lock_configuration` restrictions are applied.
+
+These are reasonable defaults for a single-tenant analytical box, but they leave
+the DuckDB SQL surface fully open to anyone who can reach it via
+`run_in_duckdb()`.
+
+## 4. Security side effects of `run_in_duckdb()`
+
+Because the function runs arbitrary DuckDB SQL, in-process, as the server OS
+user, on the shared instance, a caller can:
+
+- **Bypass the MariaDB privilege system.** Reads and writes to any
+  `ENGINE=DuckDB` table (and the whole DuckDB catalog) are possible regardless
+  of MariaDB table/column/row grants, because authorization is checked by
+  MariaDB only for normal statements — not for SQL executed inside DuckDB.
+- **Read arbitrary local files** the server process can access
+  (e.g. `SELECT * FROM read_text('/etc/passwd')`,
+  `read_csv(...)`), enabling data exfiltration.
+- **Write arbitrary local files** as the server user
+  (e.g. `COPY (...) TO '/path/file'`), which can corrupt data, fill disks, or
+  serve as a step toward code execution.
+- **Reach the network** via auto-installable extensions such as `httpfs`,
+  enabling SSRF and exfiltration to remote endpoints.
+- **Attach external databases** (`ATTACH`) and read/modify their contents.
+- **Change global DuckDB settings** on the shared instance (e.g. `SET GLOBAL
+  memory_limit`/`threads`), enabling resource-exhaustion / denial of service
+  that affects all sessions.
+
+Note that MariaDB's usual file-access guards do **not** constrain these paths:
+neither the `FILE` privilege nor `secure_file_priv` is consulted for I/O
+performed inside DuckDB.
+
+## 5. What is *not* enforced
+
+- No dedicated privilege gating `run_in_duckdb()`.
+- No mapping of MariaDB users/grants onto DuckDB objects.
+- No `secure_file_priv` / `FILE`-privilege enforcement for DuckDB file I/O.
+- No restriction on extension install/load or on external (file/network) access.
+- No per-user or per-schema isolation: a single DuckDB instance is shared by the
+  whole server.
+
+## 6. Recommendations
+
+For operators:
+
+- **Do not enable the engine in untrusted or multi-tenant environments** where
+  arbitrary accounts could call `run_in_duckdb()`. Treat the function as a
+  highly privileged, host-level capability.
+- **Restrict who can connect** and limit accounts to trusted operators when the
+  engine is loaded. Because no per-function privilege exists, access control
+  must be applied at the connection/account level.
+- **Run the server as a least-privileged OS user** and confine it (containers,
+  systemd sandboxing, restrictive filesystem permissions), since DuckDB file I/O
+  inherits the server process's rights.
+- **Isolate the data directory** so that files reachable by the server user do
+  not include secrets unrelated to the database.
+
+Potential engine hardening (not currently implemented; out of scope for this
+document but worth tracking): applying and locking DuckDB security
+configuration at instance creation — `enable_external_access=false`,
+disabling extension autoinstall/autoload, `allow_community_extensions=false`,
+`allowed_directories`, and `lock_configuration=true` — and/or gating
+`run_in_duckdb()` behind a dedicated privilege.
+
+## References
+
+- DuckDB — Securing DuckDB:
+  <https://duckdb.org/docs/operations_manual/securing_duckdb/overview>
+- `duckdb_udf.cc` — `run_in_duckdb()` implementation
+- `runtime/duckdb_manager.cc` — shared instance configuration
+- `runtime/duckdb_query.cc` — query execution path

--- a/storage/duckdb/docs/tpch_sf10_ingestion_benchmark.md
+++ b/storage/duckdb/docs/tpch_sf10_ingestion_benchmark.md
@@ -1,0 +1,113 @@
+# TPC-H SF10 Ingestion Benchmark — DuckDB vs MariaDB DuckDB Engine
+
+Comparison of loading the **same** TPC-H SF10 CSV dataset (~11 GB, 86.6M rows)
+into DuckDB through three different paths.
+
+## Hardware
+
+| Component | Value |
+|---|---|
+| CPU | 13th Gen Intel Core i7-13700H (14 cores: 6 P + 8 E, 20 threads) |
+| Architecture | x86_64 |
+| Logical CPUs | 20 (matches DuckDB's `threads=20`) |
+| RAM | 64 GB (65,501,828 kB total) |
+| Storage | NVMe SSD (`/dev/nvme0n1p2`), ext4, 833 GB volume |
+| Data location | `/git` (same NVMe volume) |
+
+## Environment
+
+| Component | Value |
+|---|---|
+| Data | TPC-H SF10, CSV, header row, `"`-quoted text fields |
+| Generator | `tpchgen-cli` v2.0.2 (Apache DataFusion `tpchgen-rs`, pure Rust) |
+| DuckDB | v1.5.2 (Variegata), CLI binary at `/duckdb` |
+| MariaDB | 11.4.13, embedded DuckDB engine (`ENGINE=DUCKDB`) |
+| DuckDB threads | 20 |
+| DuckDB `memory_limit` | 1.0 GiB (embedded default) / 8 GB (tuned) / ~80% RAM (standalone CLI) |
+| Data dir | `/git/tpch/` |
+
+## Row counts (all paths, verified)
+
+| Table | Rows |
+|---|---:|
+| lineitem | 59,986,052 |
+| orders | 15,000,000 |
+| partsupp | 8,000,000 |
+| part | 2,000,000 |
+| customer | 1,500,000 |
+| supplier | 100,000 |
+| nation | 25 |
+| region | 5 |
+| **TOTAL** | **86,586,082** |
+
+## Methods
+
+1. **Standalone CLI** — `/duckdb tpch_sf10.duckdb < ingest_sf10.sql`; native parallel
+   `COPY ... FROM '*.csv'` into a persistent DB file. Script: `ingest_sf10.sql`.
+2. **In-engine COPY** — `SELECT run_in_duckdb('COPY ... FROM ...')` runs DuckDB's
+   native CSV reader *inside* the MariaDB server process. Script: `bench_duckdb_engine.sh`.
+3. **LOAD DATA LOCAL INFILE** — standard MariaDB client path into `ENGINE=DUCKDB`
+   tables. Script: `load_data_infile.sh`.
+
+## Results — per-table wall-clock (seconds)
+
+| Table | Rows | Standalone CLI | In-engine COPY (8 GB) | LOAD DATA LOCAL INFILE |
+|---|---:|---:|---:|---:|
+| lineitem | 59,986,052 | 16.88 | 12.66 | 299.02 |
+| orders | 15,000,000 | 8.62 | 9.70 | 55.63 |
+| partsupp | 8,000,000 | 6.82 | 5.26 | 28.51 |
+| part | 2,000,000 | 2.62 | 2.70 | 8.54 |
+| customer | 1,500,000 | 2.85 | 2.16 | 7.73 |
+| supplier | 100,000 | 0.15 | 0.13 | 0.43 |
+| nation | 25 | 0.004 | 0.04 | 0.05 |
+| region | 5 | 0.006 | 0.04 | 0.05 |
+| **TOTAL** | **86,586,082** | **38.4** | **32.69** | **~400 (6.7 min)** |
+
+> In-engine COPY numbers use the tuned `memory_limit=8GB` (warm page cache). The 1 GiB
+> default totals 52.0 s (see sub-table). Run-to-run variance is non-trivial for `lineitem`
+> (measured 12.7–19.5 s at 8 GB across runs).
+
+### `memory_limit` effect on `lineitem` (in-engine COPY)
+
+| `memory_limit` | lineitem load | vs standalone (16.88 s) |
+|---|---:|---:|
+| 1.0 GiB (default) | 34.37 s | 2.0× slower |
+| 8 GB (tuned) | 12.7–19.5 s | ~0.75–1.16× |
+
+## Observations
+
+- **COPY is the fast path.** DuckDB's native CSV reader parses the file directly with
+  all 20 threads (vectorized, parallel). This holds whether run from the standalone CLI
+  or in-process via `run_in_duckdb`.
+
+- **The embedded `memory_limit=1.0 GiB` is the main in-engine COPY bottleneck.** Verified,
+  not assumed: raising it to 8 GB cut `lineitem` from 34.4 s to ~12.7 s (full re-run) — on
+  par with or faster than the standalone CLI's 16.9 s. At 8 GB the whole in-engine load
+  (32.7 s) even edges out the standalone CLI (38.4 s) under a warm cache. The cap mainly
+  hurts the largest table; smaller tables are unaffected and a couple are marginally faster
+  in-engine. `memory_limit` set via `run_in_duckdb` is instance-level and persists
+  across connections.
+
+- **`LOAD DATA LOCAL INFILE` is ~12× slower than in-engine COPY** (totals: ~400 s vs 32.7 s;
+  `lineitem`: 299 s vs 12.7 s ≈ 24×). This is a **structural code-path difference**, not a
+  tuning issue: `LOAD DATA` routes every row through MariaDB's SQL/handler layer
+  (`handler::write_row` → engine append), serializing what COPY does in parallel, and
+  bypassing DuckDB's vectorized CSV parser entirely.
+
+- **DuckDB-engine table requirements (discovered):** the engine **rejects non-UTF8
+  charsets** and **requires a PRIMARY KEY**. TPC-H natural keys were used
+  (`partsupp` and `lineitem` get composite PKs). Per-row PK index maintenance adds
+  further overhead to the `LOAD DATA` path.
+
+- **CSV quoting matters.** tpchgen emits `"`-quoted text fields because comments contain
+  commas; `LOAD DATA` needs `OPTIONALLY ENCLOSED BY '"'` and `IGNORE 1 LINES` for the header.
+
+- **Binary logging:** the server already ran with `@@log_bin = 0`; `SET SESSION
+  sql_log_bin=0` was also issued, so binlog overhead is excluded from all `LOAD DATA` numbers.
+
+## Recommendation
+
+For bulk-loading external files into the MariaDB DuckDB engine, prefer the **in-engine
+`COPY` via `run_in_duckdb`** over `LOAD DATA LOCAL INFILE`, and raise the embedded
+DuckDB `memory_limit` for large tables. Reserve `LOAD DATA` for cases where data must
+flow through the standard MariaDB SQL path.

--- a/storage/duckdb/docs/tpch_sf10_query_benchmark.md
+++ b/storage/duckdb/docs/tpch_sf10_query_benchmark.md
@@ -1,0 +1,71 @@
+# TPC-H SF10 Query Latency — native DuckDB vs MariaDB DuckDB engine
+
+Per-query latency for the 22 TPC-H queries over the same SF10 dataset (86.6M rows),
+comparing the standalone DuckDB CLI against the MariaDB DuckDB storage engine.
+
+## Hardware
+
+| Component | Value |
+|---|---|
+| CPU | 13th Gen Intel Core i7-13700H (14 cores: 6 P + 8 E, 20 threads) |
+| Architecture | x86_64 |
+| Logical CPUs | 20 (matches DuckDB's `threads=20`) |
+| RAM | 64 GB (65,501,828 kB total) |
+| Storage | NVMe SSD (`/dev/nvme0n1p2`), ext4, 833 GB volume |
+| Data location | `/git` (same NVMe volume) |
+
+## Environment
+
+| Component | Value |
+|---|---|
+| DuckDB | v1.5.2 (Variegata), CLI binary at `/duckdb`, DB file `/git/tpch/tpch_sf10.duckdb` |
+| MariaDB | 11.4.13, embedded DuckDB engine (`ENGINE=DUCKDB`), database `tpch` |
+| `duckdb_memory_limit` | 8 GiB (8589934592), set persistently in `duckdb.cnf` |
+| DuckDB threads | 20 |
+| MariaDB queries | MariaDB-dialect, split from `/tpch.sql` |
+| DuckDB queries | DuckDB-dialect, from the tpch extension `q01..q22` |
+
+## Methodology
+
+- **DuckDB:** all 22 queries run in **one warm session** with `.timer on`; per-query
+  time = reported `Run Time (s): real`. No per-query process/DB-reopen overhead.
+- **MariaDB:** queries run **sequentially**, one `mariadb` client invocation each;
+  per-query time = wall-clock. Each invocation pays a fixed client-connect +
+  SQL-layer/pushdown-setup cost (~40 ms), measured as part of the number.
+- Single representative run (numbers are stable to ~±15% across repeated runs).
+- Harness: `bench_queries.sh`; raw output: `query_timings.tsv`.
+
+## Results — per-query latency (seconds)
+
+| query | duckdb_s | mariadb_s | | query | duckdb_s | mariadb_s |
+|---|---:|---:|---|---|---:|---:|
+| q01 | 0.219 | 0.253 | | q12 | 0.062 | 0.152 |
+| q02 | 0.058 | 0.076 | | q13 | 0.257 | 0.606 |
+| q03 | 0.100 | 0.134 | | q14 | 0.047 | 0.128 |
+| q04 | 0.149 | 0.135 | | q15 | 0.041 | 0.101 |
+| q05 | 0.098 | 0.142 | | q16 | 0.068 | 0.178 |
+| q06 | 0.024 | 0.070 | | q17 | 0.065 | 0.116 |
+| q07 | 0.063 | 0.133 | | q18 | 0.251 | 0.318 |
+| q08 | 0.097 | 0.145 | | q19 | 0.096 | 0.207 |
+| q09 | 0.274 | 0.337 | | q20 | 0.055 | 0.166 |
+| q10 | 0.210 | 0.253 | | q21 | 0.259 | 0.486 |
+| q11 | 0.013 | 0.049 | | q22 | 0.056 | 0.113 |
+| | | | | **TOTAL** | **2.562** | **4.298** |
+
+## Observations
+
+- **Native DuckDB is faster on every query** once both are measured warm. Total
+  2.56 s vs 4.30 s (~1.7× over the 22-query set).
+- **A ~40 ms fixed floor dominates the cheap queries on MariaDB** (q06 0.024 vs 0.070,
+  q11 0.013 vs 0.049, q15 0.041 vs 0.101). This floor is the per-invocation `mariadb`
+  client-connect + SQL-layer/pushdown setup — not DuckDB execution. Running MariaDB
+  queries inside a single persistent session would remove most of it.
+- **On heavy queries the gap narrows**, where actual DuckDB execution dominates and the
+  fixed overhead matters less (q09 1.23×, q18 1.27×, q01 1.16×).
+- **q13 is the widest gap** (0.257 vs 0.606, 2.36×). It uses the MariaDB-rewritten
+  variant (the original DuckDB derived-column-alias syntax `) AS c_orders (c_custkey,
+  c_count)` doesn't parse in MariaDB); the LEFT JOIN + aggregate pushdown carries
+  noticeably more per-query overhead here. Root cause of the extra cost beyond the
+  fixed floor is not fully isolated.
+- **Memory limit (8 GiB vs 1 GiB default) did not affect query latency** at SF10 — these
+  queries are not memory-bound; the setting matters for bulk loads, not these scans.

--- a/storage/duckdb/duckdb.cnf
+++ b/storage/duckdb/duckdb.cnf
@@ -1,3 +1,4 @@
 [mysqld]
+plugin-maturity=alpha
 plugin-load-add=ha_duckdb.so
 #loose-duckdb-memory-limit=1073741824

--- a/storage/duckdb/tpch/01_install.sh
+++ b/storage/duckdb/tpch/01_install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install tpchgen-cli (fast pure-Rust TPC-H data generator).
+# Tries pip, then uv, then cargo. Idempotent.
+set -euo pipefail
+
+if command -v tpchgen-cli >/dev/null 2>&1; then
+  echo "tpchgen-cli already installed: $(tpchgen-cli --version 2>/dev/null || echo present)"
+  exit 0
+fi
+
+echo "Installing tpchgen-cli ..."
+if command -v pip3 >/dev/null 2>&1; then
+  pip3 install --user tpchgen-cli
+elif command -v pip >/dev/null 2>&1; then
+  pip install --user tpchgen-cli
+elif command -v uv >/dev/null 2>&1; then
+  uv tool install tpchgen-cli
+elif command -v cargo >/dev/null 2>&1; then
+  RUSTFLAGS='-C target-cpu=native' cargo install tpchgen-cli
+else
+  echo "ERROR: need one of pip3/pip, uv, or cargo to install tpchgen-cli" >&2
+  exit 1
+fi
+
+command -v tpchgen-cli >/dev/null 2>&1 \
+  || { echo "ERROR: tpchgen-cli not on PATH after install (check ~/.local/bin or ~/.cargo/bin)" >&2; exit 1; }
+echo "Installed: $(tpchgen-cli --version 2>/dev/null || echo present)"

--- a/storage/duckdb/tpch/02_generate.sh
+++ b/storage/duckdb/tpch/02_generate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Generate TPC-H data (.tbl, pipe-delimited) at scale factor $SF into $DATA_DIR.
+# Skips generation if all .tbl files already exist (set FORCE=1 to regenerate).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DIR/config.sh"
+
+command -v tpchgen-cli >/dev/null 2>&1 || { echo "ERROR: run ./01_install.sh first" >&2; exit 1; }
+
+mkdir -p "$DATA_DIR"
+
+missing=0
+for t in "${TABLES[@]}"; do [ -f "$DATA_DIR/$t.tbl" ] || missing=1; done
+if [ "$missing" = 0 ] && [ "${FORCE:-0}" != 1 ]; then
+  echo "All .tbl files already present in $DATA_DIR (set FORCE=1 to regenerate)."
+  exit 0
+fi
+
+echo "Generating TPC-H SF$SF (.tbl) into $DATA_DIR ..."
+tpchgen-cli -s "$SF" --output-dir "$DATA_DIR"
+ls -la "$DATA_DIR"/*.tbl

--- a/storage/duckdb/tpch/03_schema.sh
+++ b/storage/duckdb/tpch/03_schema.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Create schema $SCHEMA and the 8 TPC-H tables inside the embedded DuckDB,
+# via run_in_duckdb. CREATE OR REPLACE makes this idempotent.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DIR/config.sh"
+
+echo "Creating schema '$SCHEMA' and tables ..."
+duck "CREATE SCHEMA IF NOT EXISTS $SCHEMA" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.region   (r_regionkey INTEGER PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.nation   (n_nationkey INTEGER PRIMARY KEY, n_name VARCHAR, n_regionkey INTEGER, n_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.supplier (s_suppkey INTEGER PRIMARY KEY, s_name VARCHAR, s_address VARCHAR, s_nationkey INTEGER, s_phone VARCHAR, s_acctbal DECIMAL(15,2), s_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.customer (c_custkey INTEGER PRIMARY KEY, c_name VARCHAR, c_address VARCHAR, c_nationkey INTEGER, c_phone VARCHAR, c_acctbal DECIMAL(15,2), c_mktsegment VARCHAR, c_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.part     (p_partkey INTEGER PRIMARY KEY, p_name VARCHAR, p_mfgr VARCHAR, p_brand VARCHAR, p_type VARCHAR, p_size INTEGER, p_container VARCHAR, p_retailprice DECIMAL(15,2), p_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.partsupp (ps_partkey INTEGER, ps_suppkey INTEGER, ps_availqty INTEGER, ps_supplycost DECIMAL(15,2), ps_comment VARCHAR, PRIMARY KEY (ps_partkey, ps_suppkey))" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.orders   (o_orderkey BIGINT PRIMARY KEY, o_custkey INTEGER, o_orderstatus VARCHAR, o_totalprice DECIMAL(15,2), o_orderdate DATE, o_orderpriority VARCHAR, o_clerk VARCHAR, o_shippriority INTEGER, o_comment VARCHAR)" >/dev/null
+duck "CREATE OR REPLACE TABLE $SCHEMA.lineitem (l_orderkey BIGINT, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER, l_quantity DECIMAL(15,2), l_extendedprice DECIMAL(15,2), l_discount DECIMAL(15,2), l_tax DECIMAL(15,2), l_returnflag VARCHAR, l_linestatus VARCHAR, l_shipdate DATE, l_commitdate DATE, l_receiptdate DATE, l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR, PRIMARY KEY (l_orderkey, l_linenumber))" >/dev/null
+echo "Schema '$SCHEMA' ready."

--- a/storage/duckdb/tpch/04_load.sh
+++ b/storage/duckdb/tpch/04_load.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Populate $SCHEMA.* with COPY from the generated .tbl files (DuckDB reads the
+# pipe-delimited, header-less, trailing-'|' tbl format with DELIMITER '|').
+# Times each table and prints row counts.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DIR/config.sh"
+
+echo "== COPY load from $DATA_DIR into schema '$SCHEMA' (wall clock incl. client) =="
+total=0
+for t in "${TABLES[@]}"; do
+  f="$DATA_DIR/$t.tbl"
+  [ -f "$f" ] || { echo "ERROR: missing $f (run ./02_generate.sh)" >&2; exit 1; }
+  duck "TRUNCATE $SCHEMA.$t" >/dev/null 2>&1 || true
+  start=$(date +%s.%N)
+  duck "COPY $SCHEMA.$t FROM '$f' (DELIMITER '|')" >/dev/null
+  end=$(date +%s.%N)
+  total=$(awk -v a="$total" -v s="$start" -v e="$end" 'BEGIN{print a+(e-s)}')
+  awk -v s="$start" -v e="$end" -v t="$t" 'BEGIN{printf "%-10s %9.3f s\n", t, e-s}'
+done
+awk -v a="$total" 'BEGIN{printf "%-10s %9.3f s\n", "TOTAL", a}'
+
+echo "== row counts =="
+for t in "${TABLES[@]}"; do
+  printf "%-10s " "$t"
+  duck "SELECT count(*) FROM $SCHEMA.$t" | grep -Eo '^[0-9]+$' | tail -1
+done

--- a/storage/duckdb/tpch/05_run_queries.sh
+++ b/storage/duckdb/tpch/05_run_queries.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run the 22 TPC-H queries from $TPCH_SQL against $SCHEMA via run_in_duckdb,
+# timing each (wall clock, one client invocation). Writes a TSV of timings.
+# Queries get the raw MariaDB-dialect text (no pushdown rewrites): any query
+# using MariaDB-only syntax is reported as ERR.
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DIR/config.sh"
+
+[ -f "$TPCH_SQL" ] || { echo "ERROR: query file $TPCH_SQL not found" >&2; exit 1; }
+OUT="${OUT:-$DIR/query_timings.tsv}"
+
+# Split $TPCH_SQL into per-query files: Q1 is the first block (no marker),
+# each "-- Qn:" marker starts the next query.
+MQ="${TMPDIR:-/tmp}/tpch_mq"
+mkdir -p "$MQ"; rm -f "$MQ"/q*.sql
+awk 'BEGIN{idx=1} /^-- Q[0-9]+:/{idx++} {print > sprintf("'"$MQ"'/q%02d.sql", idx)}' "$TPCH_SQL"
+
+printf "query\ttime_s\n" | tee "$OUT"
+for i in $(seq 1 22); do
+  n=$(printf "%02d" "$i")
+  f="$MQ/q$n.sql"
+  [ -f "$f" ] || continue
+  combined="SET schema '$SCHEMA'; $(cat "$f")"
+  esc=$(printf '%s' "$combined" | sed "s/'/''/g")
+
+  start=$(date +%s.%N)
+  out=$("$MARIADB" -N -e "SELECT run_in_duckdb('$esc')" 2>&1)
+  end=$(date +%s.%N)
+
+  if printf '%s' "$out" | grep -qiE 'error'; then
+    tt="ERR"
+  else
+    tt=$(awk -v s="$start" -v e="$end" 'BEGIN{printf "%.3f", e-s}')
+  fi
+  printf "q%s\t%s\n" "$n" "$tt" | tee -a "$OUT"
+done
+echo "Timings written to $OUT"

--- a/storage/duckdb/tpch/README.md
+++ b/storage/duckdb/tpch/README.md
@@ -1,0 +1,55 @@
+# TPC-H kit — DuckDB storage engine (MariaDB)
+
+Reproducible TPC-H pipeline for the embedded DuckDB engine: install a generator,
+generate data, create the schema, COPY-load it, and run the 22 queries — all
+through MariaDB's `run_in_duckdb`.
+
+## Pipeline
+
+| Step | Script | What it does |
+|---|---|---|
+| 1 | `01_install.sh` | Install `tpchgen-cli` (pip / uv / cargo). |
+| 2 | `02_generate.sh` | Generate `.tbl` data at scale factor `$SF` into `$DATA_DIR`. |
+| 3 | `03_schema.sh` | Create schema `$SCHEMA` + 8 tables in the embedded DuckDB. |
+| 4 | `04_load.sh` | `COPY` each `.tbl` into `$SCHEMA.*`; prints per-table timings + row counts. |
+| 5 | `05_run_queries.sh` | Run the 22 queries from `$TPCH_SQL`; writes `query_timings.tsv`. |
+
+Run everything: `./run_all.sh` (steps are idempotent; generation is skipped if data exists).
+
+## Configuration
+
+All knobs live in `config.sh` and are overridable via environment:
+
+```bash
+SF=1 ./run_all.sh                      # scale factor 1
+DATA_DIR=/data/tpch SF=10 ./run_all.sh # custom data location
+SCHEMA=tpch_bench ./03_schema.sh       # custom DuckDB schema
+```
+
+| Var | Default | Meaning |
+|---|---|---|
+| `SF` | `10` | TPC-H scale factor |
+| `DATA_DIR` | `/git/tpch/sf<SF>` | where `.tbl` files are generated/read |
+| `SCHEMA` | `bench` | DuckDB schema populated via the UDF |
+| `TPCH_SQL` | `/tpch.sql` | source of the 22 (MariaDB-dialect) queries |
+| `MARIADB` | `mariadb` | client command |
+
+## Prerequisites
+
+- A running MariaDB server with the DuckDB engine loaded and the
+  `run_in_duckdb` function available.
+- `pip`, `uv`, or `cargo` to install the generator; `tpchgen-cli` on `PATH`
+  afterwards (pip user installs land in `~/.local/bin`).
+
+## How it works / caveats
+
+- **Generator:** `tpchgen-cli -s <SF> --output-dir <DATA_DIR>` emits classic
+  `.tbl` files (pipe-delimited, no header, trailing `|`). DuckDB loads these with
+  `COPY ... (DELIMITER '|')` — the trailing delimiter is tolerated.
+- **Load target:** data goes into a DuckDB-native schema (`bench`) inside the
+  embedded instance via `run_in_duckdb`, not into `ENGINE=DUCKDB` MariaDB
+  tables (which can't be `COPY`-loaded).
+- **Queries:** taken from `/tpch.sql` (MariaDB dialect) and executed as
+  `SET schema '<SCHEMA>'; <query>` through the UDF. The UDF receives the **raw**
+  text — the engine's dialect rewrites only apply on pushdown, so any
+  MariaDB-only syntax errors out and is reported as `ERR` in the timings.

--- a/storage/duckdb/tpch/config.sh
+++ b/storage/duckdb/tpch/config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared configuration for the TPC-H DuckDB-engine benchmark kit.
+# Override any value via environment, e.g.  SF=1 ./04_load.sh
+#
+#   SF         TPC-H scale factor                         (default 10)
+#   DATA_DIR   where .tbl files are generated/loaded from (default /git/tpch/sf<SF>)
+#   SCHEMA     DuckDB schema populated via run_in_duckdb (default bench)
+#   TPCH_SQL   MariaDB-dialect query file (source of the 22 queries)
+#   MARIADB    mariadb client command
+
+CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SF="${SF:-10}"
+DATA_DIR="${DATA_DIR:-/git/tpch/sf${SF}}"
+SCHEMA="${SCHEMA:-bench}"
+TPCH_SQL="${TPCH_SQL:-$CONFIG_DIR/tpch.sql}"
+MARIADB="${MARIADB:-mariadb}"
+
+TABLES=(region nation supplier customer part partsupp orders lineitem)
+
+# Run one statement on the embedded DuckDB through MariaDB's run_in_duckdb.
+# Single quotes in $1 are escaped so SQL string/identifier literals survive.
+# Prints the UDF result text (callers discard it when not needed).
+duck() {
+  local esc
+  esc=$(printf '%s' "$1" | sed "s/'/''/g")
+  "$MARIADB" -N -e "SELECT run_in_duckdb('$esc')"
+}

--- a/storage/duckdb/tpch/run_all.sh
+++ b/storage/duckdb/tpch/run_all.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# End-to-end: install generator, generate data, create schema, COPY-load, run queries.
+# Each step is idempotent; re-running skips generation when data already exists.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$DIR/01_install.sh"
+"$DIR/02_generate.sh"
+"$DIR/03_schema.sh"
+"$DIR/04_load.sh"
+"$DIR/05_run_queries.sh"

--- a/storage/duckdb/tpch/tpch.sql
+++ b/storage/duckdb/tpch/tpch.sql
@@ -1,0 +1,396 @@
+SELECT
+  l_returnflag,
+  l_linestatus,
+  SUM(l_quantity) AS sum_qty,
+  SUM(l_extendedprice) AS sum_base_price,
+  SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+  SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+  AVG(l_quantity) AS avg_qty,
+  AVG(l_extendedprice) AS avg_price,
+  AVG(l_discount) AS avg_disc,
+  COUNT(*) AS count_order
+FROM lineitem
+WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL 90 DAY
+GROUP BY l_returnflag, l_linestatus
+ORDER BY l_returnflag, l_linestatus;
+
+-- Q2: Minimum Cost Supplier
+SELECT
+  s_acctbal, s_name, n_name, p_partkey, p_mfgr,
+  s_address, s_phone, s_comment
+FROM part, supplier, partsupp, nation, region
+WHERE p_partkey = ps_partkey
+  AND s_suppkey = ps_suppkey
+  AND p_size = 15
+  AND p_type LIKE '%BRASS'
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'EUROPE'
+  AND ps_supplycost = (
+    SELECT MIN(ps_supplycost)
+    FROM partsupp, supplier, nation, region
+    WHERE p_partkey = ps_partkey
+      AND s_suppkey = ps_suppkey
+      AND s_nationkey = n_nationkey
+      AND n_regionkey = r_regionkey
+      AND r_name = 'EUROPE'
+  )
+ORDER BY s_acctbal DESC, n_name, s_name, p_partkey
+LIMIT 100;
+
+-- Q3: Shipping Priority
+SELECT
+  l_orderkey,
+  SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+  o_orderdate,
+  o_shippriority
+FROM customer, orders, lineitem
+WHERE c_mktsegment = 'BUILDING'
+  AND c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate < DATE '1995-03-15'
+  AND l_shipdate > DATE '1995-03-15'
+GROUP BY l_orderkey, o_orderdate, o_shippriority
+ORDER BY revenue DESC, o_orderdate
+LIMIT 10;
+
+-- Q4: Order Priority Checking
+SELECT
+  o_orderpriority,
+  COUNT(*) AS order_count
+FROM orders
+WHERE o_orderdate >= DATE '1993-07-01'
+  AND o_orderdate < DATE '1993-07-01' + INTERVAL 3 MONTH
+  AND EXISTS (
+    SELECT * FROM lineitem
+    WHERE l_orderkey = o_orderkey
+      AND l_commitdate < l_receiptdate
+  )
+GROUP BY o_orderpriority
+ORDER BY o_orderpriority;
+
+-- Q5: Local Supplier Volume
+SELECT
+  n_name,
+  SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM customer, orders, lineitem, supplier, nation, region
+WHERE c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND l_suppkey = s_suppkey
+  AND c_nationkey = s_nationkey
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'ASIA'
+  AND o_orderdate >= DATE '1994-01-01'
+  AND o_orderdate < DATE '1994-01-01' + INTERVAL 1 YEAR
+GROUP BY n_name
+ORDER BY revenue DESC;
+
+-- Q6: Forecasting Revenue Change
+SELECT
+  SUM(l_extendedprice * l_discount) AS revenue
+FROM lineitem
+WHERE l_shipdate >= DATE '1994-01-01'
+  AND l_shipdate < DATE '1994-01-01' + INTERVAL 1 YEAR
+  AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+  AND l_quantity < 24;
+
+-- Q7: Volume Shipping
+SELECT
+  supp_nation, cust_nation, l_year,
+  SUM(volume) AS revenue
+FROM (
+  SELECT
+    n1.n_name AS supp_nation,
+    n2.n_name AS cust_nation,
+    YEAR(l_shipdate) AS l_year,
+    l_extendedprice * (1 - l_discount) AS volume
+  FROM supplier, lineitem, orders, customer, nation n1, nation n2
+  WHERE s_suppkey = l_suppkey
+    AND o_orderkey = l_orderkey
+    AND c_custkey = o_custkey
+    AND s_nationkey = n1.n_nationkey
+    AND c_nationkey = n2.n_nationkey
+    AND ((n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+      OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE'))
+    AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+) AS shipping
+GROUP BY supp_nation, cust_nation, l_year
+ORDER BY supp_nation, cust_nation, l_year;
+
+-- Q8: National Market Share
+SELECT
+  o_year,
+  SUM(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 END) / SUM(volume) AS mkt_share
+FROM (
+  SELECT
+    YEAR(o_orderdate) AS o_year,
+    l_extendedprice * (1 - l_discount) AS volume,
+    n2.n_name AS nation
+  FROM part, supplier, lineitem, orders, customer, nation n1, nation n2, region
+  WHERE p_partkey = l_partkey
+    AND s_suppkey = l_suppkey
+    AND l_orderkey = o_orderkey
+    AND o_custkey = c_custkey
+    AND c_nationkey = n1.n_nationkey
+    AND n1.n_regionkey = r_regionkey
+    AND r_name = 'AMERICA'
+    AND s_nationkey = n2.n_nationkey
+    AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+    AND p_type = 'ECONOMY ANODIZED STEEL'
+) AS all_nations
+GROUP BY o_year
+ORDER BY o_year;
+
+-- Q9: Product Type Profit Measure
+SELECT
+  nation, o_year,
+  SUM(amount) AS sum_profit
+FROM (
+  SELECT
+    n_name AS nation,
+    YEAR(o_orderdate) AS o_year,
+    l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+  FROM part, supplier, lineitem, partsupp, orders, nation
+  WHERE s_suppkey = l_suppkey
+    AND ps_suppkey = l_suppkey
+    AND ps_partkey = l_partkey
+    AND p_partkey = l_partkey
+    AND o_orderkey = l_orderkey
+    AND s_nationkey = n_nationkey
+    AND p_name LIKE '%green%'
+) AS profit
+GROUP BY nation, o_year
+ORDER BY nation, o_year DESC;
+
+-- Q10: Returned Item Reporting
+SELECT
+  c_custkey, c_name,
+  SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+  c_acctbal, n_name, c_address, c_phone, c_comment
+FROM customer, orders, lineitem, nation
+WHERE c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate >= DATE '1993-10-01'
+  AND o_orderdate < DATE '1993-10-01' + INTERVAL 3 MONTH
+  AND l_returnflag = 'R'
+  AND c_nationkey = n_nationkey
+GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment
+ORDER BY revenue DESC
+LIMIT 20;
+
+-- Q11: Important Stock Identification
+SELECT
+  ps_partkey,
+  SUM(ps_supplycost * ps_availqty) AS value
+FROM partsupp, supplier, nation
+WHERE ps_suppkey = s_suppkey
+  AND s_nationkey = n_nationkey
+  AND n_name = 'GERMANY'
+GROUP BY ps_partkey
+HAVING SUM(ps_supplycost * ps_availqty) > (
+  SELECT SUM(ps_supplycost * ps_availqty) * 0.0001
+  FROM partsupp, supplier, nation
+  WHERE ps_suppkey = s_suppkey
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+)
+ORDER BY value DESC;
+
+-- Q12: Shipping Modes and Order Priority
+SELECT
+  l_shipmode,
+  SUM(CASE
+    WHEN o_orderpriority = '1-URGENT' OR o_orderpriority = '2-HIGH'
+    THEN 1 ELSE 0 END) AS high_line_count,
+  SUM(CASE
+    WHEN o_orderpriority <> '1-URGENT' AND o_orderpriority <> '2-HIGH'
+    THEN 1 ELSE 0 END) AS low_line_count
+FROM orders, lineitem
+WHERE o_orderkey = l_orderkey
+  AND l_shipmode IN ('MAIL', 'SHIP')
+  AND l_commitdate < l_receiptdate
+  AND l_shipdate < l_commitdate
+  AND l_receiptdate >= DATE '1994-01-01'
+  AND l_receiptdate < DATE '1994-01-01' + INTERVAL 1 YEAR
+GROUP BY l_shipmode
+ORDER BY l_shipmode;
+
+-- Q13: Customer Distribution
+SELECT
+  c_count, COUNT(*) AS custdist
+FROM (
+  SELECT c_custkey, COUNT(o_orderkey) AS c_count
+  FROM customer LEFT OUTER JOIN orders
+    ON c_custkey = o_custkey
+    AND o_comment NOT LIKE '%special%requests%'
+  GROUP BY c_custkey
+) AS c_orders
+GROUP BY c_count
+ORDER BY custdist DESC, c_count DESC;
+
+-- Q14: Promotion Effect
+SELECT
+  100.00 * SUM(CASE WHEN p_type LIKE 'PROMO%'
+    THEN l_extendedprice * (1 - l_discount) ELSE 0 END)
+  / SUM(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM lineitem, part
+WHERE l_partkey = p_partkey
+  AND l_shipdate >= DATE '1995-09-01'
+  AND l_shipdate < DATE '1995-09-01' + INTERVAL 1 MONTH;
+
+-- Q15: Top Supplier
+WITH revenue AS (
+  SELECT
+    l_suppkey AS supplier_no,
+    SUM(l_extendedprice * (1 - l_discount)) AS total_revenue
+  FROM lineitem
+  WHERE l_shipdate >= DATE '1996-01-01'
+    AND l_shipdate < DATE '1996-01-01' + INTERVAL 3 MONTH
+  GROUP BY l_suppkey
+)
+SELECT s_suppkey, s_name, s_address, s_phone, total_revenue
+FROM supplier, revenue
+WHERE s_suppkey = supplier_no
+  AND total_revenue = (SELECT MAX(total_revenue) FROM revenue)
+ORDER BY s_suppkey;
+
+-- Q16: Parts/Supplier Relationship
+SELECT
+  p_brand, p_type, p_size,
+  COUNT(DISTINCT ps_suppkey) AS supplier_cnt
+FROM partsupp, part
+WHERE p_partkey = ps_partkey
+  AND p_brand <> 'Brand#45'
+  AND p_type NOT LIKE 'MEDIUM POLISHED%'
+  AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+  AND ps_suppkey NOT IN (
+    SELECT s_suppkey FROM supplier
+    WHERE s_comment LIKE '%Customer%Complaints%'
+  )
+GROUP BY p_brand, p_type, p_size
+ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
+
+-- Q17: Small-Quantity-Order Revenue
+SELECT
+  SUM(l_extendedprice) / 7.0 AS avg_yearly
+FROM lineitem, part
+WHERE p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT 0.2 * AVG(l_quantity)
+    FROM lineitem
+    WHERE l_partkey = p_partkey
+  );
+
+-- Q18: Large Volume Customer
+SELECT
+  c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+  SUM(l_quantity)
+FROM customer, orders, lineitem
+WHERE o_orderkey IN (
+    SELECT l_orderkey FROM lineitem
+    GROUP BY l_orderkey
+    HAVING SUM(l_quantity) > 300
+  )
+  AND c_custkey = o_custkey
+  AND o_orderkey = l_orderkey
+GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+ORDER BY o_totalprice DESC, o_orderdate
+LIMIT 100;
+
+-- Q19: Discounted Revenue
+SELECT
+  SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM lineitem, part
+WHERE p_partkey = l_partkey
+  AND (
+    (p_brand = 'Brand#12'
+      AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+      AND l_quantity >= 1 AND l_quantity <= 1 + 10
+      AND p_size BETWEEN 1 AND 5
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON')
+    OR
+    (p_brand = 'Brand#23'
+      AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+      AND l_quantity >= 10 AND l_quantity <= 10 + 10
+      AND p_size BETWEEN 1 AND 10
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON')
+    OR
+    (p_brand = 'Brand#34'
+      AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+      AND l_quantity >= 20 AND l_quantity <= 20 + 10
+      AND p_size BETWEEN 1 AND 15
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON')
+  );
+
+-- Q20: Potential Part Promotion
+SELECT s_name, s_address
+FROM supplier, nation
+WHERE s_suppkey IN (
+    SELECT ps_suppkey FROM partsupp
+    WHERE ps_partkey IN (
+        SELECT p_partkey FROM part WHERE p_name LIKE 'forest%'
+      )
+      AND ps_availqty > (
+        SELECT 0.5 * SUM(l_quantity)
+        FROM lineitem
+        WHERE l_partkey = ps_partkey
+          AND l_suppkey = ps_suppkey
+          AND l_shipdate >= DATE '1994-01-01'
+          AND l_shipdate < DATE '1994-01-01' + INTERVAL 1 YEAR
+      )
+  )
+  AND s_nationkey = n_nationkey
+  AND n_name = 'CANADA'
+ORDER BY s_name;
+
+-- Q21: Suppliers Who Kept Orders Waiting
+SELECT s_name, COUNT(*) AS numwait
+FROM supplier, lineitem l1, orders, nation
+WHERE s_suppkey = l1.l_suppkey
+  AND o_orderkey = l1.l_orderkey
+  AND o_orderstatus = 'F'
+  AND l1.l_receiptdate > l1.l_commitdate
+  AND EXISTS (
+    SELECT * FROM lineitem l2
+    WHERE l2.l_orderkey = l1.l_orderkey
+      AND l2.l_suppkey <> l1.l_suppkey
+  )
+  AND NOT EXISTS (
+    SELECT * FROM lineitem l3
+    WHERE l3.l_orderkey = l1.l_orderkey
+      AND l3.l_suppkey <> l1.l_suppkey
+      AND l3.l_receiptdate > l3.l_commitdate
+  )
+  AND s_nationkey = n_nationkey
+  AND n_name = 'SAUDI ARABIA'
+GROUP BY s_name
+ORDER BY numwait DESC, s_name
+LIMIT 100;
+
+-- Q22: Global Sales Opportunity
+SELECT
+  cntrycode, COUNT(*) AS numcust,
+  SUM(c_acctbal) AS totacctbal
+FROM (
+  SELECT
+    SUBSTRING(c_phone FROM 1 FOR 2) AS cntrycode,
+    c_acctbal
+  FROM customer
+  WHERE SUBSTRING(c_phone FROM 1 FOR 2) IN ('13','31','23','29','30','18','17')
+    AND c_acctbal > (
+      SELECT AVG(c_acctbal) FROM customer
+      WHERE c_acctbal > 0.00
+        AND SUBSTRING(c_phone FROM 1 FOR 2) IN ('13','31','23','29','30','18','17')
+    )
+    AND NOT EXISTS (
+      SELECT * FROM orders WHERE o_custkey = c_custkey
+    )
+) AS custsale
+GROUP BY cntrycode
+ORDER BY cntrycode;


### PR DESCRIPTION
## Add TPC-H benchmark kit and update DuckDB engine README

### What
Adds a reproducible TPC-H benchmark pipeline for the embedded DuckDB storage engine and refreshes the README now that the engine lives in-tree. Also seeds the DuckDB engine error-message catalog.

### Key changes
- Add `storage/duckdb/tpch/` kit: numbered scripts (`01_install` → `05_run_queries`), `run_all.sh`, `config.sh`, and `tpch.sql` (22 queries) — all driven through `run_in_duckdb`, idempotent, scale-factor configurable via env.
- Add `storage/duckdb/tpch/README.md` documenting the pipeline, config knobs, and prerequisites.
- Update `storage/duckdb/README.md`: clone from upstream `MariaDB/server` branches, drop the separate plugin clone, fix `build.sh` paths, add a build-dependencies section.
- Add DuckDB `ER_DUCKDB_*` error messages to `sql/share/errmsg-utf8.txt`.

### How to test
`./storage/duckdb/tpch/run_all.sh` against a running MariaDB with the DuckDB engine loaded; check `query_timings.tsv`.