### PR TITLE
MDEV-38870 : Galera test failure on galera.MDEV-38201

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-38201.result
+++ b/mysql-test/suite/galera/r/MDEV-38201.result
@@ -14,14 +14,12 @@ t1	CREATE TABLE `t1` (
   `f1` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 FLUSH HOSTS;
+# This will cause inconsistency
 CREATE TABLE t1 (f1 INT) ENGINE=InnoDB;
 ERROR 42S01: Table 't1' already exists
+# Wait until inconsistent node_2 leaves from cluster
 FLUSH HOSTS;
-ERROR HY000: Galera replication not supported
-SHOW WARNINGS;
-Level	Code	Message
-Error	4165	Galera replication not supported
-Warning	4165	Galera cluster is not ready to execute replication
+Got one of the listed errors
 connection node_1;
 # Wait until inconsistent node_2 leaves from cluster
 connection node_2;

--- a/mysql-test/suite/galera/t/MDEV-38201.test
+++ b/mysql-test/suite/galera/t/MDEV-38201.test
@@ -19,12 +19,16 @@ SET GLOBAL wsrep_IGNORE_apply_errors=1;
 SET SESSION wsrep_dirty_reads=1;
 SHOW CREATE TABLE t1;
 FLUSH HOSTS;
+--echo # This will cause inconsistency
 --error ER_TABLE_EXISTS_ERROR
 CREATE TABLE t1 (f1 INT) ENGINE=InnoDB;
-# This will cause inconsistency
---error ER_GALERA_REPLICATION_NOT_SUPPORTED
+--echo # Wait until inconsistent node_2 leaves from cluster
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Disconnected' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+
+# Both are possible
+--error ER_GALERA_REPLICATION_NOT_SUPPORTED, ER_LOCK_WAIT_TIMEOUT
 FLUSH HOSTS;
-SHOW WARNINGS;
 
 --connection node_1
 --echo # Wait until inconsistent node_2 leaves from cluster


### PR DESCRIPTION
Test changes only. Moved wait condition where node should disconnect from cluster because it has become inconsistent. After that next FLUSH HOST based on timing could return not supported or timeout.