### PR TITLE
MDEV-35283: support nullable indexed vector columns

### DIFF
--- a/mysql-test/main/vector,aria.rdiff
+++ b/mysql-test/main/vector,aria.rdiff
@@ -7,7 +7,7 @@
  create table t1 (id int auto_increment primary key,
  u vector(5) not null, vector index (u),
  v vector(5) not null, vector index (v));
-@@ -12,7 +12,7 @@ t1	CREATE TABLE `t1` (
+@@ -12,7 +12,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -16,7 +16,7 @@
  show keys from t1;
  Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Ignored
  t1	0	PRIMARY	1	id	A	0	NULL	NULL		BTREE			NO
-@@ -27,7 +27,7 @@ t1	CREATE TABLE `t1` (
+@@ -27,7 +27,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`) `m`=7
@@ -25,7 +25,7 @@
  show keys from t1;
  Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Ignored
  t1	0	PRIMARY	1	id	A	0	NULL	NULL		BTREE			NO
-@@ -42,7 +42,7 @@ t1	CREATE TABLE `t1` (
+@@ -42,7 +42,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`) `m`=5
@@ -34,7 +34,7 @@
  show keys from t1;
  Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Ignored
  t1	0	PRIMARY	1	id	A	0	NULL	NULL		BTREE			NO
-@@ -343,7 +343,7 @@ t2	CREATE TABLE `t2` (
+@@ -346,7 +346,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -43,7 +43,7 @@
  drop table t1, t2;
  db.opt
  # Test insert ... select with vector index
-@@ -388,8 +388,32 @@ db.opt
+@@ -391,8 +391,32 @@
  create table t1 (id int auto_increment primary key, v vector(5) not null, vector index (v));
  insert t1 (id, v) values (1, x'e360d63ebe554f3fcdbc523f4522193f5236083d');
  truncate table t1;
@@ -76,7 +76,7 @@
  insert t1 (id, v) values (1, x'e360d63ebe554f3fcdbc523f4522193f5236083d');
  select id, hex(v) from t1;
  id	hex(v)
-@@ -401,33 +425,39 @@ t1	CREATE TABLE `t1` (
+@@ -404,33 +428,39 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -126,7 +126,7 @@
  drop database test1;
  db.opt
  #
-@@ -442,7 +472,7 @@ t1	CREATE TABLE `t1` (
+@@ -445,7 +475,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`) `distance`=cosine
@@ -135,7 +135,7 @@
  insert t1 (v) values (x'e360d63ebe554f3fcdbc523f4522193f5236083d'),
  (x'f511303f72224a3fdd05fe3eb22a133ffae86a3f'),
  (x'f09baa3ea172763f123def3e0c7fe53e288bf33e'),
-@@ -504,9 +534,11 @@ insert t1 (v) values (x'e360d63ebe554f3fcdbc523f4522193f5236083d'),
+@@ -507,9 +537,11 @@
  # ADD/DROP COLUMN, ALGORITHM=COPY
  alter table t1 add column a int, algorithm=copy;
  db.opt
@@ -149,7 +149,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -515,12 +547,14 @@ t1	CREATE TABLE `t1` (
+@@ -518,12 +550,14 @@
    `a` int(11) DEFAULT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -167,7 +167,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -528,13 +562,15 @@ t1	CREATE TABLE `t1` (
+@@ -531,13 +565,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -186,7 +186,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -543,12 +579,14 @@ t1	CREATE TABLE `t1` (
+@@ -546,12 +582,14 @@
    PRIMARY KEY (`id`),
    KEY `a` (`id`),
    VECTOR KEY `v` (`v`)
@@ -204,7 +204,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -556,13 +594,15 @@ t1	CREATE TABLE `t1` (
+@@ -559,13 +597,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -223,7 +223,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -571,12 +611,14 @@ t1	CREATE TABLE `t1` (
+@@ -574,12 +614,14 @@
    PRIMARY KEY (`id`),
    KEY `a` (`id`),
    VECTOR KEY `v` (`v`)
@@ -241,7 +241,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -584,13 +626,15 @@ t1	CREATE TABLE `t1` (
+@@ -587,13 +629,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -260,7 +260,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -599,12 +643,14 @@ t1	CREATE TABLE `t1` (
+@@ -602,12 +646,14 @@
    `a` int(11) DEFAULT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -278,7 +278,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -612,24 +658,27 @@ t1	CREATE TABLE `t1` (
+@@ -615,24 +661,27 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -311,7 +311,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -637,24 +686,27 @@ t1	CREATE TABLE `t1` (
+@@ -640,24 +689,27 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -344,7 +344,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -662,7 +714,7 @@ t1	CREATE TABLE `t1` (
+@@ -665,7 +717,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -353,7 +353,7 @@
  # ADD/DROP INDEX, ALGORITHM=INPLACE (non-vector)
  alter table t1 add index a(id), algorithm=inplace;
  ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY
-@@ -685,31 +737,15 @@ ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITH
+@@ -688,31 +740,15 @@
  alter table t1 modify column v vector(7) not null, algorithm=inplace;
  ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY
  # ADD/CHANGE/DROP/MODIFY COLUMN, ALGORITHM=INPLACE (non-vector)
@@ -389,7 +389,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -717,13 +753,15 @@ t1	CREATE TABLE `t1` (
+@@ -720,13 +756,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -408,7 +408,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -731,14 +769,16 @@ t1	CREATE TABLE `t1` (
+@@ -734,14 +772,16 @@
    `w` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`w`)
@@ -428,7 +428,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -746,7 +786,7 @@ t1	CREATE TABLE `t1` (
+@@ -749,7 +789,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `w` (`v`)
@@ -437,7 +437,7 @@
  alter table t1 rename key w to v;
  # IF [NOT] EXISTS
  create vector index if not exists v on t1(v);
-@@ -757,77 +797,22 @@ drop index if exists v on t1;
+@@ -760,77 +800,22 @@
  Warnings:
  Note	1091	Can't DROP INDEX `v`; check that it exists
  db.opt
@@ -518,8 +518,8 @@
  # CHANGE/MODIFY/DROP COLUMN (vector)
  alter table t1 modify column v int;
  ERROR HY000: Incorrect arguments to VECTOR INDEX
-@@ -839,9 +824,11 @@ alter table t1 change column v v vector(6);
- ERROR 42000: All parts of a VECTOR index must be NOT NULL
+@@ -840,9 +825,11 @@
+ alter table t1 change column v v vector(6);
  alter table t1 modify column v vector(7) not null;
  db.opt
 -t1#i#01.ibd
@@ -532,7 +532,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -849,12 +836,14 @@ t1	CREATE TABLE `t1` (
+@@ -850,12 +837,14 @@
    `v` vector(7) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -550,7 +550,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -862,17 +851,18 @@ t1	CREATE TABLE `t1` (
+@@ -863,17 +852,18 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -572,10 +572,21 @@
  drop table t1;
  create table t1(v vector(5) not null, vector index(v));
  alter table t1 add column a int;
-@@ -889,5 +879,5 @@ Table	Create Table
+@@ -890,7 +880,7 @@
  t	CREATE TABLE `t` (
    `v` vector(1) NOT NULL,
    VECTOR KEY `v` (`v`) `distance`=cosine
 -) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 +) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci PAGE_CHECKSUM=1
  drop table t;
+ #
+ # MDEV-35821 - vector index sizes are not in INDEX_LENGTH
+@@ -921,7 +911,7 @@
+   `v` vector(3) DEFAULT NULL,
+   PRIMARY KEY (`id`),
+   VECTOR KEY `v` (`v`)
+-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
++) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci PAGE_CHECKSUM=1
+ # Insert rows with NULL and non-NULL vector values
+ insert into t1 (v) values (vec_fromtext('[1, 0, 0]'));
+ insert into t1 (v) values (NULL);

--- a/mysql-test/main/vector,myisam.rdiff
+++ b/mysql-test/main/vector,myisam.rdiff
@@ -1,6 +1,6 @@
---- vector.result
-+++ vector,myisam.reject
-@@ -388,8 +388,30 @@
+--- a/mysql-test/main/vector.result
++++ b/mysql-test/main/vector.result
+@@ -391,8 +391,30 @@
  create table t1 (id int auto_increment primary key, v vector(5) not null, vector index (v));
  insert t1 (id, v) values (1, x'e360d63ebe554f3fcdbc523f4522193f5236083d');
  truncate table t1;
@@ -31,7 +31,7 @@
  insert t1 (id, v) values (1, x'e360d63ebe554f3fcdbc523f4522193f5236083d');
  select id, hex(v) from t1;
  id	hex(v)
-@@ -407,27 +429,33 @@
+@@ -410,27 +432,33 @@
  # Test RENAME TABLE with vector index
  create table t1 (id int auto_increment primary key, v vector(5) not null, vector index (v));
  db.opt
@@ -74,7 +74,7 @@
  drop database test1;
  db.opt
  #
-@@ -504,9 +532,11 @@
+@@ -507,9 +535,11 @@
  # ADD/DROP COLUMN, ALGORITHM=COPY
  alter table t1 add column a int, algorithm=copy;
  db.opt
@@ -88,7 +88,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -515,12 +545,14 @@
+@@ -518,12 +548,14 @@
    `a` int(11) DEFAULT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -106,7 +106,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -528,13 +560,15 @@
+@@ -531,13 +563,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -125,7 +125,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -543,12 +577,14 @@
+@@ -546,12 +580,14 @@
    PRIMARY KEY (`id`),
    KEY `a` (`id`),
    VECTOR KEY `v` (`v`)
@@ -143,7 +143,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -556,13 +592,15 @@
+@@ -559,13 +595,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -162,7 +162,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -571,12 +609,14 @@
+@@ -574,12 +612,14 @@
    PRIMARY KEY (`id`),
    KEY `a` (`id`),
    VECTOR KEY `v` (`v`)
@@ -180,7 +180,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -584,13 +624,15 @@
+@@ -587,13 +627,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -199,7 +199,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -599,12 +641,14 @@
+@@ -602,12 +644,14 @@
    `a` int(11) DEFAULT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -217,7 +217,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -612,24 +656,27 @@
+@@ -615,24 +659,27 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -250,7 +250,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -637,24 +684,27 @@
+@@ -640,24 +687,27 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -283,7 +283,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -662,7 +712,7 @@
+@@ -665,7 +715,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -292,7 +292,7 @@
  # ADD/DROP INDEX, ALGORITHM=INPLACE (non-vector)
  alter table t1 add index a(id), algorithm=inplace;
  ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY
-@@ -685,31 +735,15 @@
+@@ -688,31 +738,15 @@
  alter table t1 modify column v vector(7) not null, algorithm=inplace;
  ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY
  # ADD/CHANGE/DROP/MODIFY COLUMN, ALGORITHM=INPLACE (non-vector)
@@ -328,7 +328,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -717,13 +751,15 @@
+@@ -720,13 +754,15 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -347,7 +347,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -731,14 +767,16 @@
+@@ -734,14 +770,16 @@
    `w` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`w`)
@@ -367,7 +367,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -746,7 +784,7 @@
+@@ -749,7 +787,7 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `w` (`v`)
@@ -376,7 +376,7 @@
  alter table t1 rename key w to v;
  # IF [NOT] EXISTS
  create vector index if not exists v on t1(v);
-@@ -757,77 +795,22 @@
+@@ -760,77 +798,22 @@
  Warnings:
  Note	1091	Can't DROP INDEX `v`; check that it exists
  db.opt
@@ -457,8 +457,8 @@
  # CHANGE/MODIFY/DROP COLUMN (vector)
  alter table t1 modify column v int;
  ERROR HY000: Incorrect arguments to VECTOR INDEX
-@@ -839,9 +822,11 @@
- ERROR 42000: All parts of a VECTOR index must be NOT NULL
+@@ -840,9 +823,11 @@
+ alter table t1 change column v v vector(6);
  alter table t1 modify column v vector(7) not null;
  db.opt
 -t1#i#01.ibd
@@ -471,7 +471,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -849,12 +834,14 @@
+@@ -850,12 +835,14 @@
    `v` vector(7) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -489,7 +489,7 @@
  show create table t1;
  Table	Create Table
  t1	CREATE TABLE `t1` (
-@@ -862,17 +849,18 @@
+@@ -863,17 +850,18 @@
    `v` vector(5) NOT NULL,
    PRIMARY KEY (`id`),
    VECTOR KEY `v` (`v`)
@@ -511,10 +511,21 @@
  drop table t1;
  create table t1(v vector(5) not null, vector index(v));
  alter table t1 add column a int;
-@@ -889,5 +877,5 @@
+@@ -890,7 +878,7 @@
  t	CREATE TABLE `t` (
    `v` vector(1) NOT NULL,
    VECTOR KEY `v` (`v`) `distance`=cosine
 -) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 +) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
  drop table t;
+ #
+ # MDEV-35821 - vector index sizes are not in INDEX_LENGTH
+@@ -921,7 +909,7 @@
+   `v` vector(3) DEFAULT NULL,
+   PRIMARY KEY (`id`),
+   VECTOR KEY `v` (`v`)
+-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
++) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+ # Insert rows with NULL and non-NULL vector values
+ insert into t1 (v) values (vec_fromtext('[1, 0, 0]'));
+ insert into t1 (v) values (NULL);

--- a/mysql-test/main/vector.result
+++ b/mysql-test/main/vector.result
@@ -837,9 +837,7 @@ ERROR HY000: Incorrect arguments to VECTOR INDEX
 alter table t1 change column v v int;
 ERROR HY000: Incorrect arguments to VECTOR INDEX
 alter table t1 modify column v vector(5);
-ERROR 42000: All parts of a VECTOR index must be NOT NULL
 alter table t1 change column v v vector(6);
-ERROR 42000: All parts of a VECTOR index must be NOT NULL
 alter table t1 modify column v vector(7) not null;
 db.opt
 t1#i#01.ibd
@@ -910,4 +908,61 @@ from information_schema.tables
 where table_schema = database() and table_name = 't1';
 has_index_length
 1
+drop table t1;
+#
+# MDEV-35283 - support nullable indexed vector columns
+#
+# Create table with nullable vector column and vector index
+create table t1 (id int auto_increment primary key, v vector(3), vector index (v));
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `v` vector(3) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  VECTOR KEY `v` (`v`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+# Insert rows with NULL and non-NULL vector values
+insert into t1 (v) values (vec_fromtext('[1, 0, 0]'));
+insert into t1 (v) values (NULL);
+insert into t1 (v) values (vec_fromtext('[0, 1, 0]'));
+insert into t1 (v) values (NULL);
+insert into t1 (v) values (vec_fromtext('[0, 0, 1]'));
+# Vector index maintenance should handle rows with NULL vectors
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[1, 0.2, 0.1]')) limit 5;
+id	vec_totext(v)
+1	[1,0,0]
+3	[0,1,0]
+5	[0,0,1]
+# UPDATE: NULL -> non-NULL
+update t1 set v = vec_fromtext('[1, 1, 0]') where id = 2;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[1, 0.9, 0.1]')) limit 5;
+id	vec_totext(v)
+2	[1,1,0]
+1	[1,0,0]
+3	[0,1,0]
+5	[0,0,1]
+# UPDATE: non-NULL -> NULL
+update t1 set v = NULL where id = 1;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[0, 0, 1]')) limit 5;
+id	vec_totext(v)
+5	[0,0,1]
+3	[0,1,0]
+2	[1,1,0]
+# UPDATE: NULL -> NULL (no-op)
+update t1 set v = NULL where id = 4;
+# DELETE row with NULL vector
+delete from t1 where id = 4;
+# DELETE row with non-NULL vector
+delete from t1 where id = 5;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[0, 1, 0]')) limit 5;
+id	vec_totext(v)
+3	[0,1,0]
+2	[1,1,0]
+# Verify vec_distance returns NULL when one argument is NULL
+select id, vec_distance_euclidean(v, vec_fromtext('[1, 0, 0]')) as dist from t1 order by id;
+id	dist
+1	NULL
+2	1
+3	1.4142135623730951
 drop table t1;

--- a/mysql-test/main/vector.test
+++ b/mysql-test/main/vector.test
@@ -409,9 +409,7 @@ show create table t1;
 alter table t1 modify column v int;
 --error ER_WRONG_ARGUMENTS
 alter table t1 change column v v int;
---error ER_INDEX_CANNOT_HAVE_NULL
 alter table t1 modify column v vector(5);
---error ER_INDEX_CANNOT_HAVE_NULL
 alter table t1 change column v v vector(6);
 alter table t1 modify column v vector(7) not null;
 list_files $datadir/test;
@@ -457,5 +455,46 @@ flush tables;
 select index_length > 0 as has_index_length
 from information_schema.tables
 where table_schema = database() and table_name = 't1';
+
+drop table t1;
+
+--echo #
+--echo # MDEV-35283 - support nullable indexed vector columns
+--echo #
+
+--echo # Create table with nullable vector column and vector index
+create table t1 (id int auto_increment primary key, v vector(3), vector index (v));
+show create table t1;
+
+--echo # Insert rows with NULL and non-NULL vector values
+insert into t1 (v) values (vec_fromtext('[1, 0, 0]'));
+insert into t1 (v) values (NULL);
+insert into t1 (v) values (vec_fromtext('[0, 1, 0]'));
+insert into t1 (v) values (NULL);
+insert into t1 (v) values (vec_fromtext('[0, 0, 1]'));
+
+--echo # Vector index maintenance should handle rows with NULL vectors
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[1, 0.2, 0.1]')) limit 5;
+
+--echo # UPDATE: NULL -> non-NULL
+update t1 set v = vec_fromtext('[1, 1, 0]') where id = 2;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[1, 0.9, 0.1]')) limit 5;
+
+--echo # UPDATE: non-NULL -> NULL
+update t1 set v = NULL where id = 1;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[0, 0, 1]')) limit 5;
+
+--echo # UPDATE: NULL -> NULL (no-op)
+update t1 set v = NULL where id = 4;
+
+--echo # DELETE row with NULL vector
+delete from t1 where id = 4;
+
+--echo # DELETE row with non-NULL vector
+delete from t1 where id = 5;
+select id, vec_totext(v) from t1 where v is not null order by vec_distance_euclidean(v, vec_fromtext('[0, 1, 0]')) limit 5;
+
+--echo # Verify vec_distance returns NULL when one argument is NULL
+select id, vec_distance_euclidean(v, vec_fromtext('[1, 0, 0]')) as dist from t1 order by id;
 
 drop table t1;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -10219,13 +10219,12 @@ int TABLE::hlindexes_on_update()
   DBUG_ASSERT(s->hlindexes() == (hlindex != NULL));
   if (hlindex && hlindex->in_use)
   {
-    int err;
-    // mark deleted node invalid and insert node for new row
-    if ((err= mhnsw_invalidate(this, record[1], key_info + s->keys)) ||
-        (err= mhnsw_insert(this, key_info + s->keys)))
+    KEY *keyinfo= key_info + s->keys;
+    if (int err= mhnsw_invalidate(this, record[1], keyinfo))
+      return err;
+    if (int err= mhnsw_insert(this, keyinfo))
       return err;
   }
-
   return 0;
 }
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3757,11 +3757,6 @@ mysql_prepare_create_table_finalize(THD *thd, HA_CREATE_INFO *create_info,
       case Key::VECTOR:
         if (sql_field->check_vcol_for_key(thd))
           DBUG_RETURN(TRUE);
-        if (!(sql_field->flags & NOT_NULL_FLAG))
-        {
-          my_error(ER_INDEX_CANNOT_HAVE_NULL, MYF(0), "VECTOR");
-          DBUG_RETURN(TRUE);
-        }
         if (create_info->tmp_table())
         {
           my_error(ER_NO_INDEX_ON_TEMPORARY, MYF(0), "VECTOR",

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1408,9 +1408,7 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
 {
   THD *thd= table->in_use;
   TABLE *graph= table->hlindex;
-  MY_BITMAP *old_map= dbug_tmp_use_all_columns(table, &table->read_set);
   Field *vec_field= keyinfo->key_part->field;
-  String buf, *res= vec_field->val_str(&buf);
   MHNSW_Share *ctx;
 
   /* metadata are checked on open */
@@ -1419,7 +1417,12 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
   DBUG_ASSERT(keyinfo->usable_key_parts == 1);
   DBUG_ASSERT(vec_field->binary());
   DBUG_ASSERT(vec_field->cmp_type() == STRING_RESULT);
-  DBUG_ASSERT(res); // ER_INDEX_CANNOT_HAVE_NULL
+  if (vec_field->is_null_in_record(table->record[0]))
+    return 0;
+
+  MY_BITMAP *old_map= dbug_tmp_use_all_columns(table, &table->read_set);
+  String buf, *res= vec_field->val_str(&buf);
+  DBUG_ASSERT(res);
   DBUG_ASSERT(table->file->ref_length <= graph->field[FIELD_TREF]->field_length);
   DBUG_ASSERT(res->length() > 0 && res->length() % 4 == 0);
 
@@ -1665,6 +1668,10 @@ int mhnsw_invalidate(TABLE *table, const uchar *rec, KEY *keyinfo)
   handler *h= table->file;
   MHNSW_Share *ctx;
 
+  DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
+  if (keyinfo->key_part->field->is_null_in_record(rec))
+    return 0;
+
   int err= MHNSW_Share::acquire(&ctx, table, true);
   SCOPE_EXIT([ctx, table](){ ctx->release(table); });
   if (err)
@@ -1672,7 +1679,6 @@ int mhnsw_invalidate(TABLE *table, const uchar *rec, KEY *keyinfo)
 
   /* metadata are checked on open */
   DBUG_ASSERT(graph);
-  DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
   DBUG_ASSERT(keyinfo->usable_key_parts == 1);
   DBUG_ASSERT(h->ref_length <= graph->field[FIELD_TREF]->field_length);
 


### PR DESCRIPTION
Allow creating VECTOR INDEX on nullable columns. NULL values are simply not indexed - rows with NULL vectors won't be found via the vector index, but the CREATE TABLE/ALTER TABLE is permitted.

Changes:
- Remove NOT_NULL_FLAG check for vector index creation in mysql_prepare_create_table_finalize()
- Add NULL checks in hlindexes_on_insert/update/delete to skip vector index operations when the vector field is NULL
- Handle UPDATE transitions: NULL->non-NULL (insert only), non-NULL->NULL (invalidate only), NULL->NULL (skip)
- Remove obsolete DBUG_ASSERTs in mhnsw_insert() that assumed non-NULL was enforced by ER_INDEX_CANNOT_HAVE_NULL