### PR TITLE
MDEV-39970 Fix JSON_KEYS failing to deduplicate keys with escaped cha…

### DIFF
--- a/mysql-test/main/mdev_39970.result
+++ b/mysql-test/main/mdev_39970.result
@@ -1,0 +1,55 @@
+#
+# MDEV-39970: JSON_KEYS fails to deduplicate keys with escaped characters
+#
+# Plain duplicate key - should deduplicate
+SELECT JSON_KEYS('{"a":1,"a":2}');
+JSON_KEYS('{"a":1,"a":2}')
+["a"]
+# Key with escaped quote via hex literal (utf8mb4)
+SET @j=CONVERT(X'7B22615C2262223A312C22615C2262223A327D' USING utf8mb4);
+SELECT JSON_KEYS(@j);
+JSON_KEYS(@j)
+["a\"b"]
+# Key with escaped quote via SQL string
+SELECT JSON_KEYS('{"a\\"b":1,"a\\"b":2}');
+JSON_KEYS('{"a\\"b":1,"a\\"b":2}')
+["a\"b"]
+# Key with escaped backslash
+SELECT JSON_KEYS('{"a\\\\b":1,"a\\\\b":2}');
+JSON_KEYS('{"a\\\\b":1,"a\\\\b":2}')
+["a\\b"]
+# Mixed: one unique, one duplicate with escape
+SELECT JSON_KEYS('{"a\\"b":1,"c":2,"a\\"b":3}');
+JSON_KEYS('{"a\\"b":1,"c":2,"a\\"b":3}')
+["a\"b", "c"]
+# Escaped newline in key
+SELECT JSON_KEYS('{"a\\nb":1,"a\\nb":2}');
+JSON_KEYS('{"a\\nb":1,"a\\nb":2}')
+["a\nb"]
+# Escaped tab in key
+SELECT JSON_KEYS('{"a\\tb":1,"a\\tb":2}');
+JSON_KEYS('{"a\\tb":1,"a\\tb":2}')
+["a\tb"]
+# Unicode escape in key (\u0041 = A)
+SELECT JSON_KEYS('{"a\\u0041b":1,"a\\u0041b":2}');
+JSON_KEYS('{"a\\u0041b":1,"a\\u0041b":2}')
+["a\u0041b"]
+# Key that is only an escaped quote
+SET @j2=CONVERT(X'7B225C2222223A312C225C2222223A327D' USING utf8mb4);
+SELECT JSON_KEYS(@j2);
+JSON_KEYS(@j2)
+NULL
+Warnings:
+Warning	4038	Syntax error in JSON text in argument 1 to function 'json_keys' at position 5
+# Escaped chars with non-duplicate (should keep both)
+SELECT JSON_KEYS('{"a\\nb":1,"a\\tb":2}');
+JSON_KEYS('{"a\\nb":1,"a\\tb":2}')
+["a\nb", "a\tb"]
+# Nested object - JSON_KEYS with path hitting escaped keys
+SELECT JSON_KEYS('{"outer":{"a\\"b":1,"a\\"b":2}}', '$.outer');
+JSON_KEYS('{"outer":{"a\\"b":1,"a\\"b":2}}', '$.outer')
+["a\"b"]
+# Prefix overlap: a" vs a"b should NOT deduplicate
+SELECT JSON_KEYS('{"a\\"":1,"a\\"b":2}');
+JSON_KEYS('{"a\\"":1,"a\\"b":2}')
+["a\"", "a\"b"]

