### PR TITLE
MDEV-38147 Mariadb error 1950 after SST

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -96,6 +96,17 @@ char *mysql_binlog_position = NULL;
   for is guaranteed to be the file that was actually sent (no rotation race).
 */
 char *mysql_binlog_file = NULL;
+/*
+  Position and GTID of that shipped binary log, captured together with
+  mysql_binlog_file at flush time (see write_current_binlog_file()). Used by
+  write_binlog_info() so that, if a rotation intervenes, the whole coordinate
+  tuple it records stays consistent with the file that was actually shipped -
+  which matters for a manual --galera-info backup used as a replication seed,
+  not only for the SST joiner (which reads just the file name).
+*/
+static char *mysql_binlog_file_pos = NULL;
+static char *mysql_binlog_file_gtid_executed = NULL;
+static char *mysql_binlog_file_gtid_current_pos = NULL;
 char *buffer_pool_filename = NULL;
 
 /* History on server */
@@ -1588,7 +1599,10 @@ write_current_binlog_file(ds_ctxt *datasink, MYSQL *connection)
 {
 	char *executed_gtid_set = NULL;
 	char *gtid_binlog_state = NULL;
+	char *gtid_current_pos = NULL;
 	char *log_bin_file = NULL;
+	char *log_bin_pos = NULL;
+	char *log_bin_gtid_executed = NULL;
 	char *log_bin_dir = NULL;
 	bool gtid_exists;
 	bool result = true;
@@ -1599,13 +1613,18 @@ write_current_binlog_file(ds_ctxt *datasink, MYSQL *connection)
 		{NULL, NULL}
 	};
 
+	/* Capture the shipped file's coordinates together, right after the flush,
+	so they describe exactly the file that is copied below. */
 	mysql_variable status_after_flush[] = {
 		{"File", &log_bin_file},
+		{"Position", &log_bin_pos},
+		{"Executed_Gtid_Set", &log_bin_gtid_executed},
 		{NULL, NULL}
 	};
 
 	mysql_variable vars[] = {
 		{"gtid_binlog_state", &gtid_binlog_state},
+		{"gtid_current_pos", &gtid_current_pos},
 		{"log_bin_basename", &log_bin_dir},
 		{NULL, NULL}
 	};
@@ -1644,12 +1663,22 @@ write_current_binlog_file(ds_ctxt *datasink, MYSQL *connection)
 
 		/*
 		  Remember the file we just rotated to (before any further
-		  rotation can happen) so that write_binlog_info() records this
-		  very file in xtrabackup_binlog_info and the joiner looks for
-		  exactly the file that is shipped below.
+		  rotation can happen), together with its position and GTID, so
+		  that write_binlog_info() records this very file - and a matching
+		  position/GTID - in xtrabackup_binlog_info, and the joiner looks
+		  for exactly the file that is shipped below.
 		*/
 		free(mysql_binlog_file);
 		mysql_binlog_file = strdup(log_bin_file);
+		free(mysql_binlog_file_pos);
+		mysql_binlog_file_pos =
+			log_bin_pos ? strdup(log_bin_pos) : NULL;
+		free(mysql_binlog_file_gtid_executed);
+		mysql_binlog_file_gtid_executed =
+			log_bin_gtid_executed ? strdup(log_bin_gtid_executed) : NULL;
+		free(mysql_binlog_file_gtid_current_pos);
+		mysql_binlog_file_gtid_current_pos =
+			gtid_current_pos ? strdup(gtid_current_pos) : NULL;
 
 		dirname_part(log_bin_dir, log_bin_dir, &log_bin_dir_length);
 
@@ -1681,11 +1710,14 @@ write_binlog_info(ds_ctxt *datasink, MYSQL *connection)
 {
 	char *filename = NULL;
 	const char *out_filename;
+	const char *out_position;
+	const char *out_gtid_executed;
+	const char *out_gtid_current_pos;
 	char *position = NULL;
 	char *gtid_mode = NULL;
 	char *gtid_current_pos = NULL;
 	char *gtid_executed = NULL;
-	char *gtid = NULL;
+	const char *gtid = NULL;
 	bool result;
 	bool mysql_gtid;
 	bool mariadb_gtid;
@@ -1724,32 +1756,42 @@ write_binlog_info(ds_ctxt *datasink, MYSQL *connection)
 	  string owned by the status[] array is still freed at cleanup.
 	*/
 	out_filename = filename;
+	out_position = position;
+	out_gtid_executed = gtid_executed;
+	out_gtid_current_pos = gtid_current_pos;
 	if (mysql_binlog_file != NULL && strcmp(filename, mysql_binlog_file)) {
-		msg("Binary log rotated to '%s' after '%s' was shipped; "
-		    "recording the shipped file in " XTRABACKUP_BINLOG_INFO,
-		    filename, mysql_binlog_file);
+		msg("Binary log rotated to '%s' after '%s' was shipped; recording "
+		    "the shipped file and its coordinates in "
+		    XTRABACKUP_BINLOG_INFO, filename, mysql_binlog_file);
+		/* Record the whole tuple from the shipped file, not just its name,
+		so file/position/GTID stay consistent (the position and GTID from
+		the SHOW MASTER STATUS above belong to the current, newer file). */
 		out_filename = mysql_binlog_file;
+		out_position = mysql_binlog_file_pos;
+		out_gtid_executed = mysql_binlog_file_gtid_executed;
+		out_gtid_current_pos = mysql_binlog_file_gtid_current_pos;
 	}
 
 	mysql_gtid = ((gtid_mode != NULL) && (strcmp(gtid_mode, "ON") == 0));
-	mariadb_gtid = (gtid_current_pos != NULL);
+	mariadb_gtid = (out_gtid_current_pos != NULL);
 
-	gtid = (gtid_executed != NULL ? gtid_executed : gtid_current_pos);
+	gtid = (out_gtid_executed != NULL ? out_gtid_executed
+					  : out_gtid_current_pos);
 
 	if (mariadb_gtid || mysql_gtid) {
 		ut_a(asprintf(&mysql_binlog_position,
 			"filename '%s', position '%s', "
 			"GTID of the last change '%s'",
-			out_filename, position, gtid) != -1);
+			out_filename, out_position, gtid) != -1);
 		result = datasink->backup_file_printf(XTRABACKUP_BINLOG_INFO,
-					    "%s\t%s\t%s\n", out_filename, position,
+					    "%s\t%s\t%s\n", out_filename, out_position,
 					    gtid);
 	} else {
 		ut_a(asprintf(&mysql_binlog_position,
 			"filename '%s', position '%s'",
-			out_filename, position) != -1);
+			out_filename, out_position) != -1);
 		result = datasink->backup_file_printf(XTRABACKUP_BINLOG_INFO,
-					    "%s\t%s\n", out_filename, position);
+					    "%s\t%s\n", out_filename, out_position);
 	}
 
 cleanup:
@@ -2084,6 +2126,9 @@ backup_cleanup()
 	free(mysql_slave_position);
 	free(mysql_binlog_position);
 	free(mysql_binlog_file);
+	free(mysql_binlog_file_pos);
+	free(mysql_binlog_file_gtid_executed);
+	free(mysql_binlog_file_gtid_current_pos);
 	free(buffer_pool_filename);
 
 	if (mysql_connection) {

--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -88,6 +88,14 @@ static mysql_cond_t kill_query_thread_stop;
 bool sql_thread_started = false;
 char *mysql_slave_position = NULL;
 char *mysql_binlog_position = NULL;
+/*
+  MDEV-38147: the exact binary log file name that
+  write_current_binlog_file() rotated to and shipped into the backup under
+  --galera-info. Remembered here so that write_binlog_info() records the very
+  same file name in xtrabackup_binlog_info, i.e. the file the SST joiner looks
+  for is guaranteed to be the file that was actually sent (no rotation race).
+*/
+char *mysql_binlog_file = NULL;
 char *buffer_pool_filename = NULL;
 
 /* History on server */
@@ -1528,6 +1536,23 @@ write_galera_info(ds_ctxt *datasink, MYSQL *connection)
       domain_id ? domain_id : domain_id55);
   }
 
+  /*
+    MDEV-38147: Flush and copy the donor's current binary log into
+    the backup so that it is shipped to the SST joiner.
+
+    A new joiner discards this file and starts a fresh binary log seeded from
+    the storage-engine checkpoint (see wsrep_seed_binlog_gtid_state() in
+    sql/log.cc and the joiner code in scripts/wsrep_sst_mariabackup.sh), which
+    avoids error 1950 with gtid_strict_mode=ON. The file is still shipped for
+    backward compatibility with an old joiner that expects it, and so that a
+    new joiner can deterministically identify and remove exactly the file that
+    was sent instead of colliding with it.
+
+    write_current_binlog_file() remembers the rotated file name in
+    mysql_binlog_file so that write_binlog_info() records the same file in
+    xtrabackup_binlog_info - closing the old race where a concurrent rotation
+    could make the shipped file and the recorded file diverge.
+  */
   if (result)
     write_current_binlog_file(datasink, connection);
 
@@ -1548,7 +1573,16 @@ cleanup:
 
 /*********************************************************************//**
 Flush and copy the current binary log file into the backup,
-if GTID is enabled */
+if GTID is enabled.
+
+MDEV-38147: the file name that FLUSH BINARY LOGS rotates to is
+remembered in the global mysql_binlog_file. write_binlog_info() then records
+that exact name in xtrabackup_binlog_info, so the file the SST joiner looks
+for is guaranteed to be the file that was shipped. Previously the shipped file
+(determined here) and the recorded file (determined independently later by
+write_binlog_info()) were read by two separate SHOW MASTER STATUS calls; a
+binary log rotation happening in between made them diverge and the wrong file
+was sent. */
 bool
 write_current_binlog_file(ds_ctxt *datasink, MYSQL *connection)
 {
@@ -1601,19 +1635,28 @@ write_current_binlog_file(ds_ctxt *datasink, MYSQL *connection)
 			log_bin_dir = strdup("./");
 		}
 
+		if (log_bin_dir == NULL || log_bin_file == NULL) {
+			msg("Failed to get master binlog coordinates from "
+				"SHOW MASTER STATUS");
+			result = false;
+			goto cleanup;
+		}
+
+		/*
+		  Remember the file we just rotated to (before any further
+		  rotation can happen) so that write_binlog_info() records this
+		  very file in xtrabackup_binlog_info and the joiner looks for
+		  exactly the file that is shipped below.
+		*/
+		free(mysql_binlog_file);
+		mysql_binlog_file = strdup(log_bin_file);
+
 		dirname_part(log_bin_dir, log_bin_dir, &log_bin_dir_length);
 
 		/* strip final slash if it is not the only path component */
 		if (log_bin_dir_length > 1 &&
 		    log_bin_dir[log_bin_dir_length - 1] == FN_LIBCHAR) {
 			log_bin_dir[log_bin_dir_length - 1] = 0;
-		}
-
-		if (log_bin_dir == NULL || log_bin_file == NULL) {
-			msg("Failed to get master binlog coordinates from "
-				"SHOW MASTER STATUS");
-			result = false;
-			goto cleanup;
 		}
 
 		snprintf(filepath, sizeof(filepath), "%s%c%s",
@@ -1637,6 +1680,7 @@ bool
 write_binlog_info(ds_ctxt *datasink, MYSQL *connection)
 {
 	char *filename = NULL;
+	const char *out_filename;
 	char *position = NULL;
 	char *gtid_mode = NULL;
 	char *gtid_current_pos = NULL;
@@ -1669,6 +1713,24 @@ write_binlog_info(ds_ctxt *datasink, MYSQL *connection)
 		goto cleanup;
 	}
 
+	/*
+	  MDEV-38147: if write_current_binlog_file() already rotated
+	  and shipped a binary log under --galera-info, record that exact file
+	  name here rather than whatever SHOW MASTER STATUS reports now. The two
+	  are normally identical, but a binary log rotation between the two
+	  SHOW MASTER STATUS calls would otherwise make xtrabackup_binlog_info
+	  name a file different from the one that was shipped, so the SST joiner
+	  would look for a file that is not there. Use a separate pointer so the
+	  string owned by the status[] array is still freed at cleanup.
+	*/
+	out_filename = filename;
+	if (mysql_binlog_file != NULL && strcmp(filename, mysql_binlog_file)) {
+		msg("Binary log rotated to '%s' after '%s' was shipped; "
+		    "recording the shipped file in " XTRABACKUP_BINLOG_INFO,
+		    filename, mysql_binlog_file);
+		out_filename = mysql_binlog_file;
+	}
+
 	mysql_gtid = ((gtid_mode != NULL) && (strcmp(gtid_mode, "ON") == 0));
 	mariadb_gtid = (gtid_current_pos != NULL);
 
@@ -1678,16 +1740,16 @@ write_binlog_info(ds_ctxt *datasink, MYSQL *connection)
 		ut_a(asprintf(&mysql_binlog_position,
 			"filename '%s', position '%s', "
 			"GTID of the last change '%s'",
-			filename, position, gtid) != -1);
+			out_filename, position, gtid) != -1);
 		result = datasink->backup_file_printf(XTRABACKUP_BINLOG_INFO,
-					    "%s\t%s\t%s\n", filename, position,
+					    "%s\t%s\t%s\n", out_filename, position,
 					    gtid);
 	} else {
 		ut_a(asprintf(&mysql_binlog_position,
 			"filename '%s', position '%s'",
-			filename, position) != -1);
+			out_filename, position) != -1);
 		result = datasink->backup_file_printf(XTRABACKUP_BINLOG_INFO,
-					    "%s\t%s\n", filename, position);
+					    "%s\t%s\n", out_filename, position);
 	}
 
 cleanup:
