### PR TITLE
MDEV-25964:  Unexpected bypass of lock

### DIFF
--- a/mysql-test/main/group_min_max_innodb.result
+++ b/mysql-test/main/group_min_max_innodb.result
@@ -440,3 +440,57 @@ SET GLOBAL innodb_lru_scan_depth= @lru_depth.save;
 set global innodb_stats_persistent= @innodb_stats_persistent_save;
 set global innodb_stats_persistent_sample_pages=
 @innodb_stats_persistent_sample_pages_save;
+#
+# Begin 10.11 tests
+#
+CREATE TABLE t1 (pk INT, a INT, b INT, PRIMARY KEY (pk), KEY (a,b)) ENGINE=InnoDB;
+INSERT INTO t1 (pk,a) VALUES (1,11),(2,12),(3,13),(4,14);
+connect  con1,localhost,root,,;
+DELETE FROM t1 WHERE pk <= 3;
+connection default;
+INSERT INTO t1 (pk) VALUES (5);
+connection con1;
+START TRANSACTION;
+INSERT INTO t1 (pk) VALUES (6);
+connection default;
+SET @save_innodb_lock_wait_timeout= @@innodb_lock_wait_timeout;
+SET innodb_lock_wait_timeout= 1;
+EXPLAIN SELECT MIN(b), MAX(b), a FROM t1 GROUP BY a FOR UPDATE;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	#	Using index for group-by
+SELECT MIN(b), MAX(b), a FROM t1 GROUP BY a FOR UPDATE;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+connection con1;
+COMMIT;
+DROP TABLE t1;
+disconnect con1;
+connection default;
+CREATE TABLE t1 (pk INT PRIMARY KEY AUTO_INCREMENT, a INT, b INT, c INT,
+KEY (a,b,c)) ENGINE=InnoDB;
+INSERT INTO t1 (a,b,c) VALUES
+(1,1,10),(1,1,11),(1,2,20),(1,2,21),
+(2,1,10),(2,1,11),(2,2,20),(2,2,21);
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+connect  con1,localhost,root,,;
+START TRANSACTION;
+INSERT INTO t1 (a,b,c) VALUES (1,2,0);
+connection default;
+SET @save_innodb_lock_wait_timeout= @@innodb_lock_wait_timeout;
+SET innodb_lock_wait_timeout= 1;
+EXPLAIN SELECT MIN(c) FROM t1 WHERE b = 2 GROUP BY a FOR UPDATE;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	15	NULL	#	Using where; Using index for group-by
+SELECT MIN(c) FROM t1 WHERE b = 2 GROUP BY a FOR UPDATE;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+connection con1;
+COMMIT;
+DROP TABLE t1;
+disconnect con1;
+connection default;
+#
+# End 10.11 tests
+#

--- a/mysql-test/main/group_min_max_innodb.test
+++ b/mysql-test/main/group_min_max_innodb.test
@@ -323,3 +323,93 @@ SET GLOBAL innodb_lru_scan_depth= @lru_depth.save;
 set global innodb_stats_persistent= @innodb_stats_persistent_save;
 set global innodb_stats_persistent_sample_pages=
              @innodb_stats_persistent_sample_pages_save;
