### PR TITLE
MDEV-36990 : SIGFPE in get_max_range_rowid_filter_elems_for_table

### DIFF
--- a/mysql-test/main/create_select.result
+++ b/mysql-test/main/create_select.result
@@ -75,3 +75,16 @@ t2	CREATE TABLE `t2` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table t1, t2;
 # End of 12.1 tests
+#
+# MDEV-36990: SIGFPE in get_max_range_rowid_filter_elems_for_table
+#
+DROP TABLE IF EXISTS t;
+Warnings:
+Note	1051	Unknown table 'test.t'
+CREATE TABLE t (a INT,b INT,PRIMARY KEY(a),INDEX (b))Engine=InnoDB;
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+ERROR 42000: The storage engine InnoDB can't index column `a`
+SELECT * FROM t WHERE b>-1;
+a	b
+DROP TABLE IF EXISTS t;
+# End of 10.11 tests

--- a/mysql-test/main/create_select.result
+++ b/mysql-test/main/create_select.result
@@ -57,6 +57,69 @@ t1	CREATE TABLE `t1` (
 drop table t1;
 set sql_mode=default;
 # End of 10.4 tests
+# Start of 10.11 tests
+#
+# MDEV-36990: SIGFPE in get_max_range_rowid_filter_elems_for_table
+#
+DROP TABLE IF EXISTS t;
+Warnings:
+Note	1051	Unknown table 'test.t'
+CREATE TABLE t (a INT,b INT,PRIMARY KEY(a),INDEX (b))Engine=InnoDB;
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+ERROR 42000: The storage engine InnoDB can't index column `a`
+SELECT * FROM t WHERE b>-1;
+a	b
+DROP TABLE IF EXISTS t;
+#
+# MDEV-36438: Server hangs or fails on assertion after modifying key column to CHAR(0) or BINARY(0), various UBSAN issues
+#
+CREATE TABLE t (id INT PRIMARY KEY) ENGINE=innodb;
+ALTER TABLE t MODIFY id CHAR(0);
+ERROR 42000: The storage engine InnoDB can't index column `id`
+UPDATE t SET id = 1;
+DROP TABLE t;
+set sql_mode='';
+CREATE TABLE t (a INT KEY,b INT);
+INSERT INTO t VALUES (2,0);
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+ERROR 42000: The storage engine MyISAM can't index column `a`
+REPLACE INTO t VALUES (4,4);
+DROP TABLE t;
+set sql_mode=default;
+CREATE TABLE t1 (id char(10) PRIMARY KEY) engine=innodb partition BY KEY (id) partitions 12;
+INSERT INTO t1 VALUES ('1'),('2'),('3');
+ALTER IGNORE TABLE t1 MODIFY IF EXISTS id CHAR (0);
+ERROR 42000: The storage engine partition can't index column `id`
+UPDATE t1 SET id = 'a' ORDER BY null;
+DROP TABLE t1;
+set sql_mode='';
+CREATE TABLE t (a INT KEY);
+INSERT INTO t VALUES ();
+Warnings:
+Warning	1364	Field 'a' doesn't have a default value
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+ERROR 42000: The storage engine MyISAM can't index column `a`
+UPDATE t SET a=((SELECT * FROM t));
+DROP TABLE t;
+set sql_mode=default;
+CREATE TABLE t (c BINARY(0), UNIQUE(c)) ENGINE=InnoDB;
+ALTER TABLE t ADD PRIMARY KEY (c);
+ERROR 42000: The storage engine InnoDB can't index column `c`
+SELECT * FROM t;
+c
+DROP TABLE t;
+CREATE TABLE t (c BINARY(0), UNIQUE(c)) ENGINE=InnoDB;
+ALTER TABLE t ADD PRIMARY KEY (c);
+ERROR 42000: The storage engine InnoDB can't index column `c`
+SELECT * FROM t;
+c
+DROP TABLE t;
+CREATE TABLE t (c INT KEY) ENGINE=InnoDB;
+ALTER TABLE t CHANGE COLUMN c c BINARY (0);
+ERROR 42000: The storage engine InnoDB can't index column `c`
+UPDATE t SET c=REPEAT(0,0) WHERE c=REPEAT(0,0);
+DROP TABLE t;
+# End of 10.11 tests
 #
 # MDEV-37998 (Column) CHECK constraints can cause CREATE TABLE (SELECT) queries to fail
 #

--- a/mysql-test/main/create_select.test
+++ b/mysql-test/main/create_select.test
@@ -79,3 +79,16 @@ show create table t2;
 drop table t1, t2;
 
 --echo # End of 12.1 tests
+
+--echo #
+--echo # MDEV-36990: SIGFPE in get_max_range_rowid_filter_elems_for_table
+--echo #
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a INT,b INT,PRIMARY KEY(a),INDEX (b))Engine=InnoDB;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+SELECT * FROM t WHERE b>-1;
+
+DROP TABLE IF EXISTS t;
+--echo # End of 10.11 tests

--- a/mysql-test/main/create_select.test
+++ b/mysql-test/main/create_select.test
@@ -1,6 +1,7 @@
 # This does not work for RBR yet.
 --source include/have_innodb.inc
 --source include/have_binlog_format_mixed_or_statement.inc
+--source include/have_partition.inc
 
 CALL mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
 
