### PR TITLE
MDEV-39971: generate_option_list may invoke pclose(nullptr)

### DIFF
--- a/extra/generate_option_list.cc
+++ b/extra/generate_option_list.cc
@@ -92,7 +92,6 @@ std::string call_mariadbd(const char *mariadbd_path, const char *plugin_dir, con
   if (!f)
   {
     perror("failed to read mariadbd output");
-    my_pclose(f);
     exit(1);
   }
   output= read_output(f);


### PR DESCRIPTION
`call_mariadbd()`: Remove the redundant and potentially harmful call of `my_pclose(f)` when `my_popen()` failed. At least in some versions of GNU libc the function `pclose(3)` is declared with `__attribute__((nonnull))`.

Fixes up commit 7828fb475b00d4211ba8ce1ec6e9a1b06e0fc39b (MDEV-32745)