### PR TITLE
MDEV-39795: Assertion `n_reserved > 0' failed

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-encryption-alter.result
+++ b/mysql-test/suite/encryption/r/innodb-encryption-alter.result
@@ -110,3 +110,19 @@ f1	f2
 5	6
 7	8
 drop table t1,t2;
+#
+# MDEV 39795 : Assertion `n_reserved > 0' failed
+#
+SET GLOBAL innodb_encrypt_tables = ON;
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+col1 INT,
+col2 INT,
+PRIMARY KEY (id)
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+INSERT INTO t1 (col1, col2) VALUES (10, 100);
+SET STATEMENT debug_dbug = 'd,inode_page_decryption_failed' FOR
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+ERROR HY000: Got error 63 'Table is compressed or encrypted but uncompress or decrypt failed.' from InnoDB
+SET GLOBAL innodb_encrypt_tables = OFF;
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
+++ b/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
@@ -1,3 +1,17 @@
+#
+# MDEV 39795 : Assertion `n_reserved > 0' failed
+#
+SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL innodb_compression_algorithm = 'none';
+CREATE TABLE t1 (
+id INT AUTO_INCREMENT PRIMARY KEY,
+col1 INT,
+col2 INT,
+col3 INT
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+INSERT INTO t1 (col1, col2, col3) VALUES (1, 10, 100);
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
 set global innodb_compression_algorithm = 1;
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb page_compressed=1;
 show warnings;
@@ -86,3 +100,8 @@ drop procedure innodb_insert_proc;
 drop table innodb_normal;
 drop table innodb_compact;
 drop table innodb_dynamic;
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+# restart: --innodb-encrypt-tables=OFF
+ALTER TABLE t1 ADD INDEX idx_col2_col3 (col2, col3);
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
+++ b/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
@@ -86,3 +86,22 @@ drop procedure innodb_insert_proc;
 drop table innodb_normal;
 drop table innodb_compact;
 drop table innodb_dynamic;
+#
+# MDEV 39795 : Assertion `n_reserved > 0' failed
+#
+SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL innodb_compression_algorithm = 'none';
+CREATE TABLE t1 (
+id INT AUTO_INCREMENT PRIMARY KEY,
+col1 INT,
+col2 INT,
+col3 INT
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+INSERT INTO t1 (col1, col2, col3) VALUES (1, 10, 100);
+FLUSH TABLES t1 FOR EXPORT;
+# restart: --innodb-encrypt-tables=OFF
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+# restart: --innodb-encrypt-tables=OFF
+ALTER TABLE t1 ADD INDEX idx_col2_col3 (col2, col3);
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/innodb-encryption-alter.test
+++ b/mysql-test/suite/encryption/t/innodb-encryption-alter.test
@@ -131,3 +131,22 @@ disconnect con1;
 
 select * from t1;
 drop table t1,t2;
+
+--echo #
+--echo # MDEV 39795 : Assertion `n_reserved > 0' failed
+--echo #
+SET GLOBAL innodb_encrypt_tables = ON;
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  col1 INT,
+  col2 INT,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+
+INSERT INTO t1 (col1, col2) VALUES (10, 100);
+--error ER_GET_ERRMSG
+SET STATEMENT debug_dbug = 'd,inode_page_decryption_failed' FOR
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+# Cleanup
+SET GLOBAL innodb_encrypt_tables = OFF;
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
@@ -3,7 +3,29 @@
 -- source include/have_file_key_management_plugin.inc
 
 let $innodb_compression_algorithm_orig=`SELECT @@innodb_compression_algorithm`;
+let $innodb_encrypt_tables_orig=`SELECT @@innodb_encrypt_tables`;
 
+--echo #
+--echo # MDEV 39795 : Assertion `n_reserved > 0' failed
+--echo #
+
+SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL innodb_compression_algorithm = 'none';
+
+CREATE TABLE t1 (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  col1 INT,
+  col2 INT,
+  col3 INT
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+INSERT INTO t1 (col1, col2, col3) VALUES (1, 10, 100);
+FLUSH TABLES t1 FOR EXPORT; UNLOCK TABLES;
+# continue further test after restart
+
+# reset system
+--disable_query_log
+EVAL SET GLOBAL innodb_encrypt_tables = $innodb_encrypt_tables_orig;
+--enable_query_log
 # zlib
 set global innodb_compression_algorithm = 1;
 
@@ -71,3 +93,12 @@ drop table innodb_dynamic;
 --disable_query_log
 EVAL SET GLOBAL innodb_compression_algorithm = $innodb_compression_algorithm_orig;
 --enable_query_log
+
+# Continuing test for MDEV-39795
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+
+--source include/restart_mysqld.inc
+ALTER TABLE t1 ADD INDEX idx_col2_col3 (col2, col3);
+
+--echo # Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
@@ -71,3 +71,28 @@ drop table innodb_dynamic;
 --disable_query_log
 EVAL SET GLOBAL innodb_compression_algorithm = $innodb_compression_algorithm_orig;
 --enable_query_log
+
+--echo #
+--echo # MDEV 39795 : Assertion `n_reserved > 0' failed
+--echo #
+
+SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL innodb_compression_algorithm = 'none';
+
+CREATE TABLE t1 (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  col1 INT,
+  col2 INT,
+  col3 INT
+) ENGINE=InnoDB ROW_FORMAT = Compact PAGE_COMPRESSED=1;
+INSERT INTO t1 (col1, col2, col3) VALUES (1, 10, 100);
+FLUSH TABLES t1 FOR EXPORT;
+
+--source include/restart_mysqld.inc
+ALTER TABLE t1 ADD INDEX idx_col1 (col1);
+
+--source include/restart_mysqld.inc
+ALTER TABLE t1 ADD INDEX idx_col2_col3 (col2, col3);
+
+--echo # Cleanup
+DROP TABLE t1;

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -622,9 +622,9 @@ static byte *buf_page_encrypt(fil_space_t *space, buf_page_t *bpage, byte *s,
 
   const bool full_crc32= space->full_crc32();
 
-  if (!encrypted && !page_compressed)
+  if (!encrypted)
   {
-    /* No need to encrypt or compress. Clear key-version & crypt-checksum. */
+    /* No need to encrypt. Clear key-version & crypt-checksum. */
     static_assert(FIL_PAGE_FCRC32_KEY_VERSION % 4 == 0, "alignment");
     static_assert(FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION % 4 == 2,
                   "not perfect alignment");
@@ -632,7 +632,8 @@ static byte *buf_page_encrypt(fil_space_t *space, buf_page_t *bpage, byte *s,
       memset_aligned<4>(s + FIL_PAGE_FCRC32_KEY_VERSION, 0, 4);
     else
       memset_aligned<2>(s + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION, 0, 8);
-    return s;
+    if (!page_compressed)
+      return s;
   }
 
   static_assert(FIL_PAGE_FCRC32_END_LSN % 4 == 0, "alignment");

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -1674,6 +1674,7 @@ fseg_create(fil_space_t *space, ulint byte_offset, mtr_t *mtr, dberr_t *err,
 	fseg_inode_t*	inode;
 	ib_id_t		seg_id;
 	uint32_t	n_reserved = 0;
+	bool		reserved = false;
 
 	DBUG_ENTER("fseg_create");
 
@@ -1697,20 +1698,29 @@ fseg_create(fil_space_t *space, ulint byte_offset, mtr_t *mtr, dberr_t *err,
 
 inode_alloc:
 	inode = fsp_alloc_seg_inode(space, header, &iblock, mtr, err);
-
+	DBUG_EXECUTE_IF("inode_page_decryption_failed",
+		*err = DB_DECRYPTION_FAILED;
+		inode = nullptr;
+	);
+	if (*err == DB_DECRYPTION_FAILED) {
+		block = nullptr;
+		goto funct_exit;
+	}
 	if (!inode) {
 		block = nullptr;
 reserve_extent:
-		if (!has_done_reservation && !n_reserved) {
+		if (!has_done_reservation && !reserved) {
 			*err = fsp_reserve_free_extents(&n_reserved, space, 2,
 							FSP_NORMAL, mtr);
 			if (UNIV_UNLIKELY(*err != DB_SUCCESS)) {
 				DBUG_RETURN(nullptr);
 			}
 
-			ut_ad(n_reserved > 0);
-			/* Extents reserved successfully. So
-			try allocating the page or inode */
+			/* Extents (or pages for small table)
+			reserved successfully.
+			See fsp_reserve_free_extents()
+			So try allocating the page or inode */
+			reserved = true;
 			if (inode) {
 				goto page_alloc;
 			}

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -918,6 +918,10 @@ my_error_innodb(dberr_t error, const char *table, ulint flags)
 	case DB_CORRUPTION:
 		my_error(ER_NOT_KEYFILE, MYF(0), table);
 		break;
+	case DB_DECRYPTION_FAILED:
+		my_error(ER_GET_ERRMSG, MYF(0), error,
+		         ut_strerr(error), "InnoDB");
+		break;
 	case DB_TOO_BIG_RECORD: {
 		/* Note that in page0zip.ic page_zip_rec_needs_ext() rec_size
 		is limited to COMPRESSED_REC_MAX_DATA_SIZE (16K) or


### PR DESCRIPTION


<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-39795*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Problem:
========

1. Assertion `n_reserved > 0` failed in fseg_create():

fsp_reserve_free_extents() has a special condition for small tablespaces where it reserves individual pages instead of full extents. In such cases, n_reserved can be 0 even when the reservation succeeds, causing the assertion ut_ad(n_reserved > 0) to fail incorrectly.

The code was checking n_reserved to determine whether a reservation had already been attempted, but this logic breaks for small tablespaces where pages, rather than extents, are reserved.

2. Encryption metadata not cleared for compressed-only pages:

buf_page_encrypt() only cleared encryption-related metadata fields (key-version and crypt-checksum) when the page was neither encrypted nor compressed. However, these fields should also be cleared when page_compressed is true but encrypted is false, to avoid leaving stale encryption metadata in compressed-only pages.

Solution:
=========

buf_page_encrypt(): Refactored the early-return logic. Encryption metadata fields are now cleared whenever encrypted is false, regardless of page_compressed. The function returns early only when both !encrypted and !page_compressed.

fseg_create(): Introduced a boolean variable `reserved` to track whether fsp_reserve_free_extents() has been attempted, replacing the flawed check of `n_reserved > 0`. Added an early return when DB_DECRYPTION_FAILED is encountered during inode allocation.

my_error_innodb(): Added handling for DB_DECRYPTION_FAILED to report decryption errors to the user through ER_GET_ERRMSG.

## Release Notes
Fixed assertion failure `n_reserved > 0`

## How can this PR be tested?
Added MTR test case innodb_encrypt_compression_algorithm.test

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
