### PR TITLE
MDEV-39690: UBSAN: signed integer overflow in `my_strntoll_8bit`, `my_strntoll_mb2_or_mb4` during BLOB-to-integer conversion

### DIFF
--- a/mysql-test/main/ctype_latin1.result
+++ b/mysql-test/main/ctype_latin1.result
@@ -9043,3 +9043,22 @@ DROP TABLE t1;
 #
 # End of 10.6 tests
 #
+#
+# MDEV-39690: UBSAN: signed integer overflow in `my_strntoll_8bit`, `my_strntoll_mb2_or_mb4` during BLOB-to-integer conversion
+#
+SET @old_mode=@@sql_mode;
+SET sql_mode='';
+CREATE TABLE t1 (c BLOB);
+INSERT INTO t1 VALUES ('-9223372036854775808');
+SELECT * FROM t1 WHERE c IN (VALUES(1));
+c
+CREATE TABLE t2 (c VARCHAR(30) CHARACTER SET latin1);
+INSERT INTO t2 VALUES ('-9223372036854775809'),('-9223372036854775808'),('1');
+SELECT * FROM t2 WHERE c IN (VALUES(1));
+c
+1
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '-9223372036854775809'
+DROP TABLE t1, t2;
+SET @@sql_mode= @old_mode;
+# End of 10.11 tests

--- a/mysql-test/main/ctype_latin1.test
+++ b/mysql-test/main/ctype_latin1.test
@@ -559,3 +559,23 @@ DROP TABLE t1;
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-39690: UBSAN: signed integer overflow in `my_strntoll_8bit`, `my_strntoll_mb2_or_mb4` during BLOB-to-integer conversion
+--echo #
+
+SET @old_mode=@@sql_mode;
+SET sql_mode='';
+
+CREATE TABLE t1 (c BLOB);
+INSERT INTO t1 VALUES ('-9223372036854775808');
+SELECT * FROM t1 WHERE c IN (VALUES(1));
+
+CREATE TABLE t2 (c VARCHAR(30) CHARACTER SET latin1);
+INSERT INTO t2 VALUES ('-9223372036854775809'),('-9223372036854775808'),('1');
+SELECT * FROM t2 WHERE c IN (VALUES(1));
+
+DROP TABLE t1, t2;
+SET @@sql_mode= @old_mode;
+
+--echo # End of 10.11 tests

--- a/mysql-test/main/ctype_ucs.result
+++ b/mysql-test/main/ctype_ucs.result
@@ -6585,3 +6585,18 @@ SET names latin1;
 #
 # End of 10.6 tests
 #
+#
+# MDEV-39690: UBSAN: signed integer overflow in `my_strntoll_8bit`, `my_strntoll_mb2_or_mb4` during BLOB-to-integer conversion
+#
+SET @old_mode=@@sql_mode;
+SET sql_mode='';
+CREATE TABLE t1 (c VARCHAR(30) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('-9223372036854775809'),('-9223372036854775808'),('1');
+SELECT * FROM t1 WHERE c IN (VALUES(1));
+c
+1
+Warnings:
+Warning	1292	Truncated incorrect INTEGER value: '-9223372036854775809'
+DROP TABLE t1;
+SET @@sql_mode= @old_mode;
+# End of 10.11 tests

--- a/mysql-test/main/ctype_ucs.test
+++ b/mysql-test/main/ctype_ucs.test
@@ -1257,3 +1257,19 @@ SET names latin1;
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-39690: UBSAN: signed integer overflow in `my_strntoll_8bit`, `my_strntoll_mb2_or_mb4` during BLOB-to-integer conversion
+--echo #
+
+SET @old_mode=@@sql_mode;
+SET sql_mode='';
+
+CREATE TABLE t1 (c VARCHAR(30) CHARACTER SET ucs2);
+INSERT INTO t1 VALUES ('-9223372036854775809'),('-9223372036854775808'),('1');
+SELECT * FROM t1 WHERE c IN (VALUES(1));
+
+DROP TABLE t1;
+SET @@sql_mode= @old_mode;
+
+--echo # End of 10.11 tests

--- a/strings/ctype-simple.c
+++ b/strings/ctype-simple.c
@@ -658,8 +658,12 @@ longlong my_strntoll_8bit(CHARSET_INFO *cs __attribute__((unused)),
 
   if (negative)
   {
-    if (i  > (ulonglong) LONGLONG_MIN)
+    if (i  >= (ulonglong) LONGLONG_MIN)
+    {
+      if (i == (ulonglong) LONGLONG_MIN)
+        return LONGLONG_MIN;
       overflow = 1;
+    }
   }
   else if (i > (ulonglong) LONGLONG_MAX)
     overflow = 1;

--- a/strings/ctype-ucs2.c
+++ b/strings/ctype-ucs2.c
@@ -500,8 +500,12 @@ bs:
   
   if (negative)
   {
-    if (res  > (ulonglong) LONGLONG_MIN)
+    if (res  >= (ulonglong) LONGLONG_MIN)
+    {
+      if (res == (ulonglong) LONGLONG_MIN)
+        return LONGLONG_MIN;
       overflow = 1;
+    }
   }
   else if (res > (ulonglong) LONGLONG_MAX)
     overflow = 1;


### PR DESCRIPTION
fixes [MDEV-39690](https://jira.mariadb.org/browse/MDEV-39690)

### Problem:
When converting a string like '-9223372036854775808' to an integer, the parsed magnitude (2^63) equals `(ulonglong) LONGLONG_MIN` and is accepted as valid. The return expression then cast it to signed (LONGLONG_MIN) and negated it. Negating LONGLONG_MIN is signed integer overflow, i.e. undefined behaviour.

### Fix:
Handle the boundary value explicitly. When the parsed magnitude equals `(ulonglong) LONGLONG_MIN`, return LONGLONG_MIN directly. Any smaller magnitude fits in a positive longlong, so the existing cast and negation stay well defined.