### PR TITLE
MDEV-40555: Promote GitHub stars in server log and client prompt in versions 10.11 and onward

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -1408,6 +1408,9 @@ int main(int argc,char *argv[])
             mysql_thread_id(&mysql), server_version_string(&mysql));
     put_info((char*) glob_buffer.ptr(),INFO_INFO);
     put_info(ORACLE_WELCOME_COPYRIGHT_NOTICE("2000"), INFO_INFO);
+    put_info("Help others discover MariaDB."
+             " Star it on GitHub: https://github.com/MariaDB/server\n",
+             INFO_INFO);
   }
 
 #ifdef HAVE_READLINE

--- a/mysql-test/main/mysql-interactive.result
+++ b/mysql-test/main/mysql-interactive.result
@@ -10,6 +10,8 @@ Your MariaDB connection id is X
 Server version: Y
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
+Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server
+
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
 MariaDB [(none)]> delimiter $
@@ -39,6 +41,8 @@ Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is X
 Server version: Y
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server
 
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 


### PR DESCRIPTION
This cherry-picked from 346c7afe9b7071ce9c47892a83d69944b608b3da on 'main' with the intent of having PR#4262 applied on 10.11 now, and thus on all branches maintained for the next 6 months or more. I am excluding 10.6 as it is EOL soon.

This is similar to #4262 but without the `SERVER_MATURITY_LEVEL` limit in order to actually show the message to users in stable releases.