### PR TITLE
MDEV-39198 Reject empty string for startup options to mariadbd

### DIFF
--- a/mysql-test/main/mysqld_option_err.result
+++ b/mysql-test/main/mysqld_option_err.result
@@ -1,5 +1,7 @@
 Test that unknown option is not silently ignored.
 Test bad binlog format.
+Test empty value for --create-tmp-table-binlog-formats is rejected.
+FOUND 1 /create-tmp-table-binlog-formats cannot be empty/ in mysqltest.log
 Test bad default storage engine.
 Test non-numeric value passed to number option.
 Test with invalid path

--- a/mysql-test/main/mysqld_option_err.test
+++ b/mysql-test/main/mysqld_option_err.test
@@ -30,6 +30,15 @@ mkdir $MYSQLTEST_VARDIR/tmp/mysqld_option_err;
 --exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --log-bin --binlog-format=badformat >>$MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log 2>&1
 
 
+--echo Test empty value for --create-tmp-table-binlog-formats is rejected.
+--error 1
+--exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --create-tmp-table-binlog-formats= >>$MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log 2>&1
+
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log
+
+--let SEARCH_PATTERN=create-tmp-table-binlog-formats cannot be empty
+--source include/search_pattern_in_file.inc
+
 --echo Test bad default storage engine.
 --error 1
 --exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --default-storage-engine=nonexistentengine >>$MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log 2>&1
@@ -49,8 +58,6 @@ mkdir $MYSQLTEST_VARDIR/tmp/mysqld_option_err;
 --echo Test that bad value for plugin enum option is rejected correctly.
 --error 1
 --exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --plugin-maturity=experimental --plugin-load=example=ha_example --plugin-example=FORCE --plugin-example-enum-var=noexist >>$MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log 2>&1
-
---let SEARCH_FILE = $MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log
 
 --echo Test to see if multiple unknown options will be displayed in the error output
 --error 7

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9186,6 +9186,13 @@ static int get_options(int *argc_ptr, char ***argv_ptr)
                                            OLD_MODE_COMPAT_5_1_CHECKSUM);
   }
 
+  if (!global_system_variables.create_temporary_table_binlog_formats)
+  {
+    sql_print_error("--create-tmp-table-binlog-formats cannot be empty. "
+                    "Allowed values are STATEMENT or MIXED,STATEMENT");
+    return 1;
+  }
+
   if (global_system_variables.net_buffer_length > 
       global_system_variables.max_allowed_packet)
   {


### PR DESCRIPTION
## Description

Previously, empty value start up commands were accepted silently, configuring the variable to default value. This change adds an explicit empty-string check to reject startup options with empty values.

## How can this PR be tested?

Before the change, `--create-tmp-table-binlog-formats=''` is accepted

```
> ./build/sql/mariadbd --datadir=./data --user=root --create-tmp-table-binlog-formats='' &

2026-04-22 18:03:10 0 [Note] Starting MariaDB 12.3.2-MariaDB source revision  server_uid eqtiwfxRtNmJ5Y8UE8JB3iQbx6w= as process 13800
2026-04-22 18:03:10 0 [Note] Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server
2026-04-22 18:03:10 0 [Note] InnoDB: Compressed tables use zlib 1.3.2
2026-04-22 18:03:10 0 [Note] InnoDB: Number of transaction pools: 1
2026-04-22 18:03:10 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
2026-04-22 18:03:10 0 [Note] mariadbd: O_TMPFILE is not supported on /tmp (disabling future attempts)
2026-04-22 18:03:10 0 [Warning] mariadbd: io_uring_queue_init() failed with EPERM: sysctl kernel.io_uring_disabled has the value 2, or 1 and the user of the process is not a member of sysctl kernel.io_uring_group. (see man 2 io_uring_setup).
create_uring failed: falling back to libaio
2026-04-22 18:03:10 0 [Note] InnoDB: Using Linux native AIO
2026-04-22 18:03:10 0 [Note] InnoDB: innodb_buffer_pool_size_max=8388608m, innodb_buffer_pool_size=128m
2026-04-22 18:03:10 0 [Note] InnoDB: Completed initialization of buffer pool
2026-04-22 18:03:10 0 [Note] InnoDB: File system buffers for log disabled (block size=4096 bytes)
2026-04-22 18:03:10 0 [Note] InnoDB: End of log at LSN=231689
2026-04-22 18:03:10 0 [Note] InnoDB: Opened 3 undo tablespaces
2026-04-22 18:03:10 0 [Note] InnoDB: 128 rollback segments in 3 undo tablespaces are active.
2026-04-22 18:03:10 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
2026-04-22 18:03:10 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
2026-04-22 18:03:10 0 [Note] InnoDB: log sequence number 231689; transaction id 210
2026-04-22 18:03:10 0 [Note] InnoDB: Loading buffer pool(s) from /quick-rebuilds/data/ib_buffer_pool
2026-04-22 18:03:10 0 [Note] Plugin 'FEEDBACK' is disabled.
2026-04-22 18:03:10 0 [Note] InnoDB: Buffer pool(s) load completed at 260422 18:03:10
2026-04-22 18:03:10 0 [Note] Server socket created on IP: '0.0.0.0', port: '3306'.
2026-04-22 18:03:10 0 [Note] Server socket created on IP: '::', port: '3306'.
2026-04-22 18:03:10 0 [Note] mariadbd: Event Scheduler: Loaded 0 events
2026-04-22 18:03:10 0 [Note] ./build/sql/mariadbd: ready for connections.
Version: '12.3.2-MariaDB'  socket: '/tmp/mysql.sock'  port: 3306  Source distribution

...
MariaDB [(none)]> SELECT @@GLOBAL.create_tmp_table_binlog_formats;
+------------------------------------------+
| @@GLOBAL.create_tmp_table_binlog_formats |
+------------------------------------------+
| STATEMENT                                |
+------------------------------------------+
1 row in set (0.000 sec)

MariaDB [(none)]> SELECT @@SESSION.create_tmp_table_binlog_formats;
+-------------------------------------------+
| @@SESSION.create_tmp_table_binlog_formats |
+-------------------------------------------+
| STATEMENT                                 |
+-------------------------------------------+
1 row in set (0.000 sec)
```

After the change, an error is logged at start up.

```
> ./build/sql/mariadbd --datadir=./data --user=root --create-tmp-table-binlog-formats='' &

2026-07-15 21:46:26 0 [ERROR] --create-tmp-table-binlog-formats cannot be empty. Allowed values are STATEMENT or MIXED,STATEMENT
```

MTR test case is added to existing 'mysqld_option_err' test.

# **Basing the PR against the correct MariaDB version**

* [x]  _This is a new feature and the PR is based against the latest MariaDB development branch._

## **Copyright**

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.