### PR TITLE
MDEV-39828 Stabilize query_cache_executable_comments counter checks

### DIFF
--- a/mysql-test/main/query_cache_executable_comments.result
+++ b/mysql-test/main/query_cache_executable_comments.result
@@ -25,7 +25,7 @@ INSERT INTO t1 VALUES (1),(2),(3);
 # Case 1: forward MySQL-compatible executable comment /*!NNNNNN ... */
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT /*!50300 c1 */ FROM t1;
 SELECT /*!50300 c1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
@@ -44,15 +44,15 @@ hits	statement_text
 # Case 2: forward MariaDB-only executable comment /*M!NNNNNN ... */
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT /*M!50300 c1 */ FROM t1;
 SELECT /*M!50300 c1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	2
+Qcache_inserts	1
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	2
+Qcache_hits	1
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	1
@@ -65,15 +65,15 @@ hits	statement_text
 # marked not safe to cache and no entry is stored.
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT /*!!999999 c1 */ FROM t1;
 SELECT /*!!999999 c1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	2
+Qcache_inserts	0
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	2
+Qcache_hits	0
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	0
@@ -84,15 +84,15 @@ hits	statement_text
 # Same buffer mutation as case 3; not cached.
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT /*M!!999999 c1 */ FROM t1;
 SELECT /*M!!999999 c1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	2
+Qcache_inserts	0
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	2
+Qcache_hits	0
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	0
@@ -104,15 +104,15 @@ hits	statement_text
 # overwrites the leading '!' with a space; not cached.
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT c1 /*!999999 + 1 */ FROM t1;
 SELECT c1 /*!999999 + 1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	2
+Qcache_inserts	0
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	2
+Qcache_hits	0
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	0
@@ -123,15 +123,15 @@ hits	statement_text
 # version is <= the server, so the body is SKIPPED; not cached.
 #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT c1 /*!!100000 + 1 */ FROM t1;
 SELECT c1 /*!!100000 + 1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	2
+Qcache_inserts	0
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	2
+Qcache_hits	0
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	0
@@ -142,7 +142,7 @@ hits	statement_text
 #
 SET LOCAL query_cache_strip_comments= ON;
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 SELECT /*!50300 c1 */ FROM t1;
 SELECT /*!50300 c1 */ FROM t1;
 SELECT /*!!999999 c1 */ FROM t1;
@@ -153,10 +153,10 @@ SELECT c1 /*!!100000 + 1 */ FROM t1;
 SELECT c1 /*!!100000 + 1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	6
+Qcache_inserts	4
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	6
+Qcache_hits	4
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	4

--- a/mysql-test/main/query_cache_executable_comments.test
+++ b/mysql-test/main/query_cache_executable_comments.test
@@ -40,7 +40,7 @@ INSERT INTO t1 VALUES (1),(2),(3);
 --echo # Case 1: forward MySQL-compatible executable comment /*!NNNNNN ... */
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT /*!50300 c1 */ FROM t1;
 SELECT /*!50300 c1 */ FROM t1;
@@ -54,7 +54,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo # Case 2: forward MariaDB-only executable comment /*M!NNNNNN ... */
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT /*M!50300 c1 */ FROM t1;
 SELECT /*M!50300 c1 */ FROM t1;
@@ -70,7 +70,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo # marked not safe to cache and no entry is stored.
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT /*!!999999 c1 */ FROM t1;
 SELECT /*!!999999 c1 */ FROM t1;
@@ -85,7 +85,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo # Same buffer mutation as case 3; not cached.
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT /*M!!999999 c1 */ FROM t1;
 SELECT /*M!!999999 c1 */ FROM t1;
@@ -101,7 +101,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo # overwrites the leading '!' with a space; not cached.
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT c1 /*!999999 + 1 */ FROM t1;
 SELECT c1 /*!999999 + 1 */ FROM t1;
@@ -116,7 +116,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo # version is <= the server, so the body is SKIPPED; not cached.
 --echo #
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT c1 /*!!100000 + 1 */ FROM t1;
 SELECT c1 /*!!100000 + 1 */ FROM t1;
@@ -131,7 +131,7 @@ SELECT hits, statement_text FROM information_schema.query_cache_info;
 --echo #
 SET LOCAL query_cache_strip_comments= ON;
 RESET QUERY CACHE;
-FLUSH STATUS;
+FLUSH GLOBAL STATUS;
 --disable_result_log
 SELECT /*!50300 c1 */ FROM t1;
 SELECT /*!50300 c1 */ FROM t1;


### PR DESCRIPTION
## Description

The test `main.query_cache_executable_comments` is unreliable and fails on
the builders ([MDEV-39828](https://jira.mariadb.org/browse/MDEV-39828)).
It asserts the absolute values of the global status counters `Qcache_inserts`
and `Qcache_hits`, but resets them per case with `FLUSH STATUS`.

`FLUSH STATUS` does not reset the global counters `query_cache.hits` /
`query_cache.inserts`. As a result the recorded values were
actually cumulative from server start, and the test only passed against a
pristine `mysqld`. When the server instance is reused with prior query-cache
activity (server reuse, `--repeat`), the leftover counter values are
added to every assertion, producing a constant offset and a "Result length
mismatch". 

Fix: Replace the `FLUSH STATUS` calls with `FLUSH GLOBAL
STATUS` which actually resets the Qcache counters. This is the idiomatic pattern
already used by every other query-cache test (`query_cache.test`,
`query_cache_with_views.test`, `subselect_cache.test`, the `query_cache*.inc`
includes, etc.).

## How can this PR be tested?
Execute the `main.query_cache_executable_comments` test in `mysql-test-run`.

### Before this change:
The test passes in isolation but fails whenever the server is reused with
prior query-cache activity. This is reproducible with `--repeat=2` (the
second iteration reuses the same `mysqld` instance):

```
@@ -30,10 +30,10 @@
 SELECT /*!50300 c1 */ FROM t1;
 SHOW STATUS LIKE 'Qcache_inserts';
 Variable_name	Value
-Qcache_inserts	1
+Qcache_inserts	7
 SHOW STATUS LIKE 'Qcache_hits';
 Variable_name	Value
-Qcache_hits	1
+Qcache_hits	3
 SHOW STATUS LIKE 'Qcache_queries_in_cache';
 Variable_name	Value
 Qcache_queries_in_cache	1
...
Result length mismatch
```

### After this change:
Running the test with `--repeat=2` in
`mysql-test-run` shows no failures, with the server reused throughout:

```
==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
worker[01] mysql-test-run: WARNING: running this script as _root_ will cause some tests to be skipped
main.query_cache_executable_comments     [ pass ]    108
main.query_cache_executable_comments     [ 2 pass ]     28
--------------------------------------------------------------------------
The servers were restarted 0 times

Completed: All 2 tests were successful.
```

## Basing the PR against the correct MariaDB version
* [x] _This is a bug fix, and the PR is based against the branch 13.0._

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.