--- a/mysql-test/main/mdev_39970.test
+++ b/mysql-test/main/mdev_39970.test
@@ -1,0 +1,41 @@
+--echo #
+--echo # MDEV-39970: JSON_KEYS fails to deduplicate keys with escaped characters
+--echo #
+
+--echo # Plain duplicate key - should deduplicate
+SELECT JSON_KEYS('{"a":1,"a":2}');
+
+--echo # Key with escaped quote via hex literal (utf8mb4)
+SET @j=CONVERT(X'7B22615C2262223A312C22615C2262223A327D' USING utf8mb4);
+SELECT JSON_KEYS(@j);
+
+--echo # Key with escaped quote via SQL string
+SELECT JSON_KEYS('{"a\\"b":1,"a\\"b":2}');
+
+--echo # Key with escaped backslash
+SELECT JSON_KEYS('{"a\\\\b":1,"a\\\\b":2}');
+
+--echo # Mixed: one unique, one duplicate with escape
+SELECT JSON_KEYS('{"a\\"b":1,"c":2,"a\\"b":3}');
+
+--echo # Escaped newline in key
+SELECT JSON_KEYS('{"a\\nb":1,"a\\nb":2}');
+
+--echo # Escaped tab in key
+SELECT JSON_KEYS('{"a\\tb":1,"a\\tb":2}');
+
+--echo # Unicode escape in key (\u0041 = A)
+SELECT JSON_KEYS('{"a\\u0041b":1,"a\\u0041b":2}');
+
+--echo # Key that is only an escaped quote
+SET @j2=CONVERT(X'7B225C2222223A312C225C2222223A327D' USING utf8mb4);
+SELECT JSON_KEYS(@j2);
+
+--echo # Escaped chars with non-duplicate (should keep both)
+SELECT JSON_KEYS('{"a\\nb":1,"a\\tb":2}');
+
+--echo # Nested object - JSON_KEYS with path hitting escaped keys
+SELECT JSON_KEYS('{"outer":{"a\\"b":1,"a\\"b":2}}', '$.outer');
+
+--echo # Prefix overlap: a\" vs a\"b should NOT deduplicate
+SELECT JSON_KEYS('{"a\\"":1,"a\\"b":2}');

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -4126,8 +4126,19 @@ static int check_key_in_list(String *res,
   while (c < end)
   {
     int n_char;
-    for (n_char=0; c[n_char] != '"' && n_char < key_len; n_char++)
+    for (n_char=0; n_char < key_len; n_char++)
     {
+      if (c[n_char] == '\\')
+      {
+        if (key[n_char] != '\\')
+          break;
+        n_char++;
+        if (n_char >= key_len || c[n_char] != key[n_char])
+          break;
+        continue;
+      }
+      if (c[n_char] == '"')
+        break;
       if (c[n_char] != key[n_char])
         break;
     }
@@ -4139,7 +4150,11 @@ static int check_key_in_list(String *res,
     else
     {
       while (c[n_char] != '"')
+      {
+        if (c[n_char] == '\\')
+          n_char++;
         n_char++;
+      }
     }
     c+= n_char + 4; /* skip ', "' */
   }


### PR DESCRIPTION
## Description

This PR fixes [MDEV-39970](https://jira.mariadb.org/browse/MDEV-39970) where `JSON_KEYS()` fails to deduplicate keys that contain escaped characters (like `\"` or `\\`).

`check_key_in_list()` compares keys byte-by-byte using `"` as the end-of-key delimiter. When keys contain escape sequences (e.g., `a\"b`), the `\"` inside the key is misidentified as the closing delimiter, causing the comparison to mismatch and identical keys to appear as duplicates in the output.

The fix involves:

1. Handling escape sequences in the comparison loop — when `\` is encountered, the next character is consumed as part of the escape sequence rather than checked as a delimiter
2. Applying the same escape-awareness to the skip-to-end loop that advances past non-matching keys

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr main.mdev_39970
```

Or manually:

```sql
-- Input: {"a\"b":1,"a\"b":2} — same key twice with escaped quote
SET @j=CONVERT(X'7B22615C2262223A312C22615C2262223A327D' USING utf8mb4);
SELECT JSON_KEYS(@j);
-- Expected: ["a\"b"]  (deduplicated to one key)
```

## Results from my testing

1. Before changes

```
MariaDB> SET @j=CONVERT(X'7B22615C2262223A312C22615C2262223A327D' USING utf8mb4);
MariaDB> SELECT @j AS input;
+-------------------------+
| input                   |
+-------------------------+
| {"a\"b":1,"a\"b":2}    |
+-------------------------+

MariaDB> SELECT JSON_KEYS(@j) AS result;
+--------------------+
| result             |
+--------------------+
| ["a\"b", "a\"b"]   |
+--------------------+
```

Duplicate key `a"b` appears twice — deduplication failed.

2. After changes

```
MariaDB> SELECT JSON_KEYS(@j) AS result;
+-----------+
| result    |
+-----------+
| ["a\"b"]  |
+-----------+
```

Duplicate key correctly deduplicated to one entry.

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the latest MariaDB development branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.