@@ -64,6 +65,75 @@ drop table t1;
 set sql_mode=default;
 
 --echo # End of 10.4 tests
+
+--echo # Start of 10.11 tests
+
+--echo #
+--echo # MDEV-36990: SIGFPE in get_max_range_rowid_filter_elems_for_table
+--echo #
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a INT,b INT,PRIMARY KEY(a),INDEX (b))Engine=InnoDB;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+SELECT * FROM t WHERE b>-1;
+DROP TABLE IF EXISTS t;
+
+--echo #
+--echo # MDEV-36438: Server hangs or fails on assertion after modifying key column to CHAR(0) or BINARY(0), various UBSAN issues
+--echo #
+
+CREATE TABLE t (id INT PRIMARY KEY) ENGINE=innodb;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t MODIFY id CHAR(0);
+UPDATE t SET id = 1;
+DROP TABLE t;
+
+set sql_mode='';
+CREATE TABLE t (a INT KEY,b INT);
+INSERT INTO t VALUES (2,0);
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+REPLACE INTO t VALUES (4,4);
+DROP TABLE t;
+set sql_mode=default;
+
+CREATE TABLE t1 (id char(10) PRIMARY KEY) engine=innodb partition BY KEY (id) partitions 12;
+INSERT INTO t1 VALUES ('1'),('2'),('3');
+--error ER_WRONG_KEY_COLUMN
+ALTER IGNORE TABLE t1 MODIFY IF EXISTS id CHAR (0);
+--error 0,ER_DUP_ENTRY
+UPDATE t1 SET id = 'a' ORDER BY null;
+DROP TABLE t1;
+
+set sql_mode='';
+CREATE TABLE t (a INT KEY);
+INSERT INTO t VALUES ();
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t CHANGE COLUMN a a BINARY (0);
+UPDATE t SET a=((SELECT * FROM t));
+DROP TABLE t;
+set sql_mode=default;
+
+CREATE TABLE t (c BINARY(0), UNIQUE(c)) ENGINE=InnoDB;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t ADD PRIMARY KEY (c);
+SELECT * FROM t;
+DROP TABLE t;
+
+CREATE TABLE t (c BINARY(0), UNIQUE(c)) ENGINE=InnoDB;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t ADD PRIMARY KEY (c);
+SELECT * FROM t;
+DROP TABLE t;
+
+CREATE TABLE t (c INT KEY) ENGINE=InnoDB;
+--error ER_WRONG_KEY_COLUMN
+ALTER TABLE t CHANGE COLUMN c c BINARY (0);
+UPDATE t SET c=REPEAT(0,0) WHERE c=REPEAT(0,0);
+DROP TABLE t;
+
+--echo # End of 10.11 tests
 
 --echo #
 --echo # MDEV-37998 (Column) CHECK constraints can cause CREATE TABLE (SELECT) queries to fail

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2963,8 +2963,8 @@ my_bool init_key_part_spec(THD *thd, Alter_info *alter_info,
     else if (!(file->ha_table_flags() & HA_NO_PREFIX_CHAR_KEYS))
       key_part_length= kp.length;
   }
-  else if (key_part_length == 0 && (column->flags & NOT_NULL_FLAG) &&
-           !*is_hash_field_needed)
+  else if (key_part_length == 0 && ((column->flags & NOT_NULL_FLAG) ||
+    key.type == Key::PRIMARY) && !*is_hash_field_needed)
   {
     my_error(ER_WRONG_KEY_COLUMN, MYF(0), file->table_type(), field_name.str);
     DBUG_RETURN(TRUE);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2963,8 +2963,13 @@ my_bool init_key_part_spec(THD *thd, Alter_info *alter_info,
     else if (!(file->ha_table_flags() & HA_NO_PREFIX_CHAR_KEYS))
       key_part_length= kp.length;
   }
-  else if (key_part_length == 0 && (column->flags & NOT_NULL_FLAG) &&
-           !*is_hash_field_needed)
+  /*
+      A PRIMARY KEY column is implicitly NOT NULL, but NOT_NULL_FLAG is only
+      set later, in the key loop of mysql_prepare_create_table_finalize().
+      Test the key type directly so zero-length PK parts are rejected here.
+    */
+  else if (key_part_length == 0 && ((column->flags & NOT_NULL_FLAG) ||
+    key.type == Key::PRIMARY) && !*is_hash_field_needed)
   {
     my_error(ER_WRONG_KEY_COLUMN, MYF(0), file->table_type(), field_name.str);
     DBUG_RETURN(TRUE);


### PR DESCRIPTION
fixes [MDEV-36990](https://jira.mariadb.org/browse/MDEV-36990)

### Problem:
A zero-length column (CHAR(0), VARCHAR(0), BINARY(0), VARBINARY(0)) was accepted as a PRIMARY KEY column. The resulting zero-length key part left ref_length == 0, causing a division by zero in get_max_range_rowid_filter_elems_for_table().

### Cause:
init_key_part_spec() rejected a zero-length key part only when the column had NOT_NULL_FLAG.  A PRIMARY KEY column becomes implicitly NOT NULL only later, in the key loop of mysql_prepare_create_table_finalize(), so at validation time the flag is still clear.

### Fix:
Reject a zero-length key part also when key.type == Key::PRIMARY. Nullable zero-length columns remain indexable by non-unique and UNIQUE keys.