### PR TITLE
MDEV-28509: Dereferenced null pointer of type 'struct JOIN_TAB' in ad…

### DIFF
--- a/mysql-test/main/win.result
+++ b/mysql-test/main/win.result
@@ -4793,5 +4793,26 @@ c1	c2
 2	2
 DROP TABLE t1;
 #
+# MDEV-28509: Access null pointer during add_key_field call
+#
+CREATE TABLE t1 (i INT);
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+i
+# The same crash occurs when the WHERE uses < instead of !=.
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+i
+SET @save_sql_mode= @@sql_mode;
+SET sql_mode= ONLY_FULL_GROUP_BY;
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+i
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+i
+SET @@sql_mode= @save_sql_mode;
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #

--- a/mysql-test/main/win.test
+++ b/mysql-test/main/win.test
@@ -3109,5 +3109,26 @@ from t1;
 DROP TABLE t1;
 
 --echo #
+--echo # MDEV-28509: Access null pointer during add_key_field call
+--echo #
+CREATE TABLE t1 (i INT);
+
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+
+--echo # The same crash occurs when the WHERE uses < instead of !=.
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+
+SET @save_sql_mode= @@sql_mode;
+SET sql_mode= ONLY_FULL_GROUP_BY;
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+SET @@sql_mode= @save_sql_mode;
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.11 tests
 --echo #

--- a/mysql-test/suite/encryption/r/tempfiles_encrypted.result
+++ b/mysql-test/suite/encryption/r/tempfiles_encrypted.result
@@ -4799,6 +4799,27 @@ c1	c2
 2	2
 DROP TABLE t1;
 #
+# MDEV-28509: Access null pointer during add_key_field call
+#
+CREATE TABLE t1 (i INT);
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+i
+# The same crash occurs when the WHERE uses < instead of !=.
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+i
+SET @save_sql_mode= @@sql_mode;
+SET sql_mode= ONLY_FULL_GROUP_BY;
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i != 5;
+i
+WITH cte AS (SELECT i FROM (SELECT i FROM t1 GROUP BY i) dt WINDOW w AS (PARTITION BY i))
+SELECT a.i FROM cte a JOIN cte b ON a.i=b.i WHERE a.i < 5;
+i
+SET @@sql_mode= @save_sql_mode;
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #
 #

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -27469,6 +27469,14 @@ setup_group(THD *thd, Ref_ptr_array ref_pointer_array, TABLE_LIST *tables,
   uint org_fields=all_fields.elements;
 
   thd->where= THD_WHERE::GROUP_STATEMENT;
+
+  // Don't allow markers to remain undefined upon return from setup_group
+  SCOPE_EXIT([order] () {
+    for (ORDER *ord_field= order; ord_field; ord_field= ord_field->next)
+      if ((*ord_field->item)->marker == UNDEF_POS)
+        (*ord_field->item)->marker= 0;
+  });
+
   for (ord= order; ord; ord= ord->next)
   {
     if (find_order_in_list(thd, ref_pointer_array, tables, ord, fields,


### PR DESCRIPTION
…d_key_field

This patch fixes a crash when calculating join statistics during query optimization for queries with an unused WINDOW definition.  Put another way, the system may crash when a query defines a WINDOW but doesn't then refer to it.

Item::marker is overloaded for different uses, many of which treat it as a bit field.  However, the setup_group function uses it to mark that a field was found when traversing a GROUP BY.  Originally, this marking set the Item::marker field to 1 to indicate that it was found.  Later on in setup_group (and only when SQL mode ONLY_FULL_GROUP_BY is enabled), we would skip any such marked fields when checking that fields only referenced those found in the GROUP BY; otherwise, it would be silly to find fields of the GROUP BY within the GROUP BY field itself.  Setting Item::marker to 1 seemed mostly harmless at that point in time.  But later, in git sha 4d143a6ff6, we introduced several changes: (1) the value of marker in setup_group was changed from 1 to UNDEF_POS, (2) Item::marker was changed from uint8 to int8 (which has since been changed to an int), and (3) UNDEF_POS which is defined to be -1 was also added.

Queries that define WINDOWs internally will setup groups and orders as part of query processing via the setup_group function.  Consequently because of the behavior described earlier above, such queries may have items with markers as UNDEF_POS (-1, or 0xffffffff) which is the same as marking all of the flag bits as set.  This is disastrous for those users of Item::marker which refer to it as a bit field, because every flag bit appears set at once, including bits that are mutually exclusive in meaning.  Even a masked test such as marker & SUBSTITUTION_FL returns true when marker is -1.  In particular, the method Item_direct_view_ref::grouping_field_transformer_for_where then treats the ref as flagged for substitution and takes the wrong execution path, leading to the crash.

Upon return from the setup_group function, we set the value of the marker flag to zero if we set it to -1.  This preserves the marker behavior for 'full group by' (if configured) while not otherwise allowing the marker flag state to leak outside of this function.