### PR TITLE
MDEV-30297 Server crash / assertion failure in Compare_identifiers::operator upon dropping period with empty name

### DIFF
--- a/mysql-test/suite/period/r/alter.result
+++ b/mysql-test/suite/period/r/alter.result
@@ -222,3 +222,12 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table t1;
 # End of 10.5 tests
+#
+# MDEV-30297 Server crash / assertion failure in Compare_identifiers::operator upon dropping period with empty name
+#
+create table t (a int);
+alter table t drop period if exists for ``;
+Warnings:
+Note	1091	Can't DROP PERIOD ``; check that it exists
+drop table t;
+# End of 10.11 tests

--- a/mysql-test/suite/period/t/alter.test
+++ b/mysql-test/suite/period/t/alter.test
@@ -190,3 +190,13 @@ show create table t1;
 drop table t1;
 
 --echo # End of 10.5 tests
+
+--echo #
+--echo # MDEV-30297 Server crash / assertion failure in Compare_identifiers::operator upon dropping period with empty name
+--echo #
+create table t (a int);
+alter table t drop period if exists for ``;
+
+drop table t;
+
+--echo # End of 10.11 tests

--- a/sql/vers_string.h
+++ b/sql/vers_string.h
@@ -66,7 +66,11 @@ public:
   { }
   bool streq(const Lex_cstring_with_compare& b) const
   {
-    return Lex_cstring::length == b.length && 0 == Compare()(*this, b);
+    if (length != b.length)
+      return false;
+    if (str == NULL || b.str == NULL)
+      return str == b.str;
+    return length == 0 || 0 == Compare()(*this, b);
   }
   operator const char* () const
   {


### PR DESCRIPTION
fixes [MDEV-30297](https://jira.mariadb.org/browse/MDEV-30297)

### Problem:
`ALTER TABLE ... DROP PERIOD IF EXISTS FOR ``` can trigger an assertion failure in debug builds and crash in non-debug builds.

### Cause:
Lex_cstring_with_compare::streq() may invoke Compare_identifiers on default-constructed Lex_cstring objects (str == NULL, length == 0). Compare_identifiers assumes non-null string pointers and asserts or crashes when called with a null pointer.

### Fix:
Add null-pointer handling to Lex_cstring_with_compare::streq() and avoid calling Compare_identifiers when either string pointer is null. This prevents invalid comparisons while preserving existing behavior for initialized strings.