### PR TITLE
MDEV-39468 Mariabackup: redo log copier stalls and fails with misleading error message

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -346,6 +346,26 @@ read_mysql_one_value(MYSQL *mysql, const char *query)
   return read_mysql_one_value(mysql, query, 0/*offset*/, 1/*total columns*/);
 }
 
+/** Poll InnoDB's durably flushed redo LSN from the running server.
+Log copier uses this as its parse limit; it never accepts a redo log
+record whose end exceeds this LSN
+@param connection MariaDB client connection
+@retval 0 on failure, lsn on success */
+uint64_t get_log_flushed_lsn(MYSQL *connection) noexcept
+{
+  char *lsn_str= nullptr;
+  mysql_variable status[] = {{"Innodb_lsn_flushed", &lsn_str},
+                             {NULL, NULL}};
+  uint64_t lsn= 0;
+  read_mysql_variables(connection,
+                       "SHOW STATUS LIKE 'Innodb_lsn_flushed'",
+                       status, true);
+  if (lsn_str)
+    lsn= strtoull(lsn_str, nullptr, 10);
+  free_mysql_variables(status);
+  return lsn;
+}
+
 
 static
 bool

--- a/extra/mariabackup/backup_mysql.h
+++ b/extra/mariabackup/backup_mysql.h
@@ -2,6 +2,7 @@
 #define XTRABACKUP_BACKUP_MYSQL_H
 
 #include <mysql.h>
+#include <cstdint>
 #include <string>
 #include <unordered_set>
 #include "datasink.h"
@@ -97,4 +98,6 @@ bool
 write_slave_info(ds_ctxt *datasink, MYSQL *connection);
 
 ulonglong get_current_lsn(MYSQL *connection);
+
+uint64_t get_log_flushed_lsn(MYSQL *connection) noexcept;
 #endif

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -205,7 +205,7 @@ struct xb_filter_entry_t{
 /** whether log_copying_thread() is active; protected by recv_sys.mutex */
 static bool log_copying_running;
 /** the log parsing function for --backup */
-static recv_sys_t::parser backup_log_parse;
+static recv_sys_t::parser backup_log_parse_low;
 /** for --backup, target LSN to copy the log to; protected by recv_sys.mutex */
 lsn_t metadata_to_lsn;
 
@@ -3443,6 +3443,50 @@ skip:
 	return(FALSE);
 }
 
