### PR TITLE
MDEV-40316: Infer: PULSE_RESOURCE_LEAK in connect

### DIFF
--- a/storage/connect/filamzip.cpp
+++ b/storage/connect/filamzip.cpp
@@ -232,6 +232,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 
 		if (lstat(fn, &fileinfo) < 0) {
 			snprintf(g->Message, sizeof(g->Message), "%s: %s", fn, strerror(errno));
+			closedir(dir);
 			return true;
 		} else if (!S_ISREG(fileinfo.st_mode))
 			continue;      // Not a regular file (should test for links)

--- a/storage/connect/tabmul.cpp
+++ b/storage/connect/tabmul.cpp
@@ -1171,13 +1171,16 @@ int TDBSDR::FindInDir(PGLOBAL g)
 
     if (lstat(Fpath, &Fileinfo) < 0) {
       snprintf(g->Message, sizeof(g->Message), "%s: %s", Fpath, strerror(errno));
+      closedir(dir);
       return -1;
     } else if (S_ISDIR(Fileinfo.st_mode) && *Entry->d_name != '.') {
       // Look in the name sub-directory
       strcat(strcat(Direc, Entry->d_name), "/");
 
-      if ((k= FindInDir(g)) < 0)
+      if ((k= FindInDir(g)) < 0) {
+        closedir(dir);
         return k;
+      }
       else
         n += k;
 


### PR DESCRIPTION
fixes [MDEV-40316](https://jira.mariadb.org/browse/MDEV-40316)
### Problem:
Infer found file descriptors left open on some error code paths in connect storage engine.

### Fix:
Close file descriptors on error before returning.