### PR TITLE
MDEV-39981 Fix ST_GEOMFROMGEOJSON returning wrong result with reverse…

### DIFF
--- a/mysql-test/main/mdev_39981.result
+++ b/mysql-test/main/mdev_39981.result
@@ -1,0 +1,48 @@
+#
+# MDEV-39981: ST_GEOMFROMGEOJSON returns wrong result with reversed key order
+#
+# GeometryCollection: type before geometries (baseline)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"type":"GeometryCollection","geometries":[]}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"type":"GeometryCollection","geometries":[]}'))
+GEOMETRYCOLLECTION EMPTY
+# GeometryCollection: geometries before type (empty)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}'))
+GEOMETRYCOLLECTION EMPTY
+# GeometryCollection: geometries before type (non-empty)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[0,1]}],"type":"GeometryCollection"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[0,1]}],"type":"GeometryCollection"}'))
+GEOMETRYCOLLECTION(POINT(0 1))
+# GeometryCollection: multiple geometries before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[1,2]},{"type":"Point","coordinates":[3,4]}],"type":"GeometryCollection"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[1,2]},{"type":"Point","coordinates":[3,4]}],"type":"GeometryCollection"}'))
+GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))
+# Point: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[0,1],"type":"Point"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[0,1],"type":"Point"}'))
+POINT(0 1)
+# LineString: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[0,0],[1,1],[2,2]],"type":"LineString"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[0,0],[1,1],[2,2]],"type":"LineString"}'))
+LINESTRING(0 0,1 1,2 2)
+# Polygon: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]],"type":"Polygon"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]],"type":"Polygon"}'))
+POLYGON((0 0,1 0,1 1,0 1,0 0))
+# FeatureCollection: features before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[5,6]},"properties":{}}],"type":"FeatureCollection"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[5,6]},"properties":{}}],"type":"FeatureCollection"}'))
+GEOMETRYCOLLECTION(POINT(5 6))
+# Feature: geometry before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometry":{"type":"Point","coordinates":[7,8]},"type":"Feature","properties":{}}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometry":{"type":"Point","coordinates":[7,8]},"type":"Feature","properties":{}}'))
+POINT(7 8)
+# Unknown keys interspersed (should be ignored)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"foo":"bar","geometries":[],"type":"GeometryCollection","extra":123}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"foo":"bar","geometries":[],"type":"GeometryCollection","extra":123}'))
+GEOMETRYCOLLECTION EMPTY
+# Deeply nested geometries before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[9,10]}]}],"type":"GeometryCollection"}'));
+ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[9,10]}]}],"type":"GeometryCollection"}'))
+GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(9 10)))
+# End of test

--- a/mysql-test/main/mdev_39981.test
+++ b/mysql-test/main/mdev_39981.test
@@ -1,0 +1,38 @@
+--echo #
+--echo # MDEV-39981: ST_GEOMFROMGEOJSON returns wrong result with reversed key order
+--echo #
+
+--echo # GeometryCollection: type before geometries (baseline)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"type":"GeometryCollection","geometries":[]}'));
+
+--echo # GeometryCollection: geometries before type (empty)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}'));
+
+--echo # GeometryCollection: geometries before type (non-empty)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[0,1]}],"type":"GeometryCollection"}'));
+
+--echo # GeometryCollection: multiple geometries before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"Point","coordinates":[1,2]},{"type":"Point","coordinates":[3,4]}],"type":"GeometryCollection"}'));
+
+--echo # Point: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[0,1],"type":"Point"}'));
+
+--echo # LineString: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[0,0],[1,1],[2,2]],"type":"LineString"}'));
+
+--echo # Polygon: coordinates before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]],"type":"Polygon"}'));
+
+--echo # FeatureCollection: features before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[5,6]},"properties":{}}],"type":"FeatureCollection"}'));
+
+--echo # Feature: geometry before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometry":{"type":"Point","coordinates":[7,8]},"type":"Feature","properties":{}}'));
+
+--echo # Unknown keys interspersed (should be ignored)
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"foo":"bar","geometries":[],"type":"GeometryCollection","extra":123}'));
+
+--echo # Deeply nested geometries before type
+SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[9,10]}]}],"type":"GeometryCollection"}'));
+
+--echo # End of test

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -696,6 +696,8 @@ Geometry *Geometry::create_from_json(Geometry_buffer *buffer,
           coord_start= geom_start;
           goto create_geom;
         }
+        if (json_skip_level(je))
+          goto err_return;
       }
     }
     else if (key_len == features_keyname_len &&
@@ -712,6 +714,8 @@ Geometry *Geometry::create_from_json(Geometry_buffer *buffer,
         features_start= je->value_begin;
         if (fcoll_type_found)
           goto handle_feature_collection;
+        if (json_skip_level(je))
+          goto err_return;
       }
     }
     else if (key_len == geometry_keyname_len &&
@@ -724,6 +728,8 @@ Geometry *Geometry::create_from_json(Geometry_buffer *buffer,
         geometry_start= je->value_begin;
         if (feature_type_found)
           goto handle_geometry_key;
+        if (json_skip_level(je))
+          goto err_return;
       }
       else
         goto err_return;


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39981](https://jira.mariadb.org/browse/MDEV-39981) where `ST_GEOMFROMGEOJSON()` crashes or returns wrong results when GeoJSON keys appear in a non-standard order (e.g., `"geometries"` before `"type"`).

The GeoJSON parser in `spatial.cc` expects `"type"` to appear before other keys. When `"geometries"`, `"features"`, or `"geometry"` appear first, the parser saves the value start position for later re-parsing but fails to call `json_skip_level()` to advance the scanner past the value. This leaves the JSON scanner in an inconsistent state, causing crashes or incorrect parsing of subsequent keys.

The fix involves:

1. Adding `json_skip_level()` calls in the three affected key handlers (geometries, features, geometry) when the type has not yet been determined — matching the existing pattern already used by the coordinates handler.

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39981
```

Or manually (crashes without fix):

```sql
SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}'));
SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[5,6]},"properties":{}}],"type":"FeatureCollection"}'));
SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometry":{"type":"Point","coordinates":[7,8]},"type":"Feature","properties":{}}'));
```

## Results from my testing

1. Before changes (server crashes)

```
MariaDB> SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}'));
ERROR 2026 (HY000): TLS/SSL error: unexpected eof while reading
-- (server crashed)
```

2. After changes

```
MariaDB> SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometries":[],"type":"GeometryCollection"}')) AS r1;
+------------------------+
| r1                     |
+------------------------+
| GEOMETRYCOLLECTION EMPTY|
+------------------------+

MariaDB> SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"features":[...],"type":"FeatureCollection"}')) AS r2;
+------------------------------+
| r2                           |
+------------------------------+
| GEOMETRYCOLLECTION(POINT(5 6))|
+------------------------------+

MariaDB> SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"geometry":{"type":"Point","coordinates":[7,8]},"type":"Feature","properties":{}}')) AS r3;
+------------+
| r3         |
+------------+
| POINT(7 8) |
+------------+
```

GeoJSON is now parsed correctly regardless of key order, as required by the RFC 7946 spec (key order MUST NOT affect interpretation).

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.