### PR TITLE
MDEV-22943 - Assertion 'marked_for_read()' failed in Field_varstring::val_str on CHECKSUM TABLE

### DIFF
--- a/mysql-test/main/row-checksum-old.result
+++ b/mysql-test/main/row-checksum-old.result
@@ -142,3 +142,19 @@ drop table t1;
 #
 # End of 10.2 tests
 #
+#
+# MDEV-22943 Assertion 'marked_for_read()' failed in Field_varstring::val_str on CHECKSUM TABLE
+#
+SET SQL_MODE="";
+CREATE TABLE t (v1 VARCHAR (255) AS (c1) PERSISTENT, c1 VARCHAR(50)) COLLATE=latin1_general_ci ENGINE=MyISAM;
+INSERT INTO t VALUES(1,0xff00fef0);
+CHECKSUM TABLE t EXTENDED;
+Table	Checksum
+test.t	1051406892
+drop table t;
+CREATE TABLE t (a BLOB, b BLOB GENERATED ALWAYS AS (a) VIRTUAL) ENGINE=MyISAM;
+INSERT INTO t values (1,1),(2,2);
+CHECKSUM TABLE t;
+Table	Checksum
+test.t	3642141250
+drop table t;

--- a/mysql-test/main/row-checksum.result
+++ b/mysql-test/main/row-checksum.result
@@ -142,3 +142,19 @@ drop table t1;
 #
 # End of 10.2 tests
 #
+#
+# MDEV-22943 Assertion 'marked_for_read()' failed in Field_varstring::val_str on CHECKSUM TABLE
+#
+SET SQL_MODE="";
+CREATE TABLE t (v1 VARCHAR (255) AS (c1) PERSISTENT, c1 VARCHAR(50)) COLLATE=latin1_general_ci ENGINE=MyISAM;
+INSERT INTO t VALUES(1,0xff00fef0);
+CHECKSUM TABLE t EXTENDED;
+Table	Checksum
+test.t	1051406892
+drop table t;
+CREATE TABLE t (a BLOB, b BLOB GENERATED ALWAYS AS (a) VIRTUAL) ENGINE=MyISAM;
+INSERT INTO t values (1,1),(2,2);
+CHECKSUM TABLE t;
+Table	Checksum
+test.t	3642141250
+drop table t;

--- a/mysql-test/main/row-checksum.test
+++ b/mysql-test/main/row-checksum.test
@@ -100,3 +100,22 @@ drop table t1;
 --echo #
 --echo # End of 10.2 tests
 --echo #
+
+--echo #
+--echo # MDEV-22943 Assertion 'marked_for_read()' failed in Field_varstring::val_str on CHECKSUM TABLE
+--echo #
+
+SET SQL_MODE="";
+--disable_warnings
+CREATE TABLE t (v1 VARCHAR (255) AS (c1) PERSISTENT, c1 VARCHAR(50)) COLLATE=latin1_general_ci ENGINE=MyISAM;
+INSERT INTO t VALUES(1,0xff00fef0);
+CHECKSUM TABLE t EXTENDED;
+
+drop table t;
+
+--disable_warnings
+CREATE TABLE t (a BLOB, b BLOB GENERATED ALWAYS AS (a) VIRTUAL) ENGINE=MyISAM;
+INSERT INTO t values (1,1),(2,2);
+CHECKSUM TABLE t;
+
+drop table t;

--- a/sql/item.h
+++ b/sql/item.h
@@ -8536,7 +8536,11 @@ inline void TABLE::use_all_stored_columns()
   bitmap_set_all(read_set);
   if (Field **vf= vfield)
     for (; *vf; vf++)
-      bitmap_clear_bit(read_set, (*vf)->field_index);
+    {
+      if (!(*vf)->stored_in_db())
+        bitmap_clear_bit(read_set, (*vf)->field_index);
+    }
+
 }
 
 #endif /* SQL_ITEM_INCLUDED */


### PR DESCRIPTION
fixes [MDEV-22943](https://jira.mariadb.org/browse/MDEV-22943)

### Problem:
CHECKSUM TABLE EXTENDED on a MyISAM table containing a persistent generated column can trigger a marked_for_read() assertion in Field_varstring::val_str().

### Cause:
TABLE::use_all_stored_columns() marks all columns in read_set and then clears the bitmap entry for every field in vfield.

This unintentionally excludes persistent (stored) generated columns from the read bitmap, even though they are physically stored in the row. Later, checksum calculation reads the generated column via Field::val_str(), which asserts because the field is not marked for read.

### Fix:
Only clear read_set bits for non-stored virtual generated columns. Keep persistent generated columns marked as readable since they are stored in the table and may be accessed by operations such as CHECKSUM TABLE EXTENDED.