### PR TITLE
MDEV-39772 SET GLOBAL innodb_log_archive=OFF breaks recovery

### DIFF
--- a/mysql-test/suite/innodb/r/blob-crash.result
+++ b/mysql-test/suite/innodb/r/blob-crash.result
@@ -14,6 +14,7 @@ INSERT INTO t1 (a, b) VALUES (4, '4');
 INSERT INTO t1 (a, b) VALUES (5, '5');
 begin;
 INSERT INTO t1 (a, b) VALUES (6, REPEAT('a', 4*1024*1024));
+SET GLOBAL innodb_log_archive=ON;
 SELECT a, right(b, 50) FROM t1;
 a	right(b, 50)
 1	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,6 +28,7 @@ a	right(b, 50)
 #
 begin;
 UPDATE t1 set b = REPEAT('a', 4*1024*1024) where a = 5 ;
+SET GLOBAL innodb_log_archive=OFF;
 SELECT a, right(b, 50) FROM t1;
 a	right(b, 50)
 1	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,6 +137,7 @@ UPDATE t3 set f2 = concat(f2, repeat(',', 10)) where f1 = 3;
 connection default;
 SET GLOBAL innodb_flush_log_at_trx_commit=1;
 DELETE FROM t1 WHERE a=4;
+disconnect con1;
 select f1, length(f2), length(f3) from t3;
 f1	length(f2)	length(f3)
 2	30	30
@@ -146,4 +149,20 @@ f1	right(f2, 30)	right(f3, 20)
 check table t3;
 Table	Op	Msg_type	Msg_text
 test.t3	check	status	OK
-DROP TABLE t1,t3;
+DROP TABLE t3;
+BEGIN;
+INSERT INTO t1 (a, b) VALUES (6, REPEAT('a', 4*1024*1024));
+ROLLBACK;
+SET GLOBAL innodb_log_archive=ON;
+begin;
+UPDATE t1 set b = REPEAT('a', 4*1024*1024) where a = 5 ;
+SET GLOBAL innodb_log_archive=OFF;
+connect  con1,localhost,root,,;
+begin;
+UPDATE t1 set b = REPEAT('#', 50000) where a = 1;
+connection default;
+disconnect con1;
+SELECT a, right(b, 50) FROM t1;
+a	right(b, 50)
+5	five
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/log_archive.result
+++ b/mysql-test/suite/innodb/r/log_archive.result
@@ -74,6 +74,7 @@ INNODB_LSN_CURRENT	18446744073705357310
 INNODB_LSN_FLUSHED	18446744073705357310
 INNODB_LSN_LAST_CHECKPOINT	18446744073705357279
 INNODB_LSN_ARCHIVED	18446744073705357279
+FOUND 1 /InnoDB: ignoring .*ffffffffffc00000\.log/ in mysqld.1.err
 # restart: --innodb-log-recovery-start=0
 SELECT variable_name, variable_value FROM information_schema.global_status
 WHERE variable_name = 'INNODB_LSN_ARCHIVED';

--- a/mysql-test/suite/innodb/t/blob-crash.test
+++ b/mysql-test/suite/innodb/t/blob-crash.test
@@ -33,6 +33,7 @@ INSERT INTO t1 (a, b) VALUES (6, REPEAT('a', 4*1024*1024));
 let $shutdown_timeout=0;
 let $restart_noprint=2;
 --source include/restart_mysqld.inc
+SET GLOBAL innodb_log_archive=ON;
 
 SELECT a, right(b, 50) FROM t1;
 
@@ -50,6 +51,7 @@ UPDATE t1 set b = REPEAT('a', 4*1024*1024) where a = 5 ;
 
 let $shutdown_timeout=0;
 --source include/restart_mysqld.inc
+SET GLOBAL innodb_log_archive=OFF;
 
 SELECT a, right(b, 50) FROM t1;
 
@@ -203,9 +205,29 @@ DELETE FROM t1 WHERE a=4;
 
 let $shutdown_timeout=0;
 --source include/restart_mysqld.inc
+disconnect con1;
 
 select f1, length(f2), length(f3) from t3;
 select f1, right(f2, 30), right(f3, 20) from t3;
 check table t3;
+DROP TABLE t3;
 
-DROP TABLE t1,t3;
+BEGIN;
+INSERT INTO t1 (a, b) VALUES (6, REPEAT('a', 4*1024*1024));
+ROLLBACK;
+SET GLOBAL innodb_log_archive=ON;
+
+begin;
+UPDATE t1 set b = REPEAT('a', 4*1024*1024) where a = 5 ;
+
+--source include/restart_mysqld.inc
+SET GLOBAL innodb_log_archive=OFF;
+connect (con1,localhost,root,,);
+begin;
+UPDATE t1 set b = REPEAT('#', 50000) where a = 1;
+connection default;
+--source include/restart_mysqld.inc
+disconnect con1;
+SELECT a, right(b, 50) FROM t1;
+
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/log_archive.test
+++ b/mysql-test/suite/innodb/t/log_archive.test
@@ -204,12 +204,14 @@ EOF
 
 SELECT variable_name, variable_value FROM information_schema.global_status
 WHERE variable_name LIKE 'INNODB_LSN%';
+let SEARCH_PATTERN = InnoDB: ignoring .*ffffffffffc00000\\.log;
+--source include/search_pattern_in_file.inc
+
 --let $restart_parameters= --innodb-log-recovery-start=0
 --source include/restart_mysqld.inc
 SELECT variable_name, variable_value FROM information_schema.global_status
 WHERE variable_name = 'INNODB_LSN_ARCHIVED';
-
-let SEARCH_PATTERN = InnoDB: ignoring .*ffffffffffc00000\\.log;
+# no more "ignoring" message at this point
 --source include/search_pattern_in_file.inc
 
 --source include/shutdown_mysqld.inc

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -5565,7 +5565,11 @@ inline void log_t::set_recovered() noexcept
   ut_ad(!resize_log.is_opened());
   ut_ad(!resize_buf);
   ut_ad(!resize_flush_buf);
-  circular_recovery_from_sequence_bit_0= !archive &&
+  /* If innodb_log_archive=ON, we always write the sequence bit as 0.
+  A subsequent log_t::set_archive(archive=false, ...) must wait for
+  a checkpoint, to guarantee that recovery with innodb_log_archive=OFF
+  will observe all sequence bits as 1. */
+  circular_recovery_from_sequence_bit_0= archive ||
     !get_sequence_bit(last_checkpoint_lsn);
   ut_ad(write_size >= 512);
   ut_ad(ut_is_2pow(write_size));


### PR DESCRIPTION
## Description
### [MDEV-39772](https://jira.mariadb.org/browse/MDEV-39772): `SET GLOBAL innodb_log_archive=OFF` breaks recovery

`log_t::set_recovered()`: Set `circular_recovery_from_sequence_bit_0` if the log was recovered in the `innodb_log_archive=ON` format, so that a subsequent `SET GLOBAL innodb_log_archive=OFF` will properly wait for a checkpoint before changing the format.

This fixes up #4405.
## How can this PR be tested?
```sh
mysql-test/mtr --parallel=auto innodb.blob-crash
```
The `innodb_page_size=4k` and `innodb_page_size=8k` variants of that test would fail when the fix is absent.