### PR TITLE
MDEV-27724: plugins.multiauth normalize dlopen errors

### DIFF
--- a/mysql-test/suite/plugins/t/multiauth.test
+++ b/mysql-test/suite/plugins/t/multiauth.test
@@ -208,10 +208,11 @@ create user mysqltest1 identified via ed25519 as password("good");
 grant select on test.* to mysqltest1;
 show create user mysqltest1;
 --echo # no plugin = failure
-# covers Linux (1st re), FreeBSD (2nd), AIX (3rd and 4th)
---replace_regex /loaded: .*client_ed25519.so: cannot open shared object file: No such file or directory/loaded: no such file/ /loaded: Cannot open.*client_ed25519.so./loaded: no such file/ /loaded: .*Could not load module.*client_ed25519.so.\n/loaded: no such file/ /System error: No such file or directory//
+# covers Linux, MacOS (1st re), FreeBSD (2nd), AIX (3rd and 4th)
+--replace_regex /(?s)loaded: .*no such file( or directory)?\)?/loaded: no such file/i /loaded: Cannot open.*client_ed25519.so./loaded: no such file/ /loaded: .*Could not load module.*client_ed25519.so.\n/loaded: no such file/ /System error: No such file or directory//
 --error 1
 --exec $try_auth -u mysqltest1 -pgood --plugin-dir=$plugindir/no
+
 alter user mysqltest1 identified via ed25519 as password("good") OR mysql_native_password as password("works");
 show create user mysqltest1;
 --echo # no plugin = failure


### PR DESCRIPTION
macos particuarlly had a long error message ending in (no such file). Normalize the regex.

"image not found" was an error of old macos so omitted.