### PR TITLE
MDEV-37781 ASAN build crashes on deep query with low thread stack

### DIFF
--- a/mysql-test/main/thread_stack_overrun.opt
+++ b/mysql-test/main/thread_stack_overrun.opt
@@ -1,0 +1,1 @@
+--thread-stack=256K

--- a/mysql-test/main/thread_stack_overrun.result
+++ b/mysql-test/main/thread_stack_overrun.result
@@ -1,0 +1,6 @@
+#
+# MDEV-37781 ASAN build crashes with low thread stack
+#
+EXECUTE IMMEDIATE CONCAT('SELECT 1', REPEAT('+1', @@global.thread_stack));
+ERROR HY000: Thread stack overrun:  # bytes used of a # byte stack, and # bytes needed. Consider increasing the thread_stack system variable.
+# End of 10.11 tests

--- a/mysql-test/main/thread_stack_overrun.test
+++ b/mysql-test/main/thread_stack_overrun.test
@@ -1,0 +1,17 @@
+--echo #
+--echo # MDEV-37781 ASAN build crashes with low thread stack
+--echo #
+
+--source include/not_embedded.inc
+
+# Expression like 1+1+...+1  recurses once per term in fix_fields().
+# As each recursion level consumes at least one byte of stack, we use
+# @@global.thread_stack terms to have a guaranteed stack overrun
+# on any platform, no matter the frame size.
+
+--replace_regex /[0-9]+ bytes used of a [0-9]+ byte stack, and [0-9]+ bytes needed/# bytes used of a # byte stack, and # bytes needed/
+
+--error ER_STACK_OVERRUN_NEED_MORE
+EXECUTE IMMEDIATE CONCAT('SELECT 1', REPEAT('+1', @@global.thread_stack));
+
+--echo # End of 10.11 tests

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7636,7 +7636,6 @@ __attribute__((optimize("-O0")))
 #endif
 check_stack_overrun(THD *thd, long margin, uchar *buf __attribute__((unused)))
 {
-#ifndef __SANITIZE_ADDRESS__
   long stack_used;
   DBUG_ASSERT(thd == current_thd);
   DBUG_ASSERT(thd->thread_stack);
@@ -7661,7 +7660,6 @@ check_stack_overrun(THD *thd, long margin, uchar *buf __attribute__((unused)))
 #ifndef DBUG_OFF
   max_stack_used= MY_MAX(max_stack_used, stack_used);
 #endif
-#endif /* __SANITIZE_ADDRESS__ */
   return 0;
 }
 


### PR DESCRIPTION
check_stack_overrun() was compiled out under ASAN, so a deeply nested expression recursed in Item_func::fix_fields() until the stack was exhausted and the server crashed instead of reporting ER_STACK_OVERRUN_NEED_MORE.

Since MDEV-34533 (Monty) the stack usage seems to be accounted correctly under ASAN via my_get_stack_pointer(), so the check seems to works there too.

Fix:
Remove the `#ifndef __SANITIZE_ADDRESS__`  guard from check_stack_overrun()

Add a test for ER_STACK_OVERRUN_NEED_MORE