### PR TITLE
MDEV-39952:  Skip binlog_in_engine tests that need mariabackup

### DIFF
--- a/mysql-test/include/have_mariabackup_binary.inc
+++ b/mysql-test/include/have_mariabackup_binary.inc
@@ -1,0 +1,8 @@
+# Skip unless the mariabackup binary was built (WITH_MARIABACKUP).
+# This differs from have_mariabackup.inc, which also requires the Galera
+# transfer tool (socat or nc).  Tests that source this file copy the backup
+# to a local directory instead of streaming it, so that tool is not needed.
+
+if (!$XTRABACKUP) {
+  skip Needs mariabackup;
+}

--- a/mysql-test/suite/binlog_in_engine/include/mariabackup_slave_provision.inc
+++ b/mysql-test/suite/binlog_in_engine/include/mariabackup_slave_provision.inc
@@ -1,4 +1,5 @@
 --source include/have_innodb_binlog.inc
+--source include/have_mariabackup_binary.inc
 # Test does a lot of queries that take a lot of CPU under Valgrind.
 --source include/not_valgrind.inc
 

--- a/mysql-test/suite/binlog_in_engine/mariabackup_binlog_dir.test
+++ b/mysql-test/suite/binlog_in_engine/mariabackup_binlog_dir.test
@@ -1,5 +1,6 @@
 --source include/not_embedded.inc
 --source include/have_innodb_binlog.inc
+--source include/have_mariabackup_binary.inc
 
 --source include/reset_master.inc
 

--- a/mysql-test/suite/binlog_in_engine/mariabackup_binlogs.test
+++ b/mysql-test/suite/binlog_in_engine/mariabackup_binlogs.test
@@ -1,6 +1,7 @@
 --source include/not_embedded.inc
 --source include/have_debug.inc
 --source include/have_innodb_binlog.inc
+--source include/have_mariabackup_binary.inc
 
 --source include/reset_master.inc
 


### PR DESCRIPTION
Several tests in the binlog_in_engine suite run the mariabackup binary but did not check that it was built.  When the server is built with WITH_MARIABACKUP=OFF, the test runner leaves the mariabackup command empty and these tests fail instead of being skipped.

Add include/have_mariabackup_binary.inc, which skips the test when the binary is not available, and source it from the affected tests. Unlike have_mariabackup.inc, it does not also require socat or nc, because these tests copy the backup to a local directory rather than streaming it.