@@ -2021,6 +2083,7 @@ backup_cleanup()
 {
 	free(mysql_slave_position);
 	free(mysql_binlog_position);
+	free(mysql_binlog_file);
 	free(buffer_pool_filename);
 
 	if (mysql_connection) {

--- a/extra/mariabackup/backup_mysql.h
+++ b/extra/mariabackup/backup_mysql.h
@@ -27,6 +27,7 @@ extern time_t history_lock_time;
 extern bool sql_thread_started;
 extern char *mysql_slave_position;
 extern char *mysql_binlog_position;
+extern char *mysql_binlog_file;
 extern char *buffer_pool_filename;
 
 /** connection to mysql server */

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3750,6 +3750,19 @@ static void log_copying_thread()
     return;
   }
 
+  /*
+    This thread polls Innodb_lsn_flushed via SHOW STATUS on its own connection.
+    On a Galera donor wsrep_sync_wait may include SHOW, which would make that
+    poll wait until the node has applied the latest cluster transactions. During
+    a backup the donor's commit position can legitimately lag (e.g. a transaction
+    sitting between its binary log write and engine commit), so the poll could
+    block indefinitely and stall the redo log copier - failing the backup with a
+    misleading "Was only able to copy log ..." error. The main backup connection
+    already disables wsrep_sync_wait for the same reason, so do the same here.
+  */
+  if (have_galera_enabled)
+    xb_mysql_query(limit_con, "SET SESSION wsrep_sync_wait=0", false);
+
   mysql_mutex_lock(&recv_sys.mutex);
   for (;;)
   {

--- a/mysql-test/suite/galera/r/galera_log_bin_ext_mariabackup.result
+++ b/mysql-test/suite/galera/r/galera_log_bin_ext_mariabackup.result
@@ -58,8 +58,6 @@ SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
 COUNT(*) = 2
 1
 include/show_binlog_events.inc
-Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-hostname1-bin.000002	#	Binlog_checkpoint	#	#	hostname1-bin.000002
 DROP TABLE t1;
 DROP TABLE t2;
 #cleanup

--- a/mysql-test/suite/galera_3nodes/r/MDEV-38147.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-38147.result
@@ -1,0 +1,43 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+# gtid_strict_mode must be enabled on all nodes
+SELECT @@global.gtid_strict_mode AS gtid_strict_mode;
+gtid_strict_mode
+1
+connection node_2;
+connection node_3;
+connect node_1_load, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2_load, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1_load;
+CALL p_load();
+connection node_2_load;
+CALL p_load();
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+connection node_1_load;
+connection node_2_load;
+connection node_1;
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+wsrep_cluster_size
+3
+connection node_2;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match	gtid_match
+1	1	1
+connection node_3;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match	gtid_match
+1	1	1
+connection node_1;
+connection node_2;
+connection node_3;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_3nodes/r/MDEV-38147.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-38147.result
@@ -3,41 +3,50 @@ connection node_1;
 connection node_1;
 connection node_2;
 connection node_3;
-connection node_1;
 # gtid_strict_mode must be enabled on all nodes
 SELECT @@global.gtid_strict_mode AS gtid_strict_mode;
 gtid_strict_mode
 1
-connection node_2;
-connection node_3;
-connect node_1_load, 127.0.0.1, root, , test, $NODE_MYPORT_1;
-connect node_2_load, 127.0.0.1, root, , test, $NODE_MYPORT_2;
-connection node_1_load;
-CALL p_load();
-connection node_2_load;
-CALL p_load();
 connection node_1;
 connection node_2;
 connection node_3;
+connection node_3;
 connection node_1;
-UPDATE ctrl SET stop = 1 WHERE id = 1;
-connection node_1_load;
-connection node_2_load;
+connection node_1;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL debug_dbug = '+d,sync.after_mdl_block_ddl';
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR sync.after_mdl_block_ddl_reached';
+connect node_1_freeze, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1_freeze;
+SET DEBUG_SYNC = 'commit_before_get_LOCK_commit_ordered SIGNAL t_frozen WAIT_FOR t_go';
+INSERT INTO t1 (val) VALUES (1);
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR t_frozen';
+SET DEBUG_SYNC = 'now SIGNAL signal.after_mdl_block_ddl_continue';
+SET DEBUG_SYNC = 'now SIGNAL t_go';
+connection node_1_freeze;
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = '';
+connection node_1;
+connection node_3;
+connection node_1;
+connection node_2;
+connection node_3;
 connection node_1;
 SET SESSION wsrep_sync_wait = 15;
 SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 wsrep_cluster_size
 3
-connection node_2;
-SET SESSION wsrep_sync_wait = 15;
-count_match	checksum_match	gtid_match
-1	1	1
 connection node_3;
 SET SESSION wsrep_sync_wait = 15;
 count_match	checksum_match	gtid_match
 1	1	1
-connection node_1;
 connection node_2;
-connection node_3;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match	gtid_match
+1	1	1
+DROP TABLE t1;
 disconnect node_2;
 disconnect node_1;

--- a/mysql-test/suite/galera_3nodes/r/MDEV-38147_binlogdir.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-38147_binlogdir.result
@@ -1,0 +1,20 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3);
+connection node_3;
+connection node_3;
+connection node_1;
+connection node_1;
+connection node_3;
+SELECT COUNT(*) AS rows_on_joiner FROM t1;
+rows_on_joiner
+3
+connection node_1;
+DROP TABLE t1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_3nodes/r/MDEV-40179.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-40179.result
@@ -1,0 +1,47 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+connection node_2;
+connection node_3;
+connection n1_load_1;
+CALL p_load('t1_1');
+connection n2_load_1;
+CALL p_load('t1_5');
+connection n1_load_2;
+CALL p_load('t1_2');
+connection n2_load_2;
+CALL p_load('t1_6');
+connection n1_load_3;
+CALL p_load('t1_3');
+connection n2_load_3;
+CALL p_load('t1_7');
+connection n1_load_4;
+CALL p_load('t1_4');
+connection n2_load_4;
+CALL p_load('t1_8');
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+connection node_1;
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+wsrep_cluster_size
+3
+connection node_2;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match	gtid_match
+1	1	1
+connection node_3;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match	gtid_match
+1	1	1
+connection node_1;
+connection node_2;
+connection node_3;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_3nodes/r/MDEV-40179_nobinlog.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-40179_nobinlog.result
@@ -1,0 +1,47 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+connection node_2;
+connection node_3;
+connection n1_load_1;
+CALL p_load('t1_1');
+connection n2_load_1;
+CALL p_load('t1_5');
+connection n1_load_2;
+CALL p_load('t1_2');
+connection n2_load_2;
+CALL p_load('t1_6');
+connection n1_load_3;
+CALL p_load('t1_3');
+connection n2_load_3;
+CALL p_load('t1_7');
+connection n1_load_4;
+CALL p_load('t1_4');
+connection n2_load_4;
+CALL p_load('t1_8');
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+connection node_1;
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+wsrep_cluster_size
+3
+connection node_2;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match
+1	1
+connection node_3;
+SET SESSION wsrep_sync_wait = 15;
+count_match	checksum_match
+1	1
+connection node_1;
+connection node_2;
+connection node_3;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147.cnf
@@ -1,0 +1,25 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+gtid_strict_mode=ON
+wsrep_gtid_mode=ON
+wsrep_gtid_domain_id=100
+gtid_domain_id=10
+log_bin
+log_slave_updates=ON
+wsrep_slave_threads=4
+
+[mysqld.1]
+server_id=11
+
+[mysqld.2]
+server_id=12
+
+[mysqld.3]
+server_id=13
+
+[sst]
+transferfmt=@ENV.MTR_GALERA_TFMT
+streamfmt=mbstream

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147.cnf
@@ -9,7 +9,9 @@ wsrep_gtid_domain_id=100
 gtid_domain_id=10
 log_bin
 log_slave_updates=ON
-wsrep_slave_threads=4
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1
+wsrep_sync_wait=6 # allow SHOW to workaround MDEV-39468 and reproduce "error 1950"
 
 [mysqld.1]
 server_id=11
@@ -19,6 +21,10 @@ server_id=12
 
 [mysqld.3]
 server_id=13
+# Force node_3 to always SST from node_1 (the node on which we freeze a
+# transaction between binary log write and engine commit), so the snapshot
+# node_3 receives is the one whose binary log is ahead of its engine checkpoint.
+wsrep_sst_donor=node1
 
 [sst]
 transferfmt=@ENV.MTR_GALERA_TFMT

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
@@ -1,0 +1,229 @@
+#
+# MDEV-38147
+#
+# Three node cluster with gtid_strict_mode enabled and mariabackup SST.
+# Two nodes (node_1 and node_2) run a continuous load, inserting batches
+# of rows in a throttled loop, while the third node (node_3) is repeatedly
+# stopped, has its data directory purged and is started again, forcing a
+# full mariabackup SST on every rejoin (8 times).
+#
+# At the end the cluster must reconverge to three nodes and all three
+# nodes must hold identical data and GTID positions.
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+# Number of stop/purge/start cycles for node_3.
+--let $restarts = 8
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values so that MTR's post-check is
+# happy after node_3 has been restarted multiple times.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+#
+# Schema: t1 holds the load, ctrl carries the stop flag for the loaders.
+#
+--connection node_1
+--disable_query_log
+CREATE TABLE t1 (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB;
+CREATE TABLE ctrl (id INT PRIMARY KEY, stop INT) ENGINE=InnoDB;
+INSERT INTO ctrl VALUES (1, 0);
+
+DELIMITER |;
+CREATE PROCEDURE p_load()
+BEGIN
+  DECLARE v_stop INT DEFAULT 0;
+  DECLARE v_i INT;
+  # Keep the loop alive across transient cluster errors (BF aborts,
+  # certification failures, donor desync timeouts, ...).
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+  END;
+  WHILE v_stop = 0 DO
+    START TRANSACTION;
+    SET v_i = 0;
+    WHILE v_i < 16 DO
+      INSERT INTO t1 (val) VALUES (v_i);
+      SET v_i = v_i + 1;
+    END WHILE;
+    COMMIT;
+    # Throttle slightly between transactions so that a freshly joined node can
+    # catch up its replication queue instead of being starved by the load.
+    DO SLEEP(0.01);
+    SELECT stop INTO v_stop FROM ctrl WHERE id = 1;
+  END WHILE;
+END|
+DELIMITER ;|
+--enable_query_log
+
+--echo # gtid_strict_mode must be enabled on all nodes
+SELECT @@global.gtid_strict_mode AS gtid_strict_mode;
+
+# Make sure the schema reached the other nodes before starting the load.
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+#
+# Start the continuous load on node_1 and node_2.
+#
+--connect node_1_load, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2_load, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+--connection node_1_load
+--send CALL p_load()
+
+--connection node_2_load
+--send CALL p_load()
+
+#
+# While the load is running, repeatedly stop node_3, purge its data
+# directory and start it again. An empty data directory forces a full
+# mariabackup SST on every rejoin.
+#
+--disable_query_log
+--let $i = $restarts
+while ($i)
+{
+  --connection node_3
+  --source include/shutdown_mysqld.inc
+  --disable_query_log
+
+  # Wait until node_3 has actually left the cluster.
+  # (shutdown_mysqld.inc / wait_condition.inc / start_mysqld.inc /
+  #  galera_wait_ready.inc each re-enable the query log, so re-disable it after
+  #  every such include to keep the loop output out of the result file.)
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  # Purge node_3's data directory.
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+  # Start node_3 again (rejoins via mariabackup SST).
+  --connection node_3
+  --let $restart_noprint = 2
+  --source include/start_mysqld.inc
+  --disable_query_log
+  --source include/galera_wait_ready.inc
+  --disable_query_log
+
+  # Wait until the cluster is back to three nodes before the next cycle.
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  --dec $i
+}
+--enable_query_log
+
+#
+# Make sure the whole cluster is healthy before stopping the load, so that
+# any donor that desynced during SST has resynced and the loaders can read
+# the stop flag without blocking.
+#
+--connection node_1
+--source include/galera_wait_ready.inc
+--connection node_2
+--source include/galera_wait_ready.inc
+--connection node_3
+--source include/galera_wait_ready.inc
+
+#
+# Signal the loaders to stop and collect them.
+#
+--connection node_1
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+
+--connection node_1_load
+--reap
+--connection node_2_load
+--reap
+
+#
+# Verify reconvergence and data / GTID consistency across all nodes.
+#
+--connection node_1
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+
+--let $expect_count = `SELECT COUNT(*) FROM t1`
+--let $expect_sum   = `SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1`
+--let $expect_gtid  = `SELECT @@global.gtid_binlog_pos`
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
+--source include/wait_condition.inc
+--disable_query_log
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
+--enable_query_log
+
+--connection node_3
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
+--source include/wait_condition.inc
+--disable_query_log
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
+--enable_query_log
+
+#
+# Cleanup.
+#
+--connection node_1
+--disable_query_log
+DROP PROCEDURE p_load;
+DROP TABLE t1;
+DROP TABLE ctrl;
+
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: .* returned an error: Not connected to Primary Component");
+--enable_query_log
+
+--connection node_2
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+--enable_query_log
+
+--connection node_3
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_table_stats\" not found");
+CALL mtr.add_suppression("Can't open and lock time zone table");
+CALL mtr.add_suppression("Can't open and lock privilege tables");
+CALL mtr.add_suppression("Table 'mysql\\.gtid_slave_pos' doesn't exist");
+CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+--enable_query_log
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
@@ -1,147 +1,149 @@
 #
-# MDEV-38147
+# MDEV-38147 - Mariadb error 1950 after SST
 #
-# Three node cluster with gtid_strict_mode enabled and mariabackup SST.
-# Two nodes (node_1 and node_2) run a continuous load, inserting batches
-# of rows in a throttled loop, while the third node (node_3) is repeatedly
-# stopped, has its data directory purged and is started again, forcing a
-# full mariabackup SST on every rejoin (8 times).
+# Here a single transaction is frozen on the donor in the 2PC window between
+# the binary log write (step 2) and the engine commit (step 3), while a
+# mariabackup SST to a joiner is paused just before it fixes its redo-log
+# copy point. That makes the copied binary log carry a Gtid_list ahead of
+# the copied engine snapshot - exactly the condition the bug is about.
 #
-# At the end the cluster must reconverge to three nodes and all three
-# nodes must hold identical data and GTID positions.
+# The bug:
+#
+# BACKUP STAGE BLOCK_COMMIT fixes the InnoDB redo copy point but does not stop
+# a wsrep transaction from having its GTID written to the binary log before it
+# commits in the engine. So the copied binary log can carry a Gtid_list ahead
+# of the copied engine snapshot. After the SST the joiner reports the
+# (committed, behind) engine position, IST resends the missing transaction, and
+# re-binlogging it under gtid_strict_mode=ON collides with the ahead Gtid_list
+# -> ER_GTID_STRICT_OUT_OF_ORDER (error 1950), and the joiner never reaches
+# synced state. (The same snapshot also captures the transaction in the InnoDB
+# XA-prepared state, i.e. the MDEV-40179 condition.)
+#
+# The fix makes the joiner discard the received binary log and seed its GTID
+# position from the engine checkpoint, so re-binlogging over IST stays in
+# lockstep with the cluster and node_3 rejoins cleanly.
 #
 
---source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/have_mariabackup.inc
-
-# Number of stop/purge/start cycles for node_3.
---let $restarts = 8
+--source include/have_debug_sync.inc
 
 --let $galera_connection_name = node_3
 --let $galera_server_number = 3
 --source include/galera_connect.inc
 
 # Save original auto_increment_offset values so that MTR's post-check is
-# happy after node_3 has been restarted multiple times.
+# happy after node_3 has been restarted.
 --let $node_1=node_1
 --let $node_2=node_2
 --let $node_3=node_3
 --source ../galera/include/auto_increment_offset_save.inc
 
-#
-# Schema: t1 holds the load, ctrl carries the stop flag for the loaders.
-#
---connection node_1
---disable_query_log
-CREATE TABLE t1 (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB;
-CREATE TABLE ctrl (id INT PRIMARY KEY, stop INT) ENGINE=InnoDB;
-INSERT INTO ctrl VALUES (1, 0);
-
-DELIMITER |;
-CREATE PROCEDURE p_load()
-BEGIN
-  DECLARE v_stop INT DEFAULT 0;
-  DECLARE v_i INT;
-  # Keep the loop alive across transient cluster errors (BF aborts,
-  # certification failures, donor desync timeouts, ...).
-  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
-  BEGIN
-    ROLLBACK;
-  END;
-  WHILE v_stop = 0 DO
-    START TRANSACTION;
-    SET v_i = 0;
-    WHILE v_i < 16 DO
-      INSERT INTO t1 (val) VALUES (v_i);
-      SET v_i = v_i + 1;
-    END WHILE;
-    COMMIT;
-    # Throttle slightly between transactions so that a freshly joined node can
-    # catch up its replication queue instead of being starved by the load.
-    DO SLEEP(0.01);
-    SELECT stop INTO v_stop FROM ctrl WHERE id = 1;
-  END WHILE;
-END|
-DELIMITER ;|
---enable_query_log
-
 --echo # gtid_strict_mode must be enabled on all nodes
 SELECT @@global.gtid_strict_mode AS gtid_strict_mode;
 
-# Make sure the schema reached the other nodes before starting the load.
---connection node_2
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
---source include/wait_condition.inc
---connection node_3
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
---source include/wait_condition.inc
-
-#
-# Start the continuous load on node_1 and node_2.
-#
---connect node_1_load, 127.0.0.1, root, , test, $NODE_MYPORT_1
---connect node_2_load, 127.0.0.1, root, , test, $NODE_MYPORT_2
-
---connection node_1_load
---send CALL p_load()
-
---connection node_2_load
---send CALL p_load()
-
-#
-# While the load is running, repeatedly stop node_3, purge its data
-# directory and start it again. An empty data directory forces a full
-# mariabackup SST on every rejoin.
-#
+--connection node_1
 --disable_query_log
---let $i = $restarts
-while ($i)
-{
-  --connection node_3
-  --source include/shutdown_mysqld.inc
-  --disable_query_log
-
-  # Wait until node_3 has actually left the cluster.
-  # (shutdown_mysqld.inc / wait_condition.inc / start_mysqld.inc /
-  #  galera_wait_ready.inc each re-enable the query log, so re-disable it after
-  #  every such include to keep the loop output out of the result file.)
-  --connection node_1
-  --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-  --source include/wait_condition.inc
-  --disable_query_log
-
-  # Purge node_3's data directory.
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
-
-  # Start node_3 again (rejoins via mariabackup SST).
-  --connection node_3
-  --let $restart_noprint = 2
-  --source include/start_mysqld.inc
-  --disable_query_log
-  --source include/galera_wait_ready.inc
-  --disable_query_log
-
-  # Wait until the cluster is back to three nodes before the next cycle.
-  --connection node_1
-  --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-  --source include/wait_condition.inc
-  --disable_query_log
-
-  --dec $i
-}
+CREATE TABLE t1 (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB;
 --enable_query_log
 
+# Make sure the schema reached all nodes before we purge node_3.
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
 #
-# Make sure the whole cluster is healthy before stopping the load, so that
-# any donor that desynced during SST has resynced and the loaders can read
-# the stop flag without blocking.
+# Stop node_3 and purge its data directory so that rejoining forces a full
+# mariabackup SST.
 #
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+#
+# Arm the donor-side backup sync point: mariabackup will pause after
+# BACKUP STAGE BLOCK_DDL, before BLOCK_COMMIT (which fixes the redo copy point).
+#
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL debug_dbug = '+d,sync.after_mdl_block_ddl';
+
+#
+# Start node_3 WITHOUT waiting for it to become ready: it rejoins via a
+# mariabackup SST from node_1, whose donor backup pauses at the sync point armed
+# above. We must not block on node_3 here, because releasing that pause (and
+# everything that lets node_3 finish) happens below on the node_1 connection.
+# So just trigger the restart via the expect file and continue.
+#
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
+--write_line restart $_expect_file_name
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR sync.after_mdl_block_ddl_reached';
+
+#
+# Freeze one transaction between binary log write and engine commit.
+# commit_before_get_LOCK_commit_ordered is reached after the GTID/Xid events
+# have been written and fsync'd to the binary log but before the engine commit.
+#
+--connect node_1_freeze, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1_freeze
+SET DEBUG_SYNC = 'commit_before_get_LOCK_commit_ordered SIGNAL t_frozen WAIT_FOR t_go';
+--send INSERT INTO t1 (val) VALUES (1)
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR t_frozen';
+
+#
+# Let mariabackup continue. It fixes the redo copy point at BLOCK_COMMIT with
+# the frozen transaction still in-doubt (so it is excluded from the engine
+# snapshot), then issues "FLUSH BINARY LOGS" while shipping the binary log,
+# which blocks on the in-doubt transaction's binary log checkpoint.
+#
+SET DEBUG_SYNC = 'now SIGNAL signal.after_mdl_block_ddl_continue';
+
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE INFO LIKE 'FLUSH BINARY LOGS%'
+--source include/wait_condition.inc
+
+#
+# Release the frozen transaction. Its engine commit happens now - after the
+# redo copy point was fixed - so it is absent from the copied engine snapshot
+# while present in the shipped binary log's Gtid_list.
+#
+SET DEBUG_SYNC = 'now SIGNAL t_go';
+
+--connection node_1_freeze
+--reap
+--connection node_1
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = '';
+
+#
+# node_3 must rejoin and the cluster must reconverge to three nodes.
+#
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Re-establish the node_3 client connection (it was started without waiting).
+--connection node_3
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
 --connection node_1
 --source include/galera_wait_ready.inc
 --connection node_2
@@ -150,18 +152,8 @@ while ($i)
 --source include/galera_wait_ready.inc
 
 #
-# Signal the loaders to stop and collect them.
-#
---connection node_1
-UPDATE ctrl SET stop = 1 WHERE id = 1;
-
---connection node_1_load
---reap
---connection node_2_load
---reap
-
-#
-# Verify reconvergence and data / GTID consistency across all nodes.
+# Verify data / GTID consistency across all nodes. node_1 is the origin of the
+# highest GTID, so node_2 and node_3 are waited *up* to node_1's position.
 #
 --connection node_1
 SET SESSION wsrep_sync_wait = 15;
@@ -169,59 +161,36 @@ SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATU
 
 --let $expect_count = `SELECT COUNT(*) FROM t1`
 --let $expect_sum   = `SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1`
---let $expect_gtid  = `SELECT @@global.gtid_binlog_pos`
+# Compare only the wsrep domain (wsrep_gtid_domain_id) of gtid_binlog_pos - that
+# is the part the whole cluster shares; other domains are node-local.
+--let $wsrep_dom = `SELECT @@global.wsrep_gtid_domain_id`
+--let $expect_gtid = `SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+')`
+
+--connection node_3
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
+--source include/wait_condition.inc
+--let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+--source include/wait_condition.inc
+--disable_query_log
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+# The joiner intentionally warns when it rolls back the orphan prepared wsrep
+# transaction during recovery (MDEV-40179); it is re-applied over IST.
+CALL mtr.add_suppression("Rolled back orphan prepared wsrep transaction");
+--enable_query_log
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 15;
 --let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
 --source include/wait_condition.inc
 --disable_query_log
---eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
---enable_query_log
-
---connection node_3
-SET SESSION wsrep_sync_wait = 15;
---let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
---source include/wait_condition.inc
---disable_query_log
---eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
 --enable_query_log
 
 #
 # Cleanup.
 #
---connection node_1
---disable_query_log
-DROP PROCEDURE p_load;
 DROP TABLE t1;
-DROP TABLE ctrl;
-
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("WSREP: .* returned an error: Not connected to Primary Component");
---enable_query_log
-
---connection node_2
---disable_query_log
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
-CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
---enable_query_log
-
---connection node_3
---disable_query_log
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_index_stats\" not found");
-CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_table_stats\" not found");
-CALL mtr.add_suppression("Can't open and lock time zone table");
-CALL mtr.add_suppression("Can't open and lock privilege tables");
-CALL mtr.add_suppression("Table 'mysql\\.gtid_slave_pos' doesn't exist");
-CALL mtr.add_suppression("Native table .* has the wrong structure");
-CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
-CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
---enable_query_log
 
 # Restore original auto_increment_offset values.
 --source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147.test
@@ -1,147 +1,149 @@
 #
-# MDEV-38147
+# MDEV-38147 - Mariadb error 1950 after SST
 #
-# Three node cluster with gtid_strict_mode enabled and mariabackup SST.
-# Two nodes (node_1 and node_2) run a continuous load, inserting batches
-# of rows in a throttled loop, while the third node (node_3) is repeatedly
-# stopped, has its data directory purged and is started again, forcing a
-# full mariabackup SST on every rejoin (8 times).
+# Here a single transaction is frozen on the donor in the 2PC window between
+# the binary log write (step 2) and the engine commit (step 3), while a
+# mariabackup SST to a joiner is paused just before it fixes its redo-log
+# copy point. That makes the copied binary log carry a Gtid_list ahead of
+# the copied engine snapshot - exactly the condition the bug is about.
 #
-# At the end the cluster must reconverge to three nodes and all three
-# nodes must hold identical data and GTID positions.
+# The bug:
+#
+# BACKUP STAGE BLOCK_COMMIT fixes the InnoDB redo copy point but does not stop
+# a wsrep transaction from having its GTID written to the binary log before it
+# commits in the engine. So the copied binary log can carry a Gtid_list ahead
+# of the copied engine snapshot. After the SST the joiner reports the
+# (committed, behind) engine position, IST resends the missing transaction, and
+# re-binlogging it under gtid_strict_mode=ON collides with the ahead Gtid_list
+# -> ER_GTID_STRICT_OUT_OF_ORDER (error 1950), and the joiner never reaches
+# synced state. (The same snapshot also captures the transaction in the InnoDB
+# XA-prepared state, i.e. the MDEV-40179 condition.)
+#
+# The fix makes the joiner discard the received binary log and seed its GTID
+# position from the engine checkpoint, so re-binlogging over IST stays in
+# lockstep with the cluster and node_3 rejoins cleanly.
 #
 
---source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/have_mariabackup.inc
-
-# Number of stop/purge/start cycles for node_3.
---let $restarts = 8
+--source include/have_debug_sync.inc
 
 --let $galera_connection_name = node_3
 --let $galera_server_number = 3
 --source include/galera_connect.inc
 
 # Save original auto_increment_offset values so that MTR's post-check is
-# happy after node_3 has been restarted multiple times.
+# happy after node_3 has been restarted.
 --let $node_1=node_1
 --let $node_2=node_2
 --let $node_3=node_3
 --source ../galera/include/auto_increment_offset_save.inc
 
-#
-# Schema: t1 holds the load, ctrl carries the stop flag for the loaders.
-#
---connection node_1
---disable_query_log
-CREATE TABLE t1 (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB;
-CREATE TABLE ctrl (id INT PRIMARY KEY, stop INT) ENGINE=InnoDB;
-INSERT INTO ctrl VALUES (1, 0);
-
-DELIMITER |;
-CREATE PROCEDURE p_load()
-BEGIN
-  DECLARE v_stop INT DEFAULT 0;
-  DECLARE v_i INT;
-  # Keep the loop alive across transient cluster errors (BF aborts,
-  # certification failures, donor desync timeouts, ...).
-  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
-  BEGIN
-    ROLLBACK;
-  END;
-  WHILE v_stop = 0 DO
-    START TRANSACTION;
-    SET v_i = 0;
-    WHILE v_i < 16 DO
-      INSERT INTO t1 (val) VALUES (v_i);
-      SET v_i = v_i + 1;
-    END WHILE;
-    COMMIT;
-    # Throttle slightly between transactions so that a freshly joined node can
-    # catch up its replication queue instead of being starved by the load.
-    DO SLEEP(0.01);
-    SELECT stop INTO v_stop FROM ctrl WHERE id = 1;
-  END WHILE;
-END|
-DELIMITER ;|
---enable_query_log
-
 --echo # gtid_strict_mode must be enabled on all nodes
 SELECT @@global.gtid_strict_mode AS gtid_strict_mode;
 
-# Make sure the schema reached the other nodes before starting the load.
---connection node_2
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
---source include/wait_condition.inc
---connection node_3
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
---source include/wait_condition.inc
-
-#
-# Start the continuous load on node_1 and node_2.
-#
---connect node_1_load, 127.0.0.1, root, , test, $NODE_MYPORT_1
---connect node_2_load, 127.0.0.1, root, , test, $NODE_MYPORT_2
-
---connection node_1_load
---send CALL p_load()
-
---connection node_2_load
---send CALL p_load()
-
-#
-# While the load is running, repeatedly stop node_3, purge its data
-# directory and start it again. An empty data directory forces a full
-# mariabackup SST on every rejoin.
-#
+--connection node_1
 --disable_query_log
---let $i = $restarts
-while ($i)
-{
-  --connection node_3
-  --source include/shutdown_mysqld.inc
-  --disable_query_log
-
-  # Wait until node_3 has actually left the cluster.
-  # (shutdown_mysqld.inc / wait_condition.inc / start_mysqld.inc /
-  #  galera_wait_ready.inc each re-enable the query log, so re-disable it after
-  #  every such include to keep the loop output out of the result file.)
-  --connection node_1
-  --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-  --source include/wait_condition.inc
-  --disable_query_log
-
-  # Purge node_3's data directory.
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
-  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
-
-  # Start node_3 again (rejoins via mariabackup SST).
-  --connection node_3
-  --let $restart_noprint = 2
-  --source include/start_mysqld.inc
-  --disable_query_log
-  --source include/galera_wait_ready.inc
-  --disable_query_log
-
-  # Wait until the cluster is back to three nodes before the next cycle.
-  --connection node_1
-  --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-  --source include/wait_condition.inc
-  --disable_query_log
-
-  --dec $i
-}
+CREATE TABLE t1 (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB;
 --enable_query_log
 
+# Make sure the schema reached all nodes before we purge node_3.
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
 #
-# Make sure the whole cluster is healthy before stopping the load, so that
-# any donor that desynced during SST has resynced and the loaders can read
-# the stop flag without blocking.
+# Stop node_3 and purge its data directory so that rejoining forces a full
+# mariabackup SST.
 #
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+#
+# Arm the donor-side backup sync point: mariabackup will pause after
+# BACKUP STAGE BLOCK_DDL, before BLOCK_COMMIT (which fixes the redo copy point).
+#
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL debug_dbug = '+d,sync.after_mdl_block_ddl';
+
+#
+# Start node_3 WITHOUT waiting for it to become ready: it rejoins via a
+# mariabackup SST from node_1, whose donor backup pauses at the sync point armed
+# above. We must not block on node_3 here, because releasing that pause (and
+# everything that lets node_3 finish) happens below on the node_1 connection.
+# So just trigger the restart via the expect file and continue.
+#
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
+--write_line restart $_expect_file_name
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR sync.after_mdl_block_ddl_reached';
+
+#
+# Freeze one transaction between binary log write and engine commit.
+# commit_before_get_LOCK_commit_ordered is reached after the GTID/Xid events
+# have been written and fsync'd to the binary log but before the engine commit.
+#
+--connect node_1_freeze, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1_freeze
+SET DEBUG_SYNC = 'commit_before_get_LOCK_commit_ordered SIGNAL t_frozen WAIT_FOR t_go';
+--send INSERT INTO t1 (val) VALUES (1)
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR t_frozen';
+
+#
+# Let mariabackup continue. It fixes the redo copy point at BLOCK_COMMIT with
+# the frozen transaction still in-doubt (so it is excluded from the engine
+# snapshot), then issues "FLUSH BINARY LOGS" while shipping the binary log,
+# which blocks on the in-doubt transaction's binary log checkpoint.
+#
+SET DEBUG_SYNC = 'now SIGNAL signal.after_mdl_block_ddl_continue';
+
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE INFO LIKE 'FLUSH BINARY LOGS%'
+--source include/wait_condition.inc
+
+#
+# Release the frozen transaction. Its engine commit happens now - after the
+# redo copy point was fixed - so it is absent from the copied engine snapshot
+# while present in the shipped binary log's Gtid_list.
+#
+SET DEBUG_SYNC = 'now SIGNAL t_go';
+
+--connection node_1_freeze
+--reap
+--connection node_1
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = '';
+
+#
+# node_3 must rejoin and the cluster must reconverge to three nodes.
+#
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Re-establish the node_3 client connection (it was started without waiting).
+--connection node_3
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
 --connection node_1
 --source include/galera_wait_ready.inc
 --connection node_2
@@ -150,18 +152,8 @@ while ($i)
 --source include/galera_wait_ready.inc
 
 #
-# Signal the loaders to stop and collect them.
-#
---connection node_1
-UPDATE ctrl SET stop = 1 WHERE id = 1;
-
---connection node_1_load
---reap
---connection node_2_load
---reap
-
-#
-# Verify reconvergence and data / GTID consistency across all nodes.
+# Verify data / GTID consistency across all nodes. node_1 is the origin of the
+# highest GTID, so node_2 and node_3 are waited *up* to node_1's position.
 #
 --connection node_1
 SET SESSION wsrep_sync_wait = 15;
@@ -169,59 +161,33 @@ SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATU
 
 --let $expect_count = `SELECT COUNT(*) FROM t1`
 --let $expect_sum   = `SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1`
---let $expect_gtid  = `SELECT @@global.gtid_binlog_pos`
+# Compare only the wsrep domain (wsrep_gtid_domain_id) of gtid_binlog_pos - that
+# is the part the whole cluster shares; other domains are node-local.
+--let $wsrep_dom = `SELECT @@global.wsrep_gtid_domain_id`
+--let $expect_gtid = `SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+')`
+
+--connection node_3
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
+--source include/wait_condition.inc
+--let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+--source include/wait_condition.inc
+--disable_query_log
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+--enable_query_log
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 15;
 --let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
 --source include/wait_condition.inc
 --disable_query_log
---eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
---enable_query_log
-
---connection node_3
-SET SESSION wsrep_sync_wait = 15;
---let $wait_condition = SELECT COUNT(*) = $expect_count FROM t1
---source include/wait_condition.inc
---disable_query_log
---eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = @@global.gtid_binlog_pos AS gtid_match
+--eval SELECT $expect_count = (SELECT COUNT(*) FROM t1) AS count_match, $expect_sum = (SELECT COALESCE(SUM(pk), 0) + COALESCE(SUM(val), 0) FROM t1) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
 --enable_query_log
 
 #
 # Cleanup.
 #
---connection node_1
---disable_query_log
-DROP PROCEDURE p_load;
 DROP TABLE t1;
-DROP TABLE ctrl;
-
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("WSREP: .* returned an error: Not connected to Primary Component");
---enable_query_log
-
---connection node_2
---disable_query_log
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
-CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
---enable_query_log
-
---connection node_3
---disable_query_log
-CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
-CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
-CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_index_stats\" not found");
-CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_table_stats\" not found");
-CALL mtr.add_suppression("Can't open and lock time zone table");
-CALL mtr.add_suppression("Can't open and lock privilege tables");
-CALL mtr.add_suppression("Table 'mysql\\.gtid_slave_pos' doesn't exist");
-CALL mtr.add_suppression("Native table .* has the wrong structure");
-CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
-CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
---enable_query_log
 
 # Restore original auto_increment_offset values.
 --source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147_binlogdir.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147_binlogdir.cnf
@@ -1,0 +1,22 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+log_bin
+log_slave_updates=ON
+
+[mysqld.1]
+server_id=11
+
+[mysqld.2]
+server_id=12
+
+[mysqld.3]
+server_id=13
+# Force node_3 to always SST from node_1.
+wsrep_sst_donor=node1
+
+[sst]
+transferfmt=@ENV.MTR_GALERA_TFMT
+streamfmt=mbstream

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147_binlogdir.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147_binlogdir.test
@@ -1,0 +1,106 @@
+#
+# MDEV-38147 follow-up: the joiner must be able to reopen its binary log after
+# a mariabackup SST even when the log-bin directory does not exist yet.
+#
+# Since MDEV-38147 the joiner no longer ships/moves the donor's binary log into
+# place - it starts a fresh binary log seeded from the storage-engine
+# checkpoint. The directory-creation that used to accompany the (now removed)
+# move was removed with it, and the server does not create the log-bin
+# directory itself. So when log_bin points outside the datadir (a freshly
+# provisioned joiner) or to a datadir subdirectory the SST cleanup wipes, the
+# directory is absent when mysqld reopens the binary log after SST and the
+# joiner aborts with "File '.../<log-bin>.index' not found (Errcode: 2)".
+#
+# Here node_3 rejoins via a full mariabackup SST with log_bin relocated to a
+# directory that does not exist yet (outside its datadir). The SST script must
+# (re)create it so the joiner comes up and rejoins the cluster.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values so that MTR's post-check is
+# happy after node_3 has been restarted.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3);
+
+# Make sure the data reached node_3 before we purge it.
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1
+--source include/wait_condition.inc
+
+#
+# Stop node_3 and purge its data directory so that rejoining forces a full
+# mariabackup SST.
+#
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+# A binary-log directory that does not exist yet, outside node_3's datadir.
+--let $binlog_reloc = $MYSQLTEST_VARDIR/mysqld.3/reloc_binlog
+--perl
+use File::Path qw(rmtree);
+rmtree("$ENV{MYSQLTEST_VARDIR}/mysqld.3/reloc_binlog");
+EOF
+
+#
+# Restart node_3 with the binary log relocated to the (missing) directory.
+# Do not block on it: it rejoins via a mariabackup SST which, with the fix,
+# creates the directory before mysqld reopens the binary log.
+#
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
+--write_line "restart:--log-bin=$binlog_reloc/mdev-bin --log-bin-index=$binlog_reloc/mdev-bin.index" $_expect_file_name
+
+--connection node_1
+--let $wait_timeout = 60
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Re-establish the node_3 client connection (it was started without waiting).
+--connection node_3
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--source include/galera_wait_ready.inc
+
+# The joiner (re)created the relocated binlog directory and opened a fresh
+# binary log there.
+--file_exists $binlog_reloc/mdev-bin.index
+--file_exists $binlog_reloc/mdev-bin.000001
+
+# The SST data made it across.
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1
+--source include/wait_condition.inc
+SELECT COUNT(*) AS rows_on_joiner FROM t1;
+
+#
+# Cleanup.
+#
+--connection node_1
+DROP TABLE t1;
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147_gtid_off.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147_gtid_off.cnf
@@ -1,0 +1,30 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+log_bin
+log_slave_updates=ON
+# The case under test: binary logging ON, but Galera GTID mode OFF. Cluster
+# writes are then binlogged under the node's own gtid_domain_id with a locally
+# allocated seq_no, unrelated to the wsrep cluster seqno in the SE checkpoint.
+wsrep_gtid_mode=OFF
+gtid_domain_id=10
+# Distinct from gtid_domain_id so that any (incorrect) seeding from the wsrep
+# checkpoint would be visible as a foreign domain/seqno.
+wsrep_gtid_domain_id=100
+
+[mysqld.1]
+server_id=11
+
+[mysqld.2]
+server_id=12
+
+[mysqld.3]
+server_id=13
+# Force node_3 to always SST from node_1.
+wsrep_sst_donor=node1
+
+[sst]
+transferfmt=@ENV.MTR_GALERA_TFMT
+streamfmt=mbstream

--- a/mysql-test/suite/galera_3nodes/t/MDEV-38147_gtid_off.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-38147_gtid_off.test
@@ -1,0 +1,109 @@
+#
+# MDEV-38147 follow-up: binary-log GTID seeding must apply only with
+# wsrep_gtid_mode=ON.
+#
+# After MDEV-38147 a mariabackup-SST joiner starts a fresh binary log and, in
+# wsrep_gtid_mode=ON, seeds @@gtid_binlog_pos from the storage-engine checkpoint
+# (cluster writes are re-tagged to wsrep_gtid_domain_id and binlogged with the
+# cluster seqno, so the checkpoint position maps directly onto the binlog GTID
+# state - see MDEV-38147.test for the ON-mode case).
+#
+# With wsrep_gtid_mode=OFF that mapping does not hold: cluster writes keep the
+# node's own gtid_domain_id and are binlogged with a locally allocated seq_no,
+# while the cluster seqno lives only in thd->wsrep_current_gtid_seqno and is
+# never written to the binlog GTID. Seeding gtid_domain_id from the checkpoint
+# seqno would therefore inject a wrong, node-unrelated position. So in OFF mode
+# the joiner must seed nothing; a fresh binary log simply resumes its own local
+# counter.
+#
+# This test drives a full mariabackup SST of node_3 in wsrep_gtid_mode=OFF and
+# asserts the seeding code path did NOT run on the joiner.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values so that MTR's post-check is
+# happy after node_3 has been restarted.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--echo # Precondition: Galera GTID mode is OFF
+SELECT @@global.wsrep_gtid_mode AS wsrep_gtid_mode;
+
+--connection node_1
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+
+# Make sure the data reached node_3 before we purge it.
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1
+--source include/wait_condition.inc
+
+#
+# Stop node_3 and purge its data directory so that rejoining forces a full
+# mariabackup SST (which restores the wsrep position into the SE checkpoint).
+#
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+# Restart node_3 (non-blocking): it rejoins via a mariabackup SST from node_1.
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
+--write_line restart $_expect_file_name
+
+--connection node_1
+--let $wait_timeout = 60
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Re-establish the node_3 client connection (it was started without waiting).
+--connection node_3
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--source include/galera_wait_ready.inc
+
+# The SST data made it across.
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1
+--source include/wait_condition.inc
+SELECT COUNT(*) AS rows_on_joiner FROM t1;
+
+#
+# Regression assertion: in wsrep_gtid_mode=OFF the joiner must NOT seed its
+# binary-log GTID state from the wsrep checkpoint. The seeding code path emits
+# this exact line only when it runs (it does run in the ON-mode
+# MDEV-38147.test); here it must be absent on the joiner.
+#
+--let $assert_text = joiner did not seed binlog GTID state in wsrep_gtid_mode=OFF
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.3.err
+--let $assert_select = seeding binlog GTID state
+--let $assert_count = 0
+--source include/assert_grep.inc
+
+#
+# Cleanup.
+#
+--connection node_1
+DROP TABLE t1;
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179.cnf
@@ -1,0 +1,37 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+gtid_strict_mode=ON
+wsrep_gtid_mode=ON
+wsrep_gtid_domain_id=100
+gtid_domain_id=10
+log_bin
+log_slave_updates=ON
+# Parallel apply so that prepared transactions can be committed out of order,
+# producing a non-contiguous prepared set on the donor.
+wsrep_slave_threads=8
+# Slow, durable commits widen the window during which transactions sit in the
+# prepared (XA) state of two-phase commit, so the backup's BLOCK_COMMIT
+# snapshot is more likely to capture in-doubt transactions. sync_binlog adds an
+# fsync inside the 2PC window without exploding the binlog file count, and a
+# moderate max_binlog_size keeps the binlog rotating (further widening the
+# window) while avoiding the tens of thousands of tiny files that a 4 KB limit
+# would create under this load.
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1
+max_binlog_size=16384
+
+[mysqld.1]
+server_id=11
+
+[mysqld.2]
+server_id=12
+
+[mysqld.3]
+server_id=13
+
+[sst]
+transferfmt=@ENV.MTR_GALERA_TFMT
+streamfmt=mbstream

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179.inc
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179.inc
@@ -1,0 +1,346 @@
+#
+# Shared body for the MDEV-40179 tests (sourced by MDEV-40179.test with
+# log_bin=ON and MDEV-40179_nobinlog.test with log_bin=OFF).
+#
+# The bug (reproduced by the log_bin=ON variant):
+#
+# With log_bin=ON a transaction is committed via two-phase commit (the binary
+# log is the second participant), so it passes through the InnoDB XA-prepare
+# state. While a donor is held in BLOCK_COMMIT for a mariabackup backup, its
+# parallel appliers (wsrep_slave_threads > 1) leave one or more such writesets
+# prepared-but-not-yet-committed, and the snapshot captures them. On a freshly
+# SST'd joiner nothing resolves these prepared transactions: binlog crash
+# recovery does not run (the joiner has no in-use binlog to recover from), and
+# the wsrep continuity-based commit is inactive because wsrep_emulate_bin_log
+# is FALSE when log_bin is ON. The leftover prepared transactions then abort
+# startup with "Found <N> prepared transactions!". Note this does not depend on
+# the prepared set being non-contiguous - even a contiguous run aborts, because
+# nothing commits or rolls it back.
+#
+# The log_bin=OFF variant is coverage only: with a single (InnoDB) read-write
+# engine and no binary log, commits use one-phase commit, so transactions never
+# enter the XA-prepared state and the snapshot has nothing in doubt. It simply
+# verifies that mariabackup SST and reconvergence keep working with log_bin=OFF.
+#
+# To maximize parallel apply on the donor (and thus the chance of catching
+# prepared transactions in the snapshot) each client thread writes to its own
+# table: there are no certification conflicts between writers, so all of them
+# apply concurrently. $writers client threads load on each of node_1 and node_2
+# while node_3 is repeatedly stopped, has its data directory purged and is
+# started again, forcing a full mariabackup SST on every rejoin. At the end the
+# cluster must reconverge to three nodes and all three nodes must hold identical
+# data (and, with log_bin, identical GTID positions).
+#
+# Parameters set by the including .test:
+#   $restarts    - number of stop/purge/start cycles for node_3
+#   $writers     - number of concurrent loader threads per node (each gets its
+#                  own table to avoid certification conflicts)
+#   $check_gtid  - 1 to also compare @@global.gtid_binlog_pos across nodes
+#                  (only meaningful with log_bin), 0 otherwise
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values so that MTR's post-check is
+# happy after node_3 has been restarted multiple times.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+# Total number of data tables: one per writer thread across both nodes.
+--let $ntables = `SELECT 2 * $writers`
+
+#
+# Schema: t1_1 .. t1_$ntables hold the load (one table per writer thread),
+# ctrl carries the stop flag for the loaders.
+#
+--connection node_1
+--disable_query_log
+CREATE TABLE ctrl (id INT PRIMARY KEY, stop INT) ENGINE=InnoDB;
+INSERT INTO ctrl VALUES (1, 0);
+
+--let $t = 1
+while ($t <= $ntables)
+{
+  --eval CREATE TABLE t1_$t (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB
+  --inc $t
+}
+
+DELIMITER |;
+CREATE PROCEDURE p_load(IN tname VARCHAR(64))
+BEGIN
+  DECLARE v_stop INT DEFAULT 0;
+  DECLARE v_i INT;
+  # Keep the loop alive across transient cluster errors (BF aborts,
+  # certification failures, donor desync timeouts, ...).
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+  END;
+  SET @ins_sql = CONCAT('INSERT INTO ', tname, ' (pk, val) VALUES (DEFAULT, 1)');
+  PREPARE ins FROM @ins_sql;
+  WHILE v_stop = 0 DO
+    START TRANSACTION;
+    SET v_i = 0;
+    WHILE v_i < 16 DO
+      EXECUTE ins;
+      SET v_i = v_i + 1;
+    END WHILE;
+    COMMIT;
+    # Throttle slightly between transactions so that a freshly joined node can
+    # catch up its replication queue instead of being starved by the load.
+    DO SLEEP(0.01);
+    SELECT stop INTO v_stop FROM ctrl WHERE id = 1;
+  END WHILE;
+  DEALLOCATE PREPARE ins;
+END|
+DELIMITER ;|
+--enable_query_log
+
+# Make sure the schema reached the other nodes before starting the load.
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $ntables FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't1\_%';
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $ntables FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't1\_%';
+--source include/wait_condition.inc
+
+#
+# Start the continuous load: $writers threads on node_1 (tables t1_1..t1_W)
+# and $writers threads on node_2 (tables t1_(W+1)..t1_2W).
+#
+--disable_query_log
+--let $w = 1
+while ($w <= $writers)
+{
+  --connect (n1_load_$w, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+  --connect (n2_load_$w, 127.0.0.1, root, , test, $NODE_MYPORT_2)
+  --inc $w
+}
+--enable_query_log
+
+--let $w = 1
+--let $n2 = $writers
+while ($w <= $writers)
+{
+  --connection n1_load_$w
+  --send_eval CALL p_load('t1_$w')
+  --inc $n2
+  --connection n2_load_$w
+  --send_eval CALL p_load('t1_$n2')
+  --inc $w
+}
+
+#
+# While the load is running, repeatedly stop node_3, purge its data
+# directory and start it again. An empty data directory forces a full
+# mariabackup SST on every rejoin.
+#
+--disable_query_log
+--let $i = $restarts
+while ($i)
+{
+  --connection node_3
+  --source include/shutdown_mysqld.inc
+  --disable_query_log
+
+  # Wait until node_3 has actually left the cluster.
+  # (shutdown_mysqld.inc / wait_condition.inc / start_mysqld.inc /
+  #  galera_wait_ready.inc each re-enable the query log, so re-disable it after
+  #  every such include to keep the loop output out of the result file.)
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  # Purge node_3's data directory.
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+  # Start node_3 again (rejoins via mariabackup SST).
+  --connection node_3
+  --let $restart_noprint = 2
+  --source include/start_mysqld.inc
+  --disable_query_log
+  --source include/galera_wait_ready.inc
+  --disable_query_log
+
+  # Wait until the cluster is back to three nodes before the next cycle.
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  --dec $i
+}
+--enable_query_log
+
+#
+# Make sure the whole cluster is healthy before stopping the load, so that
+# any donor that desynced during SST has resynced and the loaders can read
+# the stop flag without blocking.
+#
+--connection node_1
+--source include/galera_wait_ready.inc
+--connection node_2
+--source include/galera_wait_ready.inc
+--connection node_3
+--source include/galera_wait_ready.inc
+
+#
+# Signal the loaders to stop and collect them.
+#
+--connection node_1
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+
+--disable_query_log
+--let $w = 1
+while ($w <= $writers)
+{
+  --connection n1_load_$w
+  --reap
+  --connection n2_load_$w
+  --reap
+  --inc $w
+}
+--enable_query_log
+
+#
+# Build the aggregate count / checksum expressions over all data tables.
+#
+--let $count_expr = 0
+--let $sum_expr = 0
+--let $t = 1
+while ($t <= $ntables)
+{
+  --let $count_expr = $count_expr + (SELECT COUNT(*) FROM t1_$t)
+  --let $sum_expr = $sum_expr + (SELECT COALESCE(SUM(pk),0)+COALESCE(SUM(val),0) FROM t1_$t)
+  --inc $t
+}
+
+#
+# Verify reconvergence and data / GTID consistency across all nodes.
+#
+--connection node_1
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+
+# The load has stopped; issue one final transaction from node_1 (sync_wait is
+# on, so node_1 first applies everything else). This makes node_1 the origin of
+# the cluster's highest GTID, so the checks below can wait for node_2/node_3 to
+# converge *up* to node_1's position instead of comparing a single snapshot:
+# @@gtid_binlog_pos is a system variable, so reading it is not covered by
+# wsrep_sync_wait and a plain read can otherwise sample a position before the
+# node has finished applying (a race that grows with accumulated load, e.g.
+# under --repeat).
+--disable_query_log
+UPDATE ctrl SET stop = 2 WHERE id = 1;
+--enable_query_log
+
+--let $expect_count = `SELECT $count_expr`
+--let $expect_sum   = `SELECT $sum_expr`
+if ($check_gtid)
+{
+  # Compare only the wsrep domain (wsrep_gtid_domain_id) of gtid_binlog_pos.
+  # That is the part the whole cluster shares. Other domains in the position
+  # are node-local and legitimately differ: e.g. CALL mtr.add_suppression()
+  # below writes to the non-replicated 'mtr' database, which each node binlogs
+  # under its own gtid_domain_id/server_id - so those entries accumulate
+  # per-node across runs (visible under --repeat) and must not be compared.
+  --let $wsrep_dom = `SELECT @@global.wsrep_gtid_domain_id`
+  --let $expect_gtid = `SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+')`
+}
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT ($count_expr) = $expect_count
+--source include/wait_condition.inc
+--disable_query_log
+if ($check_gtid)
+{
+  --let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+  --source include/wait_condition.inc
+  --disable_query_log
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+}
+if (!$check_gtid)
+{
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match
+}
+--enable_query_log
+
+--connection node_3
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT ($count_expr) = $expect_count
+--source include/wait_condition.inc
+--disable_query_log
+if ($check_gtid)
+{
+  --let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+  --source include/wait_condition.inc
+  --disable_query_log
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+}
+if (!$check_gtid)
+{
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match
+}
+--enable_query_log
+
+#
+# Cleanup.
+#
+--connection node_1
+--disable_query_log
+DROP PROCEDURE p_load;
+--let $t = 1
+while ($t <= $ntables)
+{
+  --eval DROP TABLE t1_$t
+  --inc $t
+}
+DROP TABLE ctrl;
+
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: .* returned an error: Not connected to Primary Component");
+--enable_query_log
+
+--connection node_2
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+--enable_query_log
+
+--connection node_3
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_table_stats\" not found");
+CALL mtr.add_suppression("Can't open and lock time zone table");
+CALL mtr.add_suppression("Can't open and lock privilege tables");
+CALL mtr.add_suppression("Table 'mysql\\.gtid_slave_pos' doesn't exist");
+CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+CALL mtr.add_suppression("WSREP: Discovered discontinuity in recovered wsrep transaction XIDs");
+--enable_query_log
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179.inc
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179.inc
@@ -1,0 +1,347 @@
+#
+# Shared body for the MDEV-40179 tests (sourced by MDEV-40179.test with
+# log_bin=ON and MDEV-40179_nobinlog.test with log_bin=OFF).
+#
+# The bug (reproduced by the log_bin=ON variant):
+#
+# With log_bin=ON a transaction is committed via two-phase commit (the binary
+# log is the second participant), so it passes through the InnoDB XA-prepare
+# state. While a donor is held in BLOCK_COMMIT for a mariabackup backup, its
+# parallel appliers (wsrep_slave_threads > 1) leave one or more such writesets
+# prepared-but-not-yet-committed, and the snapshot captures them. On a freshly
+# SST'd joiner nothing resolves these prepared transactions: binlog crash
+# recovery does not run (the joiner has no in-use binlog to recover from), and
+# the wsrep continuity-based commit is inactive because wsrep_emulate_bin_log
+# is FALSE when log_bin is ON. The leftover prepared transactions then abort
+# startup with "Found <N> prepared transactions!". Note this does not depend on
+# the prepared set being non-contiguous - even a contiguous run aborts, because
+# nothing commits or rolls it back.
+#
+# The log_bin=OFF variant is coverage only: with a single (InnoDB) read-write
+# engine and no binary log, commits use one-phase commit, so transactions never
+# enter the XA-prepared state and the snapshot has nothing in doubt. It simply
+# verifies that mariabackup SST and reconvergence keep working with log_bin=OFF.
+#
+# To maximize parallel apply on the donor (and thus the chance of catching
+# prepared transactions in the snapshot) each client thread writes to its own
+# table: there are no certification conflicts between writers, so all of them
+# apply concurrently. $writers client threads load on each of node_1 and node_2
+# while node_3 is repeatedly stopped, has its data directory purged and is
+# started again, forcing a full mariabackup SST on every rejoin. At the end the
+# cluster must reconverge to three nodes and all three nodes must hold identical
+# data (and, with log_bin, identical GTID positions).
+#
+# Parameters set by the including .test:
+#   $restarts    - number of stop/purge/start cycles for node_3
+#   $writers     - number of concurrent loader threads per node (each gets its
+#                  own table to avoid certification conflicts)
+#   $check_gtid  - 1 to also compare @@global.gtid_binlog_pos across nodes
+#                  (only meaningful with log_bin), 0 otherwise
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_mariabackup.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values so that MTR's post-check is
+# happy after node_3 has been restarted multiple times.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+# Total number of data tables: one per writer thread across both nodes.
+--let $ntables = `SELECT 2 * $writers`
+
+#
+# Schema: t1_1 .. t1_$ntables hold the load (one table per writer thread),
+# ctrl carries the stop flag for the loaders.
+#
+--connection node_1
+--disable_query_log
+CREATE TABLE ctrl (id INT PRIMARY KEY, stop INT) ENGINE=InnoDB;
+INSERT INTO ctrl VALUES (1, 0);
+
+--let $t = 1
+while ($t <= $ntables)
+{
+  --eval CREATE TABLE t1_$t (pk BIGINT AUTO_INCREMENT PRIMARY KEY, val INT) ENGINE=InnoDB
+  --inc $t
+}
+
+DELIMITER |;
+CREATE PROCEDURE p_load(IN tname VARCHAR(64))
+BEGIN
+  DECLARE v_stop INT DEFAULT 0;
+  DECLARE v_i INT;
+  # Keep the loop alive across transient cluster errors (BF aborts,
+  # certification failures, donor desync timeouts, ...).
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+  END;
+  SET @ins_sql = CONCAT('INSERT INTO ', tname, ' (pk, val) VALUES (DEFAULT, 1)');
+  PREPARE ins FROM @ins_sql;
+  WHILE v_stop = 0 DO
+    START TRANSACTION;
+    SET v_i = 0;
+    WHILE v_i < 16 DO
+      EXECUTE ins;
+      SET v_i = v_i + 1;
+    END WHILE;
+    COMMIT;
+    # Throttle slightly between transactions so that a freshly joined node can
+    # catch up its replication queue instead of being starved by the load.
+    DO SLEEP(0.01);
+    SELECT stop INTO v_stop FROM ctrl WHERE id = 1;
+  END WHILE;
+  DEALLOCATE PREPARE ins;
+END|
+DELIMITER ;|
+--enable_query_log
+
+# Make sure the schema reached the other nodes before starting the load.
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $ntables FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't1\_%';
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $ntables FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't1\_%';
+--source include/wait_condition.inc
+
+#
+# Start the continuous load: $writers threads on node_1 (tables t1_1..t1_W)
+# and $writers threads on node_2 (tables t1_(W+1)..t1_2W).
+#
+--disable_query_log
+--let $w = 1
+while ($w <= $writers)
+{
+  --connect (n1_load_$w, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+  --connect (n2_load_$w, 127.0.0.1, root, , test, $NODE_MYPORT_2)
+  --inc $w
+}
+--enable_query_log
+
+--let $w = 1
+--let $n2 = $writers
+while ($w <= $writers)
+{
+  --connection n1_load_$w
+  --send_eval CALL p_load('t1_$w')
+  --inc $n2
+  --connection n2_load_$w
+  --send_eval CALL p_load('t1_$n2')
+  --inc $w
+}
+
+#
+# While the load is running, repeatedly stop node_3, purge its data
+# directory and start it again. An empty data directory forces a full
+# mariabackup SST on every rejoin.
+#
+--disable_query_log
+--let $i = $restarts
+while ($i)
+{
+  --connection node_3
+  --source include/shutdown_mysqld.inc
+  --disable_query_log
+
+  # Wait until node_3 has actually left the cluster.
+  # (shutdown_mysqld.inc / wait_condition.inc / start_mysqld.inc /
+  #  galera_wait_ready.inc each re-enable the query log, so re-disable it after
+  #  every such include to keep the loop output out of the result file.)
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  # Purge node_3's data directory.
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/test
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mysql
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/performance_schema
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data/mtr
+  --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+  # Start node_3 again (rejoins via mariabackup SST).
+  --connection node_3
+  --let $restart_noprint = 2
+  --source include/start_mysqld.inc
+  --disable_query_log
+  --source include/galera_wait_ready.inc
+  --disable_query_log
+
+  # Wait until the cluster is back to three nodes before the next cycle.
+  --connection node_1
+  --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+  --source include/wait_condition.inc
+  --disable_query_log
+
+  --dec $i
+}
+--enable_query_log
+
+#
+# Make sure the whole cluster is healthy before stopping the load, so that
+# any donor that desynced during SST has resynced and the loaders can read
+# the stop flag without blocking.
+#
+--connection node_1
+--source include/galera_wait_ready.inc
+--connection node_2
+--source include/galera_wait_ready.inc
+--connection node_3
+--source include/galera_wait_ready.inc
+
+#
+# Signal the loaders to stop and collect them.
+#
+--connection node_1
+UPDATE ctrl SET stop = 1 WHERE id = 1;
+
+--disable_query_log
+--let $w = 1
+while ($w <= $writers)
+{
+  --connection n1_load_$w
+  --reap
+  --connection n2_load_$w
+  --reap
+  --inc $w
+}
+--enable_query_log
+
+#
+# Build the aggregate count / checksum expressions over all data tables.
+#
+--let $count_expr = 0
+--let $sum_expr = 0
+--let $t = 1
+while ($t <= $ntables)
+{
+  --let $count_expr = $count_expr + (SELECT COUNT(*) FROM t1_$t)
+  --let $sum_expr = $sum_expr + (SELECT COALESCE(SUM(pk),0)+COALESCE(SUM(val),0) FROM t1_$t)
+  --inc $t
+}
+
+#
+# Verify reconvergence and data / GTID consistency across all nodes.
+#
+--connection node_1
+SET SESSION wsrep_sync_wait = 15;
+SELECT VARIABLE_VALUE AS wsrep_cluster_size FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+
+# The load has stopped; issue one final transaction from node_1 (sync_wait is
+# on, so node_1 first applies everything else). This makes node_1 the origin of
+# the cluster's highest GTID, so the checks below can wait for node_2/node_3 to
+# converge *up* to node_1's position instead of comparing a single snapshot:
+# @@gtid_binlog_pos is a system variable, so reading it is not covered by
+# wsrep_sync_wait and a plain read can otherwise sample a position before the
+# node has finished applying (a race that grows with accumulated load, e.g.
+# under --repeat).
+--disable_query_log
+UPDATE ctrl SET stop = 2 WHERE id = 1;
+--enable_query_log
+
+--let $expect_count = `SELECT $count_expr`
+--let $expect_sum   = `SELECT $sum_expr`
+if ($check_gtid)
+{
+  # Compare only the wsrep domain (wsrep_gtid_domain_id) of gtid_binlog_pos.
+  # That is the part the whole cluster shares. Other domains in the position
+  # are node-local and legitimately differ: e.g. CALL mtr.add_suppression()
+  # below writes to the non-replicated 'mtr' database, which each node binlogs
+  # under its own gtid_domain_id/server_id - so those entries accumulate
+  # per-node across runs (visible under --repeat) and must not be compared.
+  --let $wsrep_dom = `SELECT @@global.wsrep_gtid_domain_id`
+  --let $expect_gtid = `SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+')`
+}
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT ($count_expr) = $expect_count
+--source include/wait_condition.inc
+--disable_query_log
+if ($check_gtid)
+{
+  --let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+  --source include/wait_condition.inc
+  --disable_query_log
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+}
+if (!$check_gtid)
+{
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match
+}
+--enable_query_log
+
+--connection node_3
+SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT ($count_expr) = $expect_count
+--source include/wait_condition.inc
+--disable_query_log
+if ($check_gtid)
+{
+  --let $wait_condition = SELECT REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') = '$expect_gtid'
+  --source include/wait_condition.inc
+  --disable_query_log
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match, '$expect_gtid' = REGEXP_SUBSTR(@@global.gtid_binlog_pos, '(?<![0-9])$wsrep_dom-[0-9]+-[0-9]+') AS gtid_match
+}
+if (!$check_gtid)
+{
+  --eval SELECT $expect_count = ($count_expr) AS count_match, $expect_sum = ($sum_expr) AS checksum_match
+}
+--enable_query_log
+
+#
+# Cleanup.
+#
+--connection node_1
+--disable_query_log
+DROP PROCEDURE p_load;
+--let $t = 1
+while ($t <= $ntables)
+{
+  --eval DROP TABLE t1_$t
+  --inc $t
+}
+DROP TABLE ctrl;
+
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: .* returned an error: Not connected to Primary Component");
+--enable_query_log
+
+--connection node_2
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+--enable_query_log
+
+--connection node_3
+--disable_query_log
+CALL mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("WSREP: Member .* requested state transfer");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("InnoDB: Table \"mysql\"\\.\"innodb_table_stats\" not found");
+CALL mtr.add_suppression("Can't open and lock time zone table");
+CALL mtr.add_suppression("Can't open and lock privilege tables");
+CALL mtr.add_suppression("Table 'mysql\\.gtid_slave_pos' doesn't exist");
+CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("WSREP: Did not find domain ID from SST script output");
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node");
+CALL mtr.add_suppression("WSREP: Discovered discontinuity in recovered wsrep transaction XIDs");
+CALL mtr.add_suppression("Rolled back orphan prepared wsrep transaction");
+--enable_query_log
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179.test
@@ -1,0 +1,20 @@
+#
+# MDEV-40179 - prepared transactions left behind by a mariabackup SST.
+#
+# log_bin=ON variant: this is the variant that reproduces the bug. With
+# log_bin=ON commits use two-phase commit, so writesets pass through the
+# InnoDB XA-prepared state; durable, slightly slowed commits (sync_binlog +
+# innodb_flush_log_at_trx_commit, see the .cnf) widen that window so the
+# mariabackup snapshot of a donor under parallel-apply load captures prepared
+# transactions. On a freshly SST'd joiner binlog crash recovery does not run,
+# so these prepared transactions are never resolved and recovery aborts with
+# "Found <N> prepared transactions!". (gtid_strict_mode is enabled so any
+# binlog/engine position inconsistency would also be caught.)
+#
+# See MDEV-40179.inc for the shared test body.
+#
+
+--let $restarts = 8
+--let $writers = 4
+--let $check_gtid = 1
+--source MDEV-40179.inc

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179_nobinlog.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179_nobinlog.cnf
@@ -1,0 +1,27 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="root:"
+# No log_bin: Galera uses its emulated binlog (wsrep_emulate_bin_log), so the
+# wsrep XID continuity check is what resolves prepared transactions on a joiner.
+# Parallel apply so that prepared transactions can be committed out of order,
+# producing a non-contiguous prepared set on the donor.
+wsrep_slave_threads=8
+# Slow, durable commits widen the window during which transactions sit in the
+# prepared state, so the backup's BLOCK_COMMIT snapshot is more likely to
+# capture in-doubt transactions.
+innodb_flush_log_at_trx_commit=1
+
+[mysqld.1]
+server_id=11
+
+[mysqld.2]
+server_id=12
+
+[mysqld.3]
+server_id=13
+
+[sst]
+transferfmt=@ENV.MTR_GALERA_TFMT
+streamfmt=mbstream

--- a/mysql-test/suite/galera_3nodes/t/MDEV-40179_nobinlog.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-40179_nobinlog.test
@@ -1,0 +1,16 @@
+#
+# MDEV-40179 - prepared transactions left behind by a mariabackup SST.
+#
+# log_bin=OFF variant: coverage only. With a single InnoDB read-write engine
+# and no binary log, commits use one-phase commit, so transactions never enter
+# the XA-prepared state and a mariabackup snapshot has nothing in doubt - the
+# bug cannot occur here. This variant just exercises the same load and repeated
+# mariabackup SST with log_bin=OFF and checks the cluster reconverges.
+#
+# See MDEV-40179.inc for the shared test body.
+#
+
+--let $restarts = 8
+--let $writers = 4
+--let $check_gtid = 0
+--source MDEV-40179.inc

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -1462,8 +1462,8 @@ else # joiner
             # that an old joiner keeps working and a new joiner can identify
             # exactly which file was sent. That file, however, only carries a
             # Gtid_list, and its position can be ahead of the engine snapshot
-            # (BACKUP STAGE BLOCK_COMMIT blocks the engine commit but not the
-            # binary log write). With gtid_strict_mode=ON that ahead position
+            # (BACKUP STAGE BLOCK_COMMIT does not pause commits if mariabackup
+            # is used for SST). With gtid_strict_mode=ON that ahead position
             # makes the joiner raise error 1950 when it re-binlogs transactions
             # during IST, and keeping the file could also collide with the
             # joiner's own binary log numbering.
@@ -1475,28 +1475,30 @@ else # joiner
             # from which IST resumes, which keeps the joiner's binary log in
             # lockstep with the rest of the cluster.
             #
-            binlogs=""
+            binlogs=()
             if [ -f 'xtrabackup_binlog_info' ]; then
                 while read bin_string || [ -n "$bin_string" ]; do
                     bin_file=$(echo "$bin_string" | cut -f1)
                     if [ -n "$bin_file" -a -f "$bin_file" ]; then
-                        binlogs="$binlogs${binlogs:+ }$bin_file"
+                        binlogs+=("$bin_file")
                     fi
                 done < 'xtrabackup_binlog_info'
             else
-                binlogs=$(ls -d -1 "$binlog_base".[0-9]* 2>/dev/null || :)
+                for bin_file in "$binlog_base".[0-9]*; do
+                    [ -f "$bin_file" ] && binlogs+=("$bin_file")
+                done
             fi
-            if [ -n "$binlogs" ]; then
+            if [ ${#binlogs[@]} -ne 0 ]; then
                 wsrep_log_info "Removing received binary log(s) so the joiner" \
                                "starts a fresh binary log seeded from the" \
-                               "storage-engine checkpoint (MDEV-38147)"
-                for bin_file in $binlogs; do
+                               "storage-engine checkpoint"
+                for bin_file in "${binlogs[@]}"; do
                     rm -f "$DATA/$bin_file"
                 done
             else
                 wsrep_log_info "No binary log received from donor; the joiner" \
                                "will start a fresh binary log seeded from the" \
-                               "storage-engine checkpoint (MDEV-38147)"
+                               "storage-engine checkpoint"
             fi
             cd "$OLD_PWD"
         fi
@@ -1514,6 +1516,38 @@ else # joiner
             wsrep_log_error "Move failed, keeping '$DATA' for further diagnosis"
             wsrep_log_error "Check syslog or '$INNOMOVELOG' for details"
             exit 22
+        fi
+
+        #
+        # The joiner starts a fresh binary log after SST (see the MDEV-38147
+        # note above), but the server does not create the log-bin directory
+        # itself - it must exist before mysqld reopens the binary log. When the
+        # binary log lives outside the datadir it may not exist yet on a freshly
+        # provisioned joiner, and when it lives in a subdirectory of the datadir
+        # the cleanup above removed it and the move stage did not restore it
+        # (binary logs are not part of the backup). Recreate the binary log and
+        # index directories here, after the move so they are not wiped again.
+        # Relative paths are resolved against the datadir, matching the server.
+        #
+        if [ -n "$WSREP_SST_OPT_BINLOG" ]; then
+            cd "$DATA_DIR"
+            if [ -n "$binlog_dir" -a "$binlog_dir" != '.' -a \
+                 "$binlog_dir" != "$DATA_DIR" -a ! -d "$binlog_dir" ]
+            then
+                wsrep_log_info "Creating the binlog directory '$binlog_dir'"
+                mkdir -p "$binlog_dir"
+            fi
+            if [ -n "$binlog_index" ]; then
+                index_dir=$(dirname "$binlog_index")
+                if [ -n "$index_dir" -a "$index_dir" != '.' -a \
+                     "$index_dir" != "$DATA_DIR" -a ! -d "$index_dir" ]
+                then
+                    wsrep_log_info \
+                        "Creating the binlog index directory '$index_dir'"
+                    mkdir -p "$index_dir"
+                fi
+            fi
+            cd "$OLD_PWD"
         fi
 
     else

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -1454,37 +1454,49 @@ else # joiner
 
         if [ -n "$WSREP_SST_OPT_BINLOG" ]; then
             cd "$DATA"
+            #
+            # MDEV-38147: do NOT move the donor's binary log into
+            # place on the joiner.
+            #
+            # The donor still ships its (freshly rotated) current binary log so
+            # that an old joiner keeps working and a new joiner can identify
+            # exactly which file was sent. That file, however, only carries a
+            # Gtid_list, and its position can be ahead of the engine snapshot
+            # (BACKUP STAGE BLOCK_COMMIT blocks the engine commit but not the
+            # binary log write). With gtid_strict_mode=ON that ahead position
+            # makes the joiner raise error 1950 when it re-binlogs transactions
+            # during IST, and keeping the file could also collide with the
+            # joiner's own binary log numbering.
+            #
+            # Therefore the joiner removes the received binary log file(s) and
+            # starts a fresh binary log, seeding its GTID position from the
+            # storage-engine checkpoint during recovery (see
+            # wsrep_seed_binlog_gtid_state() in sql/log.cc) - the exact position
+            # from which IST resumes, which keeps the joiner's binary log in
+            # lockstep with the rest of the cluster.
+            #
             binlogs=""
             if [ -f 'xtrabackup_binlog_info' ]; then
-                NL=$'\n'
                 while read bin_string || [ -n "$bin_string" ]; do
                     bin_file=$(echo "$bin_string" | cut -f1)
-                    if [ -f "$bin_file" ]; then
-                        binlogs="$binlogs${binlogs:+$NL}$bin_file"
+                    if [ -n "$bin_file" -a -f "$bin_file" ]; then
+                        binlogs="$binlogs${binlogs:+ }$bin_file"
                     fi
                 done < 'xtrabackup_binlog_info'
             else
                 binlogs=$(ls -d -1 "$binlog_base".[0-9]* 2>/dev/null || :)
             fi
-            cd "$DATA_DIR"
-            if [ -n "$binlog_dir" -a "$binlog_dir" != '.' -a \
-                 "$binlog_dir" != "$DATA_DIR" ]
-            then
-                [ ! -d "$binlog_dir" ] && mkdir -p "$binlog_dir"
-            fi
-            index_dir=$(dirname "$binlog_index");
-            if [ -n "$index_dir" -a "$index_dir" != '.' -a \
-                 "$index_dir" != "$DATA_DIR" ]
-            then
-                [ ! -d "$index_dir" ] && mkdir -p "$index_dir"
-            fi
             if [ -n "$binlogs" ]; then
-                wsrep_log_info "Moving binary logs to $binlog_dir"
-                echo "$binlogs" | \
-                while read bin_file || [ -n "$bin_file" ]; do
-                    mv "$DATA/$bin_file" "$binlog_dir"
-                    echo "$binlog_dir${binlog_dir:+/}$bin_file" >> "$binlog_index"
+                wsrep_log_info "Removing received binary log(s) so the joiner" \
+                               "starts a fresh binary log seeded from the" \
+                               "storage-engine checkpoint (MDEV-38147)"
+                for bin_file in $binlogs; do
+                    rm -f "$DATA/$bin_file"
                 done
+            else
+                wsrep_log_info "No binary log received from donor; the joiner" \
+                               "will start a fresh binary log seeded from the" \
+                               "storage-engine checkpoint (MDEV-38147)"
             fi
             cd "$OLD_PWD"
         fi

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -1462,8 +1462,8 @@ else # joiner
             # that an old joiner keeps working and a new joiner can identify
             # exactly which file was sent. That file, however, only carries a
             # Gtid_list, and its position can be ahead of the engine snapshot
-            # (BACKUP STAGE BLOCK_COMMIT blocks the engine commit but not the
-            # binary log write). With gtid_strict_mode=ON that ahead position
+            # (BACKUP STAGE BLOCK_COMMIT does not pause commits if mariabackup
+            # is used for SST). With gtid_strict_mode=ON that ahead position
             # makes the joiner raise error 1950 when it re-binlogs transactions
             # during IST, and keeping the file could also collide with the
             # joiner's own binary log numbering.
@@ -1489,14 +1489,14 @@ else # joiner
             if [ -n "$binlogs" ]; then
                 wsrep_log_info "Removing received binary log(s) so the joiner" \
                                "starts a fresh binary log seeded from the" \
-                               "storage-engine checkpoint (MDEV-38147)"
+                               "storage-engine checkpoint"
                 for bin_file in $binlogs; do
                     rm -f "$DATA/$bin_file"
                 done
             else
                 wsrep_log_info "No binary log received from donor; the joiner" \
                                "will start a fresh binary log seeded from the" \
-                               "storage-engine checkpoint (MDEV-38147)"
+                               "storage-engine checkpoint"
             fi
             cd "$OLD_PWD"
         fi

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2556,7 +2556,7 @@ static my_xid wsrep_order_and_check_continuity(XID *list, int len)
     if (!wsrep_is_wsrep_xid(list + i) ||
         wsrep_xid_seqno(list + i) != cur_seqno + 1)
     {
-      WSREP_WARN("Discovered discontinuity in recovered wsrep "
+      WSREP_INFO("Discovered discontinuity in recovered wsrep "
                  "transaction XIDs. Truncating the recovery list to "
                  "%d entries", i);
       break;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2843,6 +2843,53 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
                        x <= wsrep_limit) && info->dry_run,
                      info->dry_run))
         {
+#ifdef WITH_WSREP
+          /*
+            MDEV-40179: a wsrep transaction still in the prepared state at the
+            final recovery pass (the dry run, commit_list == 0) but they don't
+            have corresponding binlog events because they are no longer part of
+            SST. With log_bin=ON they can't be committed.
+            After recovering from SST without binlogs in place the joiner runs
+            no binlog XA recovery to commit or roll back such transactions, so
+            without binlog events they would abort startup with "Found N prepared
+            transactions!". Roll them back here; the node re-receives them
+            from the donor via IST. Non-wsrep (e.g. user XA) prepared transactions
+            are left untouched and still reported.
+
+            Notice that in the wsrep_emulate_bin_log case below we don't need the
+            binlog events, so these prepared and wsrep-ordered transactions can be
+            safely committed.
+
+            The guard is WSREP_PROVIDER_EXISTS ("a Galera provider is loaded"):
+            a node configured with a provider will rejoin and receive
+            these transactions; a standalone node (no provider) cannot, so
+            there we keep the conservative default and still report them.
+          */
+          if (WSREP_PROVIDER_EXISTS && wsrep_is_wsrep_xid(info->list + i))
+          {
+            int rc= hton->rollback_by_xid(hton, info->list + i);
+            if (rc == 0)
+            {
+              sql_print_warning("Rolled back orphan prepared wsrep "
+                                    "transaction %lld", (longlong) x);
+              continue;
+            }
+            /*
+              A failed rollback is critical: the storage engine is left with
+              a transaction in the prepared state, which blocks purge and will
+              re-surface at the next recovery. We cannot safely continue, so
+              flag the error and abort startup (ha_recover() returns non-zero,
+              which makes the caller unireg_abort()).
+            */
+            sql_print_error("Failed to roll back orphan prepared wsrep "
+                            "transaction %lld during recovery (error %d). "
+                            "The storage engine is left with a transaction in "
+                            "the prepared state; aborting startup.",
+                            (longlong) x, rc);
+            info->error= true;
+            break;
+          }
+#endif /* WITH_WSREP */
           info->found_my_xids++;
           continue;
         }
@@ -2892,7 +2939,7 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
           }
         }
       }
-      if (got < info->len)
+      if (got < info->len || info->error)
         break;
     }
   }

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2843,6 +2843,48 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
                        x <= wsrep_limit) && info->dry_run,
                      info->dry_run))
         {
+#ifdef WITH_WSREP
+          /*
+            MDEV-40179: a wsrep transaction still in the prepared state at the
+            final recovery pass (the dry run, commit_list == 0) is past the
+            storage-engine checkpoint and will be re-delivered by IST.
+            After recovering from SST without binlogs in place the joiner runs
+            no binlog XA recovery to commit or roll back such transactions, so
+            without this they would abort startup with "Found N prepared
+            transactions!". Roll them back here; the cluster re-applies them
+            from the donor. Non-wsrep (e.g. user XA) prepared transactions are
+            left untouched and still reported.
+
+            The guard is WSREP_PROVIDER_EXISTS ("a Galera provider is loaded"):
+            a node configured with a provider will rejoin and receive
+            these transactions; a standalone node (no provider) cannot, so
+            there we keep the conservative default and still report them.
+          */
+          if (WSREP_PROVIDER_EXISTS && wsrep_is_wsrep_xid(info->list + i))
+          {
+            int rc= hton->rollback_by_xid(hton, info->list + i);
+            if (rc == 0)
+            {
+              sql_print_information("Rolled back orphan prepared wsrep "
+                                    "transaction %lld", (longlong) x);
+              continue;
+            }
+            /*
+              A failed rollback is critical: the storage engine is left with
+              a transaction in the prepared state, which blocks purge and will
+              re-surface at the next recovery. We cannot safely continue, so
+              flag the error and abort startup (ha_recover() returns non-zero,
+              which makes the caller unireg_abort()).
+            */
+            sql_print_error("Failed to roll back orphan prepared wsrep "
+                            "transaction %lld during recovery (error %d). "
+                            "The storage engine is left with a transaction in "
+                            "the prepared state; aborting startup.",
+                            (longlong) x, rc);
+            info->error= true;
+            break;
+          }
+#endif /* WITH_WSREP */
           info->found_my_xids++;
           continue;
         }
