### PR TITLE
MDEV-35555 UBSAN runtime error: applying non-zero offset 32 to null p…

### DIFF
--- a/mysql-test/main/partition_explicit_prune.result
+++ b/mysql-test/main/partition_explicit_prune.result
@@ -2008,3 +2008,12 @@ drop table t1;
 #
 # End of 10.4 tests
 #
+#
+# MDEV-35555 UBSAN runtime error: applying non-zero offset 32 to null pointer in sel_trees_must_be_ored
+#
+CREATE TABLE t (a INT,b CHAR,PRIMARY KEY(a,b)) PARTITION BY LINEAR KEY() PARTITIONS 2;
+EXPLAIN SELECT * FROM t WHERE a=1 OR a=2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
+DROP TABLE t;
+# End of 10.11 tests

--- a/mysql-test/main/partition_explicit_prune.test
+++ b/mysql-test/main/partition_explicit_prune.test
@@ -942,3 +942,12 @@ drop table t1;
 --echo # End of 10.4 tests
 --echo #
 
+--echo #
+--echo # MDEV-35555 UBSAN runtime error: applying non-zero offset 32 to null pointer in sel_trees_must_be_ored
+--echo #
+
+CREATE TABLE t (a INT,b CHAR,PRIMARY KEY(a,b)) PARTITION BY LINEAR KEY() PARTITIONS 2;
+EXPLAIN SELECT * FROM t WHERE a=1 OR a=2;
+DROP TABLE t;
+
+--echo # End of 10.11 tests

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -9753,7 +9753,8 @@ bool sel_trees_must_be_ored(RANGE_OPT_PARAM* param,
 
   int idx1, idx2;
   key_map::Iterator it1(oredable_keys);
-  while ((idx1= it1++) != key_map::Iterator::BITMAP_END)
+  while ((idx1= it1++) != key_map::Iterator::BITMAP_END
+         && param->key[idx1] && tree1->keys[idx1])
   {
     KEY_PART *key1_init= param->key[idx1]+tree1->keys[idx1]->part;
     KEY_PART *key1_end= param->key[idx1]+tree1->keys[idx1]->max_part_no;
@@ -9763,6 +9764,8 @@ bool sel_trees_must_be_ored(RANGE_OPT_PARAM* param,
       if (idx2 <= idx1)
         continue;
       
+      if (!param->key[idx2] || !tree2->keys[idx2])
+        break;
       KEY_PART *key2_init= param->key[idx2]+tree2->keys[idx2]->part;
       KEY_PART *key2_end= param->key[idx2]+tree2->keys[idx2]->max_part_no;
       if (!is_key_infix(key1_init, key1_end, key2_init, key2_end) &&


### PR DESCRIPTION
…ointer in sel_trees_must_be_ored

param->key[] where dereferenced but these could be null pointers.

This was the case under main.partition_explicit_prune. tree[1,2]->keys[] could also be nullptr, so we check for these too.