### PR TITLE
MDEV-39744: Assertion `buf != end` failed in `decimal_mul`

### DIFF
--- a/mysql-test/main/type_newdecimal.result
+++ b/mysql-test/main/type_newdecimal.result
@@ -3053,4 +3053,16 @@ truncate 2
 select '12185184186.000000000000000000000000000024692343000000000000000000000000000000000002' as 'exact result';
 exact result
 12185184186.000000000000000000000000000024692343000000000000000000000000000000000002
+#
+# MDEV-39744: Assertion `buf != end` failed in `decimal_mul`
+#
+SET @old_prec_incr= @@SESSION.div_precision_increment;
+SET @@SESSION.div_precision_increment=0;
+SELECT ((273 / 941) * (-299 / 450)) as x;
+x
+0
+SELECT (-299 / 450) AS neg_div;
+neg_div
+0
+SET @@SESSION.div_precision_increment=@old_prec_incr;
 # End of 10.11 tests

--- a/mysql-test/main/type_newdecimal.test
+++ b/mysql-test/main/type_newdecimal.test
@@ -2105,4 +2105,16 @@ select 12345678 * 987.000000000000000000000000000000000002 as 'truncate 1';
 select 12345678.000000000000000000000000000000000001 * 987 as 'truncate 2';
 select '12185184186.000000000000000000000000000024692343000000000000000000000000000000000002' as 'exact result';
 
+--echo #
+--echo # MDEV-39744: Assertion `buf != end` failed in `decimal_mul`
+--echo #
+
+SET @old_prec_incr= @@SESSION.div_precision_increment;
+
+SET @@SESSION.div_precision_increment=0;
+SELECT ((273 / 941) * (-299 / 450)) as x;
+SELECT (-299 / 450) AS neg_div;
+
+SET @@SESSION.div_precision_increment=@old_prec_incr;
+
 --echo # End of 10.11 tests

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -2314,6 +2314,11 @@ static int do_div_mod(const decimal_t *from1, const decimal_t *from2,
     to->sign=from1->sign != from2->sign;
     to->intg=intg0*DIG_PER_DEC1;
     to->frac=frac0*DIG_PER_DEC1;
+    if (unlikely(frac0==0 && intg0==0))
+    {
+      decimal_make_zero(to);
+      return E_DEC_OK;
+    }
   }
   buf0=to->buf;
   stop0=buf0+intg0+frac0;


### PR DESCRIPTION
fixes [MDEV-39744](https://jira.mariadb.org/browse/MDEV-39744)

### Problem:
With `div_precision_increment=0`, a division whose quotient rounds away to zero (e.g. -299/450) produced a decimal with no digit words (intg=0 and frac=0) while still keeping the sign bit set. That is a malformed value.

Multiplying such a malformed zero value by another zero reached the negative-zero check in `decimal_mul`, where there were no digit words to scan, leading to assertion failure.

### Fix:
Fix `do_div_mod`, which produced the malformed zero. `do_div_mod` already normalizes this case to a canonical zero on the modulo path; do the same on the division path: when the quotient has no digits (intg0 == 0 && frac0 == 0) return a correct decimal zero instead of a digit-less, signed value.
