### PR TITLE
MDEV-40233 HEX(emtpy ascii string) could be quicker

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -4092,11 +4092,12 @@ String *Item_func_hex::val_str_ascii_from_val_str(String *str)
 {
   DBUG_ASSERT(&tmp_value != str);
   String *res= args[0]->val_str(&tmp_value);
-  THD *thd= current_thd;
+  THD *thd;
 
   if ((null_value= (res == NULL)))
     return NULL;
 
+  thd= current_thd;
   if (res->length()*2 > thd->variables.max_allowed_packet)
   {
     push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
@@ -4107,6 +4108,8 @@ String *Item_func_hex::val_str_ascii_from_val_str(String *str)
     return NULL;
   }
 
+  if (!res->ptr() || res->length() == 0)
+    return make_empty_result(str);
   return str->set_hex(res->ptr(), res->length()) ? make_empty_result(str) : str;
 }
 


### PR DESCRIPTION
Item_func_hex::val_str_ascii_from_val_str(str) when str->ptr() is null, take a long path through returning an empty string.

Replace this path with a quick return of an make_empty_result().

Also defer thd initialization until after a potential null return. current_thd as implemented isn't cheap.