### PR TITLE
MDEV-39918 Fix crash in degenerate jtbm semi-join with recursive CTE/…

### DIFF
--- a/mysql-test/main/mdev_39918.result
+++ b/mysql-test/main/mdev_39918.result
@@ -1,0 +1,60 @@
+#
+# MDEV-39918: Crash in execute_degenerate_jtbm_semi_join with non-SINGLE_SELECT_ENGINE
+#
+# Recursive CTE with window function (original crash)
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (
+WITH RECURSIVE x(x) AS (SELECT 10 AS x)
+SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
+FROM (SELECT 1 AS x WHERE 1=0) AS d WHERE x
+);
+1
+1
+# Truly recursive CTE nested in derived table
+SELECT 1 FROM (SELECT 1 AS x) AS outer_t
+WHERE x IN (
+SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
+FROM (
+WITH RECURSIVE x(x) AS (SELECT 1 UNION SELECT x + 1 FROM x WHERE x < 3)
+SELECT * FROM x WHERE 1=0
+) AS d WHERE x
+);
+1
+1
+# Simple UNION subquery (no tables in first SELECT)
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 UNION SELECT 2);
+1
+1
+# UNION ALL with degenerate first branch
+SELECT * FROM (SELECT 1 AS x UNION ALL SELECT 2) AS t
+WHERE x IN (SELECT 1 UNION ALL SELECT 2);
+x
+1
+2
+# EXCEPT variant
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 EXCEPT SELECT 2);
+1
+1
+# INTERSECT variant
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 INTERSECT SELECT 1);
+1
+1
+# Non-degenerate subquery (has tables, should work as before)
+CREATE TABLE t1 (a INT);
+INSERT INTO t1 VALUES (1), (2), (3);
+SELECT * FROM t1 WHERE a IN (SELECT a FROM t1 WHERE a > 1);
+a
+2
+3
+DROP TABLE t1;
+# UNION with table in one branch, no table in another
+CREATE TABLE t2 (a INT);
+INSERT INTO t2 VALUES (5);
+SELECT * FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 UNION SELECT a FROM t2);
+x
+1
+DROP TABLE t2;

