### PR TITLE
MDEV-40279 galera.tmp_space_usage test failure

### DIFF
--- a/mysql-test/suite/galera/r/tmp_space_usage.result
+++ b/mysql-test/suite/galera/r/tmp_space_usage.result
@@ -13,19 +13,15 @@ create table t1(a int, b varchar(1024)) engine=innodb;
 insert into t1 select seq, repeat("a", 500) from seq_1_to_100;
 create table t2(a int, b varchar(1024)) engine=myisam;
 insert into t2 select seq, repeat("a", 500) from seq_1_to_100;
-show status like "%tmp_space%";
-Variable_name	Value
-Max_tmp_space_used	102054
-Tmp_space_used	102054
+# Tmp_space_used is greater than 0
+# Max_tmp_space_used == Tmp_space_used
 change_user foo,,;
 use test;
 select count(*) from t1;
 count(*)
 100
-show status like "%tmp_space%";
-Variable_name	Value
-Max_tmp_space_used	102054
-Tmp_space_used	0
+# Tmp_space_used has been reset to 0
+# Max_tmp_space_used is preserved across change_user
 drop table t1,t2;
 change_user root,,;
 drop user foo;

--- a/mysql-test/suite/galera/t/tmp_space_usage.test
+++ b/mysql-test/suite/galera/t/tmp_space_usage.test
@@ -27,7 +27,6 @@ insert into t2 select seq, repeat("a", 500) from seq_1_to_100;
 # for MDEV-37808.
 --let $tmp_used = query_get_value(SHOW STATUS LIKE 'Tmp_space_used', Value, 1)
 --let $max_used = query_get_value(SHOW STATUS LIKE 'Max_tmp_space_used', Value, 1)
---disable_query_log
 if ($tmp_used > 0)
 {
 --echo # Tmp_space_used is greater than 0
@@ -36,7 +35,6 @@ if ($tmp_used == $max_used)
 {
 --echo # Max_tmp_space_used == Tmp_space_used
 }
---enable_query_log
 
 change_user foo;
 use test;
@@ -48,7 +46,6 @@ select count(*) from t1;
 # bogus "Local temporary space limit reached" error.
 --let $tmp_used2 = query_get_value(SHOW STATUS LIKE 'Tmp_space_used', Value, 1)
 --let $max_used2 = query_get_value(SHOW STATUS LIKE 'Max_tmp_space_used', Value, 1)
---disable_query_log
 if ($tmp_used2 == 0)
 {
 --echo # Tmp_space_used has been reset to 0
@@ -57,7 +54,6 @@ if ($max_used2 == $max_used)
 {
 --echo # Max_tmp_space_used is preserved across change_user
 }
---enable_query_log
 
 drop table t1,t2;
 change_user root;

--- a/mysql-test/suite/galera/t/tmp_space_usage.test
+++ b/mysql-test/suite/galera/t/tmp_space_usage.test
@@ -21,12 +21,43 @@ insert into t1 select seq, repeat("a", 500) from seq_1_to_100;
 create table t2(a int, b varchar(1024)) engine=myisam;
 insert into t2 select seq, repeat("a", 500) from seq_1_to_100;
 
-show status like "%tmp_space%";
+# The exact number of bytes used for the binlog cache temporary file is
+# not portable (it depends on binary log event encoding), so instead of
+# printing the raw byte counts we only verify the relations that matter
+# for MDEV-37808.
+--let $tmp_used = query_get_value(SHOW STATUS LIKE 'Tmp_space_used', Value, 1)
+--let $max_used = query_get_value(SHOW STATUS LIKE 'Max_tmp_space_used', Value, 1)
+--disable_query_log
+if ($tmp_used > 0)
+{
+--echo # Tmp_space_used is greater than 0
+}
+if ($tmp_used == $max_used)
+{
+--echo # Max_tmp_space_used == Tmp_space_used
+}
+--enable_query_log
 
 change_user foo;
 use test;
 select count(*) from t1;
-show status like "%tmp_space%";
+
+# After change_user the session's Tmp_space_used must be reset to 0 while
+# Max_tmp_space_used is preserved. Before the fix, tmp_space_used was reset
+# incorrectly and a later truncate made it negative, which triggered a
+# bogus "Local temporary space limit reached" error.
+--let $tmp_used2 = query_get_value(SHOW STATUS LIKE 'Tmp_space_used', Value, 1)
+--let $max_used2 = query_get_value(SHOW STATUS LIKE 'Max_tmp_space_used', Value, 1)
+--disable_query_log
+if ($tmp_used2 == 0)
+{
+--echo # Tmp_space_used has been reset to 0
+}
+if ($max_used2 == $max_used)
+{
+--echo # Max_tmp_space_used is preserved across change_user
+}
+--enable_query_log
 
 drop table t1,t2;
 change_user root;


### PR DESCRIPTION
The MTR test galera.tmp_space_usage printed the exact Tmp_space_used / Max_tmp_space_used byte counts. These come from the binlog cache temporary file, whose size depends on binary log event encoding and thus varies across platforms and builds, making the test fail (e.g. 101706 vs the recorded 102054).

Rewrite the test to check only the invariants the fix is about, as is already done in main.tmp_space_usage: after the inserts Tmp_space_used is non-zero and equals Max_tmp_space_used, and after change_user Tmp_space_used is reset to 0 while Max_tmp_space_used is preserved.

Co-Authored-By: Claude Opus 4.8