### PR TITLE
MDEV-28239: rsync and mariabackup SST scripts handle sst ssl_mode option differently

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_mariabackup_verify_ca.result
+++ b/mysql-test/suite/galera/r/galera_sst_mariabackup_verify_ca.result
@@ -1,0 +1,519 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_1;
+Performing State Transfer on a server that has been shut down cleanly and restarted
+connection node_1;
+CREATE TABLE t1 (id int not null primary key,f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1,'node1_committed_before');
+INSERT INTO t1 VALUES (2,'node1_committed_before');
+INSERT INTO t1 VALUES (3,'node1_committed_before');
+INSERT INTO t1 VALUES (4,'node1_committed_before');
+INSERT INTO t1 VALUES (5,'node1_committed_before');
+COMMIT;
+connection node_2;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (6,'node2_committed_before');
+INSERT INTO t1 VALUES (7,'node2_committed_before');
+INSERT INTO t1 VALUES (8,'node2_committed_before');
+INSERT INTO t1 VALUES (9,'node2_committed_before');
+INSERT INTO t1 VALUES (10,'node2_committed_before');
+COMMIT;
+Shutting down server ...
+connection node_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (11,'node1_committed_during');
+INSERT INTO t1 VALUES (12,'node1_committed_during');
+INSERT INTO t1 VALUES (13,'node1_committed_during');
+INSERT INTO t1 VALUES (14,'node1_committed_during');
+INSERT INTO t1 VALUES (15,'node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES (16,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (17,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (18,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (19,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (20,'node1_to_be_committed_after');
+connect node_1a_galera_st_shutdown_slave, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (21,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (22,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (23,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (24,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (25,'node1_to_be_rollbacked_after');
+connection node_2;
+Starting server ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (26,'node2_committed_after');
+INSERT INTO t1 VALUES (27,'node2_committed_after');
+INSERT INTO t1 VALUES (28,'node2_committed_after');
+INSERT INTO t1 VALUES (29,'node2_committed_after');
+INSERT INTO t1 VALUES (30,'node2_committed_after');
+COMMIT;
+connection node_1;
+INSERT INTO t1 VALUES (31,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (32,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (33,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (34,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (35,'node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (36,'node1_committed_after');
+INSERT INTO t1 VALUES (37,'node1_committed_after');
+INSERT INTO t1 VALUES (38,'node1_committed_after');
+INSERT INTO t1 VALUES (39,'node1_committed_after');
+INSERT INTO t1 VALUES (40,'node1_committed_after');
+COMMIT;
+connection node_1a_galera_st_shutdown_slave;
+INSERT INTO t1 VALUES (41,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (42,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (43,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (44,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (45,'node1_to_be_rollbacked_after');
+ROLLBACK;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_15 FROM t1;
+EXPECT_15
+35
+SELECT * from t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+connection node_1;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_15 FROM t1;
+EXPECT_15
+35
+SELECT * from t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+Performing State Transfer on a server that starts from a clean var directory
+This is accomplished by shutting down node #2 and removing its var directory before restarting it
+connection node_1;
+CREATE TABLE t1 (id int not null primary key,f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1,'node1_committed_before');
+INSERT INTO t1 VALUES (2,'node1_committed_before');
+INSERT INTO t1 VALUES (3,'node1_committed_before');
+INSERT INTO t1 VALUES (4,'node1_committed_before');
+INSERT INTO t1 VALUES (5,'node1_committed_before');
+COMMIT;
+connection node_2;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (6,'node2_committed_before');
+INSERT INTO t1 VALUES (7,'node2_committed_before');
+INSERT INTO t1 VALUES (8,'node2_committed_before');
+INSERT INTO t1 VALUES (9,'node2_committed_before');
+INSERT INTO t1 VALUES (10,'node2_committed_before');
+COMMIT;
+Shutting down server ...
+connection node_1;
+Cleaning var directory ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (11,'node1_committed_during');
+INSERT INTO t1 VALUES (12,'node1_committed_during');
+INSERT INTO t1 VALUES (13,'node1_committed_during');
+INSERT INTO t1 VALUES (14,'node1_committed_during');
+INSERT INTO t1 VALUES (15,'node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES (16,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (17,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (18,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (19,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (20,'node1_to_be_committed_after');
+connect node_1a_galera_st_clean_slave, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (21,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (22,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (23,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (24,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (25,'node1_to_be_rollbacked_after');
+connection node_2;
+Starting server ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (26,'node2_committed_after');
+INSERT INTO t1 VALUES (27,'node2_committed_after');
+INSERT INTO t1 VALUES (28,'node2_committed_after');
+INSERT INTO t1 VALUES (29,'node2_committed_after');
+INSERT INTO t1 VALUES (30,'node2_committed_after');
+COMMIT;
+connection node_1;
+INSERT INTO t1 VALUES (31,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (32,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (33,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (34,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (35,'node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (36,'node1_committed_after');
+INSERT INTO t1 VALUES (37,'node1_committed_after');
+INSERT INTO t1 VALUES (38,'node1_committed_after');
+INSERT INTO t1 VALUES (39,'node1_committed_after');
+INSERT INTO t1 VALUES (40,'node1_committed_after');
+COMMIT;
+connection node_1a_galera_st_clean_slave;
+INSERT INTO t1 VALUES (41,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (42,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (43,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (44,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (45,'node1_to_be_rollbacked_after');
+ROLLBACK;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_35 FROM t1;
+EXPECT_35
+35
+SELECT * from t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+connection node_1;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_35 FROM t1;
+EXPECT_35
+35
+SELECT * from t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+Performing State Transfer on a server that has been killed and restarted
+connection node_1;
+CREATE TABLE t1 (id int not null primary key,f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1,'node1_committed_before');
+INSERT INTO t1 VALUES (2,'node1_committed_before');
+INSERT INTO t1 VALUES (3,'node1_committed_before');
+INSERT INTO t1 VALUES (4,'node1_committed_before');
+INSERT INTO t1 VALUES (5,'node1_committed_before');
+COMMIT;
+connection node_2;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (6,'node2_committed_before');
+INSERT INTO t1 VALUES (7,'node2_committed_before');
+INSERT INTO t1 VALUES (8,'node2_committed_before');
+INSERT INTO t1 VALUES (9,'node2_committed_before');
+INSERT INTO t1 VALUES (10,'node2_committed_before');
+COMMIT;
+Killing server ...
+connection node_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (11,'node1_committed_during');
+INSERT INTO t1 VALUES (12,'node1_committed_during');
+INSERT INTO t1 VALUES (13,'node1_committed_during');
+INSERT INTO t1 VALUES (14,'node1_committed_during');
+INSERT INTO t1 VALUES (15,'node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES (16,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (17,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (18,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (19,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (20,'node1_to_be_committed_after');
+connect node_1a_galera_st_kill_slave, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (21,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (22,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (23,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (24,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (25,'node1_to_be_rollbacked_after');
+connection node_2;
+Performing --wsrep-recover ...
+Starting server ...
+Using --wsrep-start-position when starting mysqld ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (26,'node2_committed_after');
+INSERT INTO t1 VALUES (27,'node2_committed_after');
+INSERT INTO t1 VALUES (28,'node2_committed_after');
+INSERT INTO t1 VALUES (29,'node2_committed_after');
+INSERT INTO t1 VALUES (30,'node2_committed_after');
+COMMIT;
+connection node_1;
+INSERT INTO t1 VALUES (31,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (32,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (33,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (34,'node1_to_be_committed_after');
+INSERT INTO t1 VALUES (35,'node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (36,'node1_committed_after');
+INSERT INTO t1 VALUES (37,'node1_committed_after');
+INSERT INTO t1 VALUES (38,'node1_committed_after');
+INSERT INTO t1 VALUES (39,'node1_committed_after');
+INSERT INTO t1 VALUES (40,'node1_committed_after');
+COMMIT;
+connection node_1a_galera_st_kill_slave;
+INSERT INTO t1 VALUES (41,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (42,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (43,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (45,'node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES (46,'node1_to_be_rollbacked_after');
+ROLLBACK;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_35 FROM t1;
+EXPECT_35
+35
+SELECT * FROM t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+connection node_1;
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_35 FROM t1;
+EXPECT_35
+35
+SELECT * FROM t1;
+id	f1
+1	node1_committed_before
+2	node1_committed_before
+3	node1_committed_before
+4	node1_committed_before
+5	node1_committed_before
+6	node2_committed_before
+7	node2_committed_before
+8	node2_committed_before
+9	node2_committed_before
+10	node2_committed_before
+11	node1_committed_during
+12	node1_committed_during
+13	node1_committed_during
+14	node1_committed_during
+15	node1_committed_during
+16	node1_to_be_committed_after
+17	node1_to_be_committed_after
+18	node1_to_be_committed_after
+19	node1_to_be_committed_after
+20	node1_to_be_committed_after
+26	node2_committed_after
+27	node2_committed_after
+28	node2_committed_after
+29	node2_committed_after
+30	node2_committed_after
+31	node1_to_be_committed_after
+32	node1_to_be_committed_after
+33	node1_to_be_committed_after
+34	node1_to_be_committed_after
+35	node1_to_be_committed_after
+36	node1_committed_after
+37	node1_committed_after
+38	node1_committed_after
+39	node1_committed_after
+40	node1_committed_after
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;

--- a/mysql-test/suite/galera/t/galera_sst_mariabackup_verify_ca.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_mariabackup_verify_ca.cnf
@@ -1,0 +1,17 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+ssl-cert=@ENV.MYSQL_TEST_DIR/std_data/server-cert.pem
+ssl-key=@ENV.MYSQL_TEST_DIR/std_data/server-key.pem
+ssl-ca=@ENV.MYSQL_TEST_DIR/std_data/cacert.pem
+
+[sst]
+ssl-mode=VERIFY_CA
+
+[mysqld.1]
+wsrep_provider_options='pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
+
+[mysqld.2]
+wsrep_provider_options='pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'

--- a/mysql-test/suite/galera/t/galera_sst_mariabackup_verify_ca.test
+++ b/mysql-test/suite/galera/t/galera_sst_mariabackup_verify_ca.test
@@ -1,0 +1,40 @@
+# mariabackup SST must treat ssl-mode=VERIFY_CA differently from
+# VERIFY_IDENTITY - verify the CA chain only, without a peer-name check.
+#
+# Steps:
+# 1. Start a 2-node cluster using mariabackup SST with ssl-mode=VERIFY_CA
+#    (configured in the .cnf).
+# 2. Force SSTs on node 2 (clean restart, empty datadir, kill) to exercise
+#    the VERIFY_CA transfer path.
+# 3. Check the cluster reconverges and data is consistent after each SST.
+# 4. Confirm the donor took the VERIFY_CA (chain-only) path, not the
+#    VERIFY_IDENTITY peer-name check.
+#
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source include/auto_increment_offset_save.inc
+
+--connection node_1
+--source suite/galera/include/galera_st_shutdown_slave.inc
+--source suite/galera/include/galera_st_clean_slave.inc
+
+--source suite/galera/include/galera_st_kill_slave.inc
+--source suite/galera/include/galera_st_kill_slave_ddl.inc
+
+# Verify the donor logs this line only when it distinguishes VERIFY_CA from
+# VERIFY_IDENTITY and verifies the chain only.
+--connection node_1
+--disable_result_log
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN = Verifying peer certificate chain for ssl-mode=VERIFY_CA
+--let SEARCH_ABORT = NOT FOUND
+--source include/search_pattern_in_file.inc
+--enable_result_log
+
+--source include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera/t/galera_sst_rsync_encrypt_with_server.test
+++ b/mysql-test/suite/galera/t/galera_sst_rsync_encrypt_with_server.test
@@ -23,4 +23,13 @@
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
 
+# ssl-mode is VERIFY_CA here: confirm the donor verified the certificate
+# chain only and did not fall back to the VERIFY_IDENTITY peer-name check.
+--disable_result_log
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN = Verifying peer certificate chain for ssl-mode=VERIFY_CA
+--let SEARCH_ABORT = NOT FOUND
+--source include/search_pattern_in_file.inc
+--enable_result_log
+
 --source include/auto_increment_offset_restore.inc

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -403,7 +403,13 @@ get_transfer()
             else
                 # CA verification
                 verify_ca_matches_cert "$tpem" "$tcert" "$tcap"
-                if [ -n "$WSREP_SST_OPT_REMOTE_USER" ]; then
+                if [ "$tmode" = 'VERIFY_CA' ]; then
+                    # VERIFY_CA verifies the chain only, not the peer
+                    # name, so leave "commonname" empty.
+                    CN_option=",commonname=''"
+                    wsrep_log_info \
+                        "Verifying peer certificate chain for ssl-mode=VERIFY_CA"
+                elif [ -n "$WSREP_SST_OPT_REMOTE_USER" ]; then
                     CN_option=",commonname='$(safe WSREP_SST_OPT_REMOTE_USER)'"
                 elif [ "$WSREP_SST_OPT_ROLE" = 'joiner' -o $encrypt -eq 4 ]
                 then

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -245,20 +245,27 @@ if [ "${SSLMODE#VERIFY}" != "$SSLMODE" ]; then
         wsrep_log_error "Can't have ssl-mode='$SSLMODE' without CA file or path"
         exit 22 # EINVAL
     fi
-    if [ -n "$WSREP_SST_OPT_REMOTE_USER" ]; then
-        CHECK_OPT="checkHost = $(safe WSREP_SST_OPT_REMOTE_USER)"
-    elif [ "$WSREP_SST_OPT_ROLE" = 'donor' ]; then
-        # check if the address is an ip-address (v4 or v6):
-        if echo "$WSREP_SST_OPT_HOST_UNESCAPED" | \
-           grep -q -E '^([0-9]+(\.[0-9]+){3}|[0-9a-fA-F]*(:[0-9a-fA-F]*){1,7})$'
-        then
-            CHECK_OPT="checkIP = $WSREP_SST_OPT_HOST_UNESCAPED"
-        else
-            CHECK_OPT="checkHost = $WSREP_SST_OPT_HOST"
+    # Only VERIFY_IDENTITY checks the peer name; VERIFY_CA verifies
+    # the chain only.
+    if [ "$SSLMODE" = 'VERIFY_IDENTITY' ]; then
+        if [ -n "$WSREP_SST_OPT_REMOTE_USER" ]; then
+            CHECK_OPT="checkHost = $(safe WSREP_SST_OPT_REMOTE_USER)"
+        elif [ "$WSREP_SST_OPT_ROLE" = 'donor' ]; then
+            # check if the address is an ip-address (v4 or v6):
+            if echo "$WSREP_SST_OPT_HOST_UNESCAPED" | \
+               grep -q -E '^([0-9]+(\.[0-9]+){3}|[0-9a-fA-F]*(:[0-9a-fA-F]*){1,7})$'
+            then
+                CHECK_OPT="checkIP = $WSREP_SST_OPT_HOST_UNESCAPED"
+            else
+                CHECK_OPT="checkHost = $WSREP_SST_OPT_HOST"
+            fi
+            if is_local_ip "$WSREP_SST_OPT_HOST_UNESCAPED"; then
+                CHECK_OPT_LOCAL='checkHost = localhost'
+            fi
         fi
-        if is_local_ip "$WSREP_SST_OPT_HOST_UNESCAPED"; then
-            CHECK_OPT_LOCAL='checkHost = localhost'
-        fi
+    else
+        wsrep_log_info \
+            "Verifying peer certificate chain for ssl-mode=VERIFY_CA"
     fi
 fi
 


### PR DESCRIPTION
Issue:
The mariabackup SST script enabled a peer certificate name check for any ssl-mode starting with VERIFY, so VERIFY_CA behaved like VERIFY_IDENTITY, unlike the rsync script.

Solution:
For VERIFY_CA verify the chain only - drop the socat "commonname" check in mariabackup and gate the rsync checkHost/checkIP on VERIFY_IDENTITY.