### PR TITLE
MDEV-39047 Impossible to create DB grant for long escaped DB name

### DIFF
--- a/mysql-test/main/grant.result
+++ b/mysql-test/main/grant.result
@@ -2848,4 +2848,24 @@ DROP USER foo;
 #
 # End of 10.4 tests
 #
+#
+# MDEV-39047 Impossible to create DB grant for long escaped DB name
+#
+CREATE USER u@localhost;
+CREATE DATABASE very_long_database_name_with_underscore_symbols_inside_the_name;
+GRANT ALL ON `very\_long\_database\_name\_with\_underscore\_symbols\_inside\_the\_name`.* TO u@localhost;
+ERROR 42000: Incorrect database name 'very\_long\_database\_name\_with\_underscore\_symbols\_inside\_the\_name'
+GRANT ALL ON `very_long_database_name_with_underscore_symbols_inside_the_name`.* TO u@localhost;
+SHOW GRANTS FOR u@localhost;
+Grants for u@localhost
+GRANT USAGE ON *.* TO `u`@`localhost`
+GRANT ALL PRIVILEGES ON `very_long_database_name_with_underscore_symbols_inside_the_name`.* TO `u`@`localhost`
+FLUSH PRIVILEGES;
+SHOW GRANTS FOR u@localhost;
+Grants for u@localhost
+GRANT USAGE ON *.* TO `u`@`localhost`
+GRANT ALL PRIVILEGES ON `very_long_database_name_with_underscore_symbols_inside_the_name`.* TO `u`@`localhost`
+DROP DATABASE very_long_database_name_with_underscore_symbols_inside_the_name;
+DROP USER u@localhost;
+# End of 10.6 tests
 update mysql.global_priv set priv=@root_priv where user='root' and host='localhost';

--- a/mysql-test/main/grant.test
+++ b/mysql-test/main/grant.test
@@ -2356,4 +2356,23 @@ DROP USER foo;
 --echo # End of 10.4 tests
 --echo #
 
+--echo #
+--echo # MDEV-39047 Impossible to create DB grant for long escaped DB name
+--echo #
+CREATE USER u@localhost;
+# 62-char db name with underscores; escaped form (\_) exceeds 64 chars and
+# was silently truncated in mysql.db, creating a broken grant.
+CREATE DATABASE very_long_database_name_with_underscore_symbols_inside_the_name;
+--error ER_WRONG_DB_NAME
+GRANT ALL ON `very\_long\_database\_name\_with\_underscore\_symbols\_inside\_the\_name`.* TO u@localhost;
+# Unescaped name fits and works
+GRANT ALL ON `very_long_database_name_with_underscore_symbols_inside_the_name`.* TO u@localhost;
+SHOW GRANTS FOR u@localhost;
+FLUSH PRIVILEGES;
+SHOW GRANTS FOR u@localhost;
+DROP DATABASE very_long_database_name_with_underscore_symbols_inside_the_name;
+DROP USER u@localhost;
+
+--echo # End of 10.6 tests
+
 update mysql.global_priv set priv=@root_priv where user='root' and host='localhost';

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -7881,6 +7881,22 @@ bool mysql_grant(THD *thd, const char *db, List <LEX_USER> &list,
     db=tmp_db;
   }
 
+  if (db)
+  {
+    /*
+      Reject a db name that would not fit in the mysql.db.Db column instead of
+      silently truncating it into a non-functional grant (MDEV-39047). Escaping
+      wildcards (\_ \%) can make the stored name longer than the actual db name.
+    */
+    Lex_cstring_strlen db_str(db);
+    if (check_string_char_length(&db_str, 0, max_dbname_length,
+                                 system_charset_info, 1))
+    {
+      my_error(ER_WRONG_DB_NAME, MYF(0), db);
+      DBUG_RETURN(TRUE);
+    }
+  }
+
   if (is_proxy)
   {
     DBUG_ASSERT(!db);


### PR DESCRIPTION
Reject GRANT if the database name (or pattern) does not fit into the `mysql.db.Db` column.

It was silently truncated previously. While this does not fix the user's underlying problem, GRANT now complains with "Incorrect database name" and lists the overlong name at GRANT time — the same `ER_WRONG_DB_NAME` that `CREATE DATABASE` already gives for an over-long name.

Retargeted to 10.6 per review. Supersedes #5336.
