### PR TITLE
MDEV-40210 Redundant CAS in async_flush_lsn::try_clear_if_at_most()

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -93,6 +93,8 @@ public:
   void try_clear_if_at_most(lsn_t threshold) noexcept
   {
     lsn_t snapshot= m_lsn.load();
+    if (!snapshot)
+      return; /* already cleared: avoid a redundant atomic CAS */
     if (threshold >= snapshot)
       m_lsn.compare_exchange_strong(snapshot, 0);
   }


### PR DESCRIPTION
MDEV-39600 added try_clear_if_at_most() to clear buf_flush_async_lsn with an atomic CAS that preserves a concurrent bump(). If the snapshot is already 0, compare_exchange_strong(0, 0) is a no-op, so return early on a zero snapshot and avoid the atomic read-modify-write. The page cleaner calls this on every pass, so in the common steady state (no async flush queued) it drops needless exclusive access to the m_lsn cache line. A zero value is already the cleared state and a concurrent bump() is preserved either way, so the result is identical.