### PR TITLE
MDEV-40143: st_isvalid() does not clear NULL state between rows

### DIFF
--- a/mysql-test/main/spatial_utility_function_isvalid.result
+++ b/mysql-test/main/spatial_utility_function_isvalid.result
@@ -473,3 +473,22 @@ c
 SELECT st_astext(ST_VALIDATE(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT(' MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( (0 2,1 2,1 3,0 3,0 2) ) ) '),  ST_GEOMFROMTEXT(' POLYGON( ( 6 6, 5 8, 0 8, 8 1, 7 6, 6 6 ) ) ') ) ) ) <> '' c;
 c
 1
+#
+# Start of 12.3 tests
+#
+CREATE TABLE t0 (c0 INT,c1 POINT);
+INSERT INTO t0 VALUES (-4, Point(0,0));
+INSERT INTO t0 VALUES (6, NULL);
+INSERT INTO t0 VALUES (9, Point(1,1));
+SELECT ST_ISVALID(t0.c1) FROM t0;
+ST_ISVALID(t0.c1)
+1
+NULL
+1
+SELECT ST_ASTEXT(t0.c1) FROM t0;
+ST_ASTEXT(t0.c1)
+POINT(0 0)
+NULL
+POINT(1 1)
+DROP TABLE t0;
+# End of 12.3 tests

--- a/mysql-test/main/spatial_utility_function_isvalid.test
+++ b/mysql-test/main/spatial_utility_function_isvalid.test
@@ -396,3 +396,17 @@ SELECT ST_IsValid(ST_GEOMFROMTEXT('  MULTIPOLYGON( ( (2 2, 2 4, 4 4, 4 2, 2 2) )
 --echo # MDEV-36042 Assertion failed in Binary_string::q_append
 --echo #
 SELECT st_astext(ST_VALIDATE(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT(' MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( (0 2,1 2,1 3,0 3,0 2) ) ) '),  ST_GEOMFROMTEXT(' POLYGON( ( 6 6, 5 8, 0 8, 8 1, 7 6, 6 6 ) ) ') ) ) ) <> '' c;
+
+--echo #
+--echo # Start of 12.3 tests
+--echo #
+
+CREATE TABLE t0 (c0 INT,c1 POINT);
+INSERT INTO t0 VALUES (-4, Point(0,0));
+INSERT INTO t0 VALUES (6, NULL);
+INSERT INTO t0 VALUES (9, Point(1,1));
+SELECT ST_ISVALID(t0.c1) FROM t0;
+SELECT ST_ASTEXT(t0.c1) FROM t0;
+DROP TABLE t0;
+
+--echo # End of 12.3 tests

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -2135,6 +2135,7 @@ longlong Item_func_isvalid::val_int()
   String *wkb= args[0]->val_str(&tmp);
   Geometry_buffer buffer;
   Geometry *geometry;
+  null_value= 1;
 
   int valid;
   if ((args[0]->null_value ||
@@ -2142,16 +2143,13 @@ longlong Item_func_isvalid::val_int()
   {
     if (!args[0]->null_value)
       my_error(ER_GIS_INVALID_DATA, MYF(0), func_name());
-    null_value= 1;
     return 1;
   }
 
   if (geometry->is_valid(&valid))
-  {
-    null_value= 1;
     return 1;
-  }
 
+  null_value= 0;
   return (longlong) valid;
 }
 


### PR DESCRIPTION
The st_isvalid() function evaluates nullability on every row.  Previously, it would preserve potentially stale null state between rows, so the first row yielding a null result for st_isvalid() would propagate to the results for the remaining rows.

Implementation-wise, this patch changes the Item_func_isvalid::val_int method implementation to work like Item_func_validate::val_str in that it assumes that the method will indicate a null result for the row unless it returns a non-null result, at which point it clears the null_value flag.