### PR TITLE
MDEV-39556 SIGSEGV in ha_mroonga::storage_set_keys_in_use on SELECT

### DIFF
--- a/storage/mroonga/ha_mroonga.cpp
+++ b/storage/mroonga/ha_mroonga.cpp
@@ -4291,18 +4291,15 @@ int ha_mroonga::wrapper_open(const char *name, int mode, uint open_options)
   if (error)
     DBUG_RETURN(error);
 
-  if (!(open_options & HA_OPEN_FOR_REPAIR)) {
-    error = open_table(name);
-    if (error)
-      DBUG_RETURN(error);
+  error = open_table(name);
+  if (error && !(open_options & HA_OPEN_FOR_REPAIR))
+    goto error_exit;
 
-    error = wrapper_open_indexes(name);
-    if (error) {
-      grn_obj_unlink(ctx, grn_table);
-      grn_table = NULL;
-      DBUG_RETURN(error);
-    }
-  }
+  error = wrapper_open_indexes(name);
+  if (error && !(open_options & HA_OPEN_FOR_REPAIR))
+    goto error_exit;
+
+  error = 0;
 
   mrn_init_alloc_root(&mem_root, 1024, 0, MYF(0));
   wrap_key_info = mrn_create_key_info_for_table(share, table, &error);
@@ -4390,6 +4387,7 @@ int ha_mroonga::wrapper_open(const char *name, int mode, uint open_options)
     }
   }
 
+error_exit:
   if (error)
   {
     grn_obj_unlink(ctx, grn_table);
@@ -4662,37 +4660,35 @@ int ha_mroonga::storage_open(const char *name, int mode, uint open_options)
     DBUG_RETURN(error);
   }
 
