### PR TITLE
MDEV-37493 I_S.ROUTINES stopped matching db name case-insensitively with lower_case_table_names=2

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -641,6 +641,7 @@ extern int my_mkdir(const char *dir, int Flags, myf MyFlags);
 extern int my_readlink(char *to, const char *filename, myf MyFlags);
 extern int my_is_symlink(const char *filename);
 extern int my_realpath(char *to, const char *filename, myf MyFlags);
+extern size_t my_canonical_case_name(const char *path, char *to, size_t to_size);
 extern File my_create_with_symlink(const char *linkname, const char *filename,
 				   mode_t createflags, int access_flags,
 				   myf MyFlags);

--- a/mysql-test/main/lowercase_routines.result
+++ b/mysql-test/main/lowercase_routines.result
@@ -1,0 +1,13 @@
+#
+# MDEV-37493 information_schema.routines.routine_schema no longer
+# matched case-insensitively with lower_case_table_names=2
+#
+CREATE DATABASE FooBar;
+CREATE PROCEDURE FooBar.testing(IN p INT) SELECT p;
+SELECT routine_schema, routine_name FROM information_schema.routines WHERE routine_schema = 'FooBar';
+routine_schema	routine_name
+foobar	testing
+SELECT specific_schema, specific_name, parameter_name FROM information_schema.parameters WHERE specific_schema = 'FOOBAR';
+specific_schema	specific_name	parameter_name
+foobar	testing	p
+DROP DATABASE FooBar;

--- a/mysql-test/main/lowercase_routines.test
+++ b/mysql-test/main/lowercase_routines.test
@@ -1,0 +1,15 @@
+--source include/lcase_names.inc
+if (`SELECT @@lower_case_table_names = 0`)
+{
+  --skip Requires lower_case_table_names=1 or 2
+}
+
+--echo #
+--echo # MDEV-37493 information_schema.routines.routine_schema no longer
+--echo # matched case-insensitively with lower_case_table_names=2
+--echo #
+CREATE DATABASE FooBar;
+CREATE PROCEDURE FooBar.testing(IN p INT) SELECT p;
+SELECT routine_schema, routine_name FROM information_schema.routines WHERE routine_schema = 'FooBar';
+SELECT specific_schema, specific_name, parameter_name FROM information_schema.parameters WHERE specific_schema = 'FOOBAR';
+DROP DATABASE FooBar;

--- a/mysql-test/main/lowercase_truename.opt
+++ b/mysql-test/main/lowercase_truename.opt
@@ -1,0 +1,1 @@
+--lower-case-table-names=2

--- a/mysql-test/main/lowercase_truename.result
+++ b/mysql-test/main/lowercase_truename.result
@@ -1,0 +1,42 @@
+#
+# I_S shows db and table names in the on-disk letter case with
+# lower_case_table_names=2, regardless of the letter case used in
+# the WHERE clause. Routine names are shown as stored in mysql.proc
+# (db lowercased, routine name in the original letter case).
+#
+CREATE DATABASE BouncyDb;
+CREATE TABLE BouncyDb.BouncyCaps (a int);
+CREATE PROCEDURE BouncyDb.BouncyProc() SELECT 1;
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='BOUNCYDB' AND table_name='BOUNCYCAPS';
+table_schema	table_name
+BouncyDb	BouncyCaps
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='bouncydb';
+table_schema	table_name
+BouncyDb	BouncyCaps
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_name='bouncycaps';
+table_schema	table_name
+BouncyDb	BouncyCaps
+SELECT schema_name FROM information_schema.schemata WHERE schema_name='BOUNCYDB';
+schema_name
+BouncyDb
+SELECT routine_schema, routine_name FROM information_schema.routines WHERE routine_schema='BOUNCYDB';
+routine_schema	routine_name
+bouncydb	BouncyProc
+SHOW TABLES FROM BOUNCYDB;
+Tables_in_BOUNCYDB
+BouncyCaps
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='NoSuchDb';
+table_schema	table_name
+DROP DATABASE BouncyDb;
+#
+# Names with characters that need filesystem-name encoding
+#
+CREATE DATABASE `Bouncy.Db 2`;
+CREATE TABLE `Bouncy.Db 2`.`Bouncy#Caps` (a int);
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='BOUNCY.DB 2' AND table_name='BOUNCY#CAPS';
+table_schema	table_name
+Bouncy.Db 2	Bouncy#Caps
+SELECT schema_name FROM information_schema.schemata WHERE schema_name='bouncy.db 2';
+schema_name
+Bouncy.Db 2
+DROP DATABASE `Bouncy.Db 2`;