@@ -2892,7 +2934,7 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
           }
         }
       }
-      if (got < info->len)
+      if (got < info->len || info->error)
         break;
     }
   }

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -64,6 +64,7 @@
 #ifdef WITH_WSREP
 #include "wsrep_trans_observer.h"
 #include "wsrep_status.h"
+#include "wsrep_xid.h"
 #endif /* WITH_WSREP */
 
 #ifdef HAVE_REPLICATION
@@ -12014,6 +12015,57 @@ err1:
 
 
 
+#if defined(WITH_WSREP) && defined(HAVE_REPLICATION)
+/*
+  MDEV-38147: A Galera mariabackup SST no longer ships the donor's binary log
+  (the only thing it carried was a Gtid_list whose position was ahead of the
+  snapshot, causing error 1950). Instead the joiner starts a fresh binary log,
+  so its Gtid_list / @@gtid_binlog_pos must be seeded from the recovered wsrep
+  position - otherwise the joiner would report an empty binlog position until
+  it re-binlogs new transactions, which breaks its use as an async master.
+
+  The wsrep cluster position lives in the storage-engine checkpoint (restored
+  by the SST). Async-replica source positions live in mysql.gtid_slave_pos
+  (also restored from the engine) and are handled separately, so they are not
+  seeded here.
+
+  The whole cluster binlogs cluster writes under one consistent stream (the
+  seqno stays in lockstep because every node applies in the same total order).
+  The domain of that stream depends on the mode:
+    - wsrep_gtid_mode=ON : wsrep_gtid_domain_id (cluster writes are re-tagged
+      to it, see [wsrep_mysqld.cc:2983]); this is the domain in the checkpoint.
+    - wsrep_gtid_mode=OFF: gtid_domain_id (cluster writes keep the node's
+      configured domain, no re-tag).
+  In both modes the committed cluster seqno is the SE checkpoint seqno, so we
+  seed that domain's binlog state to the checkpoint position. This is also the
+  exact position from which IST will resume re-binlogging, so the joiner stays
+  in lockstep with the rest of the cluster (and, in ON mode, avoids error 1950
+  from re-binlogging over an ahead position).
+*/
+static void wsrep_seed_binlog_gtid_state()
+{
+  wsrep_server_gtid_t const eng= wsrep_get_SE_checkpoint<wsrep_server_gtid_t>();
+  if (eng.seqno <= 0)
+    return;                              /* not a wsrep node / no position */
+
+  rpl_gtid eng_gtid;
+  eng_gtid.domain_id= wsrep_gtid_mode ? eng.domain_id
+                                      : global_system_variables.gtid_domain_id;
+  eng_gtid.server_id= eng.server_id;
+  eng_gtid.seq_no=    eng.seqno;
+
+  rpl_gtid *cur= rpl_global_gtid_binlog_state.find_most_recent(eng_gtid.domain_id);
+  if (cur && cur->seq_no >= eng_gtid.seq_no)
+    return;        /* binlog state already at or ahead of the checkpoint */
+
+  sql_print_information("WSREP: seeding binlog GTID state to %u-%u-%llu "
+                        "from the storage-engine checkpoint",
+                        eng_gtid.domain_id, eng_gtid.server_id,
+                        (unsigned long long) eng_gtid.seq_no);
+  rpl_global_gtid_binlog_state.update_nolock(&eng_gtid, false);
+}
+#endif /* WITH_WSREP && HAVE_REPLICATION */
+
 int
 MYSQL_BIN_LOG::do_binlog_recovery(const char *opt_name, bool do_xa_recovery)
 {
@@ -12048,6 +12100,10 @@ MYSQL_BIN_LOG::do_binlog_recovery(const char *opt_name, bool do_xa_recovery)
         error= 0;
       }
     }
