### PR TITLE
MDEV-40313 mariadb client creates `.mariadb_histor` instead of `.mari…

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -102,6 +102,8 @@ extern "C" {
 #define USE_POPEN
 }
 
+#define HISTORY_FILE ".mariadb_history"
+
 static CHARSET_INFO *charset_info= &my_charset_latin1;
 
 #if defined(_WIN32)
@@ -1427,19 +1429,19 @@ int main(int argc,char *argv[])
     else if ((home= getenv("HOME")))
     {
       size_t histfile_size=
-        strlen(home) + strlen("/.mysql_history") + 2;
+        strlen(home) + strlen("/" HISTORY_FILE) + 2;
       histfile=(char*) my_malloc(PSI_NOT_INSTRUMENTED,
             histfile_size, MYF(MY_WME));
       if (histfile)
       {
-        snprintf(histfile, histfile_size, "%s/.mariadb_history", home);
+        snprintf(histfile, histfile_size, "%s/%s", home, HISTORY_FILE);
         if (my_access(histfile, F_OK))
         {
           /* no .mariadb_history, look for historical name and use if present */
           snprintf(histfile, histfile_size, "%s/.mysql_history", home);
           /* and go back to original if not found */
           if (my_access(histfile, F_OK))
-            snprintf(histfile, histfile_size, "%s/.mariadb_history", home);
+            snprintf(histfile, histfile_size, "%s/%s", home, HISTORY_FILE);
         }
         char link_name[FN_REFLEN];
         if (my_readlink(link_name, histfile, 0) == 0 &&


### PR DESCRIPTION
…adb_history`

`histfile_size` in `client/mysql.cc` is calculated using the string "/.mysql_history" (15 chars) rather than "/.mariadb_history" (17 chars).

Because the buffer is only allocated to that shorter length, the resulting filename is truncated by 2 characters.

Thanks David Lu for the bug report and diagnosis.

```
$ strace -fe trace=file  client/mariadb -S /tmp/build-mariadb-server-11.4-debug.sock
execve("client/mariadb", ["client/mariadb", "-S", "/tmp/build-mariadb-server-11.4-d"...], 0x7fffdf93ba40 /* 97 vars */) = 0
...
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 5
Server version: 11.4.13-MariaDB-asan-debug Source distribution

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

...
openat(AT_FDCWD, "/home/dan/.mariadb_history", O_RDONLY) = 4
Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
```