### PR TITLE
MDEV-39710: Update git modules WSREP Links to mariadb-corporation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,7 @@
 	url = https://github.com/facebook/rocksdb.git
 [submodule "wsrep-lib"]
 	path = wsrep-lib
-	url = https://github.com/codership/wsrep-lib.git
-	branch = master
+	url = https://github.com/mariadb-corporation/wsrep-lib.git
 [submodule "extra/wolfssl/wolfssl"]
 	path = extra/wolfssl/wolfssl
 	url = https://github.com/wolfSSL/wolfssl.git


### PR DESCRIPTION
The .gitmodules file still uses the old Codership Github repo link. This redirects to the mariadb-corporation repo, so it isn't a functional problem, but it should still be updated to the correct repo.