### PR TITLE
MDEV-39998 Fix JSON_OVERLAPS asymmetry for nested array comparison

### DIFF
--- a/mysql-test/main/mdev_39998.result
+++ b/mysql-test/main/mdev_39998.result
@@ -1,0 +1,58 @@
+#
+# MDEV-39998: JSON_OVERLAPS asymmetry for ordered array comparison
+#
+SELECT JSON_OVERLAPS('[[1,2]]', '[[1]]') AS must_be_0;
+must_be_0
+0
+SELECT JSON_OVERLAPS('[[1]]', '[[1,2]]') AS must_be_0_too;
+must_be_0_too
+0
+SELECT JSON_OVERLAPS('[[1,2]]', '[[1,2]]') AS must_be_1;
+must_be_1
+1
+SELECT JSON_OVERLAPS('[[1,2,3]]', '[[1,2]]') AS r1,
+JSON_OVERLAPS('[[1,2]]', '[[1,2,3]]') AS r2;
+r1	r2
+0	0
+SELECT JSON_OVERLAPS('[1,2,3]', '[3,4,5]') AS scalar_overlap;
+scalar_overlap
+1
+SELECT JSON_OVERLAPS('[[]]', '[[]]') AS empty_match;
+empty_match
+1
+SELECT JSON_OVERLAPS('[[1]]', '[[]]') AS r1,
+JSON_OVERLAPS('[[]]', '[[1]]') AS r2;
+r1	r2
+0	0
+SELECT JSON_OVERLAPS('[{"a":1}]', '[{"a":1}]') AS obj_match;
+obj_match
+1
+SELECT JSON_OVERLAPS('[{"a":1,"b":2}]', '[{"a":1}]') AS r1,
+JSON_OVERLAPS('[{"a":1}]', '[{"a":1,"b":2}]') AS r2;
+r1	r2
+0	0
+SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1]]]') AS r1,
+JSON_OVERLAPS('[[[1]]]', '[[[1,2]]]') AS r2;
+r1	r2
+0	0
+SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1,2]]]') AS deep_match;
+deep_match
+1
+SELECT JSON_OVERLAPS(NULL, '[[1]]') AS r1,
+JSON_OVERLAPS('[[1]]', NULL) AS r2;
+r1	r2
+NULL	NULL
+SELECT JSON_OVERLAPS('[1,[1,2]]', '[[1,2],1]') AS mixed_match;
+mixed_match
+1
+SELECT JSON_OVERLAPS('[1,[1,2]]', '[[1],1]') AS r1,
+JSON_OVERLAPS('[[1],1]', '[1,[1,2]]') AS r2;
+r1	r2
+1	1
+SELECT JSON_OVERLAPS('[[1]]', '[[1]]') AS single_match;
+single_match
+1
+SELECT JSON_OVERLAPS('[["a"]]', '[["a","b"]]') AS r1,
+JSON_OVERLAPS('[["a","b"]]', '[["a"]]') AS r2;
+r1	r2
+0	0

