### PR TITLE
MDEV-26123: Always mark spatial index reads as locking

### DIFF
--- a/mysql-test/suite/innodb_gis/r/rtree_search.result
+++ b/mysql-test/suite/innodb_gis/r/rtree_search.result
@@ -250,3 +250,39 @@ count(*)
 drop procedure curdemo;
 drop table t3;
 drop table t1;
+#
+# MDEV 26123 : Always mark spatial index reads as locking
+#
+SET @old_autocommit = @@autocommit;
+SET @old_tx_read_only = @@session.tx_read_only;
+CREATE TABLE t1 (
+c1 INT PRIMARY KEY,
+category INT NOT NULL,
+p POINT NOT NULL,
+KEY idx_category (category),
+SPATIAL INDEX sp_idx_p (p)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES
+(1, 10, POINT(1,2));
+CREATE PROCEDURE populate_t1()
+BEGIN
+DECLARE i INT DEFAULT 2;
+WHILE i <= 5000 DO
+INSERT INTO t1 VALUES
+(i, 20, POINT(5,5));
+SET i = i + 1;
+END WHILE;
+END |
+CALL populate_t1();
+SELECT COUNT(*) FROM t1 WHERE ST_Contains(t1.p, (SELECT p FROM t1 WHERE category = 10));
+COUNT(*)
+1
+SET SESSION TRANSACTION READ ONLY;
+SET autocommit = OFF;
+SELECT COUNT(*) FROM t1 WHERE category = (SELECT category FROM t1 WHERE ST_EQUALS(p, POINT(1,2)));
+COUNT(*)
+1
+SET autocommit = @old_autocommit;
+SET SESSION tx_read_only = @old_tx_read_only;
+DROP PROCEDURE populate_t1;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb_gis/t/rtree_search.test
+++ b/mysql-test/suite/innodb_gis/t/rtree_search.test
@@ -139,3 +139,45 @@ drop procedure curdemo;
 drop table t3;
 drop table t1;
 
+--echo #
+--echo # MDEV 26123 : Always mark spatial index reads as locking
+--echo #
+SET @old_autocommit = @@autocommit;
+SET @old_tx_read_only = @@session.tx_read_only;
+
+CREATE TABLE t1 (
+    c1 INT PRIMARY KEY,
+    category INT NOT NULL,
+    p POINT NOT NULL,
+    KEY idx_category (category),
+    SPATIAL INDEX sp_idx_p (p)
+) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES
+(1, 10, POINT(1,2));
+
+DELIMITER |;
+CREATE PROCEDURE populate_t1()
+BEGIN
+    DECLARE i INT DEFAULT 2;
+
+    WHILE i <= 5000 DO
+        INSERT INTO t1 VALUES
+            (i, 20, POINT(5,5));
+        SET i = i + 1;
+    END WHILE;
+END |
+DELIMITER ;|
+CALL populate_t1();
+
+SELECT COUNT(*) FROM t1 WHERE ST_Contains(t1.p, (SELECT p FROM t1 WHERE category = 10));
+
+SET SESSION TRANSACTION READ ONLY;
+SET autocommit = OFF;
+SELECT COUNT(*) FROM t1 WHERE category = (SELECT category FROM t1 WHERE ST_EQUALS(p, POINT(1,2)));
+
+# Cleanup
+SET autocommit = @old_autocommit;
+SET SESSION tx_read_only = @old_tx_read_only;
+DROP PROCEDURE populate_t1;
+DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9012,12 +9012,8 @@ ha_innobase::index_read(
 
 	/* For R-Tree index, we will always place the page lock to
 	pages being searched */
-	if (index->is_spatial() && !m_prebuilt->trx->will_lock) {
-		if (trx_state != TRX_STATE_NOT_STARTED) {
-			DBUG_RETURN(HA_ERR_READ_ONLY_TRANSACTION);
-		} else {
-			m_prebuilt->trx->will_lock = true;
-		}
+	if (index->is_spatial()) {
+		m_prebuilt->trx->will_lock = true;
 	}
 
 	/* Note that if the index for which the search template is built is not


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-26123*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
MDEV-26123: Always mark spatial index reads as locking

A SELECT query could fail with ER_READ_ONLY_TRANSACTION when search
on spatial index is done after search on non-spatial index.

R-tree index search always require page locks. Previously,
trx->will_lock was only set for spatial indexes when the transaction
had not yet been started. If a transaction was already active due to
a prior non-spatial index access, index_read() for spatial index
returned HA_ERR_READ_ONLY_TRANSACTION instead of marking the transaction
as locking.

Fix:
- ha_innobase::index_read() : Set trx->will_lock unconditionally for
spatial index, ensuring that R-tree searches can acquire the required
page locks regardless of transaction state.

## Release Notes
Always mark Spatial Index reads as locking

## How can this PR be tested?

Added testcase inside `mysql-test/suite/innodb_gis/t/rtree_search.test` to cover the changes.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
