### PR TITLE
MDEV-39993 Use CREATE OR REPLACE in sys schema to preserve grants dur…

### DIFF
--- a/mysql-test/main/mdev_39993.result
+++ b/mysql-test/main/mdev_39993.result
@@ -1,0 +1,361 @@
+CREATE USER testuser@localhost;
+GRANT EXECUTE ON FUNCTION sys.quote_identifier TO testuser@localhost;
+GRANT EXECUTE ON PROCEDURE sys.table_exists TO testuser@localhost;
+# Grants BEFORE running upgrade
+SHOW GRANTS FOR testuser@localhost;
+Grants for testuser@localhost
+GRANT EXECUTE ON FUNCTION `sys`.`quote_identifier` TO `testuser`@`localhost`
+GRANT EXECUTE ON PROCEDURE `sys`.`table_exists` TO `testuser`@`localhost`
+GRANT USAGE ON *.* TO `testuser`@`localhost`
+# Run mariadb-upgrade (re-installs sys schema)
+Phase 1/8: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.innodb_table_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+
+Repairing tables
+mysql.innodb_index_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.innodb_table_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.transaction_registry
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+Phase 2/8: Installing used storage engines... Skipped
+Phase 3/8: Running 'mysql_fix_privilege_tables'
+Phase 4/8: Fixing views
+mysql.user                                         OK
+sys.host_summary                                   OK
+sys.host_summary_by_file_io                        OK
+sys.host_summary_by_file_io_type                   OK
+sys.host_summary_by_stages                         OK
+sys.host_summary_by_statement_latency              OK
+sys.host_summary_by_statement_type                 OK
+sys.innodb_buffer_stats_by_schema                  OK
+sys.innodb_buffer_stats_by_table                   OK
+sys.innodb_lock_waits                              OK
+sys.io_by_thread_by_latency                        OK
+sys.io_global_by_file_by_bytes                     OK
+sys.io_global_by_file_by_latency                   OK
+sys.io_global_by_wait_by_bytes                     OK
+sys.io_global_by_wait_by_latency                   OK
+sys.latest_file_io                                 OK
+sys.memory_by_host_by_current_bytes                OK
+sys.memory_by_thread_by_current_bytes              OK
+sys.memory_by_user_by_current_bytes                OK
+sys.memory_global_by_current_bytes                 OK
+sys.memory_global_total                            OK
+sys.metrics                                        OK
+sys.privileges_by_table_by_level                   OK
+sys.processlist                                    OK
+sys.ps_check_lost_instrumentation                  OK
+sys.schema_auto_increment_columns                  OK
+sys.schema_index_statistics                        OK
+sys.schema_object_overview                         OK
+sys.schema_redundant_indexes                       OK
+sys.schema_table_lock_waits                        OK
+sys.schema_table_statistics                        OK
+sys.schema_table_statistics_with_buffer            OK
+sys.schema_tables_with_full_table_scans            OK
+sys.schema_unused_indexes                          OK
+sys.session                                        OK
+sys.session_ssl_status                             OK
+sys.statement_analysis                             OK
+sys.statements_with_errors_or_warnings             OK
+sys.statements_with_full_table_scans               OK
+sys.statements_with_runtimes_in_95th_percentile    OK
+sys.statements_with_sorting                        OK
+sys.statements_with_temp_tables                    OK
+sys.user_summary                                   OK
+sys.user_summary_by_file_io                        OK
+sys.user_summary_by_file_io_type                   OK
+sys.user_summary_by_stages                         OK
+sys.user_summary_by_statement_latency              OK
+sys.user_summary_by_statement_type                 OK
+sys.version                                        OK
+sys.wait_classes_global_by_avg_latency             OK
+sys.wait_classes_global_by_latency                 OK
+sys.waits_by_host_by_latency                       OK
+sys.waits_by_user_by_latency                       OK
+sys.waits_global_by_latency                        OK
+sys.x$host_summary                                 OK
+sys.x$host_summary_by_file_io                      OK
+sys.x$host_summary_by_file_io_type                 OK
+sys.x$host_summary_by_stages                       OK
+sys.x$host_summary_by_statement_latency            OK
+sys.x$host_summary_by_statement_type               OK
+sys.x$innodb_buffer_stats_by_schema                OK
+sys.x$innodb_buffer_stats_by_table                 OK
+sys.x$innodb_lock_waits                            OK
+sys.x$io_by_thread_by_latency                      OK
+sys.x$io_global_by_file_by_bytes                   OK
+sys.x$io_global_by_file_by_latency                 OK
+sys.x$io_global_by_wait_by_bytes                   OK
+sys.x$io_global_by_wait_by_latency                 OK
+sys.x$latest_file_io                               OK
+sys.x$memory_by_host_by_current_bytes              OK
+sys.x$memory_by_thread_by_current_bytes            OK
+sys.x$memory_by_user_by_current_bytes              OK
+sys.x$memory_global_by_current_bytes               OK
+sys.x$memory_global_total                          OK
+sys.x$processlist                                  OK
+sys.x$ps_digest_95th_percentile_by_avg_us          OK
+sys.x$ps_digest_avg_latency_distribution           OK
+sys.x$ps_schema_table_statistics_io                OK
+sys.x$schema_flattened_keys                        OK
+sys.x$schema_index_statistics                      OK
+sys.x$schema_table_lock_waits                      OK
+sys.x$schema_table_statistics                      OK
+sys.x$schema_table_statistics_with_buffer          OK
+sys.x$schema_tables_with_full_table_scans          OK
+sys.x$session                                      OK
+sys.x$statement_analysis                           OK
+sys.x$statements_with_errors_or_warnings           OK
+sys.x$statements_with_full_table_scans             OK
+sys.x$statements_with_runtimes_in_95th_percentile  OK
+sys.x$statements_with_sorting                      OK
+sys.x$statements_with_temp_tables                  OK
+sys.x$user_summary                                 OK
+sys.x$user_summary_by_file_io                      OK
+sys.x$user_summary_by_file_io_type                 OK
+sys.x$user_summary_by_stages                       OK
+sys.x$user_summary_by_statement_latency            OK
+sys.x$user_summary_by_statement_type               OK
+sys.x$wait_classes_global_by_avg_latency           OK
+sys.x$wait_classes_global_by_latency               OK
+sys.x$waits_by_host_by_latency                     OK
+sys.x$waits_by_user_by_latency                     OK
+sys.x$waits_global_by_latency                      OK
+Phase 5/8: Fixing table and database names
+Phase 6/8: Checking and upgrading tables
+Processing databases
+information_schema
+mtr
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+performance_schema
+sys
+sys.sys_config                                     OK
+test
+Phase 7/8: uninstalling plugins
+Phase 8/8: Running 'FLUSH PRIVILEGES'
+OK
+# Grants AFTER running upgrade (must be preserved)
+SHOW GRANTS FOR testuser@localhost;
+Grants for testuser@localhost
+GRANT EXECUTE ON FUNCTION `sys`.`quote_identifier` TO `testuser`@`localhost`
+GRANT EXECUTE ON PROCEDURE `sys`.`table_exists` TO `testuser`@`localhost`
+GRANT USAGE ON *.* TO `testuser`@`localhost`
+# Verify routines still work after replacement
+SELECT sys.quote_identifier('test') AS quoted;
+quoted
+`test`
+# Verify CREATE OR REPLACE works for fresh routine (simulate new install)
+DROP FUNCTION IF EXISTS sys.quote_identifier;
+Phase 1/8: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.innodb_table_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+
+Repairing tables
+mysql.innodb_index_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.innodb_table_stats
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+mysql.transaction_registry
+Error    : Unknown storage engine 'InnoDB'
+error    : Corrupt
+Phase 2/8: Installing used storage engines... Skipped
+Phase 3/8: Running 'mysql_fix_privilege_tables'
+Phase 4/8: Fixing views
+mysql.user                                         OK
+sys.host_summary                                   OK
+sys.host_summary_by_file_io                        OK
+sys.host_summary_by_file_io_type                   OK
+sys.host_summary_by_stages                         OK
+sys.host_summary_by_statement_latency              OK
+sys.host_summary_by_statement_type                 OK
+sys.innodb_buffer_stats_by_schema                  OK
+sys.innodb_buffer_stats_by_table                   OK
+sys.innodb_lock_waits                              OK
+sys.io_by_thread_by_latency                        OK
+sys.io_global_by_file_by_bytes                     OK
+sys.io_global_by_file_by_latency                   OK
+sys.io_global_by_wait_by_bytes                     OK
+sys.io_global_by_wait_by_latency                   OK
+sys.latest_file_io                                 OK
+sys.memory_by_host_by_current_bytes                OK
+sys.memory_by_thread_by_current_bytes              OK
+sys.memory_by_user_by_current_bytes                OK
+sys.memory_global_by_current_bytes                 OK
+sys.memory_global_total                            OK
+sys.metrics                                        OK
+sys.privileges_by_table_by_level                   OK
+sys.processlist                                    OK
+sys.ps_check_lost_instrumentation                  OK
+sys.schema_auto_increment_columns                  OK
+sys.schema_index_statistics                        OK
+sys.schema_object_overview                         OK
+sys.schema_redundant_indexes                       OK
+sys.schema_table_lock_waits                        OK
+sys.schema_table_statistics                        OK
+sys.schema_table_statistics_with_buffer            OK
+sys.schema_tables_with_full_table_scans            OK
+sys.schema_unused_indexes                          OK
+sys.session                                        OK
+sys.session_ssl_status                             OK
+sys.statement_analysis                             OK
+sys.statements_with_errors_or_warnings             OK
+sys.statements_with_full_table_scans               OK
+sys.statements_with_runtimes_in_95th_percentile    OK
+sys.statements_with_sorting                        OK
+sys.statements_with_temp_tables                    OK
+sys.user_summary                                   OK
+sys.user_summary_by_file_io                        OK
+sys.user_summary_by_file_io_type                   OK
+sys.user_summary_by_stages                         OK
+sys.user_summary_by_statement_latency              OK
+sys.user_summary_by_statement_type                 OK
+sys.version                                        OK
+sys.wait_classes_global_by_avg_latency             OK
+sys.wait_classes_global_by_latency                 OK
+sys.waits_by_host_by_latency                       OK
+sys.waits_by_user_by_latency                       OK
+sys.waits_global_by_latency                        OK
+sys.x$host_summary                                 OK
+sys.x$host_summary_by_file_io                      OK
+sys.x$host_summary_by_file_io_type                 OK
+sys.x$host_summary_by_stages                       OK
+sys.x$host_summary_by_statement_latency            OK
+sys.x$host_summary_by_statement_type               OK
+sys.x$innodb_buffer_stats_by_schema                OK
+sys.x$innodb_buffer_stats_by_table                 OK
+sys.x$innodb_lock_waits                            OK
+sys.x$io_by_thread_by_latency                      OK
+sys.x$io_global_by_file_by_bytes                   OK
+sys.x$io_global_by_file_by_latency                 OK
+sys.x$io_global_by_wait_by_bytes                   OK
+sys.x$io_global_by_wait_by_latency                 OK
+sys.x$latest_file_io                               OK
+sys.x$memory_by_host_by_current_bytes              OK
+sys.x$memory_by_thread_by_current_bytes            OK
+sys.x$memory_by_user_by_current_bytes              OK
+sys.x$memory_global_by_current_bytes               OK
+sys.x$memory_global_total                          OK
+sys.x$processlist                                  OK
+sys.x$ps_digest_95th_percentile_by_avg_us          OK
+sys.x$ps_digest_avg_latency_distribution           OK
+sys.x$ps_schema_table_statistics_io                OK
+sys.x$schema_flattened_keys                        OK
+sys.x$schema_index_statistics                      OK
+sys.x$schema_table_lock_waits                      OK
+sys.x$schema_table_statistics                      OK
+sys.x$schema_table_statistics_with_buffer          OK
+sys.x$schema_tables_with_full_table_scans          OK
+sys.x$session                                      OK
+sys.x$statement_analysis                           OK
+sys.x$statements_with_errors_or_warnings           OK
+sys.x$statements_with_full_table_scans             OK
+sys.x$statements_with_runtimes_in_95th_percentile  OK
+sys.x$statements_with_sorting                      OK
+sys.x$statements_with_temp_tables                  OK
+sys.x$user_summary                                 OK
+sys.x$user_summary_by_file_io                      OK
+sys.x$user_summary_by_file_io_type                 OK
+sys.x$user_summary_by_stages                       OK
+sys.x$user_summary_by_statement_latency            OK
+sys.x$user_summary_by_statement_type               OK
+sys.x$wait_classes_global_by_avg_latency           OK
+sys.x$wait_classes_global_by_latency               OK
+sys.x$waits_by_host_by_latency                     OK
+sys.x$waits_by_user_by_latency                     OK
+sys.x$waits_global_by_latency                      OK
+Phase 5/8: Fixing table and database names
+Phase 6/8: Checking and upgrading tables
+Processing databases
+information_schema
+mtr
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+performance_schema
+sys
+sys.sys_config                                     OK
+test
+Phase 7/8: uninstalling plugins
+Phase 8/8: Running 'FLUSH PRIVILEGES'
+OK
+# Routine recreated successfully
+SELECT sys.quote_identifier('test') AS quoted;
+quoted
+`test`
+DROP USER testuser@localhost;

