### PR TITLE
MDEV-40070 innodb_log_archive multi-batch recovery crash

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3887,7 +3887,12 @@ recv_sys_t::parse_mtr_result recv_sys_t::parse_mmap(bool if_exists)
     }
     recv_warp s{&log_sys.buf[recv_sys.offset]};
     auto r= recv_sys.parse<recv_warp,storing,format>(s,if_exists);
-    log_sys.archived_mmap_switch_recovery_complete();
+    if (UNIV_LIKELY(r != GOT_OOM))
+      log_sys.archived_mmap_switch_recovery_complete();
+    else
+      /* rewind() must have closed the next file when invoking
+      log_sys.set_recovered_lsn(start_lsn) */
+      ut_ad(!log_sys.archived_mmap_switch());
     return r;
   }
   recv_ring s


### PR DESCRIPTION
`recv_sys_t::parse_mmap()`: When the current mini-transaction spans two log files and we run out of memory while attempting to store the parsed records into `recv_sys.pages`, the next log file would already have been closed by `recv_sys_t::rewind()`. Handle this condition specially.

This fixes a regression that was introduced in #4405. A copy of a data directory with which this crash was reproduced is available in [MDEV-40070](https://jira.mariadb.org/browse/MDEV-40070).