### PR TITLE
MDEV-40141 PAM authentication fails when started with --default-auth=dialog

### DIFF
--- a/mysql-test/suite/plugins/r/pam.result
+++ b/mysql-test/suite/plugins/r/pam.result
@@ -16,6 +16,12 @@ select user(), current_user(), database();
 user()	current_user()	database()
 test_pam@localhost	pam_test@%	test
 #
+# MDEV-40141 PAM authentication fails when started with --default-auth=dialog
+#
+[mariadb] Now, the magic number!
+PIN: user()	current_user()
+test_pam@localhost	pam_test@%
+#
 # athentication is unsuccessful
 #
 Challenge input first.

--- a/mysql-test/suite/plugins/r/pam_v1.result
+++ b/mysql-test/suite/plugins/r/pam_v1.result
@@ -16,6 +16,12 @@ select user(), current_user(), database();
 user()	current_user()	database()
 test_pam@localhost	pam_test@%	test
 #
+# MDEV-40141 PAM authentication fails when started with --default-auth=dialog
+#
+[mariadb] Now, the magic number!
+PIN: user()	current_user()
+test_pam@localhost	pam_test@%
+#
 # athentication is unsuccessful
 #
 Challenge input first.

--- a/mysql-test/suite/plugins/t/pam.test
+++ b/mysql-test/suite/plugins/t/pam.test
@@ -1,4 +1,7 @@
 let $PAM_PLUGIN_VERSION= $AUTH_PAM_SO;
+if (!$DIALOG_SO) {
+  skip No dialog client plugin;
+}
 --source pam_init.inc
 
 --write_file $MYSQLTEST_VARDIR/tmp/pam_good.txt
@@ -29,6 +32,11 @@ EOF
 --echo # note that current_user() differs from user()
 --echo #
 --exec $MYSQL_TEST -u test_pam < $MYSQLTEST_VARDIR/tmp/pam_good.txt
+
+--echo #
+--echo # MDEV-40141 PAM authentication fails when started with --default-auth=dialog
+--echo #
+--exec echo 106 | $MYSQL --default-auth=dialog -u test_pam -psecret -e "select user(), current_user()" test
 
 --echo #
 --echo # athentication is unsuccessful

--- a/mysql-test/suite/plugins/t/pam_v1.test
+++ b/mysql-test/suite/plugins/t/pam_v1.test
@@ -1,4 +1,7 @@
 let $PAM_PLUGIN_VERSION= $AUTH_PAM_V1_SO;
+if (!$DIALOG_SO) {
+  skip No dialog client plugin;
+}
 --source pam_init.inc
 
 --write_file $MYSQLTEST_VARDIR/tmp/pam_good.txt
@@ -23,6 +26,11 @@ EOF
 --echo # note that current_user() differs from user()
 --echo #
 --exec $MYSQL_TEST -u test_pam < $MYSQLTEST_VARDIR/tmp/pam_good.txt
+
+--echo #
+--echo # MDEV-40141 PAM authentication fails when started with --default-auth=dialog
+--echo #
+--exec echo 106 | $MYSQL --default-auth=dialog -u test_pam -psecret -e "select user(), current_user()" test
 
 --echo #
 --echo # athentication is unsuccessful

--- a/plugin/auth_pam/auth_pam.c
+++ b/plugin/auth_pam/auth_pam.c
@@ -158,7 +158,7 @@ static int pam_auth(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
         if ((buf_len= read_string(c_to_p[0], (char *) buf, sizeof(buf))) < 0)
           goto error_ret;
 
-        if (!pkt || !*pkt || (buf[0] >> 1) != 2)
+        if (!pkt || pkt_len <= 0 || !*pkt || (buf[0] >> 1) != 2)
         {
           PAM_DEBUG((stderr, "PAM: sending CONV string.\n"));
           if (vio->write_packet(vio, buf, buf_len))

--- a/plugin/auth_pam/auth_pam_v1.c
+++ b/plugin/auth_pam/auth_pam_v1.c
@@ -25,7 +25,7 @@ struct param {
 static int roundtrip(struct param *param, const unsigned char *buf,
                      int buf_len, unsigned char **pkt)
 {
-  if (param->cached && *param->cached && (buf[0] >> 1) == 2)
+  if (param->cached && param->cached_len > 0 && *param->cached && (buf[0] >> 1) == 2)
   {
     *pkt= param->cached;
     param->cached= NULL;


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-40141

When the client selects the dialog plugin itself (`--default-auth=dialog`),
the server sends no AuthSwitchRequest and hands the pam plugin the client's
initial reply, which is empty (dialog sends no data upfront). The plugin
decided the client had already supplied a password by testing only the first
byte of that reply, which points at stale buffer data, and so sent an empty
password to PAM instead of prompting.

Fixed by also checking the reply length, in both the v2 (`auth_pam.c`) and
v1 (`auth_pam_v1.c`) pam plugins. Adds a regression test to `plugins.pam`
and `plugins.pam_v1`.
