### PR TITLE
MDEV-39558 Merge VECTOR into BLOB/MEDIUMBLOB/LONGBLOB in type inferen…

### DIFF
--- a/mysql-test/main/vector2.result
+++ b/mysql-test/main/vector2.result
@@ -498,4 +498,71 @@ vec_totext(0x03CA397B)
 select vec_distance_euclidean(0x03CA397B, vec_fromtext('[0]'));
 vec_distance_euclidean(0x03CA397B, vec_fromtext('[0]'))
 9.64672e35
+#
+# MDEV-39558 SIGSEGV in collect_indexed_vcols_for_table, memory corruption by my_copy_8bit from charset_info_st::copy_fix
+#
+set @old_sql_mode=@@sql_mode;
+set sql_mode='';
+# original case
+CREATE TABLE t (c FLOAT(2,2) ZEROFILL,c2 SET('') CHARACTER SET'BINARY' COLLATE'BINARY',c3 DATE,KEY(c));
+ALTER TABLE t MODIFY c2 LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+REPLACE INTO t (c,c2,c3) VALUES ('','r:$u4[Z3y[HmHZ5r{FCU*0#LJOZVb][s;rm7j3N - xca *^ kt-(LE (4UP~IC:%l9/','=DpF=s=G@=d_rqbvtsjhwtgai.N.P7u}3={qDy[Un=LPeqllXoQM % fs=&mXT=e:');
+Warnings:
+Warning	1366	Incorrect double value: '' for column `test`.`t`.`c` at row 1
+Warning	1265	Data truncated for column 'c3' at row 1
+RENAME TABLE IF EXISTS t TO t4;
+CREATE TABLE t (c INT KEY,c2 VECTOR (4) NOT NULL,VECTOR INDEX (c2) M=4);
+(SELECT c2 FROM t) INTERSECT ALL (SELECT c2 FROM t4);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+drop table t, t4;
+# simplified cases
+CREATE TABLE t1(c LONGTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+drop table t1, t2;
+CREATE TABLE t1(c MEDIUMTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+drop table t1, t2;
+CREATE TABLE t1(c TEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+ERROR 42000: Column length too big for column 'UNION' (max = 16383); use BLOB or TEXT instead
+drop table t1, t2;
+CREATE TABLE t1(c TINYTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+show create table tmp;
+Table	Create Table
+tmp	CREATE TABLE `tmp` (
+  `c` vector(63) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+c
+drop table tmp, t1, t2;
+CREATE TABLE t1(c varchar(16383));
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+show create table tmp;
+Table	Create Table
+tmp	CREATE TABLE `tmp` (
+  `c` vector(16383) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+c
+drop table tmp, t1, t2;
+set sql_mode=@old_sql_mode;
 # End of 11.8 tests

--- a/mysql-test/main/vector2.test
+++ b/mysql-test/main/vector2.test
@@ -368,4 +368,83 @@ select vec_totext(0x03CA397B);
 --replace_regex /(\.\d{5})\d+/\1/
 select vec_distance_euclidean(0x03CA397B, vec_fromtext('[0]'));
 
+--echo #
+--echo # MDEV-39558 SIGSEGV in collect_indexed_vcols_for_table, memory corruption by my_copy_8bit from charset_info_st::copy_fix
+--echo #
+
+set @old_sql_mode=@@sql_mode;
+set sql_mode='';
+
+--echo # original case
+CREATE TABLE t (c FLOAT(2,2) ZEROFILL,c2 SET('') CHARACTER SET'BINARY' COLLATE'BINARY',c3 DATE,KEY(c));
+ALTER TABLE t MODIFY c2 LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+REPLACE INTO t (c,c2,c3) VALUES ('','r:$u4[Z3y[HmHZ5r{FCU*0#LJOZVb][s;rm7j3N - xca *^ kt-(LE (4UP~IC:%l9/','=DpF=s=G@=d_rqbvtsjhwtgai.N.P7u}3={qDy[Un=LPeqllXoQM % fs=&mXT=e:');
+RENAME TABLE IF EXISTS t TO t4;
+CREATE TABLE t (c INT KEY,c2 VECTOR (4) NOT NULL,VECTOR INDEX (c2) M=4);
+--error ER_TOO_BIG_FIELDLENGTH
+(SELECT c2 FROM t) INTERSECT ALL (SELECT c2 FROM t4);
+
+drop table t, t4;
+
+--echo # simplified cases
+CREATE TABLE t1(c LONGTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+
+--error ER_TOO_BIG_FIELDLENGTH
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+--error ER_TOO_BIG_FIELDLENGTH
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+drop table t1, t2;
+
+CREATE TABLE t1(c MEDIUMTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+
+--error ER_TOO_BIG_FIELDLENGTH
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+--error ER_TOO_BIG_FIELDLENGTH
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+drop table t1, t2;
+
+CREATE TABLE t1(c TEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+
+--error ER_TOO_BIG_FIELDLENGTH
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+--error ER_TOO_BIG_FIELDLENGTH
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+drop table t1, t2;
+
+CREATE TABLE t1(c TINYTEXT);
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+show create table tmp;
+
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+drop table tmp, t1, t2;
+
+CREATE TABLE t1(c varchar(16383));
+insert INTO t1 VALUES('1234567890123456789012345678901234567890123456789012345');
+CREATE TABLE t2(d VECTOR(4));
+
+create table tmp as (SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+show create table tmp;
+
+(SELECT * FROM t1) INTERSECT (SELECT * FROM t2);
+
+drop table tmp, t1, t2;
+
+set sql_mode=@old_sql_mode;
+
 --echo # End of 11.8 tests

--- a/sql/field.h
+++ b/sql/field.h
@@ -4244,6 +4244,7 @@ public:
                    unireg_check_arg, field_name_arg, collation),
      length_bytes(length_bytes_arg)
   {
+    DBUG_ASSERT(len_arg <= MAX_FIELD_VARCHARLENGTH);
     share->varchar_fields++;
   }
   Field_varstring(uint32 len_arg,bool maybe_null_arg,
@@ -4253,6 +4254,7 @@ public:
                    NONE, field_name_arg, collation),
      length_bytes(len_arg < 256 ? 1 :2)
   {
+    DBUG_ASSERT(len_arg <= MAX_FIELD_VARCHARLENGTH);
     share->varchar_fields++;
   }
 

--- a/sql/sql_type_vector.cc
+++ b/sql/sql_type_vector.cc
@@ -120,6 +120,12 @@ bool Type_handler_vector::Item_hybrid_func_fix_attributes(THD *thd,
 {
   if (func->aggregate_attributes_string(func_name, items, nitems))
     return true;
+  if (func->max_length > MAX_FIELD_VARCHARLENGTH)
+  {
+    my_error(ER_TOO_BIG_FIELDLENGTH, MYF(0), func_name.str,
+             static_cast<ulong>(MAX_FIELD_VARCHARLENGTH / sizeof(float)));
+    return true;
+  }
   //func->set_type_maybe_null(true);
   return false;
 }


### PR DESCRIPTION
…ce aggregation

VECTOR, as a subtype of VARCHAR, has max length 65532, i.e. maximum dimension of 16383. BLOB/MEDIUMBLOB/LONGBLOB (and corresponding TEXT types) each has length exceeding 65532. Therefore, when aggregating VECTOR with one of these BLOB/TEXT types, the aggregated type has length exceeding the max length of VECTOR, so it should be the BLOB/TEXT type rather than VECTOR.