### PR TITLE
MDEV-39914:  Crash in ST_SIMPLIFY used in an IN list

### DIFF
--- a/mysql-test/main/spatial_utility_function_simplify.result
+++ b/mysql-test/main/spatial_utility_function_simplify.result
@@ -559,3 +559,38 @@ SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0
 ERROR 42S22: Unknown column 'a' in 'SELECT'
 # Clean up
 DROP TABLE gis_geometrycollection;
+#
+# MDEV-39914 MariaDB crash triggered by INFORMATION_SCHEMA query with
+#            ROW_NUMBER and GIS simplify
+#
+# ST_SIMPLIFY used as a constant element of an IN list is stored into
+# the array that IN builds for its comparisons.  That array element
+# arrives with no charset, so the binary geometry written into it must
+# mark the buffer as binary before appending.  Otherwise the append
+# reads a null charset and the server crashes.
+#
+SELECT 'x' IN ('accounts','cond_instances','setup_consumers','setup_objects',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2))'), 3),
+'global_status') AS r;
+r
+0
+SELECT 'x' IN ('a',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTIPOLYGON(((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2)))'), 3),
+'b') AS r;
+r
+0
+SELECT 'x' IN ('a',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2)))'), 3),
+'b') AS r;
+r
+0
+SELECT TABLE_SCHEMA, CONCAT(ROW_NUMBER() OVER (), 1) x, ORDINAL_POSITION
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = 'performance_schema' AND
+'MULTIPOINT(1 189.7654,41,-1032.34324 9,6.4 1,4 9)' IN
+('accounts', 'cond_instances', 'setup_consumers', 'setup_objects',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2))'), 3),
+'global_status')
+ORDER BY TABLE_SCHEMA + 2 DESC, TABLE_NAME, ORDINAL_POSITION,
+(SELECT COLUMN_NAME ORDER BY 1);
+TABLE_SCHEMA	x	ORDINAL_POSITION

--- a/mysql-test/main/spatial_utility_function_simplify.test
+++ b/mysql-test/main/spatial_utility_function_simplify.test
@@ -499,3 +499,42 @@ SELECT ST_ASTEXT(ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((0 0,0 10,10 10,10 0,0 0,0
 
 --echo # Clean up
 DROP TABLE gis_geometrycollection;
+
+--echo #
+--echo # MDEV-39914 MariaDB crash triggered by INFORMATION_SCHEMA query with
+--echo #            ROW_NUMBER and GIS simplify
+--echo #
+--echo # ST_SIMPLIFY used as a constant element of an IN list is stored into
+--echo # the array that IN builds for its comparisons.  That array element
+--echo # arrives with no charset, so the binary geometry written into it must
+--echo # mark the buffer as binary before appending.  Otherwise the append
+--echo # reads a null charset and the server crashes.
+--echo #
+
+SELECT 'x' IN ('accounts','cond_instances','setup_consumers','setup_objects',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2))'), 3),
+'global_status') AS r;
+
+# The same path through the IN comparison vector is reached for every
+# geometry type ST_SIMPLIFY returns, so a multipolygon and a geometry
+# collection must also be safe.
+SELECT 'x' IN ('a',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('MULTIPOLYGON(((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2)))'), 3),
+'b') AS r;
+
+SELECT 'x' IN ('a',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2)))'), 3),
+'b') AS r;
+
+# The original report wrapped the predicate in an INFORMATION_SCHEMA query.
+# The IN predicate is constant, so it is evaluated while the comparison
+# vector is built and the result set is empty.
+SELECT TABLE_SCHEMA, CONCAT(ROW_NUMBER() OVER (), 1) x, ORDINAL_POSITION
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = 'performance_schema' AND
+'MULTIPOINT(1 189.7654,41,-1032.34324 9,6.4 1,4 9)' IN
+('accounts', 'cond_instances', 'setup_consumers', 'setup_objects',
+ST_SIMPLIFY(ST_GEOMFROMTEXT('POLYGON((10 2,5 2,5 10,-5 10,-5 2,-10 2,-10 -2,-5 -2,-5 -10,5 -10,5 -2,10 -2,10 2))'), 3),
+'global_status')
+ORDER BY TABLE_SCHEMA + 2 DESC, TABLE_NAME, ORDINAL_POSITION,
+(SELECT COLUMN_NAME ORDER BY 1);

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -2321,6 +2321,14 @@ String *Item_func_simplify::val_str(String *str)
     }
   }
 
+  /*
+    ST_SIMPLIFY returns a binary geometry.  The simplify methods append the
+    result with String::append, which consults the charset of the output
+    buffer.  When that buffer is an element of the comparison array that IN
+    builds it arrives cleared, with no charset, so mark it binary before
+    writing.
+  */
+  str->set_charset(&my_charset_bin);
   if (geometry->simplify(str, max_distance))
   {
     null_value= 1;


### PR DESCRIPTION
A geometry function writes its binary result into a buffer given by the caller.  ST_SIMPLIFY did not set the charset of that buffer.  A constant value in an IN list, though, is stored into the array that IN builds for its comparisons, and that array has no charset.  Appending the geometry then read an invalid charset and crashed the server.

Set the result buffer to the binary charset before writing the geometry, matching what the other geometry functions already do.