### PR TITLE
MDEV-39952:  Skip tests that need mariabackup

### DIFF
--- a/mysql-test/include/have_mariabackup_binary.inc
+++ b/mysql-test/include/have_mariabackup_binary.inc
@@ -1,0 +1,8 @@
+# Skip unless the mariabackup binary was built (WITH_MARIABACKUP).
+# This differs from have_mariabackup.inc, which also requires the Galera
+# transfer tool (socat or nc).  Tests that source this file copy the backup
+# to a local directory instead of streaming it, so that tool is not needed.
+
+if (!$XTRABACKUP) {
+  skip Needs mariabackup;
+}

--- a/mysql-test/suite/encryption/t/doublewrite_debug.test
+++ b/mysql-test/suite/encryption/t/doublewrite_debug.test
@@ -2,6 +2,7 @@
 --source include/have_debug.inc
 --source include/not_embedded.inc
 --source include/have_file_key_management_plugin.inc
+--source include/have_mariabackup_binary.inc
 call mtr.add_suppression("InnoDB: Encrypted page \\[page id: space=[1-9][0-9]*, page number=3\\] in file .*test.t[12]\\.ibd looks corrupted");
 call mtr.add_suppression("InnoDB: Unable to apply log to corrupted page ");
 call mtr.add_suppression("InnoDB: Plugin initialization aborted");

--- a/mysql-test/suite/encryption/t/recovery_memory.test
+++ b/mysql-test/suite/encryption/t/recovery_memory.test
@@ -1,6 +1,7 @@
 --source include/have_debug.inc
 --source include/have_innodb.inc
 --source include/have_sequence.inc
+--source include/have_mariabackup_binary.inc
 --source filekeys_plugin.inc
 
 let $basedir=$MYSQLTEST_VARDIR/tmp/backup;


### PR DESCRIPTION
Skips tests that require mariabackup if mariabackup was not built (WITH_MARIABACKUP=OFF).

Backport of the same MTR change from 12.3 but applied to additional tests.