### PR TITLE
MDEV-39559: Assertion `b` failed in `my_strnncoll_xxxx_nopad_ci`

### DIFF
--- a/mysql-test/main/long_unique_bugs.result
+++ b/mysql-test/main/long_unique_bugs.result
@@ -851,3 +851,24 @@ insert into t values (0, '');
 replace into t values (0, '123');
 drop table t;
 # End of 10.11 tests
+#
+# MDEV-39559: Assertion `b` failed in `my_strnncoll_xxxx_nopad_ci`
+#
+SET @old_trx_iso_level := @@session.transaction_isolation;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+CREATE TABLE t (x TEXT, UNIQUE(x))
+ENGINE=InnoDB
+CHARACTER SET utf8mb3 COLLATE utf8mb3_general_nopad_ci
+SELECT '' AS x;
+DROP TABLE t;
+SET @@session.transaction_isolation = @old_trx_iso_level;
+create table t1 (b text, key(b(10))) engine=myisam
+character set utf8mb3 collate utf8mb3_general_nopad_ci
+select '' as b union all select '0' as b union all select '1' as b;
+select * from t1 force index(b) where b >= '' and b < '2';
+b
+
+0
+1
+drop table t1;
+# End of 11.8 tests

--- a/mysql-test/main/long_unique_bugs.test
+++ b/mysql-test/main/long_unique_bugs.test
@@ -777,3 +777,28 @@ replace into t values (0, '123');
 drop table t;
 
 --echo # End of 10.11 tests
+
+--echo #
+--echo # MDEV-39559: Assertion `b` failed in `my_strnncoll_xxxx_nopad_ci`
+--echo #
+
+SET @old_trx_iso_level := @@session.transaction_isolation;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+CREATE TABLE t (x TEXT, UNIQUE(x))
+  ENGINE=InnoDB
+  CHARACTER SET utf8mb3 COLLATE utf8mb3_general_nopad_ci
+  SELECT '' AS x;
+
+DROP TABLE t;
+SET @@session.transaction_isolation = @old_trx_iso_level;
+
+create table t1 (b text, key(b(10))) engine=myisam
+  character set utf8mb3 collate utf8mb3_general_nopad_ci
+  select '' as b union all select '0' as b union all select '1' as b;
+
+select * from t1 force index(b) where b >= '' and b < '2';
+
+drop table t1;
+
+--echo # End of 11.8 tests

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9093,6 +9093,10 @@ int Field_blob::cmp(const uchar *a_ptr, const uchar *b_ptr) const
   memcpy(&blob1, a_ptr+packlength, sizeof(char*));
   memcpy(&blob2, b_ptr+packlength, sizeof(char*));
   size_t a_len= get_length(a_ptr), b_len= get_length(b_ptr);
+  DBUG_ASSERT(blob1 || !a_len);
+  DBUG_ASSERT(blob2 || !b_len);
+  if (!blob1) { blob1= (uchar *) ""; a_len= 0; }
+  if (!blob2) { blob2= (uchar *) ""; b_len= 0; }
   return cmp(blob1, (uint32)a_len, blob2, (uint32)b_len);
 }
 
@@ -9172,9 +9176,12 @@ void Field_blob::set_key_image(const uchar *buff,uint length)
 
 int Field_blob::key_cmp(const uchar *key_ptr, uint max_key_length) const
 {
+  DBUG_ASSERT(key_ptr);
   uchar *blob1;
   size_t blob_length=get_length(ptr);
   memcpy(&blob1, ptr+packlength, sizeof(char*));
+  DBUG_ASSERT(blob1 || !blob_length);
+  if (!blob1) { blob1= (uchar *) ""; blob_length= 0; }
   CHARSET_INFO *cs= charset();
   size_t local_char_length= max_key_length / cs->mbmaxlen;
   local_char_length= cs->charpos(blob1, blob1+blob_length,


### PR DESCRIPTION
fixes [MDEV-39559](https://jira.mariadb.org/browse/MDEV-39559)
### Problem
When verifying a `UNIQUE` constraint over an empty BLOB/TEXT column, `Field_blob::cmp(a_ptr, b_ptr)` extracts a NULL data pointer (with length 0) from the record slot and forwards it to the charset-level comparison, which asserts non-NULL pointers (added in MDEV-35717).

A zero-length blob is allowed to have a NULL data pointer in its record slot; `Field_blob::val_decimal()` already treats (NULL, 0) as an empty value. The comparison paths missed that substitution.

### Fix
- In `Field_blob::cmp(a_ptr, b_ptr)`, `Field_blob::cmp_prefix()` and `Field_blob::key_cmp(key_ptr, max_key_length)`, substitute "" for a NULL data pointer before delegating to the comparison.
- Add a debug assert in each of the above functions to document the invariant that a NULL pointer is only valid alongside zero length and (NULL, length>0) is invalid.