+/* Maximum LSN the copier may parse up to, derived from the
+server's durably-flushed redo LSN. The copier refuses to
+accept a mini-transaction whose end exceeds this, so it never
+parses the volatile tail block the server is still rewriting
+(which mmap can read torn, leading to a mis-computed mtr
+length and permanent mid-mtr drift).
+Read/written only under recv_sys.mutex. */
+static lsn_t max_parse_lsn;
+
+/* Set by backup_log_parse() when the last parse was
+rejected because the mtr crossed max_parse_lsn. It means
+"caught up, wait" condition, not a stall. */
+static bool reached_parse_limit;
+
+/** Round a flushed LSN down to a write-block boundary,
+excluding the tail block that InnoDB may still be
+rewriting/reflushing. Returns 0 if below first_lsn. */
+static lsn_t parse_limit_from_flushed(lsn_t flushed)
+{
+  const lsn_t first= log_sys.get_first_lsn();
+  if (flushed <= first)
+    return 0;
+  const lsn_t bs= log_sys.write_size;
+  return first + ((flushed - first) & ~lsn_t(bs - 1));
+}
+
+
+static recv_sys_t::parse_mtr_result backup_log_parse()
+{
+  const lsn_t limit_lsn= max_parse_lsn;
+  const lsn_t prev_lsn= recv_sys.lsn;
+  const size_t prev_offset= recv_sys.offset;
+  reached_parse_limit= false;
+  recv_sys_t::parse_mtr_result r= backup_log_parse_low(false);
+  if (r == recv_sys_t::OK && limit_lsn && recv_sys.lsn > limit_lsn)
+  {
+    recv_sys.lsn= prev_lsn;
+    recv_sys.offset= prev_offset;
+    reached_parse_limit= true;
+    return recv_sys_t::GOT_EOF;
+  }
+  return r;
+}
+
 static int
 xtrabackup_copy_mmap_snippet(ds_file_t *ds, const byte *start, const byte *end)
 {
@@ -3468,7 +3512,7 @@ static bool xtrabackup_copy_mmap_logfile()
   const byte *start= &log_sys.buf[recv_sys.offset];
   ut_d(recv_sys_t::parse_mtr_result r);
 
-  if ((ut_d(r=) backup_log_parse(false)) == recv_sys_t::OK)
+  if ((ut_d(r=) backup_log_parse()) == recv_sys_t::OK)
   {
     do
     {
@@ -3486,7 +3530,7 @@ static bool xtrabackup_copy_mmap_logfile()
         start = seq + 1;
       }
     }
-    while ((ut_d(r=) backup_log_parse(false)) == recv_sys_t::OK);
+    while ((ut_d(r=) backup_log_parse()) == recv_sys_t::OK);
 
     if (xtrabackup_copy_mmap_snippet(dst_log_file, start,
                                      &log_sys.buf[recv_sys.offset]))
@@ -3559,7 +3603,7 @@ static bool xtrabackup_copy_logfile(bool early_exit)
       if (log_sys.buf[recv_sys.offset] <= 1)
         break;
 
-      if (backup_log_parse(false) == recv_sys_t::OK)
+      if (backup_log_parse() == recv_sys_t::OK)
       {
         do
         {
@@ -3569,7 +3613,7 @@ static bool xtrabackup_copy_logfile(bool early_exit)
                                                  sequence_offset));
           *seq= 1;
         }
-        while ((r= backup_log_parse(false)) == recv_sys_t::OK);
+        while ((r= backup_log_parse()) == recv_sys_t::OK);
 
         if (ds_write(dst_log_file, log_sys.buf + start_offset,
                      recv_sys.offset - start_offset))
@@ -3599,6 +3643,9 @@ static bool xtrabackup_copy_logfile(bool early_exit)
         if (retry_count == 100)
           break;
 
+	if (reached_parse_limit)
+          break;
+
         mysql_mutex_unlock(&recv_sys.mutex);
         if (!retry_count++)
           msg("Retrying read of log at LSN=" LSN_PF, recv_sys.lsn);
@@ -3617,9 +3664,20 @@ static bool backup_wait_timeout(lsn_t lsn, lsn_t last_lsn)
 {
   if (last_lsn >= lsn)
     return true;
+
+  const lsn_t checkpoint_lsn= log_sys.last_checkpoint_lsn.load();
+  const lsn_t capacity= log_sys.file_size - log_sys.START_OFFSET;
+  const lsn_t needed= lsn - checkpoint_lsn;
+
   msg("Was only able to copy log from " LSN_PF " to " LSN_PF
-      ", not " LSN_PF "; try increasing innodb_log_file_size",
-      log_sys.last_checkpoint_lsn.load(), last_lsn, lsn);
+      ", not " LSN_PF, checkpoint_lsn, last_lsn, lsn);
+
+  if (needed <= capacity)
+    msg("mariabackup: The required redo still fits within the log "
+        "capacity, so it has not been overwritten; check whether the "
+        "server and backup configuration are the same.");
+  else
+    msg("mariabackup: Try increasing the innodb_log_file_size.");
   return false;
 }
 