+  error = storage_open_indexes(name);
+  if (error && !(open_options & HA_OPEN_FOR_REPAIR)) {
+    storage_close_columns();
+    grn_obj_unlink(ctx, grn_table);
+    grn_table = NULL;
+    DBUG_RETURN(error);
+  }
+
+  storage_set_keys_in_use();
+
   if (!(open_options & HA_OPEN_FOR_REPAIR)) {
-    error = storage_open_indexes(name);
-    if (error) {
-      storage_close_columns();
-      grn_obj_unlink(ctx, grn_table);
-      grn_table = NULL;
-      DBUG_RETURN(error);
-    }
-
-    storage_set_keys_in_use();
-
-    {
-      mrn::Lock lock(&mrn_operations_mutex);
-      mrn::PathMapper mapper(name);
-      const char *table_name = mapper.table_name();
-      size_t table_name_size = strlen(table_name);
-      if (db->is_broken_table(table_name, table_name_size)) {
-        GRN_LOG(ctx, GRN_LOG_NOTICE,
-                "Auto repair is started: <%s>",
-                name);
-        error = operations_->repair(table_name, table_name_size);
+    mrn::Lock lock(&mrn_operations_mutex);
+    mrn::PathMapper mapper(name);
+    const char *table_name = mapper.table_name();
+    size_t table_name_size = strlen(table_name);
+    if (db->is_broken_table(table_name, table_name_size)) {
+      GRN_LOG(ctx, GRN_LOG_NOTICE,
+              "Auto repair is started: <%s>",
+              name);
+      error = operations_->repair(table_name, table_name_size);
+      if (!error)
+        db->mark_table_repaired(table_name, table_name_size);
+      if (!share->disable_keys) {
         if (!error)
-          db->mark_table_repaired(table_name, table_name_size);
-        if (!share->disable_keys) {
-          if (!error)
-            error = storage_reindex();
-        }
-        GRN_LOG(ctx, GRN_LOG_NOTICE,
-                "Auto repair is done: <%s>: %s",
-                name, error == 0 ? "success" : "failure");
+          error = storage_reindex();
       }
+      GRN_LOG(ctx, GRN_LOG_NOTICE,
+              "Auto repair is done: <%s>: %s",
+              name, error == 0 ? "success" : "failure");
     }
   }
 
@@ -5237,7 +5233,7 @@ void ha_mroonga::storage_set_keys_in_use()
     if (i == table_share->primary_key) {
       continue;
     }
-    if (!grn_index_tables[i]) {
+    if (grn_index_tables && !grn_index_tables[i]) {
       /* disabled */
       table_share->keys_in_use.clear_bit(i);
       DBUG_PRINT("info", ("mroonga: key %u disabled", i));

--- a/storage/mroonga/mysql-test/mroonga/storage/r/check_table_broken.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/check_table_broken.result
@@ -9,10 +9,17 @@ INSERT INTO diaries VALUES ('Hello');
 FLUSH TABLES;
 CHECK TABLE diaries;
 Table	Op	Msg_type	Msg_text
+check_test.diaries	check	Error	system call error: No such file or directory: failed to open path: <check_test.mrn.000010C>
 check_test.diaries	check	error	Corrupt
 REPAIR TABLE diaries;
 Table	Op	Msg_type	Msg_text
+check_test.diaries	repair	Error	system call error: No such file or directory: failed to open path: <check_test.mrn.000010C>
 check_test.diaries	repair	status	OK
+SELECT *
+FROM diaries
+WHERE MATCH(title) AGAINST('+Hello' IN BOOLEAN MODE);
+title
+Hello
 DROP TABLE diaries;
 DROP DATABASE check_test;
 USE test;

--- a/storage/mroonga/mysql-test/mroonga/storage/r/check_table_innodb.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/check_table_innodb.result
@@ -1,0 +1,13 @@
+#
+# MDEV-39556 SIGSEGV in ha_mroonga::storage_set_keys_in_use on SELECT
+#
+CREATE TABLE t (c INT KEY,c2 GEOMETRY NOT NULL,SPATIAL INDEX idx_sp (c2)) ENGINE=InnoDB;
+ALTER TABLE t ENGINE=Mroonga;
+CHECK TABLE t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+SELECT COUNT(*) > 0 AS r FROM information_schema.STATISTICS;
+r
+1
+DROP TABLE t;
+# End of 10.6 tests

--- a/storage/mroonga/mysql-test/mroonga/storage/r/repair_table_no_index_file.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/repair_table_no_index_file.result
@@ -17,6 +17,7 @@ SELECT * FROM diaries WHERE MATCH(body) AGAINST("+starting" IN BOOLEAN MODE);
 ERROR HY000: system call error: No such file or directory: failed to open path: <repair_test.mrn.000010E.c>
 REPAIR TABLE diaries;
 Table	Op	Msg_type	Msg_text
+repair_test.diaries	repair	Error	system call error: No such file or directory: failed to open path: <repair_test.mrn.000010E.c>
 repair_test.diaries	repair	status	OK
 SELECT * FROM diaries;
 id	title	body

--- a/storage/mroonga/mysql-test/mroonga/storage/t/check_table_broken.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/check_table_broken.test
@@ -31,12 +31,16 @@ CREATE TABLE diaries (
 INSERT INTO diaries VALUES ('Hello');
 
 --remove_file $MYSQLD_DATADIR/check_test.mrn.000010C
-
 FLUSH TABLES;
 
 CHECK TABLE diaries;
 
 REPAIR TABLE diaries;
+
+SELECT *
+  FROM diaries
+ WHERE MATCH(title) AGAINST('+Hello' IN BOOLEAN MODE);
+
 DROP TABLE diaries;
 
 DROP DATABASE check_test;

--- a/storage/mroonga/mysql-test/mroonga/storage/t/check_table_innodb.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/check_table_innodb.test
@@ -1,0 +1,16 @@
+--source include/have_innodb.inc
+--source ../../include/mroonga/have_mroonga.inc
+
+--echo #
+--echo # MDEV-39556 SIGSEGV in ha_mroonga::storage_set_keys_in_use on SELECT
+--echo #
+
+CREATE TABLE t (c INT KEY,c2 GEOMETRY NOT NULL,SPATIAL INDEX idx_sp (c2)) ENGINE=InnoDB;
+
+ALTER TABLE t ENGINE=Mroonga;
+CHECK TABLE t;
+SELECT COUNT(*) > 0 AS r FROM information_schema.STATISTICS;
+
+DROP TABLE t;
+
+--echo # End of 10.6 tests

--- a/storage/mroonga/mysql-test/mroonga/storage/t/repair_table_no_index_file.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/repair_table_no_index_file.test
@@ -43,6 +43,7 @@ FLUSH TABLES;
 --error ER_CANT_OPEN_FILE
 SELECT * FROM diaries WHERE MATCH(body) AGAINST("+starting" IN BOOLEAN MODE);
 
+--replace_result "[io][open] " ""
 REPAIR TABLE diaries;
 
 SELECT * FROM diaries;

--- a/storage/mroonga/mysql-test/mroonga/wrapper/r/repair_table_no_files.result
+++ b/storage/mroonga/mysql-test/mroonga/wrapper/r/repair_table_no_files.result
@@ -17,6 +17,7 @@ SELECT * FROM diaries WHERE MATCH(body) AGAINST("starting");
 ERROR HY000: mroonga: failed to open table: <diaries>
 REPAIR TABLE diaries;
 Table	Op	Msg_type	Msg_text
+repair_test.diaries	repair	Error	mroonga: failed to open table: <diaries>
 repair_test.diaries	repair	status	OK
 SELECT * FROM diaries;
 id	title	body

--- a/storage/mroonga/mysql-test/mroonga/wrapper/r/repair_table_no_index_file.result
+++ b/storage/mroonga/mysql-test/mroonga/wrapper/r/repair_table_no_index_file.result
@@ -17,6 +17,7 @@ SELECT * FROM diaries WHERE MATCH(body) AGAINST("starting");
 ERROR HY000: system call error: No such file or directory: failed to open path: <repair_test.mrn.000010A>
 REPAIR TABLE diaries;
 Table	Op	Msg_type	Msg_text
+repair_test.diaries	repair	Error	system call error: No such file or directory: failed to open path: <repair_test.mrn.000010A>
 repair_test.diaries	repair	status	OK
 SELECT * FROM diaries;
 id	title	body

--- a/storage/mroonga/mysql-test/mroonga/wrapper/t/repair_table_no_index_file.test
+++ b/storage/mroonga/mysql-test/mroonga/wrapper/t/repair_table_no_index_file.test
@@ -44,6 +44,7 @@ FLUSH TABLES;
 --error ER_CANT_OPEN_FILE
 SELECT * FROM diaries WHERE MATCH(body) AGAINST("starting");
 
+--replace_result "[io][open] " ""
 REPAIR TABLE diaries;
 
 SELECT * FROM diaries;


### PR DESCRIPTION
Many pathes exist for Mroonga to open tables without opening indexes. Altering from another storage engine and accessing the information schema statistics is one mechanism.

The fix is a backport from upstream.

Backport from https://github.com/mroonga/mroonga/commit/0b3541910ede845f6ccb62241a633310f2c27f52#diff-c026dc94c7f79d426e7a68e1e69fdc0f7743296a37d6cd19c9e7117a763f242e

Fix a crash bug that may be caused after MySQL/MariaDB upgrade

GitHub: fix GH-423

MySQL/MariaDB may open Mroonga tables by "CHECK TABLES" when MySQL/MariaDB is upgraded. Mroonga didn't open indexes when a table is opened by "CHECK TABLES". If "REPAIR TABLE" is needed, a table is reopened. If "REPAIR TABLE" isn't needed, a table is NOT reopened. The table doesn't open indexes. "SELECT ... MATCH AGAINST" for the table causes a crash.

Reported by Vincent Pelletier. Thanks!!!

Backported to MariaDB by Daniel Black