### PR TITLE
MDEV-39928 Fix GitLab CI centos9 job failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,16 +217,18 @@ centos9:
     GIT_SUBMODULE_STRATEGY: normal
   script:
     - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    - dnf -y install 'dnf-command(config-manager)'
+    - dnf config-manager --set-enabled crb
     - yum install -y yum-utils rpm-build openssl-devel libeatmydata ccache
-    # Install missing dependencies
-    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/Judy-devel-1.0.5-28.el9.x86_64.rpm
-    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/bison-devel-3.7.4-5.el9.x86_64.rpm
-    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/multilib-rpm-config-1-19.el9.noarch.rpm
+    - yum install -y gcc gcc-c++ cmake make bison ncurses-devel
+    - yum install -y zlib-devel libaio-devel systemd-devel pcre2-devel
+    - yum install -y libevent-devel libxml2-devel snappy-devel lz4-devel
+    - yum install -y libcurl-devel pam-devel libzstd-devel liburing-devel
+    - yum install -y lzo-devel bzip2-devel readline-devel xz-devel cracklib-devel
+    - yum install -y Judy-devel bison-devel multilib-rpm-config
     # Configure ccache
     - source /etc/profile.d/ccache.sh
     - export CCACHE_DIR="$(pwd)/.ccache"; ccache --zero-stats
-    # This repository does not have any .spec files, so install dependencies based on CentOS spec file
-    - yum-builddep -y mariadb-server
     - mkdir builddir; cd builddir
     - cmake -DRPM=$CI_JOB_NAME $CMAKE_FLAGS .. 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
     - eatmydata make package -j 2 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log


### PR DESCRIPTION
## Description

The centos9 job in `.gitlab-ci.yml` fails because it uses `yum-builddep -y mariadb-server` to install build dependencies, but the `mariadb-server` source package has been removed from CentOS Stream 9 repositories. This affects all branches that define the centos9 job (`main`, `10.11`, `11.4`, `11.8`, `12.3`).

Fix:
- Enable the CRB repository and replace `yum-builddep -y mariadb-server` with explicit build dependency installation
- Add `liburing-devel` for io_uring support


## Release Notes

N/A

## How can this PR be tested?

Run GitLab CI on this branch and verify the centos9 job passes. The build should complete successfully.

### Before this change:

<img width="295" height="344" alt="Screenshot 2026-06-09 at 15 56 29" src="https://github.com/user-attachments/assets/86bcc196-83bd-417d-8637-bcad62589bf6" />

```
$ yum-builddep -y mariadb-server
enabling baseos-source repository
enabling appstream-source repository
enabling extras-common-source repository
enabling epel-source repository
enabling epel-cisco-openh264-source repository
CentOS Stream 9 - BaseOS - Source               1.9 MB/s | 698 kB     00:00    
CentOS Stream 9 - AppStream - Source            3.4 MB/s | 1.4 MB     00:00    
CentOS Stream 9 - Extras packages - Source       29 kB/s |  15 kB     00:00    
Extra Packages for Enterprise Linux 9 - x86_64   18 MB/s | 4.3 MB     00:00    
Extra Packages for Enterprise Linux 9 openh264   75  B/s | 1.2 kB     00:15    
no package matched: mariadb-server
Error: Some packages could not be found.
```

### After this change:

<img width="295" height="321" alt="Screenshot 2026-06-09 at 15 55 35" src="https://github.com/user-attachments/assets/800354e1-584a-491b-8bb6-3913399d93be" />

## Basing the PR against the correct MariaDB version

* [x] _This is a minor fix and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.