### PR TITLE
MDEV-38386 Fix incomplete cleanup in Galera MTR tests failing under --repeat

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-38260.result
+++ b/mysql-test/suite/galera/r/MDEV-38260.result
@@ -39,6 +39,7 @@ connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 connection node_1;
 set global wsrep_on=OFF;
 reset master;

--- a/mysql-test/suite/galera/r/galera_as_master.result
+++ b/mysql-test/suite/galera/r/galera_as_master.result
@@ -56,6 +56,7 @@ BINLOG_POSITIONS_MATCH
 1
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work');
 connection node_1;
 set global wsrep_on=OFF;

--- a/mysql-test/suite/galera/r/galera_as_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_slave.result
@@ -28,5 +28,6 @@ DROP TABLE t1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 connection node_3;
 RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
@@ -96,5 +96,6 @@ CALL mtr.add_suppression("Unsafe statement written to the binary log using state
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 connection node_3;
 RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_as_slave_ctas.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_ctas.result
@@ -29,6 +29,7 @@ call mtr.add_suppression("WSREP: Failed to apply write set: gtid:");
 connection node_1;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 call mtr.add_suppression("WSREP: unexpected async replication event: 0");
 connection node_3;
 RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid.result
@@ -25,6 +25,7 @@ connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_auto_engine.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_auto_engine.result
@@ -25,6 +25,7 @@ connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;
@@ -37,5 +38,8 @@ set global wsrep_on=ON;
 connection node_3;
 reset master;
 connection node_2;
-DROP TABLE mysql.gtid_slave_pos_InnoDB;
 CALL mtr.add_suppression("The automatically created table");
+DROP TABLE mysql.gtid_slave_pos_InnoDB;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_myisam.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_myisam.result
@@ -32,6 +32,7 @@ RESET MASTER;
 connection node_1;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL WSREP_ON=OFF;
 reset master;
 SET GLOBAL WSREP_ON=ON;

--- a/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
@@ -24,6 +24,7 @@ DROP TABLE t1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown command' on query");
 CALL mtr.add_suppression("Slave: Unknown command Error_code: 1047");
 CALL mtr.add_suppression("(Transport endpoint|Socket) is not connected");

--- a/mysql-test/suite/galera/r/galera_as_slave_replay.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_replay.result
@@ -64,6 +64,7 @@ SET DEBUG_SYNC = "RESET";
 connection node_2a;
 STOP SLAVE;
 RESET SLAVE;
+SET GLOBAL gtid_slave_pos = "";
 DROP TABLE t1;
 connection node_3;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
@@ -126,6 +126,7 @@ SELECT @@GLOBAL.gtid_slave_pos;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL replicate_ignore_table='';
 connection node_1;
 SET GLOBAL replicate_ignore_table='';

--- a/mysql-test/suite/galera/r/galera_gtid_slave.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave.result
@@ -32,6 +32,7 @@ connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_slave_replay.result
+++ b/mysql-test/suite/galera/r/galera_slave_replay.result
@@ -89,6 +89,7 @@ COUNT(*) = 1
 set session wsrep_sync_wait=0;
 STOP SLAVE;
 RESET SLAVE;
+SET GLOBAL gtid_slave_pos = "";
 SET DEBUG_SYNC = "RESET";
 DROP TABLE t1;
 connection node_3;

--- a/mysql-test/suite/galera/t/MDEV-10715.test
+++ b/mysql-test/suite/galera/t/MDEV-10715.test
@@ -1,5 +1,10 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+# This test forces a specific GTID seqno (22) and asserts an exact
+# gtid_binlog_state (1-1-23). wsrep_gtid_seq_no only accepts a value ahead of
+# the cluster's current position, so the cluster GTID state must start clean
+# on every run (e.g. with --repeat). Force a server restart before the test.
+--source include/force_restart.inc
 
 --connection node_1
 create table t1(a int);

--- a/mysql-test/suite/galera/t/MDEV-27806.test
+++ b/mysql-test/suite/galera/t/MDEV-27806.test
@@ -2,6 +2,11 @@
 # MDEV-27806 GTIDs diverge after CTAS
 #
 --source include/galera_cluster.inc
+# This test reads binlog events at absolute offsets from the LAST binlog and
+# hardcodes the binlog file names, which only hold on a freshly started
+# cluster. Force a restart so each test run (e.g. with --repeat) starts from
+# the same clean binlog state instead of accumulating events.
+--source include/force_restart.inc
 
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);

