### PR TITLE
MDEV-39689: Fix OOB reads in Table_map_log_event

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_table_map_log_event_overflow.result
+++ b/mysql-test/suite/rpl/r/rpl_table_map_log_event_overflow.result
@@ -1,0 +1,167 @@
+include/master-slave.inc
+[connection master]
+#
+# MDEV-39689: Slave Overflow on Malformed Table_map_log_event
+#
+# All tests verify that corrupted optional metadata lengths in
+# parse_* functions are handled gracefully. The slave should fall
+# back to positional column mapping and replicate successfully.
+#
+connection master;
+SET @saved_binlog_row_metadata= @@GLOBAL.binlog_row_metadata;
+SET GLOBAL binlog_row_metadata= FULL;
+connection slave;
+CALL mtr.add_suppression("Error in Log_event::read_log_event.*Found invalid event");
+CALL mtr.add_suppression("Relay log read failure");
+#
+# Test 1: parse_column_name - corrupted column name length
+#
+connection master;
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_column_name_length";
+INSERT INTO t1 VALUES (1);
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1
+1
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 2: parse_default_charset - corrupted default charset length
+#
+connection master;
+CREATE TABLE t1 (c1 VARCHAR(10) CHARSET latin1, c2 VARCHAR(10) CHARSET latin1, c3 VARCHAR(10) CHARSET utf8mb4);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_default_charset_length";
+INSERT INTO t1 VALUES ('a', 'b', 'c');
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1	c2	c3
+a	b	c
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 3: parse_column_charset - corrupted column charset length
+#
+connection master;
+CREATE TABLE t1 (c1 VARCHAR(10) CHARSET latin1);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_column_charset_length";
+INSERT INTO t1 VALUES ('a');
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1
+a
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 4: parse_set_str_value - corrupted SET string value length
+#
+connection master;
+CREATE TABLE t1 (c1 SET('a','b','c'));
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_set_str_value_length";
+INSERT INTO t1 VALUES ('a');
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1
+a
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 5: parse_geometry_type - corrupted geometry type length
+#
+connection master;
+CREATE TABLE t1 (c1 GEOMETRY NOT NULL);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_geometry_type_length";
+INSERT INTO t1 VALUES (PointFromText('POINT(0 0)'));
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT ST_AsText(c1) FROM t1;
+ST_AsText(c1)
+POINT(0 0)
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 6: parse_simple_pk - corrupted simple primary key length
+#
+connection master;
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_simple_pk_length";
+INSERT INTO t1 VALUES (1);
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1
+1
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 7: parse_pk_with_prefix - corrupted prefix primary key length
+#
+connection master;
+CREATE TABLE t1 (c1 VARCHAR(100), PRIMARY KEY(c1(10)));
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_pk_prefix_length";
+INSERT INTO t1 VALUES ('hello');
+SET @@SESSION.debug_dbug= "";
+connection slave;
+SELECT * FROM t1;
+c1
+hello
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 8: Table_map_log_event constructor - corrupted column count
+#         (slave-side injection) - slave rejects event gracefully
+#
+connection slave;
+include/stop_slave.inc
+SET @saved_dbug= @@GLOBAL.debug_dbug;
+SET @@GLOBAL.debug_dbug="+d,corrupt_table_map_colcnt_read";
+include/start_slave.inc
+connection master;
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1594]
+SET @@GLOBAL.debug_dbug= @saved_dbug;
+include/stop_slave_io.inc
+SET GLOBAL sql_slave_skip_counter= 1;
+include/start_slave.inc
+connection master;
+DROP TABLE t1;
+connection slave;
+#
+# Test 9: Table_map_log_event constructor - corrupted field metadata size
+#         (slave-side injection) - slave rejects event gracefully
+#
+connection slave;
+include/stop_slave.inc
+SET @saved_dbug= @@GLOBAL.debug_dbug;
+SET @@GLOBAL.debug_dbug="+d,corrupt_table_map_field_metadata_size_read";
+include/start_slave.inc
+connection master;
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1594]
+SET @@GLOBAL.debug_dbug= @saved_dbug;
+include/stop_slave_io.inc
+SET GLOBAL sql_slave_skip_counter= 1;
+include/start_slave.inc
+connection master;
+DROP TABLE t1;
+connection slave;
+connection master;
+SET GLOBAL binlog_row_metadata= @saved_binlog_row_metadata;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_table_map_log_event_overflow.test
+++ b/mysql-test/suite/rpl/t/rpl_table_map_log_event_overflow.test
@@ -1,0 +1,195 @@
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+--echo #
+--echo # MDEV-39689: Slave Overflow on Malformed Table_map_log_event
+--echo #
+--echo # All tests verify that corrupted optional metadata lengths in
+--echo # parse_* functions are handled gracefully. The slave should fall
+--echo # back to positional column mapping and replicate successfully.
+--echo #
+
+# binlog_row_metadata=FULL is required so the master writes optional metadata
+# (column names, charsets, PKs, etc.) into Table_map_log_events. Without it,
+# the parse_* functions under test are never exercised. Restored at end of test.
+--connection master
+SET @saved_binlog_row_metadata= @@GLOBAL.binlog_row_metadata;
+SET GLOBAL binlog_row_metadata= FULL;
+
+--connection slave
+CALL mtr.add_suppression("Error in Log_event::read_log_event.*Found invalid event");
+CALL mtr.add_suppression("Relay log read failure");
+
+--echo #
+--echo # Test 1: parse_column_name - corrupted column name length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_column_name_length";
+INSERT INTO t1 VALUES (1);
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 2: parse_default_charset - corrupted default charset length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 VARCHAR(10) CHARSET latin1, c2 VARCHAR(10) CHARSET latin1, c3 VARCHAR(10) CHARSET utf8mb4);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_default_charset_length";
+INSERT INTO t1 VALUES ('a', 'b', 'c');
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 3: parse_column_charset - corrupted column charset length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 VARCHAR(10) CHARSET latin1);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_column_charset_length";
+INSERT INTO t1 VALUES ('a');
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 4: parse_set_str_value - corrupted SET string value length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 SET('a','b','c'));
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_set_str_value_length";
+INSERT INTO t1 VALUES ('a');
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 5: parse_geometry_type - corrupted geometry type length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 GEOMETRY NOT NULL);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_geometry_type_length";
+INSERT INTO t1 VALUES (PointFromText('POINT(0 0)'));
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT ST_AsText(c1) FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 6: parse_simple_pk - corrupted simple primary key length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_simple_pk_length";
+INSERT INTO t1 VALUES (1);
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 7: parse_pk_with_prefix - corrupted prefix primary key length
+--echo #
+
+--connection master
+CREATE TABLE t1 (c1 VARCHAR(100), PRIMARY KEY(c1(10)));
+SET @@SESSION.debug_dbug="+d,corrupt_table_map_pk_prefix_length";
+INSERT INTO t1 VALUES ('hello');
+SET @@SESSION.debug_dbug= "";
+--sync_slave_with_master
+SELECT * FROM t1;
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 8: Table_map_log_event constructor - corrupted column count
+--echo #         (slave-side injection) - slave rejects event gracefully
+--echo #
+
+--connection slave
+--source include/stop_slave.inc
+SET @saved_dbug= @@GLOBAL.debug_dbug;
+SET @@GLOBAL.debug_dbug="+d,corrupt_table_map_colcnt_read";
+--source include/start_slave.inc
+
+--connection master
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+--source include/save_master_gtid.inc
+
+--connection slave
+--let $slave_sql_errno= 1594
+--source include/wait_for_slave_sql_error.inc
+SET @@GLOBAL.debug_dbug= @saved_dbug;
+--source include/stop_slave_io.inc
+SET GLOBAL sql_slave_skip_counter= 1;
+--source include/start_slave.inc
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--echo #
+--echo # Test 9: Table_map_log_event constructor - corrupted field metadata size
+--echo #         (slave-side injection) - slave rejects event gracefully
+--echo #
+
+--connection slave
+--source include/stop_slave.inc
+SET @saved_dbug= @@GLOBAL.debug_dbug;
+SET @@GLOBAL.debug_dbug="+d,corrupt_table_map_field_metadata_size_read";
+--source include/start_slave.inc
+
+--connection master
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+--source include/save_master_gtid.inc
+
+--connection slave
+--let $slave_sql_errno= 1594
+--source include/wait_for_slave_sql_error.inc
+SET @@GLOBAL.debug_dbug= @saved_dbug;
+--source include/stop_slave_io.inc
+SET GLOBAL sql_slave_skip_counter= 1;
+--source include/start_slave.inc
+
+--connection master
+DROP TABLE t1;
+--sync_slave_with_master
+
+--connection master
+SET GLOBAL binlog_row_metadata= @saved_binlog_row_metadata;
+
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3733,6 +3733,8 @@ Table_map_log_event::Table_map_log_event(const uchar *buf, uint event_len,
   uchar *ptr_after_colcnt= (uchar*) ptr_colcnt;
   VALIDATE_BYTES_READ(ptr_after_colcnt, buf, event_len);
   m_colcnt= net_field_length(&ptr_after_colcnt);
+  DBUG_EXECUTE_IF("corrupt_table_map_colcnt_read",
+                  m_colcnt= (1 << 20););
 
   DBUG_PRINT("info",("m_dblen: %lu  off: %ld  m_tbllen: %lu  off: %ld  m_colcnt: %lu  off: %ld",
                      (ulong) m_dblen, (long) (ptr_dblen - vpart),
@@ -3751,11 +3753,19 @@ Table_map_log_event::Table_map_log_event(const uchar *buf, uint event_len,
     /* Copy the different parts into their memory */
     strncpy(const_cast<char*>(m_dbnam), (const char*)ptr_dblen  + 1, m_dblen + 1);
     strncpy(const_cast<char*>(m_tblnam), (const char*)ptr_tbllen + 1, m_tbllen + 1);
+    if (unlikely(ptr_after_colcnt + m_colcnt > buf + event_len))
+    {
+      my_free(m_memory);
+      m_memory= NULL;
+      DBUG_VOID_RETURN;
+    }
     memcpy(m_coltype, ptr_after_colcnt, m_colcnt);
 
     ptr_after_colcnt= ptr_after_colcnt + m_colcnt;
     VALIDATE_BYTES_READ(ptr_after_colcnt, buf, event_len);
     m_field_metadata_size= net_field_length(&ptr_after_colcnt);
+    DBUG_EXECUTE_IF("corrupt_table_map_field_metadata_size_read",
+                    m_field_metadata_size= (1 << 20););
     if (m_field_metadata_size <= (m_colcnt * 2))
     {
       uint num_null_bytes= (m_colcnt + 7) / 8;
@@ -3763,8 +3773,24 @@ Table_map_log_event::Table_map_log_event(const uchar *buf, uint event_len,
           &m_null_bits, num_null_bytes,
           &m_field_metadata, m_field_metadata_size,
           NULL);
+      if (unlikely(ptr_after_colcnt + m_field_metadata_size > buf + event_len))
+      {
+        my_free(m_meta_memory);
+        m_meta_memory= NULL;
+        my_free(m_memory);
+        m_memory= NULL;
+        DBUG_VOID_RETURN;
+      }
       memcpy(m_field_metadata, ptr_after_colcnt, m_field_metadata_size);
       ptr_after_colcnt= (uchar*)ptr_after_colcnt + m_field_metadata_size;
+      if (unlikely(ptr_after_colcnt + num_null_bytes > buf + event_len))
+      {
+        my_free(m_meta_memory);
+        m_meta_memory= NULL;
+        my_free(m_memory);
+        m_memory= NULL;
+        DBUG_VOID_RETURN;
+      }
       memcpy(m_null_bits, ptr_after_colcnt, num_null_bytes);
       ptr_after_colcnt= (unsigned char*)ptr_after_colcnt + num_null_bytes;
     }
@@ -3837,12 +3863,19 @@ static void parse_default_charset(Table_map_log_event::Optional_metadata_fields:
                                   unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
   default_charset.default_charset= net_field_length(&p);
-  while (p < field + length)
+  if (unlikely(p > end))
+    return;
+  while (p < end)
   {
     unsigned int col_index= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
     unsigned int col_charset= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
 
     default_charset.charset_pairs.push_back(std::make_pair(col_index,
                                                            col_charset));
@@ -3860,9 +3893,15 @@ static void parse_column_charset(std::vector<unsigned int> &vec,
                                  unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
-    vec.push_back(net_field_length(&p));
+  while (p < end)
+  {
+    unsigned int charset= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
+    vec.push_back(charset);
+  }
 }
 
 /**
@@ -3876,10 +3915,13 @@ static void parse_column_name(std::vector<std::string> &vec,
                               unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
+  while (p < end)
   {
     unsigned len= net_field_length(&p);
+    if (unlikely(p + len > end))
+      return;
     vec.push_back(std::string(reinterpret_cast<char *>(p), len));
     p+= len;
   }
@@ -3900,15 +3942,20 @@ static void parse_set_str_value(std::vector<Table_map_log_event::
                                 unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
+  while (p < end)
   {
     unsigned int count= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
 
     vec.push_back(std::vector<std::string>());
     for (unsigned int i= 0; i < count; i++)
     {
       unsigned len1= net_field_length(&p);
+      if (unlikely(p + len1 > end))
+        return;
       vec.back().push_back(std::string(reinterpret_cast<char *>(p), len1));
       p+= len1;
     }
@@ -3926,9 +3973,15 @@ static void parse_geometry_type(std::vector<unsigned int> &vec,
                                 unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
-    vec.push_back(net_field_length(&p));
+  while (p < end)
+  {
+    unsigned int geom_type= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
+    vec.push_back(geom_type);
+  }
 }
 
 /**
@@ -3946,9 +3999,15 @@ static void parse_simple_pk(std::vector<Table_map_log_event::
                             unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
-    vec.push_back(std::make_pair(net_field_length(&p), 0));
+  while (p < end)
+  {
+    unsigned int col_index= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
+    vec.push_back(std::make_pair(col_index, (unsigned int) 0));
+  }
 }
 
 /**
@@ -3966,11 +4025,16 @@ static void parse_pk_with_prefix(std::vector<Table_map_log_event::
                                  unsigned char *field, unsigned int length)
 {
   unsigned char* p= field;
+  unsigned char* end= field + length;
 
-  while (p < field + length)
+  while (p < end)
   {
     unsigned int col_index= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
     unsigned int col_prefix= net_field_length(&p);
+    if (unlikely(p > end))
+      return;
     vec.push_back(std::make_pair(col_index, col_prefix));
   }
 }

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -6947,7 +6947,10 @@ bool Table_map_log_event::init_charset_field(
     for (unsigned int i= 0 ; i < m_table->s->fields ; ++i)
     {
       if (include_type(binlog_type_info_array, m_table->field[i]))
-        store_compressed_length(buf, binlog_type_info_array[i].m_cs->number);
+        store_compressed_length(
+            buf,
+            DBUG_EVALUATE_IF("corrupt_table_map_column_charset_length",
+                (1 << 10), binlog_type_info_array[i].m_cs->number));
     }
     return write_tlv_field(m_metadata_buf, column_charset_type, buf);
   }
@@ -6977,7 +6980,10 @@ bool Table_map_log_event::init_charset_field(
         DBUG_ASSERT(cs);
         if (cs->number != default_collation)
         {
-          store_compressed_length(buf, char_column_index);
+          store_compressed_length(
+              buf,
+              DBUG_EVALUATE_IF("corrupt_table_map_default_charset_length",
+                  (1 << 10), char_column_index));
           store_compressed_length(buf, cs->number);
         }
         char_column_index++;
@@ -6995,7 +7001,10 @@ bool Table_map_log_event::init_column_name_field()
   {
     size_t len= m_table->field[i]->field_name.length;
 
-    store_compressed_length(buf, len);
+    store_compressed_length(
+        buf,
+        DBUG_EVALUATE_IF("corrupt_table_map_column_name_length",
+            (1 << 10), len));
     buf.append(m_table->field[i]->field_name.str, len);
   }
   return write_tlv_field(m_metadata_buf, COLUMN_NAME, buf);
@@ -7018,7 +7027,10 @@ bool Table_map_log_event::init_set_str_value_field()
   {
     if ((typelib= binlog_type_info_array[i].m_set_typelib))
     {
-      store_compressed_length(buf, typelib->count);
+      store_compressed_length(
+          buf,
+          DBUG_EVALUATE_IF("corrupt_table_map_set_str_value_length",
+              (1 << 10), typelib->count));
       for (unsigned int i= 0; i < typelib->count; i++)
       {
         store_compressed_length(buf, typelib->type_lengths[i]);
@@ -7067,7 +7079,10 @@ bool Table_map_log_event::init_geometry_type_field()
     {
       geom_type= binlog_type_info_array[i].m_geom_type;
       DBUG_EXECUTE_IF("inject_invalid_geometry_type", geom_type= 100;);
-      store_compressed_length(buf, geom_type);
+      store_compressed_length(
+          buf,
+          DBUG_EVALUATE_IF("corrupt_table_map_geometry_type_length",
+              (1 << 10), geom_type));
     }
   }
 
@@ -7108,7 +7123,10 @@ bool Table_map_log_event::init_primary_key_field()
     for (uint i= 0; i < pk->user_defined_key_parts; i++)
     {
       KEY_PART_INFO *key_part= pk->key_part+i;
-      store_compressed_length(buf, key_part->fieldnr-1);
+      store_compressed_length(
+          buf,
+          DBUG_EVALUATE_IF("corrupt_table_map_simple_pk_length",
+              (1 << 10), key_part->fieldnr-1));
     }
     return write_tlv_field(m_metadata_buf, SIMPLE_PRIMARY_KEY, buf);
   }
@@ -7120,7 +7138,10 @@ bool Table_map_log_event::init_primary_key_field()
       KEY_PART_INFO *key_part= pk->key_part+i;
       size_t prefix= 0;
 
-      store_compressed_length(buf, key_part->fieldnr-1);
+      store_compressed_length(
+          buf,
+          DBUG_EVALUATE_IF("corrupt_table_map_pk_prefix_length",
+              (1 << 10), key_part->fieldnr-1));
 
       // Store character length but not octet length
       if (key_part->length != m_table->field[key_part->fieldnr-1]->key_length())


### PR DESCRIPTION
## Description

In MariaDB, the `Table_map_log_event` optional metadata `parse_*` functions and constructor in `sql/log_event.cc` call `net_field_length()` to decode length-encoded integers from the event buffer without validating that the decoded length or advanced pointer remains within bounds. If a corrupted or malicious binlog event contains an inflated length field, `net_field_length()` advances the read pointer past the buffer end, and subsequent reads (e.g. `strmake_root`, `memcpy`, struct assignments) perform OOB memory access.

This can result in:
- Segfaults when the OOB read hits an unmapped page
- Data leakage when heap contents are copied into column names, error messages, or struct fields
- Invalid replica behavior from garbled metadata causing table structure mismatches

### Design choice: bounds check without error propagation
The checks prevent OOB reads but do not attempt to throw errors for every possible corruption. Replication fundamentally assumes a trusted source with valid data. The goal here is hardening against accidental corruption (truncated events, garbled metadata lengths). On detecting corruption, the slave either falls back gracefully to positional column mapping (parse_* functions) or rejects the event entirely (constructor), rather than crashing or leaking heap contents via OOB reads.

### parse_* functions

This patch adds `if (unlikely(p > end)) return;` bounds checks after every `net_field_length()` call in all affected parse functions. Checks are placed **before** the decoded value is stored to any struct field, ensuring no OOB data leaks into metadata. On early return, the slave gracefully falls back to positional column mapping — no crash, no OOB read.

### Table_map_log_event constructor

Adds `if (unlikely(ptr + size > buf + event_len))` bounds checks before each `memcpy` in the constructor for `m_colcnt`, `m_field_metadata_size`, and `m_null_bits`. On detecting an overflow, the constructor frees allocated memory, sets `m_memory = NULL` (causing `is_valid()` to return false), and returns early. The slave then rejects the event gracefully with error 1594.

### Affected call sites

- `parse_default_charset`
- `parse_enum_and_set_default_charset`
- `parse_column_charset`
- `parse_enum_and_set_column_charset`
- `parse_column_name`
- `parse_set_str_value`
- `parse_geometry_type`
- `parse_simple_pk`
- `parse_pk_with_prefix`
- `Table_map_log_event` constructor (`m_colcnt`, `m_field_metadata`, `m_null_bits`)

## Release Notes

Slave no longer crashes or reads out-of-bounds memory when receiving a `Table_map_log_event` with corrupted optional metadata lengths or corrupted column count/metadata size. The slave either falls back to positional column mapping or rejects the event gracefully.

## How can this PR be tested?

New MTR test `rpl.rpl_table_map_log_event_overflow` covers 9 test cases:

**Tests 1-7 (master-side injection, parse_* functions):**
1. `parse_column_name` — corrupted column name length
2. `parse_default_charset` — corrupted default charset column index
3. `parse_column_charset` — corrupted column charset value
4. `parse_set_str_value` — corrupted SET string value count
5. `parse_geometry_type` — corrupted geometry type value
6. `parse_simple_pk` — corrupted simple primary key column index
7. `parse_pk_with_prefix` — corrupted prefix primary key column index

Each verifies the slave replicates successfully via positional fallback (no crash, correct data).

**Tests 8-9 (slave-side injection, constructor):**
8. `corrupt_table_map_colcnt_read` — inflates decoded `m_colcnt` on the slave
9. `corrupt_table_map_field_metadata_size_read` — inflates decoded `m_field_metadata_size` on the slave

Both verify the slave rejects the event with error 1594 (no crash, no OOB read).

Note: A similar bounds check could be added for `infoLen` in the `Rows_log_event` constructor (`RW_V_EXTRAINFO_TAG` block), but MariaDB never writes extra row info — it only reads it from MySQL 5.6+ masters. Since the code path is unreachable in normal MariaDB replication, it cannot be tested via MTR without extreme levels of wizardry - we recommend code review for QA, instead of expensive-to-maintain test case.

## Basing the PR against the correct MariaDB version

This fix targets the oldest LTS version 10.6 and later.
For convenience, a [branch for latest preview 13.1](https://github.com/LukeYL026/mariadb-server/tree/mdev-39689-table-map-log-event-slave-overflow-13.1) is available on fork, for simplicity when merging change to later versions.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.
