### PR TITLE
MDEV-39707 Assertion `lsn != 0' failed in log_write_up_to

### DIFF
--- a/mysql-test/suite/innodb/r/undo_space_dblwr.result
+++ b/mysql-test/suite/innodb/r/undo_space_dblwr.result
@@ -17,3 +17,10 @@ check table t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
 drop table t1;
+#
+# MDEV-39707 Assertion `lsn != 0' failed
+#
+SET @old_save_page= @@global.innodb_saved_page_number_debug;
+SET GLOBAL innodb_saved_page_number_debug=23;
+SET GLOBAL innodb_fil_make_page_dirty_debug=0;
+SET GLOBAL innodb_saved_page_number_debug= @old_save_page;

--- a/mysql-test/suite/innodb/t/undo_space_dblwr.test
+++ b/mysql-test/suite/innodb/t/undo_space_dblwr.test
@@ -44,3 +44,11 @@ let SEARCH_PATTERN= Recovered page \\[page id: space=1, page number=0\\] to '.*u
 
 check table t1;
 drop table t1;
+
+--echo #
+--echo # MDEV-39707 Assertion `lsn != 0' failed
+--echo #
+SET @old_save_page= @@global.innodb_saved_page_number_debug;
+SET GLOBAL innodb_saved_page_number_debug=23;
+SET GLOBAL innodb_fil_make_page_dirty_debug=0;
+SET GLOBAL innodb_saved_page_number_debug= @old_save_page;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17745,7 +17745,9 @@ func_exit:
 					   [FIL_PAGE_SPACE_ID]);
 	}
 	mtr.commit();
-	log_write_up_to(mtr.commit_lsn(), true);
+	if (lsn_t lsn = mtr.commit_lsn()) {
+		log_write_up_to(lsn, true);
+	}
 	goto func_exit;
 }
 #endif // UNIV_DEBUG


### PR DESCRIPTION
Problem:
========
innodb_make_page_dirty(): Unconditionally calls log_write_up_to() with mtr.commit_lsn() after committing the mini-transaction. When the mtr produced no redo records when the targeted page is full of zeroes.

Solution:
========
innodb_make_page_dirty(): Skip log_write_up_to() when commit_lsn() is zero.