### PR TITLE
MDEV-39942: use actual_rec_per_key in loose scan sj optimization

### DIFF
--- a/mysql-test/main/delete_use_source_engines.result
+++ b/mysql-test/main/delete_use_source_engines.result
@@ -3176,7 +3176,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 analyze delete from t1 where exists (select 'X' from t1 a where a.c2 = t1.c2)
 and c2 >= 3 order by c2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	a	index	t1_c2	t1_c2	10	NULL	#	16.00	20.00	25.00	Using where; Using index; LooseScan
+1	PRIMARY	a	index	t1_c2	t1_c2	10	NULL	#	16.00	18.75	25.00	Using where; Using index; LooseScan
 1	PRIMARY	t1	ref	t1_c2	t1_c2	5	test.a.c2	#	5.00	4.76	100.00	
 select * from t1;
 c1	c2	c3
@@ -5581,7 +5581,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 analyze delete from t1 where exists (select 'X' from t1 a where a.c2 = t1.c2)
 and c2 >= 3 order by c2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	a	index	t1_c2	t1_c2	10	NULL	#	16.00	20.00	25.00	Using where; Using index; LooseScan
+1	PRIMARY	a	index	t1_c2	t1_c2	10	NULL	#	16.00	18.75	25.00	Using where; Using index; LooseScan
 1	PRIMARY	t1	ref	t1_c2	t1_c2	5	test.a.c2	#	5.00	5.00	100.00	
 select * from t1;
 c1	c2	c3