--- a/mysql-test/main/mdev_39993.test
+++ b/mysql-test/main/mdev_39993.test
@@ -1,0 +1,37 @@
+#
+# MDEV-39993: mariadb-upgrade drops existing EXECUTE grants on sys stored
+# routines during upgrade because sys schema scripts use DROP+CREATE
+# instead of CREATE OR REPLACE
+#
+--source include/have_perfschema.inc
+
+CREATE USER testuser@localhost;
+
+GRANT EXECUTE ON FUNCTION sys.quote_identifier TO testuser@localhost;
+GRANT EXECUTE ON PROCEDURE sys.table_exists TO testuser@localhost;
+
+--echo # Grants BEFORE running upgrade
+--sorted_result
+SHOW GRANTS FOR testuser@localhost;
+
+--echo # Run mariadb-upgrade (re-installs sys schema)
+--exec $MYSQL_UPGRADE --force 2>&1
+
+--echo # Grants AFTER running upgrade (must be preserved)
+--sorted_result
+SHOW GRANTS FOR testuser@localhost;
+
+--echo # Verify routines still work after replacement
+SELECT sys.quote_identifier('test') AS quoted;
+
+--echo # Verify CREATE OR REPLACE works for fresh routine (simulate new install)
+DROP FUNCTION IF EXISTS sys.quote_identifier;
+--exec $MYSQL_UPGRADE --force 2>&1
+
+--echo # Routine recreated successfully
+SELECT sys.quote_identifier('test') AS quoted;
+
+# Cleanup
+--let $MYSQLD_DATADIR= `select @@datadir`
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
+DROP USER testuser@localhost;

