### PR TITLE
MDEV-39743: IS JSON was not interuptable

### DIFF
--- a/mysql-test/main/func_json_notembedded.result
+++ b/mysql-test/main/func_json_notembedded.result
@@ -48,6 +48,10 @@ select json_set(@arr,'$[1000]',1);
 ERROR 70100: Query was interrupted: execution time limit 0.0001 sec exceeded
 select ST_AsTEXT(ST_GeomFromGeoJSON(JSON_OBJECT("type", "Point", "coordinates", @arr),2)) as exp;
 ERROR 70100: Query was interrupted: execution time limit 0.0001 sec exceeded
+select @obj IS JSON;
+ERROR 70100: Query was interrupted: execution time limit 0.0001 sec exceeded
+select @arr IS JSON;
+ERROR 70100: Query was interrupted: execution time limit 0.0001 sec exceeded
 SET debug_dbug= @old_debug;
 disconnect u;
 connection default;

--- a/mysql-test/main/func_json_notembedded.test
+++ b/mysql-test/main/func_json_notembedded.test
@@ -37,6 +37,8 @@ select json_remove(@obj,'$.foo');
 select json_replace(@obj,'$.foo',1);
 select json_set(@arr,'$[1000]',1);
 select ST_AsTEXT(ST_GeomFromGeoJSON(JSON_OBJECT("type", "Point", "coordinates", @arr),2)) as exp;
+select @obj IS JSON;
+select @arr IS JSON;
 enable_abort_on_error;
 SET debug_dbug= @old_debug;
 disconnect u;

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -6499,16 +6499,21 @@ bool Item_func_is_json::val_bool()
 {
   bool result= true;
   bool unique_keys= true;
+  THD *thd;
   String *js= args[0]->val_json(&tmp_value);
 
   if ((null_value= args[0]->null_value))
     return 0;
 
+  thd= current_thd;
+  JSON_DO_PAUSE_EXECUTION(thd, 0.0002);
+
   json_scan_start(&je, js->charset(), (const uchar*)js->ptr(),
                   (const uchar*)js->end());
+  je.killed_ptr= (uint32_t *) &thd->killed;
 
   if (json_read_value(&je))
-    return negated;
+    goto js_error;
 
   switch (type_constraint)
   {
@@ -6536,17 +6541,23 @@ bool Item_func_is_json::val_bool()
       unique_keys= handle_nested_value(&je);
 
     if (je.s.error)
-      return negated;
+      goto js_error;
   }
   else
   {
     // verify JSON is well-formed
     while (json_scan_next(&je) == 0) {}
     if (je.s.error)
-      return negated;
+      goto js_error;
   }
 
   return negated ? !(result && unique_keys) : (result && unique_keys);
+js_error:
+  if (je.s.error != JE_KILLED)
+    return negated;
+  report_json_error(js, &je, 0);
+  null_value= true;
+  return 0;
 }
 
 


### PR DESCRIPTION
The IS JSON predicate in a query wasn't able to be killed, and could exceed the max_statement_time of a query.

Introduce the mechanics so that a killed query would result in the correct error.