--- a/mysql-test/main/opt_hints_join_order.result
+++ b/mysql-test/main/opt_hints_join_order.result
@@ -1411,7 +1411,7 @@ WHERE ta4.f1 IN (SELECT /*+ QB_NAME(qb1) */ f1 FROM t4) AND
 ta3.f2 IN (SELECT /*+ QB_NAME(qb2) */ f2 FROM t2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	1	100.00	
-1	PRIMARY	t2	index	f2	f2	5	NULL	3	100.00	Using where; Using index; LooseScan
+1	PRIMARY	t2	index	f2	f2	5	NULL	3	66.67	Using where; Using index; LooseScan
 1	PRIMARY	ta3	ref	f2	f2	5	test.t2.f2	1	33.33	Using index
 1	PRIMARY	ta4	index	PRIMARY	f2	5	NULL	3	100.00	Using index; Using join buffer (flat, BNL join)
 1	PRIMARY	t4	hash_ALL	NULL	#hash#$hj	5	test.ta4.f1	1	100.00	Using where; FirstMatch(ta4); Using join buffer (incremental, BNLH join)

--- a/mysql-test/main/subselect_sj_mat.result
+++ b/mysql-test/main/subselect_sj_mat.result
@@ -107,7 +107,7 @@ a1	a2
 explain extended
 select * from t1i where a1 in (select b1 from t2i where b1 > '0');
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2i	index	it2i1,it2i3	it2i1	#	NULL	5	50.00	Using where; Using index; LooseScan
+1	PRIMARY	t2i	index	it2i1,it2i3	it2i1	#	NULL	5	60.00	Using where; Using index; LooseScan
 1	PRIMARY	t1i	ref	_it1_idx	_it1_idx	#	_ref_	1	20.00	
 Warnings:
 Note	1003	select `test`.`t1i`.`a1` AS `a1`,`test`.`t1i`.`a2` AS `a2` from `test`.`t1i` semi join (`test`.`t2i`) where `test`.`t1i`.`a1` = `test`.`t2i`.`b1` and `test`.`t2i`.`b1` > '0'
@@ -130,7 +130,7 @@ a1	a2
 explain extended
 select * from t1i where (a1, a2) in (select b1, b2 from t2i where b1 > '0');
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	it2i3	#	NULL	5	50.00	Using where; Using index; LooseScan
+1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	it2i3	#	NULL	5	60.00	Using where; Using index; LooseScan
 1	PRIMARY	t1i	ref	_it1_idx	_it1_idx	#	_ref_	1	20.00	
 Warnings:
 Note	1003	select `test`.`t1i`.`a1` AS `a1`,`test`.`t1i`.`a2` AS `a2` from `test`.`t1i` semi join (`test`.`t2i`) where `test`.`t1i`.`a1` = `test`.`t2i`.`b1` and `test`.`t1i`.`a2` = `test`.`t2i`.`b2` and `test`.`t2i`.`b1` > '0'
@@ -276,7 +276,7 @@ a1	a2
 explain extended
 select * from t1i where (a1, a2) in (select b1, b2 from t2i order by b1, b2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	it2i3	18	NULL	5	50.00	Using where; Using index; LooseScan
+1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	it2i3	18	NULL	5	60.00	Using where; Using index; LooseScan
 1	PRIMARY	t1i	ref	it1i1,it1i2,it1i3	it1i3	18	test.t2i.b1,test.t2i.b2	1	20.00	Using index
 Warnings:
 Note	1003	select `test`.`t1i`.`a1` AS `a1`,`test`.`t1i`.`a2` AS `a2` from `test`.`t1i` semi join (`test`.`t2i`) where `test`.`t1i`.`a1` = `test`.`t2i`.`b1` and `test`.`t1i`.`a2` = `test`.`t2i`.`b2`
@@ -348,7 +348,7 @@ where (a1, a2) in (select b1, b2 from t2i where b1 >  '0') and
 (a1, a2) in (select c1, c2 from t3i
 where (c1, c2) in (select b1, b2 from t2i where b2 > '0'));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	#	#	#	5	50.00	#
+1	PRIMARY	t2i	index	it2i1,it2i2,it2i3	#	#	#	5	60.00	#
 1	PRIMARY	t1i	ref	it1i1,it1i2,it1i3	#	#	#	1	20.00	#
 1	PRIMARY	t3i	ref	it3i1,it3i2,it3i3	#	#	#	1	100.00	#
 1	PRIMARY	t2i	ref	it2i1,it2i2,it2i3	#	#	#	1	60.00	#
@@ -432,7 +432,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t3	ALL	NULL	#	#	#	4	15.00	#
 4	MATERIALIZED	t3	ALL	NULL	#	#	#	4	100.00	#
 3	MATERIALIZED	t3	ALL	NULL	#	#	#	4	100.00	#
-7	UNION	t2i	index	it2i1,it2i2,it2i3	#	#	#	5	50.00	#
+7	UNION	t2i	index	it2i1,it2i2,it2i3	#	#	#	5	60.00	#
 7	UNION	t1i	ref	it1i1,it1i2,it1i3	#	#	#	1	20.00	#
 7	UNION	t3i	ref	it3i1,it3i2,it3i3	#	#	#	1	100.00	#
 7	UNION	t2i	ref	it2i1,it2i2,it2i3	#	#	#	1	60.00	#

--- a/sql/opt_subselect.h
+++ b/sql/opt_subselect.h
@@ -243,8 +243,9 @@ public:
           some key components, that may make us think that loose
           scan will produce more distinct records than it actually will)
         */
-        ulong rpc;
-        if ((rpc= s->table->key_info[key].rec_per_key[max_loose_keypart]))
+        double rpc=
+            s->table->key_info[key].actual_rec_per_key(max_loose_keypart);
+        if (rpc > 0.0) // It's ok to compare like this even if it's double.
           records= records / rpc;
 
         // TODO: previous version also did /2


### PR DESCRIPTION
While performing loose scan semi-join optimization in
Loose_scan_opt::check_ref_access_part1() [opt_subselect.h],
the filtered value in the explain plan was in-consistent for a table
with index when same data was inserted using "insert into t1 values()...",
and "insert into t1 select * from t2". This is noticed when
rec_per_key[] was used to get the number of records during optimization.

However, when actual_rec_per_key() is used to get the number of records,
we don't notice this discrepancy.

This PR changes the rec_per_key[] usage to actual_rec_per_key() in the
method Loose_scan_opt::check_ref_access_part1() [opt_subselect.h]