--- a/mysql-test/main/mdev_39998.test
+++ b/mysql-test/main/mdev_39998.test
@@ -1,0 +1,51 @@
+#
+# MDEV-39998: JSON_OVERLAPS must be symmetric for nested arrays
+#
+
+--echo #
+--echo # MDEV-39998: JSON_OVERLAPS asymmetry for ordered array comparison
+--echo #
+
+# Original reported bug: prefix of nested array falsely matches
+SELECT JSON_OVERLAPS('[[1,2]]', '[[1]]') AS must_be_0;
+SELECT JSON_OVERLAPS('[[1]]', '[[1,2]]') AS must_be_0_too;
+
+# Exact match must still work
+SELECT JSON_OVERLAPS('[[1,2]]', '[[1,2]]') AS must_be_1;
+
+# Both directions must agree (symmetry)
+SELECT JSON_OVERLAPS('[[1,2,3]]', '[[1,2]]') AS r1,
+       JSON_OVERLAPS('[[1,2]]', '[[1,2,3]]') AS r2;
+
+# Scalar overlap still works
+SELECT JSON_OVERLAPS('[1,2,3]', '[3,4,5]') AS scalar_overlap;
+
+# Empty nested arrays
+SELECT JSON_OVERLAPS('[[]]', '[[]]') AS empty_match;
+SELECT JSON_OVERLAPS('[[1]]', '[[]]') AS r1,
+       JSON_OVERLAPS('[[]]', '[[1]]') AS r2;
+
+# Nested objects inside arrays
+SELECT JSON_OVERLAPS('[{"a":1}]', '[{"a":1}]') AS obj_match;
+SELECT JSON_OVERLAPS('[{"a":1,"b":2}]', '[{"a":1}]') AS r1,
+       JSON_OVERLAPS('[{"a":1}]', '[{"a":1,"b":2}]') AS r2;
+
+# Deeply nested arrays
+SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1]]]') AS r1,
+       JSON_OVERLAPS('[[[1]]]', '[[[1,2]]]') AS r2;
+SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1,2]]]') AS deep_match;
+
+# NULL handling
+SELECT JSON_OVERLAPS(NULL, '[[1]]') AS r1,
+       JSON_OVERLAPS('[[1]]', NULL) AS r2;
+
+# Mixed types in outer array
+SELECT JSON_OVERLAPS('[1,[1,2]]', '[[1,2],1]') AS mixed_match;
+SELECT JSON_OVERLAPS('[1,[1,2]]', '[[1],1]') AS r1,
+       JSON_OVERLAPS('[[1],1]', '[1,[1,2]]') AS r2;
+
+# Single element arrays
+SELECT JSON_OVERLAPS('[[1]]', '[[1]]') AS single_match;
+SELECT JSON_OVERLAPS('[["a"]]', '[["a","b"]]') AS r1,
+       JSON_OVERLAPS('[["a","b"]]', '[["a"]]') AS r2;
+

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -5071,8 +5071,8 @@ bool json_compare_arrays_in_order(json_engine_t *js, json_engine_t *value,
       return FALSE;
     }
   }
-  res= (value->state == JST_ARRAY_END || value->state == JST_OBJ_END ?
-        TRUE : FALSE);
+  res= (value->state == JST_ARRAY_END || value->state == JST_OBJ_END) &&
+       (js->state == JST_ARRAY_END || js->state == JST_OBJ_END);
   json_skip_current_level(js, value);
   return res;
 }


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39998](https://jira.mariadb.org/browse/MDEV-39998) where `JSON_OVERLAPS()` produces asymmetric results when comparing nested arrays of different lengths.

`json_compare_arrays_in_order()` only checked if the second array (`value`) reached its end after the element-by-element comparison loop. This allowed a longer first array to falsely match a shorter second array as a "prefix match", breaking the required symmetry of `JSON_OVERLAPS`.

The fix involves:

1. Adding a check that **both** array engines have reached their end state (`JST_ARRAY_END` or `JST_OBJ_END`) after the comparison loop, ensuring arrays must have the same length to be considered equal in ordered comparison.

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39998
```

Or manually:

```sql
SELECT JSON_OVERLAPS('[[1,2]]', '[[1]]') AS r1, JSON_OVERLAPS('[[1]]', '[[1,2]]') AS r2;
-- Both should return 0 (symmetric)

SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1]]]') AS r1, JSON_OVERLAPS('[[[1]]]', '[[[1,2]]]') AS r2;
-- Both should return 0 (deep nesting symmetric)
```

## Results from my testing

1. Before changes

```
MariaDB> SELECT JSON_OVERLAPS('[[1,2]]', '[[1]]') AS r1, JSON_OVERLAPS('[[1]]', '[[1,2]]') AS r2;
+----+----+
| r1 | r2 |
+----+----+
|  1 |  0 |
+----+----+

MariaDB> SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1]]]') AS r1, JSON_OVERLAPS('[[[1]]]', '[[[1,2]]]') AS r2;
+----+----+
| r1 | r2 |
+----+----+
|  1 |  0 |
+----+----+
```

The result is asymmetric — `[1,2]` is treated as "overlapping" `[1]` in one direction but not the other.

2. After changes

```
MariaDB> SELECT JSON_OVERLAPS('[[1,2]]', '[[1]]') AS r1, JSON_OVERLAPS('[[1]]', '[[1,2]]') AS r2;
+----+----+
| r1 | r2 |
+----+----+
|  0 |  0 |
+----+----+

MariaDB> SELECT JSON_OVERLAPS('[[[1,2]]]', '[[[1]]]') AS r1, JSON_OVERLAPS('[[[1]]]', '[[[1,2]]]') AS r2;
+----+----+
| r1 | r2 |
+----+----+
|  0 |  0 |
+----+----+
```

Results are now symmetric. Arrays of different lengths are correctly not considered overlapping.

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.