### PR TITLE
MDEV-40176: field_charset()->charpos(blob..) called with NULL

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9035,10 +9035,14 @@ uint Field_blob::get_key_image_itRAW(const uchar *ptr_arg, uchar *buff,
 {
   size_t blob_length= get_length(ptr_arg);
   const uchar *blob= get_ptr(ptr_arg);
-  size_t local_char_length= length / mbmaxlen();
-  local_char_length= field_charset()->charpos(blob, blob + blob_length,
-                                              local_char_length);
-  set_if_smaller(blob_length, local_char_length);
+  if (blob_length > 0)
+  {
+    size_t local_char_length= length / mbmaxlen();
+    DBUG_ASSERT(blob);
+    local_char_length= field_charset()->charpos(blob, blob + blob_length,
+                                                local_char_length);
+    set_if_smaller(blob_length, local_char_length);
+  }
 
   if (length > blob_length)
   {


### PR DESCRIPTION
Problem:
  When `my_charpos_mb()` is called by `Field_blob::get_key_image_itRAW`
  with a start/end both being NULL. Because of this the blob_length
  must have been 0.

Fix:
  Rather than relying on character set functions to calculate the
  storage of nothing, bypass the calculation as the charpos() isn't
  going to return a value less than 0 (the blob_length).