### PR TITLE
MDEV-39360: set statement optimizer_record_context for query fails

### DIFF
--- a/mysql-test/main/opt_context_replay_basic.result
+++ b/mysql-test/main/opt_context_replay_basic.result
@@ -1,4 +1,5 @@
 #enable optimizer_record_context
+set optimizer_trace=0;
 set optimizer_record_context=ON;
 show create table information_schema.optimizer_context;
 Table	Create Table
@@ -507,5 +508,41 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
 Warnings:
 Warning	4253	Failed to parse saved optimizer context:  at offset 0.
+set optimizer_replay_context='';
+drop table t1;
+#
+# MDEV-39360: "set statement optimizer_record_context=1 for query" isn't recording context
+#
+set optimizer_record_context=0;
+create table t1 (a varchar(32));
+insert into t1 values ('aaaaaa'),('bbbbbb');
+# Here context should be recorded as it is enabled for this query statement
+set statement optimizer_record_context=1 for explain select * from t1 where a >'foo' or a < 'bar';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+select context like '%bar%' from information_schema.optimizer_context;
+context like '%bar%'
+1
+# rerun above explain query. Here context shouldn't be recorded as it was disabled for the session
+explain select * from t1 where a >'foo' or a < 'bar';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+select context like '%bar%' from information_schema.optimizer_context;
+context like '%bar%'
+set optimizer_record_context=1;
+# Here context shouldn't be recorded as it is disabled for this query statement,
+# even though it is enabled for the session
+set statement optimizer_record_context=0 for explain select * from t1 where a >'foo' or a < 'bar';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+select context like '%bar%' from information_schema.optimizer_context;
+context like '%bar%'
+# Here context should be recorded as it was already enabled for the session
+explain select * from t1 where a >'foo' or a < 'bar';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+select context like '%bar%' from information_schema.optimizer_context;
+context like '%bar%'
+1
 drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_replay_basic.test
+++ b/mysql-test/main/opt_context_replay_basic.test
@@ -2,6 +2,7 @@
 --source include/have_sequence.inc
 --source include/no_view_protocol.inc
 --echo #enable optimizer_record_context
+set optimizer_trace=0;
 set optimizer_record_context=ON;
 
 --disable_replay testfile Dont replay a replay test
@@ -320,6 +321,34 @@ set optimizer_replay_context='';
 set optimizer_replay_context='NO_SUCH_VARIABLE';
 explain select * from t1 where c < 3;
 
+set optimizer_replay_context='';
+drop table t1;
+
+--echo #
+--echo # MDEV-39360: "set statement optimizer_record_context=1 for query" isn't recording context
+--echo #
+set optimizer_record_context=0;
+create table t1 (a varchar(32));
+insert into t1 values ('aaaaaa'),('bbbbbb');
+
+--echo # Here context should be recorded as it is enabled for this query statement
+set statement optimizer_record_context=1 for explain select * from t1 where a >'foo' or a < 'bar';
+select context like '%bar%' from information_schema.optimizer_context;
+
+--echo # rerun above explain query. Here context shouldn't be recorded as it was disabled for the session
+explain select * from t1 where a >'foo' or a < 'bar';
+select context like '%bar%' from information_schema.optimizer_context;
+
+set optimizer_record_context=1;
+
+--echo # Here context shouldn't be recorded as it is disabled for this query statement,
+--echo # even though it is enabled for the session
+set statement optimizer_record_context=0 for explain select * from t1 where a >'foo' or a < 'bar';
+select context like '%bar%' from information_schema.optimizer_context;
+
+--echo # Here context should be recorded as it was already enabled for the session
+explain select * from t1 where a >'foo' or a < 'bar';
+select context like '%bar%' from information_schema.optimizer_context;
 
 drop table t1;
 drop database db1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3533,9 +3533,6 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
   */
   thd->last_sql_command= lex->sql_command;
 
-  init_optimizer_context_replay_if_needed(thd);
-  init_optimizer_context_recorder_if_needed(thd, all_tables);
-
   /*
     Reset warning count for each query that uses tables
     A better approach would be to reset this for any commands
@@ -3736,6 +3733,9 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
   /* After SET STATEMENT is done, we can initialize the Optimizer Trace: */
   ots.init(thd, all_tables, lex->sql_command, &lex->var_list, thd->query(),
            thd->query_length(), thd->variables.character_set_client);
+
+  init_optimizer_context_replay_if_needed(thd);
+  init_optimizer_context_recorder_if_needed(thd, all_tables);
 
   if (thd->lex->mi.connection_name.str == NULL)
       thd->lex->mi.connection_name= thd->variables.default_master_connection;


### PR DESCRIPTION
Move the initialization of context recorder, and replay after run_set_statement_if_requested() is invoked in the mysql_execute_command() in sql_parse.cc