### PR TITLE
MDEV-39763 main.innodb_mrr_cpk fails under view protocol

### DIFF
--- a/mysql-test/main/innodb_mrr_cpk.result
+++ b/mysql-test/main/innodb_mrr_cpk.result
@@ -23,17 +23,23 @@ concat('b-', 1000 + A.a + B.a*10 + C.a*100, '=B'),
 from t0 A, t0 B, t0 C;
 create table t2 (a char(8)) charset=latin1;
 insert into t2 values ('a-1010=A'), ('a-1030=A'), ('a-1020=A');
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
 This should use join buffer:
-explain select * from t1, t2 where t1.a=t2.a;
+explain select t1.a as t1a, t2.a as t2a, t1.filler from t1, t2 where t1.a=t2.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
 1	SIMPLE	t1	eq_ref	PRIMARY	PRIMARY	8	test.t2.a	1	Using join buffer (flat, BKA join); Key-ordered scan
 This output must be sorted by value of t1.a:
-select * from t1, t2 where t1.a=t2.a;
-a	b	filler	a
-a-1010=A	b-1010=B	filler	a-1010=A
-a-1020=A	b-1020=B	filler	a-1020=A
-a-1030=A	b-1030=B	filler	a-1030=A
+select t1.a as t1a, t2.a as t2a, t1.filler from t1, t2 where t1.a=t2.a;
+t1a	t2a	filler
+a-1010=A	a-1010=A	filler
+a-1020=A	a-1020=A	filler
+a-1030=A	a-1030=A	filler
 drop table t1, t2;
 create table t1(
 a char(8) character set utf8, b int, filler char(100), 
@@ -46,27 +52,39 @@ concat('a-', 1000 + A.a + B.a*10 + C.a*100, '=A'),
 from t0 A, t0 B, t0 C;
 create table t2 (a char(8) character set utf8, b int);
 insert into t2 values ('a-1010=A', 1010), ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
 1	SIMPLE	t1	eq_ref	PRIMARY	PRIMARY	28	test.t2.a,test.t2.b	1	Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-a	b	filler	a	b
-a-1010=A	1010	filler	a-1010=A	1010
-a-1020=A	1020	filler	a-1020=A	1020
-a-1030=A	1030	filler	a-1030=A	1030
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+a	b	filler
+a-1010=A	1010	filler
+a-1020=A	1020	filler
+a-1030=A	1030	filler
 insert into t2 values ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	5	Using where
 1	SIMPLE	t1	eq_ref	PRIMARY	PRIMARY	28	test.t2.a,test.t2.b	1	Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-a	b	filler	a	b
-a-1010=A	1010	filler	a-1010=A	1010
-a-1020=A	1020	filler	a-1020=A	1020
-a-1020=A	1020	filler	a-1020=A	1020
-a-1030=A	1030	filler	a-1030=A	1030
-a-1030=A	1030	filler	a-1030=A	1030
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+a	b	filler
+a-1010=A	1010	filler
+a-1020=A	1020	filler
+a-1020=A	1020	filler
+a-1030=A	1030	filler
+a-1030=A	1030	filler
 drop table t1, t2;
 create table t1(
 a varchar(8) character set utf8, b int, filler char(100), 
@@ -79,24 +97,30 @@ concat('a-', 1000 + A.a + B.a*10 + C.a*100, '=A'),
 from t0 A, t0 B, t0 C;
 create table t2 (a char(8) character set utf8, b int);
 insert into t2 values ('a-1010=A', 1010), ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
 1	SIMPLE	t1	eq_ref	PRIMARY	PRIMARY	30	test.t2.a,test.t2.b	1	Using where; Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-a	b	filler	a	b
-a-1010=A	1010	filler	a-1010=A	1010
-a-1020=A	1020	filler	a-1020=A	1020
-a-1030=A	1030	filler	a-1030=A	1030
-explain select * from t1, t2 where t1.a=t2.a;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+a	b	filler
+a-1010=A	1010	filler
+a-1020=A	1020	filler
+a-1030=A	1030	filler
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
 1	SIMPLE	t1	ref	PRIMARY	PRIMARY	26	test.t2.a	1	Using where; Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a;
-a	b	filler	a	b
-a-1010=A	1010	filler	a-1010=A	1010
-a-1020=A	1020	filler	a-1020=A	1020
-a-1030=A	1030	filler	a-1030=A	1030
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a;
+a	b	filler
+a-1010=A	1010	filler
+a-1020=A	1020	filler
+a-1030=A	1030	filler
 drop table t1, t2;
 create table t1 (a int, b int, c int, filler char(100), primary key(a,b,c));
 insert into t1 select A.a, B.a, C.a, 'filler' from t0 A, t0 B, t0 C;
@@ -108,41 +132,47 @@ insert into t1 values (11, 33, 124,  'filler');
 insert into t1 values (11, 33, 125,  'filler');
 create table t2 (a int, b int);
 insert into t2 values (11,33), (11,22), (11,11);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
-1	SIMPLE	t1	ref	PRIMARY	PRIMARY	8	test.t2.a,test.t2.b	1	Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-a	b	c	filler	a	b
-11	11	11	filler	11	11
-11	11	12	filler	11	11
-11	11	13	filler	11	11
-11	22	1234	filler	11	22
-11	33	124	filler	11	33
-11	33	125	filler	11	33
+1	SIMPLE	t1	ref	PRIMARY	PRIMARY	8	test.t2.a,test.t2.b	9	Using join buffer (flat, BKA join); Key-ordered scan
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+a	b	filler
+11	11	filler
+11	11	filler
+11	11	filler
+11	22	filler
+11	33	filler
+11	33	filler
 set join_cache_level=0;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-a	b	c	filler	a	b
-11	33	124	filler	11	33
-11	33	125	filler	11	33
-11	22	1234	filler	11	22
-11	11	11	filler	11	11
-11	11	12	filler	11	11
-11	11	13	filler	11	11
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+a	b	filler
+11	33	filler
+11	33	filler
+11	22	filler
+11	11	filler
+11	11	filler
+11	11	filler
 set join_cache_level=6;
-explain select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
-1	SIMPLE	t1	ref	PRIMARY	PRIMARY	4	test.t2.a	1	Using where; Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
-a	b	c	filler	a	b
+1	SIMPLE	t1	ref	PRIMARY	PRIMARY	4	test.t2.a	91	Using where; Using join buffer (flat, BKA join); Key-ordered scan
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+a	b	filler
 set optimizer_switch='index_condition_pushdown=off';
-explain select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
-1	SIMPLE	t1	ref	PRIMARY	PRIMARY	4	test.t2.a	1	Using where; Using join buffer (flat, BKA join); Key-ordered scan
-select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
-a	b	c	filler	a	b
+1	SIMPLE	t1	ref	PRIMARY	PRIMARY	4	test.t2.a	91	Using where; Using join buffer (flat, BKA join); Key-ordered scan
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+a	b	filler
 set optimizer_switch='index_condition_pushdown=on';
 drop table t1,t2;
 drop table t0;
@@ -164,6 +194,12 @@ concat('kp1-', 1000 +A.a),
 concat('val-', 1000 +A.a)
 from test.t0 A ;
 create table t2 as select kp1 as a from t1;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
 set join_cache_level=8;
 set optimizer_switch='mrr=on,mrr_sort_keys=on';
 explain
@@ -201,6 +237,12 @@ INSERT INTO t1 VALUES
 (1, 9, 'one', 11), (2, 6, 'two', 12), (3, 2, 'three', 13), (4, 5, 'four', 14);
 CREATE TABLE t2 (e INT, g INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1,9), (2,6) ;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
 SELECT * FROM t1, t2 WHERE g = b AND ( a < 7 OR a > e );
 a	b	c	d	e	g
 1	9	one	11	1	9
@@ -221,6 +263,13 @@ url text CHARACTER SET utf8
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 insert into t1 select '03b2ca8c' from t0 A, t0 B limit 80;
 insert into t2 select '03b2ca8c','' from t0 A, t0 B, t0 C;
+analyze table t1, t2 persistent for all;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	Warning	Engine-independent statistics are not collected for column 'url'
+test.t2	analyze	status	OK
 set @tmp_mdev5037=@@join_cache_level;
 set join_cache_level=3;
 explain SELECT 1 FROM (SELECT url, id FROM t2 LIMIT 1 OFFSET 20) derived RIGHT JOIN t1 ON t1.id = derived.id;

--- a/mysql-test/main/innodb_mrr_cpk.test
+++ b/mysql-test/main/innodb_mrr_cpk.test
@@ -12,6 +12,7 @@
 #    #rows, the call is there at all only for applicability check
 # 
 -- source include/have_innodb.inc
+-- source include/innodb_stable_estimates.inc
 
 --disable_warnings
 drop table if exists t0,t1,t2,t3;
@@ -39,12 +40,13 @@ from t0 A, t0 B, t0 C;
 
 create table t2 (a char(8)) charset=latin1;
 insert into t2 values ('a-1010=A'), ('a-1030=A'), ('a-1020=A');
+analyze table t1, t2 persistent for all;
 
 --echo This should use join buffer:
-explain select * from t1, t2 where t1.a=t2.a;
+explain select t1.a as t1a, t2.a as t2a, t1.filler from t1, t2 where t1.a=t2.a;
 
 --echo This output must be sorted by value of t1.a:
-select * from t1, t2 where t1.a=t2.a;
+select t1.a as t1a, t2.a as t2a, t1.filler from t1, t2 where t1.a=t2.a;
 drop table t1, t2;
 
 # Try multi-column indexes
@@ -61,13 +63,15 @@ from t0 A, t0 B, t0 C;
 
 create table t2 (a char(8) character set utf8, b int);
 insert into t2 values ('a-1010=A', 1010), ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 
 # Try with dataset that causes identical lookup keys:
 insert into t2 values ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 
 drop table t1, t2;
 
@@ -84,14 +88,15 @@ from t0 A, t0 B, t0 C;
 
 create table t2 (a char(8) character set utf8, b int);
 insert into t2 values ('a-1010=A', 1010), ('a-1030=A', 1030), ('a-1020=A', 1020);
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+analyze table t1, t2 persistent for all;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 
 # 
 # Try scanning on a CPK prefix
 #
-explain select * from t1, t2 where t1.a=t2.a;
-select * from t1, t2 where t1.a=t2.a;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a;
 drop table t1, t2;
 
 #
@@ -111,25 +116,26 @@ insert into t1 values (11, 33, 125,  'filler');
 
 create table t2 (a int, b int);
 insert into t2 values (11,33), (11,22), (11,11);
+analyze table t1, t2 persistent for all;
 
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 
 # Check a real resultset for comparison:
 set join_cache_level=0;
-select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 set join_cache_level=6;
 
 
 #
 # Check that Index Condition Pushdown (BKA) actually works:
 #
-explain select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
-select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
 
 set optimizer_switch='index_condition_pushdown=off';
-explain select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
-select * from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+explain select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
+select t1.a, t2.b, t1.filler from t1, t2 where t1.a=t2.a and t2.b + t1.b > 100;
 set optimizer_switch='index_condition_pushdown=on';
 
 drop table t1,t2;
@@ -157,6 +163,7 @@ select
 from test.t0 A ;
 
 create table t2 as select kp1 as a from t1;
+analyze table t1, t2 persistent for all;
 
 set join_cache_level=8;
 set optimizer_switch='mrr=on,mrr_sort_keys=on';
@@ -187,6 +194,7 @@ INSERT INTO t1 VALUES
 
 CREATE TABLE t2 (e INT, g INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1,9), (2,6) ;
+analyze table t1, t2 persistent for all;
 
 SELECT * FROM t1, t2 WHERE g = b AND ( a < 7 OR a > e );
 
@@ -210,6 +218,7 @@ CREATE TABLE t2 (
 
 insert into t1 select '03b2ca8c' from t0 A, t0 B limit 80;
 insert into t2 select '03b2ca8c','' from t0 A, t0 B, t0 C;
+analyze table t1, t2 persistent for all;
 
 set @tmp_mdev5037=@@join_cache_level;
 set join_cache_level=3;


### PR DESCRIPTION
Since 12.3, this test has been failing under view protocol.

During the creation of the view for ICP=off, the ha_innobase::info_low gains a measurement of the nuber of rows. This measurement showed up in the explain output as a difference in row number despite no query plan change.

The majority of the SELECT statements in this test are of the form:
  SELECT * FROM t1,t2 ..

where t1 and t2 have a significant overlap in column names. The creation of the view ultimately fails with ER_DUP_FIELDNAME. No view protocol is exercised for the majority of the tests.

As such, disabled the view protocol for the portion of tests that resulted in ER_DUP_FIELDNAME when a view of them is created.