### PR TITLE
MDEV-40280: FreeBSD galera.galera_max_ws_rows test failure

### DIFF
--- a/strings/my_vsnprintf.c
+++ b/strings/my_vsnprintf.c
@@ -888,8 +888,13 @@ int my_fprintf(FILE *stream, const char* format, ...)
 }
 
 
-#ifdef __APPLE__
-/* Delete the ':' character added by Apple's implementation of strerror_r */
+/*
+  Normalize the unknown-error text so it is identical on all platforms.
+  BSD-derived libc (macOS, FreeBSD, ...) formats "Unknown error: <n>" with a
+  colon, glibc uses "Unknown error <n>" without one. Strip the colon when
+  present. glibc never emits it, so this is a no-op there - normalize by
+  behavior rather than by guessing the OS/libc.
+*/
 static void delete_colon_char(char *buf)
 {
   static const char *unknown_err= "Unknown error";
@@ -906,7 +911,6 @@ static void delete_colon_char(char *buf)
     }
   }
 }
-#endif
 
 
 /*
@@ -963,9 +967,7 @@ const char* my_strerror(char *buf, size_t len, int nr)
     strerror_r(nr, buf, len);
 #endif
 
-#ifdef __APPLE__
     delete_colon_char(buf);
-#endif
   }
 
   /*


### PR DESCRIPTION
Issue:
For unknown error numbers, BSD-derived libc (macOS, FreeBSD, ...) formats "Unknown error: <n>" with a colon, while glibc uses "Unknown error <n>". my_strerror()'s colon-stripping (MDEV-35578) was gated on __APPLE__ only, so FreeBSD output diverged from the .result.

Solution:
Normalize by behavior instead of by platform: always strip the colon after "Unknown error". glibc never emits it, so it is a no-op there, and macOS/FreeBSD/other BSD libc are all covered without enumeration. This is what MDEV-35578 already intended ("consistent across the platforms ... when present"); the __APPLE__ guard was just narrower than that intent. Runs only in the unknown-error path.