--- a/mysql-test/main/mdev_39918.test
+++ b/mysql-test/main/mdev_39918.test
@@ -1,0 +1,56 @@
+#
+# MDEV-39918: MariaDB crash triggered by recursive CTE with window function
+# in IN subquery (degenerate jtbm semi-join)
+#
+
+--echo #
+--echo # MDEV-39918: Crash in execute_degenerate_jtbm_semi_join with non-SINGLE_SELECT_ENGINE
+--echo #
+
+--echo # Recursive CTE with window function (original crash)
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (
+  WITH RECURSIVE x(x) AS (SELECT 10 AS x)
+  SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
+  FROM (SELECT 1 AS x WHERE 1=0) AS d WHERE x
+);
+
+--echo # Truly recursive CTE nested in derived table
+SELECT 1 FROM (SELECT 1 AS x) AS outer_t
+WHERE x IN (
+  SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
+  FROM (
+    WITH RECURSIVE x(x) AS (SELECT 1 UNION SELECT x + 1 FROM x WHERE x < 3)
+    SELECT * FROM x WHERE 1=0
+  ) AS d WHERE x
+);
+
+--echo # Simple UNION subquery (no tables in first SELECT)
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 UNION SELECT 2);
+
+--echo # UNION ALL with degenerate first branch
+SELECT * FROM (SELECT 1 AS x UNION ALL SELECT 2) AS t
+WHERE x IN (SELECT 1 UNION ALL SELECT 2);
+
+--echo # EXCEPT variant
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 EXCEPT SELECT 2);
+
+--echo # INTERSECT variant
+SELECT 1 FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 INTERSECT SELECT 1);
+
+--echo # Non-degenerate subquery (has tables, should work as before)
+CREATE TABLE t1 (a INT);
+INSERT INTO t1 VALUES (1), (2), (3);
+SELECT * FROM t1 WHERE a IN (SELECT a FROM t1 WHERE a > 1);
+DROP TABLE t1;
+
+--echo # UNION with table in one branch, no table in another
+CREATE TABLE t2 (a INT);
+INSERT INTO t2 VALUES (5);
+SELECT * FROM (SELECT 1 AS x) AS t
+WHERE x IN (SELECT 1 UNION SELECT a FROM t2);
+DROP TABLE t2;
+

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -6552,7 +6552,15 @@ bool setup_degenerate_jtbm_semi_joins(JOIN *join,
     {
       JOIN *subq_join= subq_pred->unit->first_select()->join;
 
-      if (!subq_join->tables_list || !subq_join->table_count)
+      /*
+        The degenerate path requires SINGLE_SELECT_ENGINE.
+        Other engine types (UNION_ENGINE for UNION/EXCEPT/INTERSECT/
+        recursive CTEs, etc.) must go through normal JTBM
+        materialization instead.
+      */
+      if ((!subq_join->tables_list || !subq_join->table_count) &&
+          subq_pred->engine->engine_type() ==
+          subselect_engine::SINGLE_SELECT_ENGINE)
       {
         if (execute_degenerate_jtbm_semi_join(thd,
                                               table,
@@ -6645,7 +6653,15 @@ bool setup_jtbm_semi_joins(JOIN *join, List<TABLE_LIST> *join_list,
       subq_pred->jtbm_record_count=rows;
       JOIN *subq_join= subq_pred->unit->first_select()->join;
 
-      if (!subq_join->tables_list || !subq_join->table_count)
+      /*
+        The degenerate path requires SINGLE_SELECT_ENGINE.
+        Other engine types (UNION_ENGINE for UNION/EXCEPT/INTERSECT/
+        recursive CTEs, etc.) must go through normal JTBM
+        materialization instead.
+      */
+      if ((!subq_join->tables_list || !subq_join->table_count) &&
+          subq_pred->engine->engine_type() ==
+          subselect_engine::SINGLE_SELECT_ENGINE)
       {
         if (!join->is_orig_degenerated &&
             execute_degenerate_jtbm_semi_join(thd, table, subq_pred,


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39918](https://jira.mariadb.org/browse/MDEV-39918) where MariaDB crashes with an assertion failure (or segfault in non-debug builds) when a recursive CTE or UNION subquery is used in an IN predicate that triggers the degenerate JTBM semi-join path.

`execute_degenerate_jtbm_semi_join()` assumes the subquery engine is `SINGLE_SELECT_ENGINE` and casts unconditionally. However, recursive CTEs, UNIONs, EXCEPTs, and INTERSECTs use `UNION_ENGINE` even when the first SELECT has no tables (`table_count == 0`). The existing condition only checked `table_count`, not the engine type.

The fix involves:

1. Adding an engine type check (`SINGLE_SELECT_ENGINE`) at both call sites before entering the degenerate path. Non-matching subqueries fall through to normal JTBM materialization.

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39918
```

Or manually (this will crash without the fix):

```sql
SELECT 1 FROM (SELECT 1 AS x) AS t
WHERE x IN (
  WITH RECURSIVE x(x) AS (SELECT 10 AS x)
  SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
  FROM (SELECT 1 AS x WHERE 1=0) AS d WHERE x
);
```

## Results from my testing

1. Before changes (server crashes)

```
mariadbd: /workspace/mariadb-server/sql/opt_subselect.cc:6455:
  bool execute_degenerate_jtbm_semi_join(THD *, TABLE_LIST *,
  Item_in_subselect *, List<Item> &):
  Assertion `subq_pred->engine->engine_type() ==
  subselect_engine::SINGLE_SELECT_ENGINE' failed.

260612 22:23:55 [ERROR] ./sql/mariadbd got signal 6 ;
Sorry, we probably made a mistake, and this is a bug.
```

Client gets: `ERROR 2026 (HY000): TLS/SSL error: unexpected eof while reading` (connection lost due to server crash).

2. After changes

```
MariaDB> SELECT 1 FROM (SELECT 1 AS x) AS t
    -> WHERE x IN (
    ->   WITH RECURSIVE x(x) AS (SELECT 10 AS x)
    ->   SELECT ROW_NUMBER() OVER (ORDER BY AVG(x))
    ->   FROM (SELECT 1 AS x WHERE 1=0) AS d WHERE x
    -> );
+---+
| 1 |
+---+
| 1 |
+---+
```

No crash. UNION/EXCEPT/INTERSECT variants also work correctly.

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.