### PR TITLE
MDEV-40006: Prepared Statement Crash in varchar_upper_cmp_transformer() for '?'

### DIFF
--- a/mysql-test/main/prepare.result
+++ b/mysql-test/main/prepare.result
@@ -115,3 +115,24 @@ drop table t1,t2;
 #
 # End of 10.6 tests
 #
+#
+# MDEV-40006: Prepared Statement Crash in varchar_upper_cmp_transformer() for '?'
+#
+set names utf8mb4;
+CREATE TABLE t1 (
+id INT,
+cs VARCHAR(10),
+KEY(cs)
+) COLLATE=utf8mb4_general_ci;
+INSERT INTO t1 (id, cs) VALUES (1, 'AA1AA'),(2, 'BB2BB'),(3, 'CC3CC');
+PREPARE s FROM 'SELECT id, cs FROM t1 WHERE UPPER(cs) IN (?, ?)';
+EXECUTE s USING 'AA1AA', 'BB2BB';
+id	cs
+1	AA1AA
+2	BB2BB
+deallocate prepare s;
+DROP TABLE t1;
+set names default;
+#
+# End of 11.4 tests
+#

--- a/mysql-test/main/prepare.test
+++ b/mysql-test/main/prepare.test
@@ -105,3 +105,28 @@ drop table t1,t2;
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-40006: Prepared Statement Crash in varchar_upper_cmp_transformer() for '?'
+--echo #
+
+set names utf8mb4;
+
+CREATE TABLE t1 (
+  id INT,
+  cs VARCHAR(10),
+  KEY(cs)
+) COLLATE=utf8mb4_general_ci;
+
+INSERT INTO t1 (id, cs) VALUES (1, 'AA1AA'),(2, 'BB2BB'),(3, 'CC3CC');
+
+PREPARE s FROM 'SELECT id, cs FROM t1 WHERE UPPER(cs) IN (?, ?)';
+EXECUTE s USING 'AA1AA', 'BB2BB';
+
+deallocate prepare s;
+DROP TABLE t1;
+set names default;
+
+--echo #
+--echo # End of 11.4 tests
+--echo #

--- a/sql/opt_rewrite_remove_casefold.cc
+++ b/sql/opt_rewrite_remove_casefold.cc
@@ -133,6 +133,8 @@ Item* Item_func_in::varchar_upper_cmp_transformer(THD *thd, uchar *arg)
     if ((tmp= is_upper_key_col(arg0)))
     {
       Item_func_in *cl= (Item_func_in*)deep_copy_with_checks(thd);
+      if (!cl)
+        return this;
       Item *res;
       cl->arguments()[0]= tmp;
       cl->walk(&Item::cleanup_excluding_const_fields_processor, 0, 0);


### PR DESCRIPTION
MDEV-40006: Prepared Statement Crash in varchar_upper_cmp_transformer() for '?'

Item_func_in::varchar_upper_cmp_transformer() clones Item_func_in
and its arguments and doesn't check if cloning has succeed.

Item_param (PS parameter, '?') doesn't implement cloning so will return
NULL from clone(). This will cause a crash.

Fixed by making varchar_upper_cmp_transformer() check clone results for NULL.
(Adding cloning support to Item_param is out of scope of this patch).