### PR TITLE
MDEV-40023 Error on unknown commands in check_expected_crash_and_restart

### DIFF
--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -4852,30 +4852,47 @@ sub check_expected_crash_and_restart {
       # test script to control when the server should start
       # up again. Keep trying for up to 5s at a time.
       my $last_line= mtr_lastlinesfromfile($expect_file, 1);
-      if ($last_line =~ /^wait/ )
+      chomp $last_line;
+      # Skip empty lines: partial writes to the expect file can be observed
+      # before the intended command is fully written.
+      next if $last_line =~ /^\s*$/;
+      # "wait" or "wait-<tag>" (tag is a diagnostic marker, usually the
+      # name of the test that wrote the file).
+      if ($last_line =~ /^wait(-\S+)?\s*$/)
       {
         mtr_verbose("Test says wait before restart") if $waits == 0;
         next;
       }
       delete $ENV{MTR_BINDIR_FORCED};
 
-      # Ignore any partial or unknown command
-      next unless $last_line =~ /^restart/;
       # If last line begins "restart:", the rest of the line is read as
       # extra command line options to add to the restarted mysqld.
-      # Anything other than 'wait' or 'restart:' (with a colon) will
-      # result in a restart with original mysqld options.
-      if ($last_line =~ /restart_bindir\s+(\S+)(:.+)?/) {
+      # "restart" or "restart-<tag>" restarts with the original options.
+      # "restart_bindir <path>[:opts]" additionally forces the mysqld
+      # binary to be picked from <path> (used during development to
+      # test upgrades between two build trees).
+      # Anything else is treated as an error to catch typos in expect
+      # file commands (e.g. MDEV-39153).
+      if ($last_line =~ /^restart_bindir\s+(\S+)(:.+)?/) {
         $ENV{MTR_BINDIR_FORCED}= $1;
         if ($2) {
           my @rest_opt= split(' ', $2);
           $mysqld->{'restart_opts'}= \@rest_opt;
         }
-      } elsif ($last_line =~ /restart:(.+)/) {
-        my @rest_opt= split(' ', $1);
-        $mysqld->{'restart_opts'}= \@rest_opt;
-      } else {
+      } elsif ($last_line =~ /^restart:(.*)$/) {
+        # Empty tail (e.g. bare 'restart:') is equivalent to 'restart'.
+        my $rest_opt_str= $1;
+        if ($rest_opt_str =~ /\S/) {
+          my @rest_opt= split(' ', $rest_opt_str);
+          $mysqld->{'restart_opts'}= \@rest_opt;
+        } else {
+          delete $mysqld->{'restart_opts'};
+        }
+      } elsif ($last_line =~ /^restart(-\S+)?\s*$/) {
         delete $mysqld->{'restart_opts'};
+      } else {
+        mtr_error("Unknown command '$last_line' in expect file " .
+                  "'$expect_file'");
       }
       unlink($expect_file);
 


### PR DESCRIPTION
## Description

`check_expected_crash_and_restart()` in `mariadb-test-run.pl` silently ignores anything in the expect file that does not start with `restart`. This let typos like `restart_abort` fall through to a default restart and made bugs like [MDEV-39153](https://jira.mariadb.org/browse/MDEV-39153) easy to miss.

Fix:
- Anchor the `wait` / `restart` / `restart_bindir` regexes and call `mtr_error()` on any unrecognized command
- `chomp $last_line` before matching so error messages don't embed a newline
- Skip empty last lines, since partial writes to the expect file can be observed before the intended command is fully written (same race the existing `-z $expect_file` check guards against)

`restart_bindir` is left in place as it is used during development to test binary/data migration between two build trees.

## Release Notes
N/A

## How can this PR be tested?
Execute the full MTR test suite — no test uses `restart_bindir`, so removing it should have no effect. The `mtr_error()` change will prevent any future invalid expect file commands from failing silently.

## Basing the PR against the correct MariaDB version
* [x] _This is a minor fix, and the PR is based against the main branch._

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.