--- a/scripts/maria_add_gis_sp.sql.in
+++ b/scripts/maria_add_gis_sp.sql.in
@@ -20,15 +20,12 @@ SET sql_mode='';
 
 @ADD_GIS_SP_SET_DELIMITER@
 
-DROP PROCEDURE IF EXISTS AddGeometryColumn;
-DROP PROCEDURE IF EXISTS DropGeometryColumn;
-
-CREATE DEFINER=`mariadb.sys`@`localhost` PROCEDURE AddGeometryColumn(catalog varchar(64), t_schema varchar(64),
+CREATE OR REPLACE DEFINER=`mariadb.sys`@`localhost` PROCEDURE AddGeometryColumn(catalog varchar(64), t_schema varchar(64),
    t_name varchar(64), geometry_column varchar(64), t_srid int) SQL SECURITY INVOKER
 begin
   set @qwe= concat('ALTER TABLE ', t_schema, '.', t_name, ' ADD ', geometry_column,' GEOMETRY REF_SYSTEM_ID=', t_srid); PREPARE ls from @qwe; execute ls; deallocate prepare ls; end @ADD_GIS_SP_EOL@
 
-CREATE DEFINER=`mariadb.sys`@`localhost` PROCEDURE DropGeometryColumn(catalog varchar(64), t_schema varchar(64),
+CREATE OR REPLACE DEFINER=`mariadb.sys`@`localhost` PROCEDURE DropGeometryColumn(catalog varchar(64), t_schema varchar(64),
    t_name varchar(64), geometry_column varchar(64)) SQL SECURITY INVOKER
 begin
   set @qwe= concat('ALTER TABLE ', t_schema, '.', t_name, ' DROP ', geometry_column); PREPARE ls from @qwe; execute ls; deallocate prepare ls; end @ADD_GIS_SP_EOL@

--- a/scripts/sys_schema/functions/extract_schema_from_file_name.sql
+++ b/scripts/sys_schema/functions/extract_schema_from_file_name.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS extract_schema_from_file_name;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION extract_schema_from_file_name (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION extract_schema_from_file_name (
         path VARCHAR(512)
     )
     RETURNS VARCHAR(64) 

--- a/scripts/sys_schema/functions/extract_table_from_file_name.sql
+++ b/scripts/sys_schema/functions/extract_table_from_file_name.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS extract_table_from_file_name;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION extract_table_from_file_name (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION extract_table_from_file_name (
         path VARCHAR(512)
     )
     RETURNS VARCHAR(64) 

--- a/scripts/sys_schema/functions/format_bytes.sql
+++ b/scripts/sys_schema/functions/format_bytes.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS format_bytes;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION format_bytes (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION format_bytes (
         -- We feed in and return TEXT here, as aggregates of
         -- bytes can return numbers larger than BIGINT UNSIGNED
         bytes TEXT

--- a/scripts/sys_schema/functions/format_path.sql
+++ b/scripts/sys_schema/functions/format_path.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS format_path;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION format_path (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION format_path (
         in_path VARCHAR(512)
     )
     RETURNS VARCHAR(512) CHARSET UTF8

--- a/scripts/sys_schema/functions/format_path_57.sql
+++ b/scripts/sys_schema/functions/format_path_57.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS format_path;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION format_path (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION format_path (
         in_path VARCHAR(512)
     )
     RETURNS VARCHAR(512) CHARSET UTF8

--- a/scripts/sys_schema/functions/format_statement.sql
+++ b/scripts/sys_schema/functions/format_statement.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS format_statement;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION format_statement (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION format_statement (
         statement LONGTEXT
     )
     RETURNS LONGTEXT

--- a/scripts/sys_schema/functions/format_time.sql
+++ b/scripts/sys_schema/functions/format_time.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS format_time;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION format_time (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION format_time (
         -- We feed in and return TEXT here, as aggregates of
         -- picoseconds can return numbers larger than BIGINT UNSIGNED
         picoseconds TEXT

--- a/scripts/sys_schema/functions/list_add.sql
+++ b/scripts/sys_schema/functions/list_add.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS list_add;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION list_add (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION list_add (
         in_list TEXT,
         in_add_value TEXT
     )

--- a/scripts/sys_schema/functions/list_drop.sql
+++ b/scripts/sys_schema/functions/list_drop.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS list_drop;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION list_drop (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION list_drop (
         in_list TEXT,
         in_drop_value TEXT
     )

--- a/scripts/sys_schema/functions/ps_is_account_enabled.sql
+++ b/scripts/sys_schema/functions/ps_is_account_enabled.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_account_enabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_account_enabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_account_enabled (
         in_host VARCHAR(60), 
         in_user VARCHAR(16)
     ) 

--- a/scripts/sys_schema/functions/ps_is_account_enabled_57.sql
+++ b/scripts/sys_schema/functions/ps_is_account_enabled_57.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_account_enabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_account_enabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_account_enabled (
         in_host VARCHAR(60), 
         in_user VARCHAR(32)
     ) 

--- a/scripts/sys_schema/functions/ps_is_consumer_enabled.sql
+++ b/scripts/sys_schema/functions/ps_is_consumer_enabled.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_consumer_enabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_consumer_enabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_consumer_enabled (
         in_consumer varchar(64)
    )
    RETURNS enum('YES', 'NO')

--- a/scripts/sys_schema/functions/ps_is_instrument_default_enabled.sql
+++ b/scripts/sys_schema/functions/ps_is_instrument_default_enabled.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_instrument_default_enabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_instrument_default_enabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_instrument_default_enabled (
         in_instrument VARCHAR(128)
     ) 
     RETURNS ENUM('YES', 'NO')

--- a/scripts/sys_schema/functions/ps_is_instrument_default_timed.sql
+++ b/scripts/sys_schema/functions/ps_is_instrument_default_timed.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_instrument_default_timed;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_instrument_default_timed (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_instrument_default_timed (
         in_instrument VARCHAR(128)
     ) 
     RETURNS ENUM('YES', 'NO')

--- a/scripts/sys_schema/functions/ps_is_thread_instrumented.sql
+++ b/scripts/sys_schema/functions/ps_is_thread_instrumented.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_is_thread_instrumented;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_thread_instrumented (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_is_thread_instrumented (
         in_connection_id BIGINT UNSIGNED
     ) RETURNS ENUM('YES', 'NO', 'UNKNOWN')
     COMMENT '

--- a/scripts/sys_schema/functions/ps_thread_account.sql
+++ b/scripts/sys_schema/functions/ps_thread_account.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_thread_account;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_account (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_account (
         in_thread_id BIGINT UNSIGNED
     ) RETURNS TEXT
     COMMENT '

--- a/scripts/sys_schema/functions/ps_thread_id.sql
+++ b/scripts/sys_schema/functions/ps_thread_id.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_thread_id;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_id (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_id (
         in_connection_id BIGINT UNSIGNED
     ) RETURNS BIGINT UNSIGNED
     COMMENT '

--- a/scripts/sys_schema/functions/ps_thread_stack.sql
+++ b/scripts/sys_schema/functions/ps_thread_stack.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_thread_stack;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_stack (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_stack (
         thd_id BIGINT UNSIGNED,
         debug BOOLEAN
     )

--- a/scripts/sys_schema/functions/ps_thread_trx_info.sql
+++ b/scripts/sys_schema/functions/ps_thread_trx_info.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS ps_thread_trx_info;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_trx_info (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION ps_thread_trx_info (
         in_thread_id BIGINT UNSIGNED
     ) RETURNS LONGTEXT
     COMMENT '

--- a/scripts/sys_schema/functions/quote_identifier.sql
+++ b/scripts/sys_schema/functions/quote_identifier.sql
@@ -13,8 +13,6 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS quote_identifier;
-
 DELIMITER $$
 
 -- https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
@@ -22,7 +20,7 @@ DELIMITER $$
 -- Before that, user variables could have any length.
 --
 -- Based on Paul Dubois' suggestion in Bug #78823/Bug #22011361.
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION quote_identifier(in_identifier TEXT)
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION quote_identifier(in_identifier TEXT)
     RETURNS TEXT CHARSET UTF8
     COMMENT '
              Description

--- a/scripts/sys_schema/functions/sys_get_config.sql
+++ b/scripts/sys_schema/functions/sys_get_config.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS sys_get_config;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION sys_get_config (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION sys_get_config (
         in_variable_name VARCHAR(128),
         in_default_value VARCHAR(128)
     )

--- a/scripts/sys_schema/functions/version_major.sql
+++ b/scripts/sys_schema/functions/version_major.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS version_major;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION version_major ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION version_major ()
     RETURNS TINYINT UNSIGNED
     COMMENT '
              Description

--- a/scripts/sys_schema/functions/version_minor.sql
+++ b/scripts/sys_schema/functions/version_minor.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS version_minor;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION version_minor ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION version_minor ()
     RETURNS TINYINT UNSIGNED
     COMMENT '
              Description

--- a/scripts/sys_schema/functions/version_patch.sql
+++ b/scripts/sys_schema/functions/version_patch.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS version_patch;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION version_patch ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION version_patch ()
     RETURNS TINYINT UNSIGNED
     COMMENT '
              Description

--- a/scripts/sys_schema/procedures/create_synonym_db.sql
+++ b/scripts/sys_schema/procedures/create_synonym_db.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS create_synonym_db;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE create_synonym_db (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE create_synonym_db (
         IN in_db_name VARCHAR(64), 
         IN in_synonym VARCHAR(64)
     )

--- a/scripts/sys_schema/procedures/diagnostics.sql
+++ b/scripts/sys_schema/procedures/diagnostics.sql
@@ -13,11 +13,9 @@
 --  along with this program; if not, write to the Free Software
 --  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA 
 
-DROP PROCEDURE IF EXISTS diagnostics;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE diagnostics (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE diagnostics (
         IN in_max_runtime int unsigned, IN in_interval int unsigned,
         IN in_auto_config enum ('current', 'medium', 'full')
     )

--- a/scripts/sys_schema/procedures/execute_prepared_stmt.sql
+++ b/scripts/sys_schema/procedures/execute_prepared_stmt.sql
@@ -13,11 +13,9 @@
 --  along with this program; if not, write to the Free Software
 --  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA 
 
-DROP PROCEDURE IF EXISTS execute_prepared_stmt;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE execute_prepared_stmt (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE execute_prepared_stmt (
         IN in_query longtext CHARACTER SET UTF8
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/optimizer_switch.sql
+++ b/scripts/sys_schema/procedures/optimizer_switch.sql
@@ -13,12 +13,9 @@
 --  along with this program; if not, write to the Free Software
 --  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS optimizer_switch_choice;
-DROP PROCEDURE IF EXISTS optimizer_switch_on;
-DROP PROCEDURE IF EXISTS optimizer_switch_off;
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_choice(IN on_off VARCHAR(3))
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_choice(IN on_off VARCHAR(3))
 COMMENT 'return @@optimizer_switch options as a result set for easier readability'
 SQL SECURITY INVOKER
 NOT DETERMINISTIC
@@ -47,7 +44,7 @@ BEGIN
   DROP TEMPORARY TABLE tmp_opt_switch;
 END$$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_on()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_on()
 COMMENT 'return @@optimizer_switch options that are on'
 SQL SECURITY INVOKER
 NOT DETERMINISTIC
@@ -56,7 +53,7 @@ BEGIN
   call optimizer_switch_choice("on");
 END$$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_off()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE optimizer_switch_off()
 COMMENT 'return @@optimizer_switch options that are off'
 SQL SECURITY INVOKER
 NOT DETERMINISTIC

--- a/scripts/sys_schema/procedures/ps_setup_disable_background_threads.sql
+++ b/scripts/sys_schema/procedures/ps_setup_disable_background_threads.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_disable_background_threads;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_background_threads ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_background_threads ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_disable_consumer.sql
+++ b/scripts/sys_schema/procedures/ps_setup_disable_consumer.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_disable_consumer;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_consumer (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_consumer (
         IN consumer VARCHAR(128)
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_disable_instrument.sql
+++ b/scripts/sys_schema/procedures/ps_setup_disable_instrument.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_disable_instrument;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_instrument (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_instrument (
         IN in_pattern VARCHAR(128)
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_disable_thread.sql
+++ b/scripts/sys_schema/procedures/ps_setup_disable_thread.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_disable_thread;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_thread (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_disable_thread (
         IN in_connection_id BIGINT
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_enable_background_threads.sql
+++ b/scripts/sys_schema/procedures/ps_setup_enable_background_threads.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_enable_background_threads;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_background_threads ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_background_threads ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_enable_consumer.sql
+++ b/scripts/sys_schema/procedures/ps_setup_enable_consumer.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_enable_consumer;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_consumer (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_consumer (
         IN consumer VARCHAR(128)
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_enable_instrument.sql
+++ b/scripts/sys_schema/procedures/ps_setup_enable_instrument.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_enable_instrument;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_instrument (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_instrument (
         IN in_pattern VARCHAR(128)
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_enable_thread.sql
+++ b/scripts/sys_schema/procedures/ps_setup_enable_thread.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_enable_thread;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_thread (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_enable_thread (
         IN in_connection_id BIGINT
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_reload_saved.sql
+++ b/scripts/sys_schema/procedures/ps_setup_reload_saved.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_reload_saved;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reload_saved ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reload_saved ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_reset_to_default.sql
+++ b/scripts/sys_schema/procedures/ps_setup_reset_to_default.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_reset_to_default;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reset_to_default (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reset_to_default (
        IN in_verbose BOOLEAN
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_reset_to_default_57.sql
+++ b/scripts/sys_schema/procedures/ps_setup_reset_to_default_57.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_reset_to_default;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reset_to_default (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_reset_to_default (
        IN in_verbose BOOLEAN
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_save.sql
+++ b/scripts/sys_schema/procedures/ps_setup_save.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_save;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_save (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_save (
         IN in_timeout INT
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/ps_setup_show_disabled.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_disabled.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_disabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled (
         IN in_show_instruments BOOLEAN,
         IN in_show_threads BOOLEAN
     )

--- a/scripts/sys_schema/procedures/ps_setup_show_disabled_consumers.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_disabled_consumers.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_disabled_consumers;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled_consumers ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled_consumers ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_show_disabled_instruments.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_disabled_instruments.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_disabled_instruments;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled_instruments ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_disabled_instruments ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_show_enabled.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_enabled.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_enabled;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled (
         IN in_show_instruments BOOLEAN,
         IN in_show_threads BOOLEAN
     )

--- a/scripts/sys_schema/procedures/ps_setup_show_enabled_consumers.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_enabled_consumers.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_enabled_consumers;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled_consumers ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled_consumers ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_setup_show_enabled_instruments.sql
+++ b/scripts/sys_schema/procedures/ps_setup_show_enabled_instruments.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_setup_show_enabled_instruments;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled_instruments ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_setup_show_enabled_instruments ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_statement_avg_latency_histogram.sql
+++ b/scripts/sys_schema/procedures/ps_statement_avg_latency_histogram.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_statement_avg_latency_histogram;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_statement_avg_latency_histogram ()
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_statement_avg_latency_histogram ()
     COMMENT '
              Description
              -----------

--- a/scripts/sys_schema/procedures/ps_trace_statement_digest.sql
+++ b/scripts/sys_schema/procedures/ps_trace_statement_digest.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_trace_statement_digest;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_statement_digest (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_statement_digest (
         IN in_digest VARCHAR(32),
         IN in_runtime INT, 
         IN in_interval DECIMAL(2,2),

--- a/scripts/sys_schema/procedures/ps_trace_thread.sql
+++ b/scripts/sys_schema/procedures/ps_trace_thread.sql
@@ -13,10 +13,8 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_trace_thread;
-
 DELIMITER $$
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_thread (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_thread (
         IN in_thread_id BIGINT UNSIGNED,
         IN in_outfile VARCHAR(255),
         IN in_max_runtime DECIMAL(20,2),

--- a/scripts/sys_schema/procedures/ps_trace_thread_57.sql
+++ b/scripts/sys_schema/procedures/ps_trace_thread_57.sql
@@ -13,10 +13,8 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_trace_thread;
-
 DELIMITER $$
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_thread (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_trace_thread (
         IN in_thread_id BIGINT UNSIGNED,
         IN in_outfile VARCHAR(255),
         IN in_max_runtime DECIMAL(20,2),

--- a/scripts/sys_schema/procedures/ps_truncate_all_tables.sql
+++ b/scripts/sys_schema/procedures/ps_truncate_all_tables.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS ps_truncate_all_tables;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_truncate_all_tables (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE ps_truncate_all_tables (
         IN in_verbose BOOLEAN
     )
     COMMENT '

--- a/scripts/sys_schema/procedures/statement_performance_analyzer.sql
+++ b/scripts/sys_schema/procedures/statement_performance_analyzer.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS statement_performance_analyzer;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE statement_performance_analyzer (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE statement_performance_analyzer (
         IN in_action ENUM('snapshot', 'overall', 'delta', 'create_table', 'create_tmp', 'save', 'cleanup'),
         IN in_table VARCHAR(129),
         IN in_views SET ('with_runtimes_in_95th_percentile', 'analysis', 'with_errors_or_warnings', 'with_full_table_scans', 'with_sorting', 'with_temp_tables', 'custom')

--- a/scripts/sys_schema/procedures/table_exists.sql
+++ b/scripts/sys_schema/procedures/table_exists.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS table_exists;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE table_exists (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE table_exists (
         IN in_db VARCHAR(64), IN in_table VARCHAR(64),
         OUT out_exists ENUM('', 'BASE TABLE', 'VIEW', 'TEMPORARY', 'SEQUENCE', 'SYSTEM VIEW', 'TEMPORARY SEQUENCE')
     )

--- a/scripts/sys_schema/templates/function.sql
+++ b/scripts/sys_schema/templates/function.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP FUNCTION IF EXISTS <function name>;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' FUNCTION <function name> (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' FUNCTION <function name> (
         /* Variables */
     )
     RETURNS <data type>

--- a/scripts/sys_schema/templates/procedure.sql
+++ b/scripts/sys_schema/templates/procedure.sql
@@ -13,11 +13,9 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-DROP PROCEDURE IF EXISTS <procedure_name>;
-
 DELIMITER $$
 
-CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE <procedure_name> (
+CREATE OR REPLACE DEFINER='mariadb.sys'@'localhost' PROCEDURE <procedure_name> (
         /* Variables */
     )
     COMMENT '


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39993](https://jira.mariadb.org/browse/MDEV-39993) where `mariadb-upgrade` drops existing `EXECUTE` grants on sys schema stored routines during upgrade because the installation scripts use `DROP IF EXISTS` + `CREATE` instead of `CREATE OR REPLACE`.

When a DBA grants `EXECUTE` on a sys schema routine (e.g., `GRANT EXECUTE ON FUNCTION sys.quote_identifier TO appuser@host`), the grant is stored in `mysql.procs_priv`. During upgrade, `DROP IF EXISTS` removes the routine and cascades to delete its grants. The subsequent `CREATE` recreates the routine but the grants are lost.

The fix involves:

1. Replacing `DROP FUNCTION/PROCEDURE IF EXISTS` + `CREATE` with `CREATE OR REPLACE` in all 55 sys schema stored routine scripts (28 functions + 25 procedures + 2 GIS procedures in `maria_add_gis_sp.sql.in`)
2. Updating the 2 template files (`templates/function.sql`, `templates/procedure.sql`) so future routines follow the same pattern
3. `CREATE OR REPLACE` atomically replaces the routine body while preserving existing grants — matching the pattern already used by sys schema views

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39993
```

Or manually:

```sql
-- Grant on a sys routine
GRANT EXECUTE ON FUNCTION sys.quote_identifier TO someuser@localhost;

-- Run upgrade
-- $ mariadb-upgrade --force

-- Check grant is preserved
SHOW GRANTS FOR someuser@localhost;
```

## Results from my testing

1. Before changes

```
MariaDB> GRANT EXECUTE ON FUNCTION sys.quote_identifier TO testuser@localhost;
MariaDB> GRANT EXECUTE ON PROCEDURE sys.table_exists TO testuser@localhost;

-- After running: mariadb-upgrade --force

MariaDB> SHOW GRANTS FOR testuser@localhost;
+----------------------------------------------+
| Grants for testuser@localhost                |
+----------------------------------------------+
| GRANT USAGE ON *.* TO `testuser`@`localhost` |
+----------------------------------------------+
```

Grants on `sys.quote_identifier` and `sys.table_exists` are gone after upgrade.

2. After changes

```
-- After running: mariadb-upgrade --force

MariaDB> SHOW GRANTS FOR testuser@localhost;
+---------------------------------------------------------------------------------+
| Grants for testuser@localhost                                                   |
+---------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO `testuser`@`localhost`                                    |
| GRANT EXECUTE ON FUNCTION `sys`.`quote_identifier` TO `testuser`@`localhost`    |
| GRANT EXECUTE ON PROCEDURE `sys`.`table_exists` TO `testuser`@`localhost`       |
+---------------------------------------------------------------------------------+

-- Routine still works after replacement:
MariaDB> SELECT sys.quote_identifier('test');
+-----------------------------+
| sys.quote_identifier('test')|
+-----------------------------+
| `test`                      |
+-----------------------------+
```

Grants preserved, routines functional.

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.