+
+--echo #
+--echo # Begin 10.11 tests
+--echo #
+
+# Default client connection to the database.
+CREATE TABLE t1 (pk INT, a INT, b INT, PRIMARY KEY (pk), KEY (a,b)) ENGINE=InnoDB;
+INSERT INTO t1 (pk,a) VALUES (1,11),(2,12),(3,13),(4,14);
+
+# Start a new, separate client connection to the database called 'con1'.
+--connect (con1,localhost,root,,)
+--send
+DELETE FROM t1 WHERE pk <= 3;
+
+# On the default connection, insert a value into the table.
+--connection default
+INSERT INTO t1 (pk) VALUES (5);
+
+# On 'con1', insert a value within a transaction and hold the transaction while
+# on the default connection try to compute an aggregate.
+--connection con1
+--reap
+
+START TRANSACTION;
+INSERT INTO t1 (pk) VALUES (6);
+
+--connection default
+SET @save_innodb_lock_wait_timeout= @@innodb_lock_wait_timeout;
+SET innodb_lock_wait_timeout= 1;
+# SELECT ... FOR UPDATE locks the rows for write operations and prevents other transactions
+# from modifying or reading the selected rows until the transaction ends.
+# This should lead to the error, not a crash.
+--replace_column 9 #
+EXPLAIN SELECT MIN(b), MAX(b), a FROM t1 GROUP BY a FOR UPDATE;
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT MIN(b), MAX(b), a FROM t1 GROUP BY a FOR UPDATE;
+SET innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+
+# Cleanup, commit the 'con1' transaction.
+--connection con1
+COMMIT;
+DROP TABLE t1;
+--disconnect con1
+
+# This scenario passes with or without the patch.  The query requests only a
+# MIN, so the max branch never runs.  The scenario is kept for coverage, to
+# execute the early return, which the patch adds in the min branch for symmetry
+# with the max branch and to honor the convention that no further reads follow
+# a fatal handler error.
+--connection default
+CREATE TABLE t1 (pk INT PRIMARY KEY AUTO_INCREMENT, a INT, b INT, c INT,
+                 KEY (a,b,c)) ENGINE=InnoDB;
+
+# Two groups over key part a.  Each group has rows with b=1 and rows with
+# b=2, with enough rows overall that the optimizer chooses the loose
+# index scan ("Using index for group-by") over a full index scan.
+INSERT INTO t1 (a,b,c) VALUES
+  (1,1,10),(1,1,11),(1,2,20),(1,2,21),
+  (2,1,10),(2,1,11),(2,2,20),(2,2,21);
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+INSERT INTO t1 (a,b,c) SELECT a,b,c FROM t1;
+
+--connect (con1,localhost,root,,)
+START TRANSACTION;
+# This uncommitted row becomes the first row of the a=1, b=2 prefix because its
+# c is smaller than every committed c in that subgroup.  The MIN read seeks
+# exactly this position, so it waits for con1.
+INSERT INTO t1 (a,b,c) VALUES (1,2,0);
+
+--connection default
+SET @save_innodb_lock_wait_timeout= @@innodb_lock_wait_timeout;
+SET innodb_lock_wait_timeout= 1;
+# The MIN read inside the loose index scan lands on the row locked by con1.
+--replace_column 9 #
+EXPLAIN SELECT MIN(c) FROM t1 WHERE b = 2 GROUP BY a FOR UPDATE;
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT MIN(c) FROM t1 WHERE b = 2 GROUP BY a FOR UPDATE;
+SET innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+
+# Cleanup, commit the 'con1' transaction.
+--connection con1
+COMMIT;
+DROP TABLE t1;
+--disconnect con1
+--connection default
+
+--echo #
+--echo # End 10.11 tests
+--echo #

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -15797,11 +15797,15 @@ int QUICK_GROUP_MIN_MAX_SELECT::next_min()
     }
 
     /*
+      The reason that next_min has more complexity than next_max() is
+      for NULLs handling.  In MariaDB, NULLs appear first in a result
+      and by default sort as less-than every other value.
+
       If the min/max argument field is NULL, skip subsequent rows in the same
       group with NULL in it. Notice that:
-      - if the first row in a group doesn't have a NULL in the field, no row
-      in the same group has (because NULL < any other value),
-      - min_max_arg_part->field->ptr points to some place in 'record'.
+       - if the first row in a group doesn't have a NULL in the field, no row
+         in the same group has (because NULL < any other value),
+       - min_max_arg_part->field->ptr points to some place in 'record'.
     */
     if (min_max_arg_part && min_max_arg_part->field->is_null())
     {

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -15718,15 +15718,51 @@ int QUICK_GROUP_MIN_MAX_SELECT::get_next()
       min_res= next_min();
       if (min_res == 0)
         update_min_result();
+      else
+      {
+        /*
+          If next_min returns an unexpected handler error (HA_ERR_...),
+          then that error will be propagated to the caller of this
+          method by returning immediately here.
+        */
+        if (min_res != HA_ERR_END_OF_FILE && min_res != HA_ERR_KEY_NOT_FOUND)
+          DBUG_RETURN(min_res); // Unrecoverable error.
+      }
     }
     /* If there is no MIN in the group, there is no MAX either. */
     if ((have_max && !have_min) ||
         (have_max && have_min && (min_res == 0)))
     {
+      /*
+        next_min() and next_max() are not symmetrical with respect to
+        how they access the underlying table.  next_min() may read the
+        index when (key_infix_len > 0) but next_max() makes no such check.
+        Hence the lock wait timeout may be seen by next_max() but not by
+        next_min() because it reads blindly.
+       */
       max_res= next_max();
       if (max_res == 0)
         update_max_result();
-      /* If a MIN was found, a MAX must have been found as well. */
+      else
+      {
+        /*
+          If next_max returns an unexpected handler error (HA_ERR_...),
+          then that error will be propagated to the caller of this
+          method by returning immediately here.
+        */
+        if (max_res != HA_ERR_END_OF_FILE &&  max_res != HA_ERR_KEY_NOT_FOUND)
+          DBUG_RETURN(max_res); // Unrecoverable error.
+      }
+
+      /*
+        If we're computing both MIN and MAX (have_min && have_max) then:
+         - Since execution has reached here, we have a record with value for
+           MIN (min_res==0).
+         - This means we must also have a record for MAX (max_res==0). It can
+           be the same record that we've found for MIN, or a different one.
+        We could also have encountered an unrecoverable error while reading
+        the MAX record but that has been handled above.
+      */
       DBUG_ASSERT((have_max && !have_min) ||
                   (have_max && have_min && (max_res == 0)));
     }
@@ -15740,6 +15776,15 @@ int QUICK_GROUP_MIN_MAX_SELECT::get_next()
                                       make_prev_keypart_map(real_key_parts),
                                       HA_READ_KEY_EXACT);
 
+    /*
+      Set the result of checking this GROUP BY group.
+      1. If we're computing a MIN, take min_res. MAX was either not computed
+         at all or it has been computed successully. Fatal errors have
+         already been checked.
+      2. Otherwise, if we're computing a MAX only, take max_res.
+      3. Otherwise, we're just enumerating GROUP BY groups and the 'result'
+         variable already has the outcome of the check.
+    */
     result= have_min ? min_res : have_max ? max_res : result;
   } while (result == HA_ERR_KEY_NOT_FOUND || result == HA_ERR_END_OF_FILE);
 


### PR DESCRIPTION
When an uncommitted transaction inserts rows into a table and another statement locks rows in the same table (SELECT ... FOR UPDATE) while computing a MIN or MAX, then:
  1. In a Debug build, the server aborts on an assertion
  2. In a Release build, the server returns wrong results These errors occur because, while reading a group of rows for computing a MAX, the transaction timeout error was swallowed.

Under the scenario described above and captured in the new test at this commit, QUICK_GROUP_MIN_MAX_SELECT::next_max() emits a lock timeout error during QUICK_GROUP_MIN_MAX_SELECT::get_next() but the error was suppressed if we computed a MIN.

Keep the MAX result when the MIN call succeeded but the MAX result failed, so the error propagates to the client.