### PR TITLE
MDEV-39862 innodb_log_archive=ON corruption after modifying file parameters

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18747,6 +18747,8 @@ buffer_pool_load_abort(
 static void innodb_log_file_buffering_update(THD *, st_mysql_sys_var*,
                                              void *, const void *save)
 {
+  /* MDEV-36828 TODO: On failure, report which other setting
+  conflicted with the request */
   mysql_mutex_unlock(&LOCK_global_system_variables);
   log_sys.set_buffered(*static_cast<const my_bool*>(save));
   mysql_mutex_lock(&LOCK_global_system_variables);
@@ -18756,6 +18758,8 @@ static void innodb_log_file_buffering_update(THD *, st_mysql_sys_var*,
 static void innodb_log_file_write_through_update(THD *, st_mysql_sys_var*,
                                                  void *, const void *save)
 {
+  /* MDEV-36828 TODO: On failure, report which other setting
+  conflicted with the request */
   mysql_mutex_unlock(&LOCK_global_system_variables);
   log_sys.set_write_through(*static_cast<const my_bool*>(save));
   mysql_mutex_lock(&LOCK_global_system_variables);
@@ -19703,6 +19707,8 @@ static MYSQL_SYSVAR_BOOL(data_file_write_through, fil_system.write_through,
 static void innodb_log_archive_update(THD *thd, st_mysql_sys_var*,
                                       void *, const void *save) noexcept
 {
+  /* MDEV-36828 TODO: On failure, report which other setting
+  conflicted with the request */
   log_sys.set_archive(*static_cast<const my_bool*>(save), thd);
 }
 

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -618,7 +618,8 @@ void log_t::set_buffered(bool buffered) noexcept
       high_level_read_only)
     return;
   log_resize_acquire();
-  if (!resize_in_progress() && is_opened() && bool(log_buffered) != buffered)
+  if (!resize_in_progress() && is_opened() && !resize_log.is_opened() &&
+      bool(log_buffered) != buffered)
   {
     if (const dberr_t err= log.close())
       log_close_failed(err);
@@ -640,7 +641,7 @@ void log_t::set_write_through(bool write_through)
   if (is_mmap() || high_level_read_only || recv_sys.rpo)
     return;
   log_resize_acquire();
-  if (!resize_in_progress() && is_opened() &&
+  if (!resize_in_progress() && is_opened() && !resize_log.is_opened() &&
       bool(log_write_through) != write_through)
   {
     os_file_close_func(log.m_file);


### PR DESCRIPTION
`log_t::set_buffered()`, `log_t::set_write_through()`: If a log file switch with `innodb_log_archive=ON` is in progress, ignore a `SET GLOBAL` statement that would attempt to modify `innodb_log_file_buffering` or `innodb_log_file_write_through`.

This prevents the log from becoming corrupted. The problem was that we would close `log_sys.log.m_file` that pointed to the latest log file and then reopen a second handle to the previous log file, which `log_sys.resize_log.m_file` is already pointing to. As a result, log records would be written to the wrong log file, causing the log to be corrupted.

The statements `SET GLOBAL innodb_log_file_buffering` and `SET GLOBAL innodb_log_file_write_through` will also be ignored when a `SET GLOBAL innodb_log_file_size` operation is in progress on a circular-format log (`ib_logfile0`). The statements will have an effect when InnoDB is holding only one log file open, which should be most of the time. These statements have no effect when the log file is mapped to persistent memory.

Whether a requested change took place can be checked by executing a statement like the following:
```sql
SELECT @@GLOBAL.innodb_log_file_buffering;
```
Tested by: @mariadb-SaahilAlam