--- a/mysql-test/main/lowercase_truename.test
+++ b/mysql-test/main/lowercase_truename.test
@@ -1,0 +1,28 @@
+--source include/have_lowercase2.inc
+
+--echo #
+--echo # I_S shows db and table names in the on-disk letter case with
+--echo # lower_case_table_names=2, regardless of the letter case used in
+--echo # the WHERE clause. Routine names are shown as stored in mysql.proc
+--echo # (db lowercased, routine name in the original letter case).
+--echo #
+CREATE DATABASE BouncyDb;
+CREATE TABLE BouncyDb.BouncyCaps (a int);
+CREATE PROCEDURE BouncyDb.BouncyProc() SELECT 1;
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='BOUNCYDB' AND table_name='BOUNCYCAPS';
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='bouncydb';
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_name='bouncycaps';
+SELECT schema_name FROM information_schema.schemata WHERE schema_name='BOUNCYDB';
+SELECT routine_schema, routine_name FROM information_schema.routines WHERE routine_schema='BOUNCYDB';
+SHOW TABLES FROM BOUNCYDB;
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='NoSuchDb';
+DROP DATABASE BouncyDb;
+
+--echo #
+--echo # Names with characters that need filesystem-name encoding
+--echo #
+CREATE DATABASE `Bouncy.Db 2`;
+CREATE TABLE `Bouncy.Db 2`.`Bouncy#Caps` (a int);
+SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema='BOUNCY.DB 2' AND table_name='BOUNCY#CAPS';
+SELECT schema_name FROM information_schema.schemata WHERE schema_name='bouncy.db 2';
+DROP DATABASE `Bouncy.Db 2`;

--- a/mysys/my_lib.c
+++ b/mysys/my_lib.c
@@ -47,6 +47,10 @@
 #define READDIR(A,B,C) (!(C=readdir(A)))
 #endif
 
+#ifdef __APPLE__
+#include <sys/attr.h>
+#endif
+
 /*
   We are assuming that directory we are reading is either has less than 
   100 files and so can be read in one initial chunk or has more than 1000
@@ -381,3 +385,79 @@ error:
   }
   DBUG_RETURN((MY_STAT *) NULL);
 } /* my_stat */
+
+
+/*
+  Get the last component of a path in the letter case it is stored on a
+  case insensitive file system.
+
+  @param path     path to an existing file or directory,
+                  must not end with a directory separator
+  @param to       buffer for the result
+  @param to_size  size of the buffer
+
+  @return length of the name in 'to', or 0 if it cannot be determined
+          (e.g. the path does not exist, or the file system is case
+          sensitive)
+*/
+
+size_t my_canonical_case_name(const char *path, char *to, size_t to_size)
+{
+#ifdef _WIN32
+  struct _finddata_t find;
+  intptr_t handle;
+  if ((handle= _findfirst(path, &find)) == -1L)
+    return 0;
+  _findclose(handle);
+  return (size_t) (strmake(to, find.name, to_size - 1) - to);
+#elif defined(__APPLE__)
+  struct attrlist attr;
+  struct
+  {
+    u_int32_t size;
+    attrreference_t name;
+    /* a file name is at most NAME_MAX UTF-16 units, 3 UTF-8 bytes each */
+    char buf[NAME_MAX * 3 + 1];
+  } info;
+  bzero((char*) &attr, sizeof(attr));
+  attr.bitmapcount= ATTR_BIT_MAP_COUNT;
+  attr.commonattr= ATTR_CMN_NAME;
+  if (getattrlist(path, &attr, &info, sizeof(info), 0))
+    return 0;
+  return (size_t) (strmake(to, (char*) &info.name + info.name.attr_dataoffset,
+                           to_size - 1) - to);
+#else
+  /*
+    No known API to query the name. readlink() on /proc/self/fd/N does not
+    work either - a dentry keeps the letter case that was used in the
+    lookup, not the on-disk one. Scan the parent directory for the entry
+    of the file.
+  */
+  size_t dirlen= dirname_length(path), res= 0;
+  const char *base= path + dirlen;
+  char buf[FN_REFLEN];
+  struct stat st;
+  DIR *dirp;
+  struct dirent *dp;
+
+  if (dirlen >= sizeof(buf))
+    return 0;
+  if (lstat(path, &st))
+    return 0;                                   /* no such path */
+
+  memcpy(buf, path, dirlen);
+  buf[dirlen]= 0;
+  if (!(dirp= opendir(dirlen ? buf : ".")))
+    return 0;
+  while ((dp= readdir(dirp)))
+  {
+    if (!strcasecmp(dp->d_name, base))
+    {
+      res= (size_t) (strmake(to, dp->d_name, to_size - 1) - to);
+      break;
+    }
+  }
+  closedir(dirp);
+  return res;
+#endif
+}

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -4386,7 +4386,7 @@ bool get_lookup_field_values(THD *thd, COND *cond, bool fix_table_name_case,
     break;
   }
 