--- a/mysql-test/suite/galera/t/MDEV-38260.test
+++ b/mysql-test/suite/galera/t/MDEV-38260.test
@@ -82,6 +82,7 @@ DROP TABLE t1;
 --connection node_2
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 
 --connection node_1
 set global wsrep_on=OFF;

--- a/mysql-test/suite/galera/t/galera_as_master.test
+++ b/mysql-test/suite/galera/t/galera_as_master.test
@@ -66,6 +66,11 @@ DROP TABLE t2, t3;
 
 STOP SLAVE;
 RESET SLAVE ALL;
+# RESET SLAVE ALL does not clear gtid_slave_pos. node_1 resets its binlog
+# (RESET MASTER) below, so without clearing the slave position here node_3
+# would skip the next run's events (e.g. with --repeat) and time out waiting
+# for the replicated tables.
+SET GLOBAL gtid_slave_pos = "";
 
 CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work');
 

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -61,6 +61,7 @@ DROP TABLE t1;
 
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 
 --connection node_3
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -80,6 +80,7 @@ CALL mtr.add_suppression("Unsafe statement written to the binary log using state
 
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 
 --connection node_3
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_ctas.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_ctas.test
@@ -72,6 +72,7 @@ call mtr.add_suppression("WSREP: Failed to apply write set: gtid:");
 --connection node_1
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 call mtr.add_suppression("WSREP: unexpected async replication event: 0");
 
 --connection node_3

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid.inc
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid.inc
@@ -78,6 +78,7 @@ DROP TABLE t1;
 
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 
 --echo #cleanup
 --connection node_1

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_auto_engine.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_auto_engine.test
@@ -10,5 +10,13 @@
 --source galera_as_slave_gtid.inc
 
 --connection node_2
-DROP TABLE mysql.gtid_slave_pos_InnoDB;
 CALL mtr.add_suppression("The automatically created table");
+DROP TABLE mysql.gtid_slave_pos_InnoDB;
+
+# The statements above write to node_2's binlog (DDL and the suppression
+# insert get Galera GTIDs in domain 0, server 2). Without resetting the
+# binlog state here, that leftover (e.g. 0-2-2) survives into the next
+# test iteration and breaks the gtid_binlog_state comparison in the .inc.
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_myisam.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_myisam.test
@@ -73,6 +73,7 @@ RESET MASTER;
 --connection node_1
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL WSREP_ON=OFF;
 reset master;
 SET GLOBAL WSREP_ON=ON;

--- a/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
@@ -80,6 +80,7 @@ DROP TABLE t1;
 
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown command' on query");
 CALL mtr.add_suppression("Slave: Unknown command Error_code: 1047");

--- a/mysql-test/suite/galera/t/galera_as_slave_replay.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_replay.test
@@ -135,6 +135,11 @@ SET DEBUG_SYNC = "RESET";
 --connection node_2a
 STOP SLAVE;
 RESET SLAVE;
+# RESET SLAVE does not clear gtid_slave_pos. node_3 resets its binlog
+# (RESET MASTER) below, so without clearing the slave position here node_2
+# would skip the next run's events (e.g. with --repeat) and time out waiting
+# for the replicated table.
+SET GLOBAL gtid_slave_pos = "";
 
 DROP TABLE t1;
 

--- a/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
@@ -131,6 +131,7 @@ SELECT @@GLOBAL.gtid_slave_pos;
 --connection node_2
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL replicate_ignore_table='';
 
 --connection node_1

--- a/mysql-test/suite/galera/t/galera_bf_abort_mariabackup.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_mariabackup.test
@@ -134,6 +134,13 @@ SET GLOBAL wsrep_mode = DEFAULT;
 --connection node_1
 DROP TABLE t;
 
+# Remove the backup target directories. mariabackup refuses to back up into a
+# non-empty directory, so leaving these behind makes the backups fail silently
+# on the next run (e.g. with --repeat) and the expected log messages never
+# appear.
+--rmdir $MYSQLTEST_VARDIR/tmp/backup
+--rmdir $MYSQLTEST_VARDIR/tmp/backup2
+
 --source include/auto_increment_offset_restore.inc
 
 --source include/galera_end.inc

--- a/mysql-test/suite/galera/t/galera_gtid_server_id.test
+++ b/mysql-test/suite/galera/t/galera_gtid_server_id.test
@@ -1,4 +1,8 @@
 --source include/galera_cluster.inc
+# This test asserts exact GTID positions (e.g. 1-11-2). Those only hold from a
+# fresh cluster, so the cluster GTID state must start clean on every run (e.g.
+# with --repeat). Force a server restart before the test.
+--source include/force_restart.inc
 
 --connection node_1
 select @@gtid_domain_id, @@server_id, @@wsrep_gtid_domain_id,@@wsrep_gtid_mode;

--- a/mysql-test/suite/galera/t/galera_gtid_slave.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave.test
@@ -9,6 +9,12 @@
 
 --source include/have_innodb.inc
 --source include/galera_cluster.inc
+# This test asserts exact gtid_binlog_state values (e.g. 1-1-2). The galera
+# wsrep GTID domain seqno is cluster-global state that "reset master" does not
+# reset, so it must start clean on every run (e.g. with --repeat). The
+# end-of-test cleanup below handles slave position and local binlogs, but only
+# a fresh cluster resets the wsrep domain seqno.
+--source include/force_restart.inc
 
 # As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
 # we open the node_3 connection here
@@ -79,6 +85,7 @@ DROP TABLE t1,t2;
 --connection node_2
 STOP SLAVE;
 RESET SLAVE ALL;
+SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
@@ -9,6 +9,12 @@
 --source include/big_test.inc
 --source include/have_innodb.inc
 --source include/galera_cluster.inc
+# This test asserts exact gtid_binlog_state values (e.g. 2-3-4, 1-1-3). The
+# galera wsrep GTID domain seqno is cluster-global state that "reset master"
+# does not reset (and the mid-test SST restart only rejoins, preserving it), so
+# the cluster must start clean on every run (e.g. with --repeat). Only a full
+# restart that re-bootstraps the cluster resets the wsrep domain seqno.
+--source include/force_restart.inc
 
 # As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
 # we open the node_3 connection here

--- a/mysql-test/suite/galera/t/galera_gtid_trx_conflict.test
+++ b/mysql-test/suite/galera/t/galera_gtid_trx_conflict.test
@@ -5,6 +5,11 @@
 --source include/galera_cluster.inc
 --source include/have_log_bin.inc
 --source include/have_innodb.inc
+# This test forces a specific GTID seqno (100). wsrep_gtid_seq_no only accepts a
+# value ahead of the cluster's current position, so the cluster GTID state must
+# start clean on every run (e.g. with --repeat). Force a server restart before
+# the test.
+--source include/force_restart.inc
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 

--- a/mysql-test/suite/galera/t/galera_last_committed_id.test
+++ b/mysql-test/suite/galera/t/galera_last_committed_id.test
@@ -3,6 +3,10 @@
 #
 
 --source include/galera_cluster.inc
+# This test asserts exact wsrep GTID values (e.g. 100-1-2). The galera wsrep
+# GTID domain seqno is cluster-global state, so the cluster must start clean on
+# every run (e.g. with --repeat). Force a server restart before the test.
+--source include/force_restart.inc
 
 # Returns domain-server-0 if no transactions have been run
 

--- a/mysql-test/suite/galera/t/galera_slave_replay.test
+++ b/mysql-test/suite/galera/t/galera_slave_replay.test
@@ -188,6 +188,11 @@ set session wsrep_sync_wait=0;
 
 STOP SLAVE;
 RESET SLAVE;
+# RESET SLAVE does not clear gtid_slave_pos. node_3 resets its binlog
+# (RESET MASTER) below, so without clearing the slave position here node_2
+# would skip the next run's events (e.g. with --repeat) and time out waiting
+# for the replicated table.
+SET GLOBAL gtid_slave_pos = "";
 SET DEBUG_SYNC = "RESET";
 
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_sst_mariabackup_encrypt_with_key_server.test
+++ b/mysql-test/suite/galera/t/galera_sst_mariabackup_encrypt_with_key_server.test
@@ -9,6 +9,11 @@
 --source include/have_innodb.inc
 --source include/have_mariabackup.inc
 --source include/have_ssl_communication.inc
+# This test asserts that the initial cluster-bootstrap SST was SSL-encrypted by
+# grepping the donor's error log. That is a one-time event, so the cluster must
+# be freshly bootstrapped on every run (e.g. with --repeat) for node_2 to SST
+# again. Force a server restart before the test.
+--source include/force_restart.inc
 
 SELECT 1;
 

--- a/mysql-test/suite/galera/t/galera_strict_require_primary_key.test
+++ b/mysql-test/suite/galera/t/galera_strict_require_primary_key.test
@@ -16,6 +16,11 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/have_aria.inc
+# This test triggers warning flood control, which suppresses further
+# REQUIRE_PRIMARY_KEY warnings for 300 seconds. That suppression state, and
+# the error-log contents the asserts grep for, must start clean on every run
+# (e.g. with --repeat), so force a server restart before the test.
+--source include/force_restart.inc
 
 call mtr.add_suppression("WSREP: wsrep_mode = REQUIRED_PRIMARY_KEY enabled\\. Table ");
 

--- a/mysql-test/suite/galera/t/galera_var_gtid_domain_id.test
+++ b/mysql-test/suite/galera/t/galera_var_gtid_domain_id.test
@@ -7,6 +7,11 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+# This test asserts exact GTID positions (e.g. 9999-1-3) and an empty initial
+# state. The galera wsrep GTID domain seqno is cluster-global state, so the
+# cluster must start clean on every run (e.g. with --repeat). Force a server
+# restart before the test.
+--source include/force_restart.inc
 
 --echo # On node_1
 --connection node_1

--- a/mysql-test/suite/galera/t/mdev_10518.test
+++ b/mysql-test/suite/galera/t/mdev_10518.test
@@ -7,6 +7,11 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+# This test asserts exact GTID positions (e.g. 4294967295-1-3) and an empty
+# initial state. The galera wsrep GTID domain seqno is cluster-global state, so
+# the cluster must start clean on every run (e.g. with --repeat). Force a
+# server restart before the test.
+--source include/force_restart.inc
 
 --echo # On node_1
 --connection node_1


### PR DESCRIPTION
A number of Galera MTR tests pass on the first run but fail on a second --repeat iteration, because server, cluster or filesystem state leaks across runs and the test does not restore a clean starting state.

Fix the cleanup (or force a fresh cluster) in the affected tests. Each fix was verified with --repeat=2 --force.

1. Stale async-slave GTID position

   RESET SLAVE [ALL] does not clear gtid_slave_pos. As the master does
   RESET MASTER in cleanup, on the next run the slave considers the
   events already applied and skips them, so the replicated tables never
   appear. Clear the position with SET GLOBAL gtid_slave_pos = "":

     galera_as_slave, galera_as_slave_autoinc, galera_as_slave_ctas,
     galera_as_slave_gtid (via galera_as_slave_gtid.inc),
     galera_as_slave_gtid_myisam, galera_as_slave_nonprim,
     galera_as_slave_with_filtering, MDEV-38260, galera_as_master,
     galera_as_slave_replay, galera_slave_replay

2. Leftover binlog GTID state from trailing cleanup

   Trailing DROP TABLE / mtr.add_suppression statements ran after the
   .inc's reset master and re-populated node_2's binlog. gtid_binlog_state
   keeps the latest seqno per (domain, server_id) pair, so a stray
   0-2-<n> survived into the next run and broke the state comparison.
   Reorder the cleanup and reset node_2's binlog last:

     galera_as_slave_gtid_auto_engine

3. Cluster-global, one-time or time-window state

   The wsrep GTID domain seqno is cluster-global and is not reset by
   reset master (nor by a mid-test SST rejoin); error-log contents,
   warning-flood suppression timers and one-time bootstrap behaviour are
   likewise not restored by in-test cleanup. Force a fresh cluster with
   include/force_restart.inc:

   - hardcoded wsrep_gtid_seq_no (only accepts a value ahead of current):
       MDEV-10715, galera_gtid_trx_conflict
   - absolute binlog offsets / hardcoded binlog file names:
       MDEV-27806
   - exact wsrep-domain GTID positions:
       galera_gtid_server_id, galera_last_committed_id,
       galera_var_gtid_domain_id, mdev_10518
   - exact gtid_binlog_state (wsrep seqno survives reset master / SST):
       galera_gtid_slave, galera_gtid_slave_sst_rsync
   - 300s warning-flood suppression timer and error-log contents:
       galera_strict_require_primary_key
   - one-time bootstrap SST asserted to be SSL-encrypted (the
     re-bootstrap re-triggers a fresh SST):
       galera_sst_mariabackup_encrypt_with_key_server

4. Leftover filesystem artifacts

   mariabackup refuses to back up into a non-empty target directory, so
   the leftover target dirs from the previous run made the backup fail
   silently and the expected log messages never appeared. Remove the
   target directories in cleanup:

     galera_bf_abort_mariabackup

Note: galera_gtid_slave needs both the gtid_slave_pos cleanup (1) and force_restart.inc (3); the cleanup alone is not enough because the test also asserts an exact wsrep-domain seqno.
