### PR TITLE
MDEV-40176: UBSAN: runtime error: applying non-zero offset in `my_charpos_mb`

### DIFF
--- a/strings/ctype-mb.c
+++ b/strings/ctype-mb.c
@@ -301,7 +301,7 @@ int my_wildcmp_mb(CHARSET_INFO *cs,
 }
 
 
-size_t my_numchars_mb(CHARSET_INFO *cs __attribute__((unused)),
+size_t my_numchars_mb(CHARSET_INFO *cs,
 		      const char *pos, const char *end)
 {
   register size_t count= 0;
@@ -315,7 +315,7 @@ size_t my_numchars_mb(CHARSET_INFO *cs __attribute__((unused)),
 }
 
 
-size_t my_charpos_mb(CHARSET_INFO *cs __attribute__((unused)),
+size_t my_charpos_mb(CHARSET_INFO *cs,
 		     const char *pos, const char *end, size_t length)
 {
   const char *start= pos;

--- a/strings/ctype-mb.c
+++ b/strings/ctype-mb.c
@@ -326,7 +326,7 @@ size_t my_charpos_mb(CHARSET_INFO *cs __attribute__((unused)),
     pos+= (mb_len= my_ismbchar(cs, pos, end)) ? mb_len : 1;
     length--;
   }
-  return (size_t) (length ? end+2-start : pos-start);
+  return (size_t) (length ? (end-start)+2 : pos-start);
 }
 
 


### PR DESCRIPTION
fixes [MDEV-40176](https://jira.mariadb.org/browse/MDEV-40176)
### Problem:
When `my_charpos_mb()` is called with pos = end = NULL and the string has fewer than `length` characters, the `end + 2 - start` return expression evaluates `end+2`, forming the pointer NULL+2. Offsetting a null pointer is undefined behavior.

### Fix:
Compute the integer difference before adding the offset. The result is identical but no invalid pointer is ever formed.