### PR TITLE
MDEV-39343 Restoring from a mysqldump from older version makes mysql_upgrade version test fail

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -877,8 +877,6 @@ static int upgrade_already_done(int silent)
     else
       verbose("This installation of MariaDB is already upgraded to %s.\n"
               "There is no need to run mysql_upgrade again.", version);
-    if (!opt_check_upgrade)
-      verbose("You can use --force if you still want to run mysql_upgrade");
   }
   return 0;
 }
@@ -1513,11 +1511,17 @@ int main(int argc, char **argv)
     printf("The --upgrade-system-tables option was used, user tables won't be touched.\n");
 
   /*
-    Read the mysql_upgrade_info file to check if mysql_upgrade
-    already has been run for this installation of MariaDB
+    If mysql_upgrade_info file already shows the current version, check
+    only the system tables. They can still be from an older version,
+    e.g if a dump from an older server was restored (MDEV-39343).
   */
-  if (!opt_force && !upgrade_already_done(0))
-    goto end;                                   /* Upgrade already done */
+  if (!opt_force && !upgrade_already_done(1))
+  {
+    verbose("This installation of MariaDB is already upgraded to %s.\n"
+            "Checking system tables only. Use --force to check all tables.",
+            upgrade_from_version);
+    opt_systables_only= TRUE;
+  }
 
   if (opt_version_check && check_version_match())
     die("Upgrade failed");
@@ -1545,7 +1549,6 @@ int main(int argc, char **argv)
 
   DBUG_ASSERT(phase == phases_total);
 
-end:
   print_conn_args("mariadb-check");
   free_used_memory();
   my_end(my_end_arg);

--- a/mysql-test/include/load_dump_and_upgrade.inc
+++ b/mysql-test/include/load_dump_and_upgrade.inc
@@ -33,6 +33,16 @@
 --echo # Loading dump of $old_version mysql schema
 --exec $MYSQL mysql < $MYSQLTEST_VARDIR/std_data/mysql_database_$old_version.dump
 
+
+# MDEV-39343: pretend mysql_upgrade has already run for the current version.
+# It must still fix the system tables restored from the older dump.
+if ($with_mysql_upgrade_info)
+{
+--let $DDIR= `select @@datadir`
+--write_line $MYSQL_SERVER_VERSION $DDIR/mysql_upgrade_info
+}
+
+
 --echo # Running mysql_upgrade
 --exec $MYSQL_UPGRADE --verbose > $MYSQL_TMP_DIR/upgrade.log
 

--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -150,10 +150,48 @@ test
 Phase 7/8: uninstalling plugins
 Phase 8/8: Running 'FLUSH PRIVILEGES'
 OK
-Run it again - should say already completed
+Run it again - should only check system tables
 This installation of MariaDB is already upgraded to X.Y.Z-MariaDB.
-There is no need to run mysql_upgrade again.
-You can use --force if you still want to run mysql_upgrade
+Checking system tables only. Use --force to check all tables.
+Phase 1/8: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry                         OK
+Phase 2/8: Installing used storage engines... Skipped
+Phase 3/8: Running 'mysql_fix_privilege_tables'
+Phase 4/8: Fixing views... Skipped
+Phase 5/8: Fixing table and database names ... Skipped
+Phase 6/8: Checking and upgrading tables... Skipped
+Phase 7/8: uninstalling plugins
+Phase 8/8: Running 'FLUSH PRIVILEGES'
+OK
 Force should run it regardless of whether it has been run before
 Phase 1/8: Checking and upgrading mysql database
 Processing databases
@@ -1929,8 +1967,47 @@ Looking for 'mariadb' as: mariadb
 This installation of MariaDB is already upgraded to X.Y.0-MariaDB.
 There is no need to run mysql_upgrade again for X.Y.Z-MariaDB, because they're both X.Y.
 This installation of MariaDB is already upgraded to X.Y.0-MariaDB.
-There is no need to run mysql_upgrade again for X.Y.Z-MariaDB, because they're both X.Y.
-You can use --force if you still want to run mysql_upgrade
+Checking system tables only. Use --force to check all tables.
+Phase 1/8: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.global_priv_bak                              OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry                         OK
+Phase 2/8: Installing used storage engines... Skipped
+Phase 3/8: Running 'mysql_fix_privilege_tables'
+Phase 4/8: Fixing views... Skipped
+Phase 5/8: Fixing table and database names ... Skipped
+Phase 6/8: Checking and upgrading tables... Skipped
+Phase 7/8: uninstalling plugins
+Phase 8/8: Running 'FLUSH PRIVILEGES'
+OK
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade with major version change
 #
@@ -2575,4 +2652,14 @@ mysql.user has data
 # Checking that mysql.user is accessible and returns some data
 SELECT COUNT(*) > 0 AS `mysql.user has data` FROM mysql.user;
 mysql.user has data
+1
+#
+# MDEV-39343 Restoring from a mysqldump from older version makes
+# mysql_upgrade version test fail
+#
+ALTER TABLE mysql.db DROP COLUMN Delete_history_priv;
+SELECT count(*) AS 'must be 1' FROM information_schema.columns
+WHERE table_schema='mysql' AND table_name='db'
+  AND column_name='Delete_history_priv';
+must be 1
 1

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -22,7 +22,7 @@ call mtr.add_suppression("Incorrect definition of table mysql.column_stats:.*");
 let $MYSQLD_DATADIR= `select @@datadir`;
 file_exists $MYSQLD_DATADIR/mysql_upgrade_info;
 
---echo Run it again - should say already completed
+--echo Run it again - should only check system tables
 --replace_result $MYSQL_SERVER_VERSION X.Y.Z-MariaDB
 --exec $MYSQL_UPGRADE 2>&1
 
@@ -545,8 +545,26 @@ call mtr.add_suppression("Column count of mysql.proc is wrong. Expected 21, foun
 --let $old_version= 10.2
 --source include/load_dump_and_upgrade.inc
 
+--let $with_mysql_upgrade_info= 1
 --let $old_version= 10.3
 --source include/load_dump_and_upgrade.inc
 
 --let $old_version= 10.4
 --source include/load_dump_and_upgrade.inc
+
+--echo #
+--echo # MDEV-39343 Restoring from a mysqldump from older version makes
+--echo # mysql_upgrade version test fail
+--echo #
+
+# Create mysql_upgrade_info with the current version
+--exec $MYSQL_UPGRADE --silent 2>&1
+file_exists $MYSQLD_DATADIR/mysql_upgrade_info;
+# Simulate restoring a dump from an older version
+ALTER TABLE mysql.db DROP COLUMN Delete_history_priv;
+# Without --force, system tables must still be checked and fixed
+--exec $MYSQL_UPGRADE --silent 2>&1
+SELECT count(*) AS 'must be 1' FROM information_schema.columns
+  WHERE table_schema='mysql' AND table_name='db'
+  AND column_name='Delete_history_priv';
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info


### PR DESCRIPTION
Do not skip the whole upgrade when mysql_upgrade_info is up to date.
System tables can still be from an older version, e.g when a dump from
an older server was restored. Only checks of user tables are skipped.