### PR TITLE
MDEV-34992 Assertion marked_for_read() failed in virtual my_time_t Field_timesta…

### DIFF
--- a/mysql-test/suite/vcol/r/vcol_misc.result
+++ b/mysql-test/suite/vcol/r/vcol_misc.result
@@ -601,3 +601,24 @@ ERROR 42S02: Table 'test.foo' doesn't exist
 INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
 # End of 10.11 tests
+#
+# Start of 11.4 tests
+#
+#
+# MDEV-34992 Assertion 'marked_for_read()' failed in virtual my_time_t Field_timestamp0::get_timestamp(const uchar*, ulong*) const
+#
+SET @old_mysql56_temporal_format = @@GLOBAL.mysql56_temporal_format;
+SET @old_explicit_defaults_for_timestamp = @@SESSION.explicit_defaults_for_timestamp;
+SET GLOBAL mysql56_temporal_format = 0;
+SET explicit_defaults_for_timestamp = 0;
+Warnings:
+Warning	1287	'explicit_defaults_for_timestamp=0' is deprecated and will be removed in a future release
+CREATE TABLE t (b TIMESTAMP, a INT AS (1 IN (DAYOFMONTH(b BETWEEN '' AND current_user) = b)));
+SELECT * FROM t, t2;
+ERROR 42S02: Table 'test.t2' doesn't exist
+SELECT * FROM t;
+b	a
+DROP TABLE t;
+SET GLOBAL mysql56_temporal_format = @old_mysql56_temporal_format;
+SET explicit_defaults_for_timestamp = @old_explicit_defaults_for_timestamp;
+# End of 11.4 tests

--- a/mysql-test/suite/vcol/t/vcol_misc.test
+++ b/mysql-test/suite/vcol/t/vcol_misc.test
@@ -577,3 +577,31 @@ INSERT INTO t1 (d1) VALUES ('2009-07-02');
 DROP TABLE t1;
 
 --echo # End of 10.11 tests
+
+--echo #
+--echo # Start of 11.4 tests
+--echo #
+
+--echo #
+--echo # MDEV-34992 Assertion 'marked_for_read()' failed in virtual my_time_t Field_timestamp0::get_timestamp(const uchar*, ulong*) const
+--echo #
+
+SET @old_mysql56_temporal_format = @@GLOBAL.mysql56_temporal_format;
+SET @old_explicit_defaults_for_timestamp = @@SESSION.explicit_defaults_for_timestamp;
+
+SET GLOBAL mysql56_temporal_format = 0;
+SET explicit_defaults_for_timestamp = 0;
+
+CREATE TABLE t (b TIMESTAMP, a INT AS (1 IN (DAYOFMONTH(b BETWEEN '' AND current_user) = b)));
+
+--error ER_NO_SUCH_TABLE
+SELECT * FROM t, t2;
+SELECT * FROM t;
+
+# Cleanup
+DROP TABLE t;
+
+SET GLOBAL mysql56_temporal_format = @old_mysql56_temporal_format;
+SET explicit_defaults_for_timestamp = @old_explicit_defaults_for_timestamp;
+
+--echo # End of 11.4 tests

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -7991,7 +7991,9 @@ Type_handler_datetime_common::convert_item_for_comparison(
 {
   if (!dynamic_cast<const Type_handler_timestamp_common*>(
                                                  counterpart->type_handler()) ||
-      !subject->type_handler()->can_return_date())
+      !subject->type_handler()->can_return_date() ||
+      !subject->const_item() ||
+      subject->with_field())
     return subject;
 
   struct Count_handler : public Internal_error_handler


### PR DESCRIPTION
fixes [MDEV-34992](https://jira.mariadb.org/browse/MDEV-34992)

### Problem:
`SELECT` on a table with a `TIMESTAMP` column and a virtual column
expression containing a field reference crashes with assertion
`marked_for_read()` in `Field_timestamp0::get_timestamp`.

### Cause:
`convert_item_for_comparison()` physically evaluates the subject item
via `Datetime dt(thd, subject, ...)` to attempt a TIMESTAMP vs DATETIME
optimization. During `vcol_fix_expr()` at `open_table()` time,
`used_tables_cache` is not yet propagated up the item tree, causing
`const_item()` to return `true` incorrectly for a non-constant expression
containing a field reference. The evaluation then reads `Field_timestamp0`
before read bitmaps are initialized, violating `marked_for_read()`.

### Fix:
Add `find_field_processor()` to the `Item` base class, overridden in
`Item_field` to return `true`. Guard `convert_item_for_comparison()` with
a `walk()` check to skip physical evaluation if the subject subtree
contains any field reference.