### PR TITLE
MDEV-39933 JSON_NORMALIZE returns wrong result for invalid JSON with …

### DIFF
--- a/mysql-test/main/mdev_39933.result
+++ b/mysql-test/main/mdev_39933.result
@@ -1,0 +1,43 @@
+#
+# MDEV-39933: Incorrect result of JSON_NORMALIZE on invalid json data
+#
+# JSON with trailing literal junk (no NUL) - should return NULL
+SELECT JSON_NORMALIZE('{"a":1}0junk');
+JSON_NORMALIZE('{"a":1}0junk')
+NULL
+# JSON_VALID correctly rejects JSON with embedded NUL byte + trailing junk
+SELECT JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
+JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1))
+0
+# JSON_NORMALIZE should also return NULL for invalid JSON with embedded NUL
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
+JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1))
+NULL
+# Additional case: just a NUL after valid JSON
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0)) USING latin1));
+JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0)) USING latin1))
+NULL
+# Valid JSON through conversion should still work
+SELECT JSON_NORMALIZE(CONVERT('{"a":1}' USING latin1));
+JSON_NORMALIZE(CONVERT('{"a":1}' USING latin1))
+{"a":1.0E0}
+# Multi-byte source charset (utf16)
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'x') USING utf16));
+JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'x') USING utf16))
+NULL
+# NUL embedded inside a JSON string value
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":"b', CHAR(0), 'c"}') USING latin1));
+JSON_NORMALIZE(CONVERT(CONCAT('{"a":"b', CHAR(0), 'c"}') USING latin1))
+NULL
+# JSON array with trailing NUL
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('[1,2,3]', CHAR(0), 'x') USING latin1));
+JSON_NORMALIZE(CONVERT(CONCAT('[1,2,3]', CHAR(0), 'x') USING latin1))
+NULL
+# Nested object - valid through conversion
+SELECT JSON_NORMALIZE(CONVERT('{"a":{"b":1}}' USING latin1));
+JSON_NORMALIZE(CONVERT('{"a":{"b":1}}' USING latin1))
+{"a":{"b":1.0E0}}
+# Empty string
+SELECT JSON_NORMALIZE(CONVERT('' USING latin1));
+JSON_NORMALIZE(CONVERT('' USING latin1))
+NULL

--- a/mysql-test/main/mdev_39933.test
+++ b/mysql-test/main/mdev_39933.test
@@ -1,0 +1,33 @@
+--echo #
+--echo # MDEV-39933: Incorrect result of JSON_NORMALIZE on invalid json data
+--echo #
+
+--echo # JSON with trailing literal junk (no NUL) - should return NULL
+SELECT JSON_NORMALIZE('{"a":1}0junk');
+
+--echo # JSON_VALID correctly rejects JSON with embedded NUL byte + trailing junk
+SELECT JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
+
+--echo # JSON_NORMALIZE should also return NULL for invalid JSON with embedded NUL
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
+
+--echo # Additional case: just a NUL after valid JSON
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0)) USING latin1));
+
+--echo # Valid JSON through conversion should still work
+SELECT JSON_NORMALIZE(CONVERT('{"a":1}' USING latin1));
+
+--echo # Multi-byte source charset (utf16)
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'x') USING utf16));
+
+--echo # NUL embedded inside a JSON string value
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":"b', CHAR(0), 'c"}') USING latin1));
+
+--echo # JSON array with trailing NUL
+SELECT JSON_NORMALIZE(CONVERT(CONCAT('[1,2,3]', CHAR(0), 'x') USING latin1));
+
+--echo # Nested object - valid through conversion
+SELECT JSON_NORMALIZE(CONVERT('{"a":{"b":1}}' USING latin1));
+
+--echo # Empty string
+SELECT JSON_NORMALIZE(CONVERT('' USING latin1));

--- a/strings/json_normalize.c
+++ b/strings/json_normalize.c
@@ -1030,15 +1030,14 @@ json_normalize(DYNAMIC_STRING *result,
     if (!s_utf8)
       return 1;
     memset(s_utf8, 0x00, in_size);
-    my_convert(s_utf8, (uint32)in_size, &my_charset_utf8mb4_bin,
-               s, (uint32)size, cs, &convert_err);
+    in_size= my_convert(s_utf8, (uint32)in_size, &my_charset_utf8mb4_bin,
+                       s, (uint32)size, cs, &convert_err);
     if (convert_err)
     {
        my_free(s_utf8);
        return 1;
     }
     in= s_utf8;
-    in_size= strlen(s_utf8);
   }
 
 


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39933](https://jira.mariadb.org/browse/MDEV-39933) where `JSON_NORMALIZE()` incorrectly returns a normalized result instead of NULL for invalid JSON containing embedded NUL bytes after charset conversion.

`json_normalize()` uses `strlen()` to determine the converted string length, but `strlen()` stops at the first NUL byte. This silently truncates the string to the valid JSON prefix, so `JSON_NORMALIZE` sees only `{"a":1}` instead of `{"a":1}\0junk` — returning a normalized result for what `JSON_VALID` correctly rejects.

The fix involves:

1. Using `my_convert()`'s return value (actual bytes written) instead of `strlen()`, which correctly accounts for embedded NUL bytes.

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39933
```

Or manually:

```sql
-- JSON_VALID correctly says this is invalid
SELECT JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
-- Returns: 0

-- JSON_NORMALIZE should agree (return NULL for invalid JSON)
SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
```

## Results from my testing

1. Before changes

```
MariaDB> SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1)) AS result;
+------------+
| result     |
+------------+
| {"a":1.0E0}|
+------------+

MariaDB> SELECT JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1)) AS valid;
+-------+
| valid |
+-------+
|     0 |
+-------+
```

`JSON_VALID` says it's invalid but `JSON_NORMALIZE` returns a result — inconsistent.

2. After changes

```
MariaDB> SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1)) AS result;
+--------+
| result |
+--------+
| NULL   |
+--------+

MariaDB> SELECT JSON_VALID(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1)) AS valid;
+-------+
| valid |
+-------+
|     0 |
+-------+
```

Both functions now agree: invalid JSON returns NULL/0.

## Affected versions

Reproduced on 10.11, 11.4, 11.8, and 12.3 (as confirmed in Jira comments). Lowest checked version: 10.11 with commit b89cb5d5c73263c.

Reproducer:

```sql
SELECT JSON_NORMALIZE(CONVERT(CONCAT('{"a":1}', CHAR(0), 'junk') USING latin1));
```

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.

* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.