### PR TITLE
MDEV-40237: Partition info nullptr dereference

### DIFF
--- a/sql/partition_info.h
+++ b/sql/partition_info.h
@@ -495,7 +495,9 @@ bool partition_info::vers_fix_field_list(THD * thd)
   Field *row_end= table->vers_end_field();
   // needed in handle_list_of_fields()
   row_end->flags|= GET_FIXED_FIELDS_FLAG;
-  Name_resolution_context *context= &thd->lex->current_select->context;
+  Name_resolution_context *context= (thd->lex && thd->lex->current_select)
+                                    ? &thd->lex->current_select->context
+                                    : nullptr;
   Item *row_end_item= new (thd->mem_root) Item_field(thd, context, row_end);
   Item *row_end_ts= new (thd->mem_root) Item_func_unix_timestamp(thd, row_end_item);
   set_part_expr(thd, row_end_ts, false);


### PR DESCRIPTION
thd->lex is null in InnoDB purge thd. The Item_field can take a NULL context as a pointer for resolving field names.