-  if (lower_case_table_names == 1 && !rc)
+  if (lower_case_table_names && !rc)
   {
     /* 
       We can safely do in-place upgrades here since all of the above cases
@@ -4479,6 +4479,31 @@ static int make_db_list(THD *thd, Dynamic_array<LEX_CSTRING*> *files,
       if (files->append_val(&INFORMATION_SCHEMA_NAME))
         return 1;
       return 0;
+    }
+    if (lower_case_table_names == 2)
+    {
+      /*
+        The lookup value is lowercased, but on disk the database name
+        has its original letter case. Find it, so that I_S shows the
+        true name.
+      */
+      char path[FN_REFLEN + 1], fname[SAFE_NAME_LEN + 1],
+           name_buff[SAFE_NAME_LEN + 1];
+      size_t len= build_table_filename(path, sizeof(path) - 1,
+                                       lookup_field_vals->db_value.str,
+                                       "", "", 0);
+      path[len - 1]= 0;                         // remove ending '\'
+      if (my_canonical_case_name(path, fname, sizeof(fname)))
+      {
+        LEX_CSTRING *name;
+        uint name_len= filename_to_tablename(fname, name_buff,
+                                             sizeof(name_buff));
+        if (!(name= thd->make_clex_string(name_buff, name_len)) ||
+            files->append(name))
+          return 1;
+        return 0;
+      }
+      /* No such db: fall through, to preserve the error behavior */
     }
     if (files->append_val(&lookup_field_vals->db_value))
       return 1;
@@ -4627,12 +4652,39 @@ make_table_name_list(THD *thd, Dynamic_array<LEX_CSTRING*> *table_names,
             table_names->append(name))
           return 1;
       }
+      return 0;
     }
-    else
+    if (lower_case_table_names == 2)
     {
-      if (table_names->append_val(&lookup_field_vals->table_value))
-        return 1;
+      /*
+        The lookup value is lowercased, but on disk the table name has
+        its original letter case. Find it, so that I_S shows the true
+        name.
+      */
+      char tbl_path[FN_REFLEN + 1], fname[SAFE_NAME_LEN + 1],
+           name_buff[SAFE_NAME_LEN + 1];
+      size_t len;
+      build_table_filename(tbl_path, sizeof(tbl_path) - 1, db_name->str,
+                           lookup_field_vals->table_value.str, reg_ext, 0);
+      if ((len= my_canonical_case_name(tbl_path, fname, sizeof(fname))) >
+          reg_ext_length)
+      {
+        LEX_CSTRING *name;
+        uint name_len;
+        fname[len - reg_ext_length]= 0;         // remove ".frm"
+        name_len= filename_to_tablename(fname, name_buff, sizeof(name_buff));
+        if (!(name= thd->make_clex_string(name_buff, name_len)) ||
+            table_names->append(name))
+          return 1;
+        return 0;
+      }
+      /*
+        No .frm file: nonexistent table, or a table discoverable only
+        via its engine. Fall through and use the lookup value.
+      */
     }
+    if (table_names->append_val(&lookup_field_vals->table_value))
+      return 1;
     return 0;
   }
 
@@ -6892,6 +6944,9 @@ int fill_schema_proc(THD *thd, TABLE_LIST *tables, COND *cond)
     // There can be no matching records for the condition
     DBUG_RETURN(0);
   }
+
+  /* db names are stored in lower case in mysql.proc, if lower_case_table_names */
+  DBUG_ASSERT(ok_for_lower_case_names(lookup.db_value.str));
 
   start_new_trans new_trans(thd);
 


### PR DESCRIPTION
Since MDEV-14432, get_lookup_field_values() lowercases the WHERE value only for lower_case_table_names=1. But mysql.proc.db always stores lowercase when lower_case_table_names is non-zero, so with lower_case_table_names=2 the index lookup in fill_schema_proc() missed.

Fix: lowercase I_S lookup values for any non-zero lower_case_table_names again. To show db and table names in I_S in their on-disk letter case (MDEV-14432), resolve exactly-pinned names in make_db_list() and make_table_name_list() with a new mysys function my_canonical_case_name(). Unlike before, the true name is now shown even when the WHERE value uses a different letter case than the on-disk name.