### PR TITLE
MDEV-37869 binlog.binlog_unsafe fails on Windows

### DIFF
--- a/mysql-test/include/show_binlog_events.inc
+++ b/mysql-test/include/show_binlog_events.inc
@@ -8,6 +8,7 @@
 # [--let $binlog_start= <POSITION> ]
 # [--let $binlog_limit= 1, 3 ]
 # [--let $skip_checkpoint_events= 1]
+# [--let $skip_tablemap_events= 1]
 # --source include/show_binlog_events.inc
 #
 # Parameters:

--- a/mysql-test/include/show_events.inc
+++ b/mysql-test/include/show_events.inc
@@ -128,6 +128,10 @@ if ($skip_checkpoint_events)
 {
   let $filter_script=Binlog_checkpoint;
 }
+if ($skip_tablemap_events)
+{
+  let $filter_script=Table_map;
+}
 
 
 #--let $select_columns= 1 3 6

--- a/mysql-test/suite/binlog/r/binlog_unsafe.result
+++ b/mysql-test/suite/binlog/r/binlog_unsafe.result
@@ -2543,14 +2543,8 @@ include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
 master-bin.000001	#	Annotate_rows	#	#	insert into t2(a) values(new.a)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
 master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Annotate_rows	#	#	insert into t3(a) values(new.a)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
 master-bin.000001	#	Write_rows_v1	#	#	table_id: #
 master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Query	#	#	COMMIT

--- a/mysql-test/suite/binlog/t/binlog_unsafe.test
+++ b/mysql-test/suite/binlog/t/binlog_unsafe.test
@@ -646,6 +646,7 @@ SET SESSION binlog_format = MIXED;
 --echo # Check if the statement is logged in row format.
 let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1);
 INSERT INTO t1 SET a = 2;
+--let $skip_tablemap_events= 1
 --source include/show_binlog_events.inc
 
 # clean up


### PR DESCRIPTION
And macos.

The order of the Table_map don't actually matter in this test. The important aspect is the Annotate_rows and Write_rows_v1 events.

Lets exclude the Table_map events in the show_binlog_events.inc aspect of this test.

The show_events.inc has been extended to support this $skip_tablemap_events=1 variable. $skip_checkpoint_event only has two usages so we haven't tried to support both together until needed.