### PR TITLE
MDEV-40310 Connect use-of-uninitialized-value in XFILE::Write

### DIFF
--- a/storage/connect/mysql-test/connect/r/datest.result
+++ b/storage/connect/mysql-test/connect/r/datest.result
@@ -57,3 +57,29 @@ col1
 2015-01-01
 2015-02-01
 DROP TABLE t1;
+#
+# MDEV-40310 use-of-uninitialized-value in XFILE::Write(_global*, void*, int, int, bool&)
+#
+CREATE TABLE t1 (d DATE KEY,
+dt DATETIME NOT NULL,
+y YEAR NOT NULL,
+KEY(d), KEY(dt), KEY(y)) ENGINE=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+INSERT IGNORE INTO t1 VALUES(1,1,-1);
+Warnings:
+Warning	1265	Data truncated for column 'd' at row 1
+Warning	1265	Data truncated for column 'dt' at row 1
+Warning	1264	Out of range value for column 'y' at row 1
+Warning	1105	Non matching Value types
+INSERT INTO t1
+VALUES ('2026-07-10', '2026-07-10 14:30:45', '2026');
+Warnings:
+Warning	1105	Non matching Value types
+SELECT * FROM t1;
+d	dt	y
+1970-01-01	1970-01-01 00:00:00	0000
+2026-07-10	2026-07-10 14:30:45	2026
+DROP TABLE t1;
+# End of 11.8 tests

--- a/storage/connect/mysql-test/connect/t/datest.test
+++ b/storage/connect/mysql-test/connect/t/datest.test
@@ -26,3 +26,22 @@ SELECT * FROM t1 WHERE col1 >= '2015-02-01';
 SELECT * FROM t1 WHERE col1 < '2015-02-01';
 SELECT * FROM t1 WHERE col1 <= '2015-02-01';
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-40310 use-of-uninitialized-value in XFILE::Write(_global*, void*, int, int, bool&)
+--echo #
+
+CREATE TABLE t1 (d DATE KEY,
+                dt DATETIME NOT NULL,
+                y YEAR NOT NULL,
+                KEY(d), KEY(dt), KEY(y)) ENGINE=CONNECT;
+INSERT IGNORE INTO t1 VALUES(1,1,-1);
+
+INSERT INTO t1
+VALUES ('2026-07-10', '2026-07-10 14:30:45', '2026');
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--echo # End of 11.8 tests

--- a/storage/connect/valblk.cpp
+++ b/storage/connect/valblk.cpp
@@ -81,8 +81,8 @@ PVBLK AllocValBlock(PGLOBAL g, void *mp, int type, int nval, int len,
         blkp = new(g) TYPBLK<int>(mp, nval, type);
 
       break;
-    case TYPE_DATE:        // ?????
-      blkp = new(g) DATBLK(mp, nval);
+    case TYPE_DATE:
+      blkp = new(g) TYPBLK<ulonglong>(mp, nval, type, 0, true);
       break;
     case TYPE_BIGINT:
       if (un)


### PR DESCRIPTION
When writing date types to an index, Connect Engine only had 4 bytes initialized, however 8 bytes where being written.

Changed the type to 8 bytes.