### PR TITLE
MDEV-27569  Valgrind/MSAN errors in ha_partition::swap_blobs() for BLOB not in secondary index

### DIFF
--- a/mysql-test/suite/parts/r/partition_special_innodb.result
+++ b/mysql-test/suite/parts/r/partition_special_innodb.result
@@ -354,3 +354,18 @@ connection con2;
 DROP TABLE t1;
 disconnect con2;
 connection default;
+#
+# MDEV-27569  Valgrind/MSAN errors in ha_partition::swap_blobs()
+#		for BLOB not in secondary index
+#
+CREATE TABLE t1(f1 INT, f2 INT, f3 TEXT, KEY(f2),
+PRIMARY KEY(f1))ENGINE=InnoDB
+PARTITION BY HASH(f1) PARTITIONS 2;
+INSERT INTO t1(f1, f2) SELECT seq, seq%10 FROM seq_1_to_20;
+EXPLAIN SELECT * FROM t1 WHERE f1 >= 1900 or f2 in (2,4) LIMIT 1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index_merge	PRIMARY,f2	f2,PRIMARY	5,4	NULL	8	Using sort_union(f2,PRIMARY); Using where
+SELECT * FROM t1 WHERE f1 >= 1900 or f2 in (2,4) LIMIT 1;
+f1	f2	f3
+2	2	NULL
+DROP TABLE t1;

--- a/mysql-test/suite/parts/t/partition_special_innodb.test
+++ b/mysql-test/suite/parts/t/partition_special_innodb.test
@@ -30,6 +30,7 @@ let $debug= 0;
 
 # The server must support partitioning.
 --source include/have_partition.inc
+--source include/have_sequence.inc
 
 #------------------------------------------------------------------------------#
 # Engine specific settings and requirements
@@ -232,3 +233,15 @@ DROP TABLE t1;
 
 --disconnect con2
 --connection default
+
+--echo #
+--echo # MDEV-27569  Valgrind/MSAN errors in ha_partition::swap_blobs()
+--echo #		for BLOB not in secondary index
+--echo #
+CREATE TABLE t1(f1 INT, f2 INT, f3 TEXT, KEY(f2),
+		PRIMARY KEY(f1))ENGINE=InnoDB
+		PARTITION BY HASH(f1) PARTITIONS 2;
+INSERT INTO t1(f1, f2) SELECT seq, seq%10 FROM seq_1_to_20;
+EXPLAIN SELECT * FROM t1 WHERE f1 >= 1900 or f2 in (2,4) LIMIT 1;
+SELECT * FROM t1 WHERE f1 >= 1900 or f2 in (2,4) LIMIT 1;
+DROP TABLE t1;

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -3148,6 +3148,18 @@ static bool row_sel_store_mysql_rec(
 	ut_ad(rec_clust || index == prebuilt->index);
 	ut_ad(!rec_clust || dict_index_is_clust(index));
 
+	/* Secondary index reads populate only templated columns.
+	Seed the NULL bitmap from default_rec so uncovered columns
+	read as SQL NULL in ha_partition::swap_blobs(). */
+	if (!dict_index_is_clust(index) &&
+	    prebuilt->m_mysql_table &&
+	    prebuilt->m_mysql_table->s->blob_fields &&
+	    prebuilt->null_bitmap_len) {
+		ut_ad(prebuilt->default_rec);
+		memcpy(mysql_rec, prebuilt->default_rec,
+		       prebuilt->null_bitmap_len);
+	}
+
 	if (UNIV_LIKELY_NULL(prebuilt->blob_heap)) {
 		row_mysql_prebuilt_free_blob_heap(prebuilt);
 	}


### PR DESCRIPTION
Problem:
=======
On a partitioned table containing a BLOB/TEXT column, an ordered index scan calls ha_partition::swap_blobs() for every buffered row, because it is being called only when table has blob fields.

When the buffered row comes from a secondary index that does not cover the blob (e.g. KEY(f2) on (f2,f1)), InnoDB's row_sel_store_mysql_rec() populates only the templated columns. The blob column's null bit and its value-pointer bytes in table->record[0] are left uninitialized. The partition handler memcpy() this record into rec_buf, then swap_blobs() evaluates blob->is_null(), reading the uninitialized null bit leads to "use-of-uninitialized-value".

Solution:
=========
row_sel_store_mysql_rec(): When the record is being stored from a secondary index, seed the NULL bitmap of mysql_rec from prebuilt->default_rec before populating the templated columns. Columns present in the index template have their NULL bit rewritten explicitly while the row is stored, so only the columns absent from the template (the uncovered blob) rely on this seed. default_rec marks such nullable columns as NULL and preserves the reserved NULL bit, so the uncovered blob is now defined as NULL.

Because of this, ha_partition::swap_blobs() skips it via its "!bitmap_is_set(read_set) || blob->is_null()" guard and never calls Field_blob::cached()/get_ptr(). This avoids not only the uninitialized null-bit read and the follow-on uninitialized blob value-pointer read.