### PR TITLE
MDEV-40265: Add UUID type support in DuckDB storage engine

### DIFF
--- a/storage/duckdb/cmake/duckdb.cmake
+++ b/storage/duckdb/cmake/duckdb.cmake
@@ -51,6 +51,18 @@ SET(_DUCKDB_STATIC_LIBS
 MESSAGE(STATUS "=== Building DuckDB from submodule (${DUCKDB_SUBMODULE_DIR}) ===")
 ADD_SUBMODULE(third_parties/duckdb)
 
+# Upstream sets DUCKDB_EXTENSION_JEMALLOC_LINKED via add_extension_definitions(),
+# which runs in extension/ but NOT in src/, so allocator.cpp (in duckdb_static)
+# compiles the glibc malloc() path even though libjemalloc_extension.a is linked.
+# Define it globally + add the jemalloc header dir so the USE_JEMALLOC branch is active.
+SET(_DUCKDB_EXTRA_CXX_FLAGS "-DDUCKDB_EXTENSION_JEMALLOC_LINKED=1 -I${DUCKDB_SUBMODULE_DIR}/extension/jemalloc/include")
+# GCC 16+ warns about DuckDB classes in SFINAE contexts (upstream issue, not ours).
+# Silence it for DuckDB's own ExternalProject build too.
+MY_CHECK_CXX_COMPILER_FLAG("-Wsfinae-incomplete")
+IF(have_CXX__Wsfinae_incomplete)
+  STRING(APPEND _DUCKDB_EXTRA_CXX_FLAGS " -Wno-sfinae-incomplete")
+ENDIF()
+
 ExternalProject_Add(duckdb_build
   PREFIX          "${_DUCKDB_BUILD_DIR}"
   SOURCE_DIR      "${DUCKDB_SUBMODULE_DIR}"
@@ -68,11 +80,7 @@ ExternalProject_Add(duckdb_build
     -DBUILD_TPCE=OFF
     -DEXTENSION_STATIC_BUILD=1
     "-DDUCKDB_EXTENSION_CONFIGS=${CMAKE_CURRENT_SOURCE_DIR}/cmake/duckdb_extensions.cmake"
-    # Upstream sets DUCKDB_EXTENSION_JEMALLOC_LINKED via add_extension_definitions(),
-    # which runs in extension/ but NOT in src/, so allocator.cpp (in duckdb_static)
-    # compiles the glibc malloc() path even though libjemalloc_extension.a is linked.
-    # Define it globally + add the jemalloc header dir so the USE_JEMALLOC branch is active.
-    "-DCMAKE_CXX_FLAGS=-DDUCKDB_EXTENSION_JEMALLOC_LINKED=1 -I${DUCKDB_SUBMODULE_DIR}/extension/jemalloc/include"
+    "-DCMAKE_CXX_FLAGS=${_DUCKDB_EXTRA_CXX_FLAGS}"
     -DENABLE_SANITIZER=FALSE
     -DENABLE_UBSAN=OFF
     -DOVERRIDE_GIT_DESCRIBE=v1.5.4-0-g0000000000

--- a/storage/duckdb/convertor/ddl_convertor.cc
+++ b/storage/duckdb/convertor/ddl_convertor.cc
@@ -446,6 +446,9 @@ std::string FieldConvertor::convert_type(const Field *field)
 {
   std::string ret;
 
+  if (is_uuid_field(field))
+    return "UUID";
+
   enum_field_types field_type= field->real_type();
   bool is_unsigned= (field->flags & UNSIGNED_FLAG) != 0;
   bool has_charset= field->has_charset();

--- a/storage/duckdb/convertor/ddl_convertor.h
+++ b/storage/duckdb/convertor/ddl_convertor.h
@@ -29,6 +29,26 @@
 #include "sql_class.h"
 #include "field.h"
 
+static inline const Type_collection *duckdb_uuid_type_collection()
+{
+  static const Type_collection *const coll=
+      []() -> const Type_collection *
+      {
+        static const LEX_CSTRING uuid_name= {STRING_WITH_LEN("uuid")};
+        const Type_handler *th=
+            Type_handler::handler_by_name(current_thd, uuid_name);
+        return th ? th->type_collection() : nullptr;
+      }();
+  return coll;
+}
+
+static inline bool is_uuid_field(const Field *field)
+{
+  const Type_collection *uuid_coll= duckdb_uuid_type_collection();
+  return uuid_coll &&
+         field->type_handler()->type_collection() == uuid_coll;
+}
+
 class BaseConvertor
 {
 public:

--- a/storage/duckdb/convertor/dml_convertor.cc
+++ b/storage/duckdb/convertor/dml_convertor.cc
@@ -127,6 +127,15 @@ void append_field_value_to_sql(String &target_str, Field *field)
   case MYSQL_TYPE_MEDIUM_BLOB:
   case MYSQL_TYPE_LONG_BLOB: {
     field->val_str(&field_value);
+
+    if (is_uuid_field(field))
+    {
+      target_str.append(STRING_WITH_LEN("'"));
+      target_str.append(field_value);
+      target_str.append(STRING_WITH_LEN("'::UUID"));
+      break;
+    }
+
     std::string hex_str= toHex(field_value.c_ptr_safe(), field_value.length());
 
     if (FieldConvertor::convert_type(field) == "BLOB")

--- a/storage/duckdb/convertor/duckdb_select.cc
+++ b/storage/duckdb/convertor/duckdb_select.cc
@@ -76,6 +76,12 @@ void store_duckdb_field_in_mysql_format(Field *field, duckdb::Value &value,
     case MYSQL_TYPE_VARCHAR:
     case MYSQL_TYPE_STRING:
     case MYSQL_TYPE_VAR_STRING: {
+      if (is_uuid_field(field))
+      {
+        auto str= value.GetValue<duckdb::string>();
+        field->store(str.c_str(), str.size(), system_charset_info);
+        break;
+      }
       if (field->has_charset())
       {
         DBUG_ASSERT(field->charset() != &my_charset_bin);

--- a/storage/duckdb/mysql-test/duckdb/r/duckdb_uuid.result
+++ b/storage/duckdb/mysql-test/duckdb/r/duckdb_uuid.result
@@ -1,0 +1,138 @@
+#
+# UUID data type round-trip in the DuckDB storage engine.
+#
+DROP DATABASE IF EXISTS duckdb_uuid;
+CREATE DATABASE duckdb_uuid CHARACTER SET utf8mb4;
+USE duckdb_uuid;
+
+# (1) UUID primary key, non-batch insert (suite default)
+
+CREATE TABLE t1 (id UUID PRIMARY KEY, name VARCHAR(32)) ENGINE=DuckDB;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` uuid NOT NULL,
+  `name` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=DUCKDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+INSERT INTO t1 VALUES
+('65297af6-6630-11f1-8ad2-5e1b9081e705', 'a'),
+('00000000-0000-0000-0000-000000000001', 'b'),
+('ffffffff-ffff-ffff-ffff-ffffffffffff', 'c');
+SELECT id, name FROM t1;
+id	name
+00000000-0000-0000-0000-000000000001	b
+65297af6-6630-11f1-8ad2-5e1b9081e705	a
+ffffffff-ffff-ffff-ffff-ffffffffffff	c
+SELECT name FROM t1 WHERE id = '65297af6-6630-11f1-8ad2-5e1b9081e705';
+name
+a
+SELECT id FROM t1 ORDER BY id;
+id
+00000000-0000-0000-0000-000000000001
+65297af6-6630-11f1-8ad2-5e1b9081e705
+ffffffff-ffff-ffff-ffff-ffffffffffff
+
+# (2) UPDATE / DELETE by UUID primary key
+
+UPDATE t1 SET name = 'B' WHERE id = '00000000-0000-0000-0000-000000000001';
+SELECT name FROM t1 WHERE id = '00000000-0000-0000-0000-000000000001';
+name
+B
+DELETE FROM t1 WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+SELECT id, name FROM t1;
+id	name
+00000000-0000-0000-0000-000000000001	B
+65297af6-6630-11f1-8ad2-5e1b9081e705	a
+DROP TABLE t1;
+
+# (3) UUID as non-key column, including NULL
+
+CREATE TABLE t2 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t2 VALUES
+(1, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+(2, NULL);
+SELECT id, u FROM t2 ORDER BY id;
+id	u
+1	ffffffff-ffff-ffff-ffff-ffffffffffff
+2	NULL
+DROP TABLE t2;
+
+# (4) UUID DEFAULT literal
+
+CREATE TABLE t3 (
+id INT PRIMARY KEY,
+u UUID DEFAULT '00000000-0000-0000-0000-000000000000'
+) ENGINE=DuckDB;
+INSERT INTO t3 (id) VALUES (1);
+SELECT id, u FROM t3;
+id	u
+1	00000000-0000-0000-0000-000000000000
+DROP TABLE t3;
+
+# (5) UUID round-trip in batch insert mode
+
+SET @saved_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;
+SET GLOBAL duckdb_dml_in_batch = ON;
+CREATE TABLE t4 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t4 VALUES
+(1, '65297af6-6630-11f1-8ad2-5e1b9081e705'),
+(2, '00000000-0000-0000-0000-000000000001');
+SELECT id, u FROM t4 ORDER BY id;
+id	u
+1	65297af6-6630-11f1-8ad2-5e1b9081e705
+2	00000000-0000-0000-0000-000000000001
+DROP TABLE t4;
+SET GLOBAL duckdb_dml_in_batch = @saved_dml_in_batch;
+
+# (6) Cross-engine: InnoDB UUID column scanned via DuckDB join
+
+CREATE TABLE t_duck (id INT PRIMARY KEY, tag VARCHAR(16)) ENGINE=DuckDB;
+CREATE TABLE t_inno (id INT PRIMARY KEY, u UUID) ENGINE=InnoDB;
+INSERT INTO t_duck VALUES (1, 'one'), (2, 'two');
+INSERT INTO t_inno VALUES
+(1, '65297af6-6630-11f1-8ad2-5e1b9081e705'),
+(2, '00000000-0000-0000-0000-000000000001');
+SELECT d.tag, i.u
+FROM t_duck d JOIN t_inno i ON d.id = i.id
+ORDER BY d.id;
+tag	u
+one	65297af6-6630-11f1-8ad2-5e1b9081e705
+two	00000000-0000-0000-0000-000000000001
+
+# (7) UUID() function — generate, store, round-trip
+
+CREATE TABLE t5 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t5 VALUES (1, UUID()), (2, UUID()), (3, UUID());
+SELECT COUNT(*) FROM t5 WHERE u IS NOT NULL;
+COUNT(*)
+3
+SELECT COUNT(DISTINCT u) FROM t5;
+COUNT(DISTINCT u)
+3
+
+# (8) UUID() as DEFAULT, batch mode
+
+SET @saved_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;
+SET GLOBAL duckdb_dml_in_batch = ON;
+CREATE TABLE t6 (id INT PRIMARY KEY, u UUID DEFAULT UUID()) ENGINE=DuckDB;
+INSERT INTO t6 (id) VALUES (1), (2), (3);
+SELECT COUNT(*) FROM t6 WHERE u IS NOT NULL;
+COUNT(*)
+3
+SELECT COUNT(DISTINCT u) FROM t6;
+COUNT(DISTINCT u)
+3
+DROP TABLE t6;
+SET GLOBAL duckdb_dml_in_batch = @saved_dml_in_batch;
+
+# (9) Self-join on generated UUID PK
+
+CREATE TABLE t7 (id UUID DEFAULT UUID() PRIMARY KEY, val INT) ENGINE=DuckDB;
+INSERT INTO t7 (val) VALUES (10), (20), (30);
+SELECT COUNT(*) FROM t7 a JOIN t7 b ON a.id = b.id;
+COUNT(*)
+3
+DROP TABLE t7;
+DROP TABLE t5;
+DROP DATABASE duckdb_uuid;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_uuid.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_uuid.test
@@ -1,0 +1,119 @@
+--source ../include/have_duckdb.inc
+--source include/have_sequence.inc
+
+--echo #
+--echo # UUID data type round-trip in the DuckDB storage engine.
+--echo #
+
+--disable_warnings
+DROP DATABASE IF EXISTS duckdb_uuid;
+--enable_warnings
+
+CREATE DATABASE duckdb_uuid CHARACTER SET utf8mb4;
+USE duckdb_uuid;
+
+--echo
+--echo # (1) UUID primary key, non-batch insert (suite default)
+--echo
+CREATE TABLE t1 (id UUID PRIMARY KEY, name VARCHAR(32)) ENGINE=DuckDB;
+SHOW CREATE TABLE t1;
+
+INSERT INTO t1 VALUES
+  ('65297af6-6630-11f1-8ad2-5e1b9081e705', 'a'),
+  ('00000000-0000-0000-0000-000000000001', 'b'),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'c');
+
+--sorted_result
+SELECT id, name FROM t1;
+SELECT name FROM t1 WHERE id = '65297af6-6630-11f1-8ad2-5e1b9081e705';
+SELECT id FROM t1 ORDER BY id;
+
+--echo
+--echo # (2) UPDATE / DELETE by UUID primary key
+--echo
+UPDATE t1 SET name = 'B' WHERE id = '00000000-0000-0000-0000-000000000001';
+SELECT name FROM t1 WHERE id = '00000000-0000-0000-0000-000000000001';
+DELETE FROM t1 WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+--sorted_result
+SELECT id, name FROM t1;
+DROP TABLE t1;
+
+--echo
+--echo # (3) UUID as non-key column, including NULL
+--echo
+CREATE TABLE t2 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t2 VALUES
+  (1, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+  (2, NULL);
+SELECT id, u FROM t2 ORDER BY id;
+DROP TABLE t2;
+
+--echo
+--echo # (4) UUID DEFAULT literal
+--echo
+CREATE TABLE t3 (
+  id INT PRIMARY KEY,
+  u UUID DEFAULT '00000000-0000-0000-0000-000000000000'
+) ENGINE=DuckDB;
+INSERT INTO t3 (id) VALUES (1);
+SELECT id, u FROM t3;
+DROP TABLE t3;
+
+--echo
+--echo # (5) UUID round-trip in batch insert mode
+--echo
+SET @saved_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;
+SET GLOBAL duckdb_dml_in_batch = ON;
+CREATE TABLE t4 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t4 VALUES
+  (1, '65297af6-6630-11f1-8ad2-5e1b9081e705'),
+  (2, '00000000-0000-0000-0000-000000000001');
+SELECT id, u FROM t4 ORDER BY id;
+DROP TABLE t4;
+SET GLOBAL duckdb_dml_in_batch = @saved_dml_in_batch;
+
+--echo
+--echo # (6) Cross-engine: InnoDB UUID column scanned via DuckDB join
+--echo
+CREATE TABLE t_duck (id INT PRIMARY KEY, tag VARCHAR(16)) ENGINE=DuckDB;
+CREATE TABLE t_inno (id INT PRIMARY KEY, u UUID) ENGINE=InnoDB;
+INSERT INTO t_duck VALUES (1, 'one'), (2, 'two');
+INSERT INTO t_inno VALUES
+  (1, '65297af6-6630-11f1-8ad2-5e1b9081e705'),
+  (2, '00000000-0000-0000-0000-000000000001');
+
+--sorted_result
+SELECT d.tag, i.u
+  FROM t_duck d JOIN t_inno i ON d.id = i.id
+  ORDER BY d.id;
+
+--echo
+--echo # (7) UUID() function — generate, store, round-trip
+--echo
+CREATE TABLE t5 (id INT PRIMARY KEY, u UUID) ENGINE=DuckDB;
+INSERT INTO t5 VALUES (1, UUID()), (2, UUID()), (3, UUID());
+SELECT COUNT(*) FROM t5 WHERE u IS NOT NULL;
+SELECT COUNT(DISTINCT u) FROM t5;
+
+--echo
+--echo # (8) UUID() as DEFAULT, batch mode
+--echo
+SET @saved_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;
+SET GLOBAL duckdb_dml_in_batch = ON;
+CREATE TABLE t6 (id INT PRIMARY KEY, u UUID DEFAULT UUID()) ENGINE=DuckDB;
+INSERT INTO t6 (id) VALUES (1), (2), (3);
+SELECT COUNT(*) FROM t6 WHERE u IS NOT NULL;
+SELECT COUNT(DISTINCT u) FROM t6;
+DROP TABLE t6;
+SET GLOBAL duckdb_dml_in_batch = @saved_dml_in_batch;
+
+--echo
+--echo # (9) Self-join on generated UUID PK
+--echo
+CREATE TABLE t7 (id UUID DEFAULT UUID() PRIMARY KEY, val INT) ENGINE=DuckDB;
+INSERT INTO t7 (val) VALUES (10), (20), (30);
+SELECT COUNT(*) FROM t7 a JOIN t7 b ON a.id = b.id;
+DROP TABLE t7;
+
+DROP TABLE t5;
+DROP DATABASE duckdb_uuid;

--- a/storage/duckdb/runtime/cross_engine_scan.cc
+++ b/storage/duckdb/runtime/cross_engine_scan.cc
@@ -149,6 +149,8 @@ static duckdb::LogicalType field_to_logical_type(const Field *field)
   case MYSQL_TYPE_VAR_STRING:
   case MYSQL_TYPE_SET:
   case MYSQL_TYPE_ENUM:
+    if (is_uuid_field(field))
+      return duckdb::LogicalType::UUID;
     return duckdb::LogicalType::VARCHAR;
   default:
     return duckdb::LogicalType::VARCHAR;
@@ -220,6 +222,8 @@ static duckdb::Value field_to_duckdb_value(Field *field)
   default: {
     String buf;
     field->val_str(&buf);
+    if (is_uuid_field(field))
+      return duckdb::Value::UUID(std::string(buf.ptr(), buf.length()));
     return duckdb::Value(std::string(buf.ptr(), buf.length()));
   }
   }

--- a/storage/duckdb/runtime/delta_appender.cc
+++ b/storage/duckdb/runtime/delta_appender.cc
@@ -439,6 +439,13 @@ int DeltaAppender::append_mysql_field(const Field *field_arg,
     String tmp(buf, sizeof(buf), &my_charset_bin);
     field->val_str(&tmp);
 
+    if (is_uuid_field(field))
+    {
+      appender->Append(
+          duckdb::Value::UUID(std::string(tmp.ptr(), tmp.length())));
+      break;
+    }
+
     bool is_blob= false;
     if (blob_type_map != nullptr)
       is_blob= bitmap_is_set(blob_type_map, field->field_index);


### PR DESCRIPTION

## MDEV-40265: Add UUID type support in DuckDB storage engine

### What
Adds end-to-end UUID type handling so MariaDB's native UUID columns map correctly to DuckDB's UUID type across DDL, DML, SELECT, batch inserts, and cross-engine scans.

### Key changes
- **ddl_convertor.h/cc** — is_uuid_field() helper + MYSQL_TYPE_STRING/VARCHAR → DuckDB UUID mapping in convert_type() 
- **dml_convertor.cc** — format UUID literals as '…'::UUID instead of hex-encoded BLOBs
- **duckdb_select.cc** — read UUID values back as plain strings into MariaDB fields
- **delta_appender.cc** — UUID-aware path in batch appender
- **cross_engine_scan.cc** — UUID handling during cross-engine joins
- **duckdb_uuid.test/.result** — 9-scenario regression test (PK, NULL, DEFAULT, batch, cross-engine, UUID() function, self-join)

### How to test
```bash
./mtr --suite=duckdb duckdb_uuid
```
