### PR TITLE
MDEV-39963  InnoDB system tablespace autoshrink fails when the tail extent is an empty XDES_FREE_FRAG extent

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -3492,15 +3492,35 @@ dberr_t fsp_traverse_extents(
 
     if (find_last_used_extent)
     {
-      ulint state= xdes_get_state(descr);
-      if (state == XDES_FREE)
-        *last_used_extent= cur_extent;
-      else if (state == XDES_FREE_FRAG &&
-               !(cur_extent & (srv_page_size - 1)) &&
-               xdes_get_n_used(descr) == 2)
-        /* Extent Descriptor Page */
-        *last_used_extent= cur_extent;
-      else return DB_SUCCESS;
+      /* A descriptor extent (one that starts with an extent
+      descriptor page) always keeps 2 pages permanently allocated:
+      1) Descriptor/header page
+      2) Change buffer bitmap page
+      In that case, we could consider this extent as empty.
+
+      Normal FSP_FREE_FRAG extent has no permanent pages, so its
+      empty case (n_used == 0). But between MDEV-13542 and
+      MDEV-31333, fsp_free_page() read xdes_get_n_used() before
+      clearing the freed page's XDES_FREE_BIT, so freeing the
+      last page of a fragment extent left an empty (n_used == 0)
+      FREE_FRAG extent behind. Such extents also can be reclaimable
+      just like XDES_FREE */
+      switch (xdes_get_state(descr)) {
+      case XDES_FREE:
+        break;
+      case XDES_FREE_FRAG:
+        {
+          const uint32_t n_used{xdes_get_n_used(descr)};
+          if (n_used == 0 || (n_used == 2 &&
+                              !(cur_extent & (srv_page_size - 1))))
+            /* Empty frag extent or descriptor extent */
+            break;
+        }
+        /* fall through */
+      default:
+        return DB_SUCCESS;
+      }
+      *last_used_extent= cur_extent;
     }
     else
     {


### PR DESCRIPTION
Problem:
========
- The InnoDB system tablespace fails to autoshrink even when it is almost entirely free. Defragmentation reports success but no space is reclaimed, and the log shows the high-water mark pinned at the end of the file.

fsp_traverse_extents(): when locating the last used extent, descends from the end of the tablespace and treats an extent as reclaimable only when it is XDES_FREE, or the descriptor-page extent (XDES_FREE_FRAG with two used pages).
Every other XDES_FREE_FRAG extent stops the scan.

An XDES_FREE_FRAG extent with zero used pages can legitimately exist on disk: it is left behind when an emptied fragment extent is not moved from FSP_FREE_FRAG to FSP_FREE (the condition fixed in MDEV-31333) . Such an empty extent is logically identical to XDES_FREE, but the traversal mistakes it for a used extent, pins last_used_extent at the end of the file, and the shrink reclaims nothing.

Solution:
========
fsp_traverse_extents(): Treat an XDES_FREE_FRAG extent with no used pages (n_used == 0) the same as XDES_FREE