### PR TITLE
Fix `Gtid_log_event::is_part_of_group()`

### DIFF
--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -3777,6 +3777,9 @@ public:
                    enum enum_binlog_checksum_alg checksum_alg,
                    uint32 *domain_id, uint32 *server_id, uint64 *seq_no,
                    uchar *flags2, const Format_description_log_event *fdev);
+#ifdef HAVE_REPLICATION
+  bool is_part_of_group() override { return true; }
+#endif
 #endif
 };
 


### PR DESCRIPTION
It is the only event type that returns `true` in
`Log_event::is_part_of_group(enum Log_event_type)` but `false` in `Log_event::is_part_of_group()`.

---

Opening this draft to test on the CI.
I don’t actually know how the program worked fine and how this change will observably affect it.
I only know that, internally, this difference prevents flagging `Relay_log_info::is_in_group()` on standalone event groups (e.g., DDL), but not sure what that means in practice.