### PR TITLE
MDEV-40142 main.func_xxh fails under --view-protocol

### DIFF
--- a/mysql-test/main/func_xxh.result
+++ b/mysql-test/main/func_xxh.result
@@ -116,11 +116,11 @@ bin_ne
 1
 ## 8. Charset conversion
 SET NAMES utf8mb4;
-SELECT XXH32(CONVERT('café' USING utf8mb4));
-XXH32(CONVERT('café' USING utf8mb4))
+SELECT XXH32(_utf8mb4 'café') as utf8exp;
+utf8exp
 1341024521
-SELECT XXH32(CONVERT('café' USING latin1));
-XXH32(CONVERT('café' USING latin1))
+SELECT XXH32(CONVERT(_utf8mb4 'café' USING latin1)) as latin1exp;
+latin1exp
 2242119311
 ## 9. Reject non-string types
 SELECT XXH32(1);
@@ -165,7 +165,7 @@ NULL	NULL	NULL
 	0	0
 beta	993120499	1451779014391855821
 alpha	1378942857	12739993147785832021
-SELECT * FROM t_gen WHERE h3s = XXH3('alpha');
+SELECT * FROM t_gen WHERE h3s = XXH3(_utf8mb4'alpha');
 d	h32v	h3s
 alpha	1378942857	12739993147785832021
 DROP TABLE t_gen;

--- a/mysql-test/main/func_xxh.test
+++ b/mysql-test/main/func_xxh.test
@@ -77,8 +77,8 @@ SELECT XXH32(_latin1 'ABC' COLLATE latin1_bin) <> XXH32(_latin1 'abc' COLLATE la
 
 --echo ## 8. Charset conversion
 SET NAMES utf8mb4;
-SELECT XXH32(CONVERT('café' USING utf8mb4));
-SELECT XXH32(CONVERT('café' USING latin1));
+SELECT XXH32(_utf8mb4 'café') as utf8exp;
+SELECT XXH32(CONVERT(_utf8mb4 'café' USING latin1)) as latin1exp;
 
 --echo ## 9. Reject non-string types
 --error ER_ILLEGAL_PARAMETER_DATA_TYPE_FOR_OPERATION
@@ -126,7 +126,7 @@ INSERT INTO t_gen (d) VALUES ('alpha'),('beta'),(NULL),('');
 
 SELECT d, h32v, h3s FROM t_gen ORDER BY h3s;
 
-SELECT * FROM t_gen WHERE h3s = XXH3('alpha');
+SELECT * FROM t_gen WHERE h3s = XXH3(_utf8mb4'alpha');
 
 DROP TABLE t_gen;
 
@@ -134,7 +134,9 @@ DROP TABLE t_gen;
 CREATE OR REPLACE FUNCTION fxh32(s VARCHAR(255)) RETURNS INT UNSIGNED DETERMINISTIC RETURN XXH32(s);
 CREATE OR REPLACE FUNCTION fxh3(s VARCHAR(255)) RETURNS BIGINT UNSIGNED DETERMINISTIC RETURN XXH3(s);
 
+--disable_view_protocol
 SELECT fxh32('abc') = XXH32('abc'), fxh3('abc') = XXH3('abc');
+--enable_view_protocol
 
 DROP FUNCTION fxh32;
 DROP FUNCTION fxh3;


### PR DESCRIPTION
Under --view-protocol, SET NAMES utf8mb4 isn't copied to the connection the view protocol is running on. As a result the SELECT statements, from which the view are created, have string literals are interpreted as latin1.

Cast the string literals explicitly to utf8mb4 for consistent results. Also rename the column on select queries to ensure result name is compatible with latin1.