### PR TITLE
MDEV-39153 Fix sporadic main.change_master_default mismatch

### DIFF
--- a/mysql-test/main/change_master_default.result
+++ b/mysql-test/main/change_master_default.result
@@ -201,10 +201,6 @@ slave_heartbeat_period	15.000
 RESET SLAVE 'unset' ALL;
 CHANGE MASTER 'unset' TO master_host='127.0.1.3';
 # Validate command line options
-# restart_abort: --master-heartbeat-period=''
-# restart_abort: --master-heartbeat-period=123abc
-# restart_abort: --master-heartbeat-period=-1
-# restart_abort: --master-heartbeat-period=4294967.296
 # restart: --skip-slave-start --master-heartbeat-period=0.000499
 SELECT connection_name, slave_heartbeat_period
 FROM information_schema.slave_status ORDER BY connection_name;

--- a/mysql-test/main/change_master_default.test
+++ b/mysql-test/main/change_master_default.test
@@ -10,6 +10,10 @@
 
 # only need CHANGE MASTER and IS.slave_status
 --source include/have_binlog_format_mixed.inc
+# This test uses --exec $MYSQLD directly, which bypasses MTR's automatic
+# --user=root injection. mysqld refuses to start as root without --user=root,
+# so skip the test when running as root.
+--source include/not_as_root.inc
 
 CREATE PROCEDURE show_defaultable_fields()
 SELECT connection_name,
@@ -104,21 +108,16 @@ CHANGE MASTER 'unset' TO master_host='127.0.1.3';
 --echo # Validate command line options
 
 # Invalid `--master-heartbeat-period` values should abort the server
-# (`restart_abort` includes a wait for the server to exit on its own,
-#  e.g., due to a startup error.)
 --source include/shutdown_mysqld.inc
---let $restart_parameters= restart_abort: --master-heartbeat-period=''
---echo # $restart_parameters
---write_line "$restart_parameters" $_expect_file_name
---let $restart_parameters= restart_abort: --master-heartbeat-period=123abc
---echo # $restart_parameters
---write_line "$restart_parameters" $_expect_file_name
---let $restart_parameters= restart_abort: --master-heartbeat-period=-1
---echo # $restart_parameters
---write_line "$restart_parameters" $_expect_file_name
---let $restart_parameters= restart_abort: --master-heartbeat-period=4294967.296
---echo # $restart_parameters
---write_line "$restart_parameters" $_expect_file_name
+
+--disable_result_log
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --master-heartbeat-period=123abc
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --master-heartbeat-period=-1
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --master-heartbeat-period=4294967.296
+--enable_result_log
 
 # Numbers between 0 and 0.5 exclusive should warn about rounding to 0 (disabled)
 --let $restart_parameters= --skip-slave-start --master-heartbeat-period=0.000499


### PR DESCRIPTION
## Description

The test `main.change_master_default` sporadically fails with `slave_heartbeat_period` showing `60.000` instead of `0.000`. The test used `restart_abort:` commands in the expect file, which MTR never recognized - they fell through to the `else` branch, which deleted `restart_opts` and started the server with defaults.

Replace `restart_abort` with direct `--exec $MYSQLD` calls to properly test invalid heartbeat options

## Release Notes
N/A

## How can this PR be tested?
Execute the `main.change_master_default` test in `mysql-test-run`.

### Before this change:
There were sporadic failures like so:
```
@@ -209,9 +209,9 @@
 SELECT connection_name, slave_heartbeat_period
 FROM information_schema.slave_status ORDER BY connection_name;
 connection_name	slave_heartbeat_period
-	0.000
-defaulted	0.000
-unset	0.000
+	60.000
+defaulted	60.000
+unset	60.000
 CALL mtr.add_suppression('.*master-heartbeat-period.+0.*disabl.+');
 FOUND 1 /\[Warning\] .*master-heartbeat-period.+0.*disabl.+/ in mysqld.1.err
 # restart: --skip-slave-start --skip-master-ssl --master-ssl --skip-master-ssl-verify-server-cert --master-ssl-verify-server-cert --master-use-gtid=NO --autoset-master-use-gtid --master-heartbeat-period=45 --autoset-master-heartbeat-period
Result length mismatch
```
### After this change:
Running this test 50 times consecutively with `--repeat=50` in `mysql-test-run` shows no failures:
```
==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
worker[01] mysql-test-run: WARNING: running this script as _root_ will cause some tests to be skipped
main.change_master_default               [ pass ]   4428
main.change_master_default               [ 2 pass ]   4370
main.change_master_default               [ 3 pass ]   4412
main.change_master_default               [ 4 pass ]   4506
main.change_master_default               [ 5 pass ]   4413
...
main.change_master_default               [ 50 pass ]   4425
--------------------------------------------------------------------------
The servers were restarted 1 times
Spent 221.983 of 248 seconds executing testcases

Completed: All 50 tests were successful.
```

## Basing the PR against the correct MariaDB version
* [x] _This is a bug fix, and the PR is based against the branch 12.3._

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.