### PR TITLE
MDEV-39207:  mark test as not_embedded

### DIFF
--- a/mysql-test/suite/sys_vars/t/session_track_system_variables_example.test
+++ b/mysql-test/suite/sys_vars/t/session_track_system_variables_example.test
@@ -1,4 +1,5 @@
 --source include/have_example_plugin.inc
+--source include/not_embedded.inc
 
 --echo #
 --echo # MDEV-39207 plugin variables disappear from session_track_system_variables list


### PR DESCRIPTION
Test fails on embedded CI because original not_embedded flag was not preserved