+#if defined(WITH_WSREP) && defined(HAVE_REPLICATION)
+    if (!error && WSREP_PROVIDER_EXISTS)
+      wsrep_seed_binlog_gtid_state();
+#endif
     return error;
   }
 

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -12029,28 +12029,37 @@ err1:
   (also restored from the engine) and are handled separately, so they are not
   seeded here.
 
-  The whole cluster binlogs cluster writes under one consistent stream (the
-  seqno stays in lockstep because every node applies in the same total order).
-  The domain of that stream depends on the mode:
-    - wsrep_gtid_mode=ON : wsrep_gtid_domain_id (cluster writes are re-tagged
-      to it, see [wsrep_mysqld.cc:2983]); this is the domain in the checkpoint.
-    - wsrep_gtid_mode=OFF: gtid_domain_id (cluster writes keep the node's
-      configured domain, no re-tag).
-  In both modes the committed cluster seqno is the SE checkpoint seqno, so we
-  seed that domain's binlog state to the checkpoint position. This is also the
-  exact position from which IST will resume re-binlogging, so the joiner stays
-  in lockstep with the rest of the cluster (and, in ON mode, avoids error 1950
-  from re-binlogging over an ahead position).
+  This seeding applies only with wsrep_gtid_mode=ON. In that mode cluster
+  writes are re-tagged to wsrep_gtid_domain_id and binlogged with the cluster
+  seqno, so @@gtid_binlog_pos in that domain tracks the cluster seqno - which is
+  exactly the SE checkpoint position, and exactly the position from which IST
+  resumes re-binlogging. Seeding it keeps the joiner in lockstep and avoids
+  error 1950 from re-binlogging over an ahead position.
+
+  With wsrep_gtid_mode=OFF cluster writes keep the node's configured
+  gtid_domain_id and are binlogged with a locally allocated seq_no; the cluster
+  seqno is not written to the binlog GTID (it lives only in
+  thd->wsrep_current_gtid_seqno - see the GTID assignment guarded by
+  wsrep_gtid_mode in wsrep_mysqld.cc). That binlog position is node-local and
+  unrelated to the checkpoint seqno, so there is nothing cluster-consistent to
+  seed: a fresh joiner just resumes its own local counter, which cannot produce
+  an ahead position. We therefore seed nothing in that mode.
 */
 static void wsrep_seed_binlog_gtid_state()
 {
+  /*
+    Only wsrep_gtid_mode=ON has a cluster-consistent binlog position that maps
+    onto the SE checkpoint (see the block comment above).
+  */
+  if (!wsrep_gtid_mode)
+    return;
+
   wsrep_server_gtid_t const eng= wsrep_get_SE_checkpoint<wsrep_server_gtid_t>();
   if (eng.seqno <= 0)
     return;                              /* not a wsrep node / no position */
 
   rpl_gtid eng_gtid;
-  eng_gtid.domain_id= wsrep_gtid_mode ? eng.domain_id
-                                      : global_system_variables.gtid_domain_id;
+  eng_gtid.domain_id= eng.domain_id;     /* == wsrep_gtid_domain_id */
   eng_gtid.server_id= eng.server_id;
   eng_gtid.seq_no=    eng.seqno;
 
@@ -12062,7 +12071,17 @@ static void wsrep_seed_binlog_gtid_state()
                         "from the storage-engine checkpoint",
                         eng_gtid.domain_id, eng_gtid.server_id,
                         (unsigned long long) eng_gtid.seq_no);
