### PR TITLE
MDEV-38843: bump wsrep-lib on 10.11 to the commit-order fix

### DIFF
--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -68,6 +68,7 @@ public:
   void debug_sync(const char*) override;
   void debug_crash(const char*) override;
   int bf_rollback() override;
+  void notify_state_change() override { }
 private:
   friend class Wsrep_server_service;
   THD* m_thd;


### PR DESCRIPTION
Issue: the 10.6->10.11 merges dropped the wsrep-lib pin bump, so the commit-order fix (5eeef4009d5) never reached 10.11.

Solution: advance wsrep-lib to 5eeef4009d5 and restore the Wsrep_client_service::notify_state_change() override it requires.