### PR TITLE
fix plugins.feedback_os_release failure on sles-1600

### DIFF
--- a/plugin/feedback/utils.cc
+++ b/plugin/feedback/utils.cc
@@ -141,7 +141,7 @@ static struct utsname ubuf;
 #ifdef TARGET_OS_LINUX
 #include <glob.h>
 static bool have_distribution= false;
-static char distribution[256];
+static char distribution[1024];
 
 static const char *masks[]= {
   "/etc/*-version", "/etc/*-release",


### PR DESCRIPTION
just the comment at the beginning of its /etc/os-release is already more than 256 bytes

Was in the bb-11.8-release branch but didn't make it back for some reason.