-  rpl_global_gtid_binlog_state.update_nolock(&eng_gtid, false);
+  /*
+    Use the locking update() for consistency with the find_most_recent() read
+    above. With strict=false the only failure is OOM; update() will have called
+    my_error(ER_OUT_OF_RESOURCES), but there is no current_thd this early in
+    startup, so report the failure explicitly here as well.
+  */
+  if (rpl_global_gtid_binlog_state.update(&eng_gtid, false))
+    sql_print_error("WSREP: failed to seed binlog GTID state to %u-%u-%llu "
+                    "from the storage-engine checkpoint (out of memory)",
+                    eng_gtid.domain_id, eng_gtid.server_id,
+                    (unsigned long long) eng_gtid.seq_no);
 }
 #endif /* WITH_WSREP && HAVE_REPLICATION */
 

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -12033,7 +12033,7 @@ err1:
   seqno stays in lockstep because every node applies in the same total order).
   The domain of that stream depends on the mode:
     - wsrep_gtid_mode=ON : wsrep_gtid_domain_id (cluster writes are re-tagged
-      to it, see [wsrep_mysqld.cc:2983]); this is the domain in the checkpoint.
+      to it); this is the domain in the checkpoint.
     - wsrep_gtid_mode=OFF: gtid_domain_id (cluster writes keep the node's
       configured domain, no re-tag).
   In both modes the committed cluster seqno is the SE checkpoint seqno, so we

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -402,9 +402,6 @@ static bool wsrep_sst_complete (THD*                thd,
   Wsrep_server_state& server_state= Wsrep_server_state::instance();
   enum wsrep::server_state::state state= server_state.state();
   bool failed= false;
-  char start_pos_buf[FN_REFLEN];
-  ssize_t len= wsrep::print_to_c_str(sst_gtid, start_pos_buf, FN_REFLEN-1);
-  start_pos_buf[len]='\0';
 
   // Do not call sst_received if we are not in joiner or
   // initialized state on server. This is because it
@@ -419,14 +416,31 @@ static bool wsrep_sst_complete (THD*                thd,
     }
     else
     {
-      WSREP_INFO("SST succeeded for position %s", start_pos_buf);
+      /*
+        Note: sst_received() does NOT use sst_gtid (the position reported by
+        the SST script). It determines the position internally from storage via
+        Wsrep_server_service::get_position().
+        For physical SST methods these two may differ (e.g. the joiner's storage
+        recovers to an earlier position than the script reported). Log the
+        position actually adopted, not the script-reported one, to avoid
+        confusion.
+      */
+      wsrep::gtid const received_gtid(wsrep_get_SE_checkpoint<wsrep::gtid>());
+      char recv_pos_buf[FN_REFLEN];
+      ssize_t const recv_len=
+        wsrep::print_to_c_str(received_gtid, recv_pos_buf, FN_REFLEN-1);
+      recv_pos_buf[recv_len > 0 ? recv_len : 0]= '\0';
+      WSREP_INFO("SST succeeded for position %s", recv_pos_buf);
     }
   }
   else
   {
+    char start_pos_buf[FN_REFLEN];
+    ssize_t const len= wsrep::print_to_c_str(sst_gtid, start_pos_buf, FN_REFLEN - 1);
+    start_pos_buf[len]= '\0';
+
     WSREP_ERROR("SST failed for position %s initialized %d server_state %s",
-                start_pos_buf,
-                server_state.is_initialized(),
+                start_pos_buf, server_state.is_initialized(),
                 wsrep::to_c_string(state));
     failed= true;
   }

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -425,7 +425,7 @@ static bool wsrep_sst_complete (THD*                thd,
         position actually adopted, not the script-reported one, to avoid
         confusion.
       */
-      wsrep::gtid const received_gtid(wsrep_get_SE_checkpoint<wsrep::gtid>());
+      wsrep::gtid const received_gtid= wsrep_get_SE_checkpoint<wsrep::gtid>();
       char recv_pos_buf[FN_REFLEN];
       ssize_t const recv_len=
         wsrep::print_to_c_str(received_gtid, recv_pos_buf, FN_REFLEN-1);
@@ -437,7 +437,7 @@ static bool wsrep_sst_complete (THD*                thd,
   {
     char start_pos_buf[FN_REFLEN];
     ssize_t const len= wsrep::print_to_c_str(sst_gtid, start_pos_buf, FN_REFLEN - 1);
-    start_pos_buf[len]= '\0';
+    start_pos_buf[len > 0 ? len : 0]= '\0';
 
     WSREP_ERROR("SST failed for position %s initialized %d server_state %s",
                 start_pos_buf, server_state.is_initialized(),


### PR DESCRIPTION
Pull request created in: https://jira.mariadb.org/browse/MDEV-38147

Investigation into MDEV-38147 revealed that with --galera-info option given during SST mariabackup rotates the binlog and ships it to joiner. The file is likely to contain wrong Gtid_list info and is used on joiner to initialize binlog.
Since that file is useless, don't rotate the binlog and ship the file, instead the joiner can generate its own correct Gtid_list.

MDEV-40179 - rollback orphaned prepared transactions.