@@ -3674,16 +3732,43 @@ static bool backup_wait_for_lsn(lsn_t lsn)
 static void log_copying_thread()
 {
   my_thread_init();
+  MYSQL *limit_con= xb_mysql_connect();
   mysql_mutex_lock(&recv_sys.mutex);
-  while (!xtrabackup_copy_logfile(false) &&
-         (!metadata_last_lsn || metadata_last_lsn > recv_sys.lsn))
+  for (;;)
   {
+    /* Refresh the max_parse_lsn before each copy pass.
+    To reach the exact target in the final phase
+    (BACKUP STAGE BLOCK COMMIT), avoid block aligning for it.
+    Because the final target could be in the midblock. So aligning
+    it will make the copier thread never reaches the target and
+    could lead to hang. Outside the final phase, always limit the
+    lsn with block aligned */
+    const lsn_t final_target= metadata_last_lsn > metadata_to_lsn
+      ? metadata_last_lsn : metadata_to_lsn;
+    if (final_target)
+      max_parse_lsn= final_target;
+    else if (limit_con)
+    {
+      mysql_mutex_unlock(&recv_sys.mutex);
+      lsn_t flushed= get_log_flushed_lsn(limit_con);
+      mysql_mutex_lock(&recv_sys.mutex);
+      if (flushed)
+        max_parse_lsn= parse_limit_from_flushed(flushed);
+    }
+
+    if (xtrabackup_copy_logfile(false))
+      break;
+    if (final_target && final_target <= recv_sys.lsn)
+      break;
+
     timespec abstime;
     set_timespec_nsec(abstime, 1000000ULL * xtrabackup_log_copy_interval);
     mysql_cond_timedwait(&log_copying_stop, &recv_sys.mutex, &abstime);
   }
   log_copying_running= false;
   mysql_mutex_unlock(&recv_sys.mutex);
+  if (limit_con)
+    mysql_close(limit_con);
   my_thread_end();
 }
 
@@ -5614,8 +5699,11 @@ fail:
 	/* copy log file by current position */
 
 	mysql_mutex_lock(&recv_sys.mutex);
-	backup_log_parse = recv_sys.get_backup_parser();
+	backup_log_parse_low = recv_sys.get_backup_parser();
 	recv_sys.lsn = log_sys.last_checkpoint_lsn;
+
+	if (lsn_t flushed= get_log_flushed_lsn(mysql_connection))
+          max_parse_lsn= parse_limit_from_flushed(flushed);
 
 	const bool log_copy_failed = xtrabackup_copy_logfile(true);
 


### PR DESCRIPTION
Problem:
========
During backup process, log copier thread stalls at lsn and fails with the misleading "Was only able to copy log from X to Y, not Z; try increasing innodb_log_file_size", even when the redo was intact and the log far from full.

Problem is that copier advances recv_sys.lsn only on CRC-validated mtr, but it parses the redo at the server is concurrently writing. InnoDB rewrites the current partial write block repeatedly as mini-transaction fills it, so an mmap read (or) pread of a page being written can observe a torn/intermediate image of the tail block. If that tail block happens to parse as a longer, still valid crc valid mtr then recv_sys.lsn, recv_sys.offset gets advanced wrongly and points to middle of the mini-transaction. In that case, later parse return GOT_EOF always and copier thread never reaches target and fails

Solution:
=========
Poll the server's durably-flushed LSN (status var Innodb_lsn_flushed) and limit the redo log copier based on it.

backup_log_parse(): parses one mtr and if it exceeds the limit rolls back recv_sys.lsn/offset and reports GOT_EOF; the copier re-parses those bytes on a later pass once the fence has advanced past them. Used on both the mmap and buffered paths.

parse_limit_from_flushed(): Rounds the flushed LSN down to a write-block boundary, excluding the tail block InnoDB may still be rewriting

log_copying_thread(): opens its own connection (it runs concurrently with the main thread, which owns mysql_connection) and refreshes the max_limit for parsing of redo log in each pass.

In the final backup phase (BACKUP STAGE BLOCK_COMMIT) it gates on the exact target max(metadata_last_lsn, metadata_to_lsn) with no block-align, so the last partial block is copied in full up to the target.

The stall diagnostic / retry spin is suppressed on a reached_parse_limit wait so a normal "caught up, wait" is not misreported as drift.

get_log_flushed_lsn(): Added to get log_flushed_lsn from SHOW STATUS outout;