### PR TITLE
MDEV-40234 String_copier::well_formed_copy inefficient for appending …

### DIFF
--- a/mysql-test/main/ctype_uca.result
+++ b/mysql-test/main/ctype_uca.result
@@ -15406,3 +15406,13 @@ SET join_cache_level=DEFAULT;
 #
 # End of 10.5 tests
 #
+#
+# MDEV-40234 String_copier::well_formed_copy inefficient for appending 0
+#
+SELECT CHARSET(CONVERT(_utf8"" USING ucs2)) as c;
+c
+ucs2
+SELECT CHARSET(CONVERT(_ucs2"" USING utf8mb4)) as c;
+c
+utf8mb4
+# End of 10.11 tests

--- a/mysql-test/main/ctype_uca.test
+++ b/mysql-test/main/ctype_uca.test
@@ -725,3 +725,13 @@ SET join_cache_level=DEFAULT;
 --echo #
 --echo # End of 10.5 tests
 --echo #
+
+
+--echo #
+--echo # MDEV-40234 String_copier::well_formed_copy inefficient for appending 0
+--echo #
+
+SELECT CHARSET(CONVERT(_utf8"" USING ucs2)) as c;
+SELECT CHARSET(CONVERT(_ucs2"" USING utf8mb4)) as c;
+
+--echo # End of 10.11 tests

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -7445,10 +7445,19 @@ int Field_string::store(const char *from, size_t length,CHARSET_INFO *cs)
   /* See the comment for Field_long::store(long long) */
   DBUG_ASSERT(!table || table->in_use == current_thd);
 
-  rc= well_formed_copy_with_check((char*) ptr, field_length,
-                                  cs, from, length,
-                                  Field_string::char_length(),
-                                  false, &copy_length);
+  if (length)
+    rc= well_formed_copy_with_check((char*) ptr, field_length,
+                                    cs, from, length,
+                                    Field_string::char_length(),
+                                    false, &copy_length);
+  else
+  {
+    /*
+      well_formed_copy_with_check() for 0 bytes is always well formed.
+    */
+    rc= 0;
+    copy_length= 0;
+  }
 
   /* Append spaces if the string was shorter than the field. */
   if (copy_length < field_length)
@@ -8013,10 +8022,19 @@ int Field_varstring::store(const char *from,size_t length,CHARSET_INFO *cs)
   uint copy_length;
   int rc;
 
-  rc= well_formed_copy_with_check((char*) get_data(), field_length,
-                                  cs, from, length,
-                                  Field_varstring::char_length(),
-                                  true, &copy_length);
+
+  if (length)
+  {
+    rc= well_formed_copy_with_check((char*) get_data(), field_length,
+                                    cs, from, length,
+                                    Field_varstring::char_length(),
+                                    true, &copy_length);
+  }
+  else
+  {
+    rc= 0;
+    copy_length =0;
+  }
 
   store_length(copy_length);
 

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3843,11 +3843,18 @@ String *Item_func_conv_charset::val_str(String *str)
     return null_value ? 0 : &str_value;
   String *arg= args[0]->val_str(&tmp_value);
   String_copier_for_item copier(current_thd);
-  return ((null_value= args[0]->null_value ||
-                       copier.copy_with_warn(collation.collation, str,
-                                             arg->charset(), arg->ptr(),
-                                             arg->length(), arg->length()))) ?
-    0 : str;
+  if ((null_value= args[0]->null_value))
+    return 0;
+  if (arg->length() == 0)
+  {
+    static const char empty[MY_CS_MBMAXLEN]= {0}; /* comparison */
+    str->set(empty, 0, collation.collation);
+    return str;
+  }
+  return (null_value= copier.copy_with_warn(collation.collation, str,
+                                            arg->charset(), arg->ptr(),
+                                            arg->length(), arg->length())
+          ? 0 : str;
 }
 
 bool Item_func_conv_charset::fix_length_and_dec(THD *thd)

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -3215,6 +3215,16 @@ String *Item_char_typecast::val_str_generic(String *str)
         res= reuse(res, prefix.length());
       goto end;
     }
+    if (res->length() == 0)
+    {
+      /*
+        The most efficient conversion of empty string, is another empty
+        string of the target character set.
+      */
+      static const char empty[MY_CS_MBMAXLEN]= {0};
+      res->set(empty, 0, cs);
+      return res;
+    }
     // Character set conversion, or bad bytes were found.
     if (!(res= copy(res, cs)))
       return 0;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -14117,9 +14117,12 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   */
   DBUG_ASSERT(db || !db_len);
   // Don't pass db==nullptr to avoid UB nullptr+0 inside copy_with_error()
-  if (unlikely(thd->copy_with_error(system_charset_info,
-                                    (LEX_STRING*) &mpvio->db,
-                                    thd->charset(), db ? db : "", db_len)))
+  // and unnecessary string charset conversion of ""
+  if (db_len == 0)
+    mpvio->db= {STRING_WITH_LEN("")};
+  else if(unlikely(thd->copy_with_error(system_charset_info,
+                                        (LEX_STRING*) &mpvio->db,
+                                        thd->charset(), db, db_len)))
     return packet_error;
 
   user_len= copy_and_convert(user_buff, sizeof(user_buff) - 1,

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2533,6 +2533,7 @@ bool THD::copy_fix(CHARSET_INFO *dstcs, LEX_STRING *dst,
   size_t dst_length= dstcs->mbmaxlen * src_length;
   if (alloc_lex_string(dst, dst_length + 1))
     DBUG_RETURN(true);                          // EOM
+  DBUG_ASSERT(src_length);
   dst->length= status->well_formed_copy(dstcs, dst->str, dst_length,
                                         srccs, src, src_length, src_length);
   dst->str[dst->length]= '\0';

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1708,7 +1708,10 @@ dispatch_command_return dispatch_command(enum enum_server_command command, THD *
   {
     LEX_CSTRING tmp;
     status_var_increment(thd->status_var.com_stat[SQLCOM_CHANGE_DB]);
-    if (unlikely(thd->copy_with_error(system_charset_info, (LEX_STRING*) &tmp,
+    if (unlikely(!packet_length))
+      /* copy_with_error, is an expensive way to convert an empty string */
+      tmp= {STRING_WITH_LEN("")};
+    else if (unlikely(thd->copy_with_error(system_charset_info, (LEX_STRING*) &tmp,
                                       thd->charset(), packet, packet_length)))
       break;
     if (!mysql_change_db(thd, &tmp, FALSE))

--- a/sql/sql_string.cc
+++ b/sql/sql_string.cc
@@ -1123,6 +1123,8 @@ String_copier::well_formed_copy(CHARSET_INFO *to_cs,
       (to_cs == from_cs) ||
       my_charset_same(from_cs, to_cs))
   {
+    /* hit this assertion and should be simplifing at higher level */
+    DBUG_ASSERT(from_length);
     m_cannot_convert_error_pos= NULL;
     return (uint) to_cs->copy_fix(to, to_length, from, from_length,
                                   nchars, this);


### PR DESCRIPTION
…0 bytes

For all the copying in Field*str::store, lets make a quick path when we're copy 0 bytes in a compatible character set.