### PR TITLE
MDEV-39706  Assertion `!thd || !coordinator_thd' failed

### DIFF
--- a/mysql-test/suite/innodb/r/purge_pessimistic.result
+++ b/mysql-test/suite/innodb/r/purge_pessimistic.result
@@ -34,3 +34,21 @@ col1
 DROP TABLE t2;
 SET @@GLOBAL.debug_dbug = @old_debug_dbug;
 SET DEBUG_SYNC='RESET';
+#
+#  MDEV-39706  Assertion `!thd || !coordinator_thd' failed
+#
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+connect con1,localhost,root,,;
+UPDATE t1 set f1= f1 + 1;
+DELETE FROM t1;
+connection default;
+disconnect con1;
+COMMIT;
+SET @old_view_update= @@global.innodb_trx_purge_view_update_only_debug;
+SET @@GLOBAL.innodb_trx_purge_view_update_only_debug=1;
+SET STATEMENT max_statement_time=0.1 FOR SET GLOBAL innodb_max_purge_lag_wait=1;
+SET @@GLOBAL.innodb_trx_purge_view_update_only_debug=@old_view_update;
+InnoDB		0 transactions not purged
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/undo_space_dblwr.result
+++ b/mysql-test/suite/innodb/r/undo_space_dblwr.result
@@ -17,3 +17,10 @@ check table t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
 drop table t1;
+#
+# MDEV-39707 Assertion `lsn != 0' failed
+#
+SET @old_save_page= @@global.innodb_saved_page_number_debug;
+SET GLOBAL innodb_saved_page_number_debug=23;
+SET GLOBAL innodb_fil_make_page_dirty_debug=0;
+SET GLOBAL innodb_saved_page_number_debug= @old_save_page;

--- a/mysql-test/suite/innodb/t/purge_pessimistic.test
+++ b/mysql-test/suite/innodb/t/purge_pessimistic.test
@@ -49,3 +49,24 @@ DROP TABLE t2;
 
 SET @@GLOBAL.debug_dbug = @old_debug_dbug;
 SET DEBUG_SYNC='RESET';
+
+--echo #
+--echo #  MDEV-39706  Assertion `!thd || !coordinator_thd' failed
+--echo #
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+
+connect(con1,localhost,root,,);
+UPDATE t1 set f1= f1 + 1;
+DELETE FROM t1;
+
+connection default;
+disconnect con1;
+COMMIT;
+SET @old_view_update= @@global.innodb_trx_purge_view_update_only_debug;
+SET @@GLOBAL.innodb_trx_purge_view_update_only_debug=1;
+SET STATEMENT max_statement_time=0.1 FOR SET GLOBAL innodb_max_purge_lag_wait=1;
+SET @@GLOBAL.innodb_trx_purge_view_update_only_debug=@old_view_update;
+--source include/wait_all_purged.inc
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/undo_space_dblwr.test
+++ b/mysql-test/suite/innodb/t/undo_space_dblwr.test
@@ -44,3 +44,11 @@ let SEARCH_PATTERN= Recovered page \\[page id: space=1, page number=0\\] to '.*u
 
 check table t1;
 drop table t1;
+
+--echo #
+--echo # MDEV-39707 Assertion `lsn != 0' failed
+--echo #
+SET @old_save_page= @@global.innodb_saved_page_number_debug;
+SET GLOBAL innodb_saved_page_number_debug=23;
+SET GLOBAL innodb_fil_make_page_dirty_debug=0;
+SET GLOBAL innodb_saved_page_number_debug= @old_save_page;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17745,7 +17745,9 @@ func_exit:
 					   [FIL_PAGE_SPACE_ID]);
 	}
 	mtr.commit();
-	log_write_up_to(mtr.commit_lsn(), true);
+	if (lsn_t lsn = mtr.commit_lsn()) {
+		log_write_up_to(lsn, true);
+	}
 	goto func_exit;
 }
 #endif // UNIV_DEBUG

--- a/storage/innobase/include/trx0purge.h
+++ b/storage/innobase/include/trx0purge.h
@@ -506,6 +506,14 @@ public:
 
   /** Reset the state of a purge_worker_task at the end of a batch */
   inline void reset_worker_thd(THD *thd) const noexcept;
+
+#ifdef UNIV_DEBUG
+  int reset_coordinator() noexcept
+  {
+    coordinator_thd= nullptr;
+    return 0;
+  }
+#endif /* UNIV_DEBUG */
 };
 
 /** The global data structure coordinating a purge */

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1472,7 +1472,10 @@ TRANSACTIONAL_TARGET ulint trx_purge(ulint n_tasks, ulint history_size)
 
   purge_sys.clone_oldest_view(thd);
 
-  ut_d(if (srv_purge_view_update_only_debug) return 0);
+#ifdef UNIV_DEBUG
+  if (srv_purge_view_update_only_debug)
+    return purge_sys.reset_coordinator();
+#endif /* UNIV_DEBUG */
 
   /* Fetch the UNDO recs that need to be purged. */
   ulint n_work= 0;


### PR DESCRIPTION
Problem:
========
  - This assert was introduced in commit 0152c617e80ccf3f33d3ea4b50c17d5f588613b1 (MDEV-39261), which sets coordinator_thd in clone_oldest_view() and resets it to nullptr in batch_cleanup() at the end of the batch.
When innodb_trx_purge_view_update_only_debug is enabled, InnoDB fail to reset coordinator_thd. As a result, InnoDB fails with assert in next batch

Solution:
========
trx_purge(): Reset coordinator_thd to nullptr when innodb_trx_purge_view_update_only_debug is enabled.

Note:
=====
Avoided adding test case because cannot --source wait_all_purged.inc with
innodb_trx_purge_view_update_only_debug=1 purge never removes history, So the history list
never reaches 0 and the wait would hang forever.