### PR TITLE
MDEV-39813 ST_GeomFromGeoJSON does not control recursion depth

### DIFF
--- a/mysql-test/main/disabled.def
+++ b/mysql-test/main/disabled.def
@@ -16,4 +16,3 @@ mysql_embedded           : Bug#12561297 2011-05-14 Anitha Dependent on PB2 chang
 file_contents            : MDEV-6526 these files are not installed anymore
 max_statement_time       : cannot possibly work, depends on timing
 partition_open_files_limit : open_files_limit check broken by MDEV-18360
-gis-json                 : MDEV-39813 infinite recursion

--- a/mysql-test/main/gis-json.result
+++ b/mysql-test/main/gis-json.result
@@ -123,19 +123,6 @@ Warning	4048	Incorrect GeoJSON format specified for st_geomfromgeojson function.
 #
 # End of 10.2 tests
 #
-#
-# MDEV-39813 ST_GeomFromGeoJSON does not control recursion depth
-#
-SELECT ST_GeomFromGeoJSON(
-concat(
-repeat('{"type":"GeometryCollection","geometries":[', 2000),
-'{"type":"Point","coordinates":[0,0]}',
-repeat(']}', 2000)
-)) as exp;
-exp
-NULL
-Warnings:
-Warning	4040	Limit of 32 on JSON nested structures depth is reached in argument 1 to function 'st_geomfromgeojson' at position 473
 # End of 10.6 tests
 #
 # MDEV-34079: ST_AsGeoJSON returns incorrect value for empty geometry

--- a/mysql-test/main/gis-json.test
+++ b/mysql-test/main/gis-json.test
@@ -59,16 +59,6 @@ SELECT ST_ASTEXT(ST_GEOMFROMGEOJSON('{"type": ["POINT"], "coINates": [0,0] }')) 
 --echo # End of 10.2 tests
 --echo #
 
---echo #
---echo # MDEV-39813 ST_GeomFromGeoJSON does not control recursion depth
---echo #
-
-SELECT ST_GeomFromGeoJSON(
-  concat(
-    repeat('{"type":"GeometryCollection","geometries":[', 2000),
-    '{"type":"Point","coordinates":[0,0]}',
-    repeat(']}', 2000)
-  )) as exp;
 
 --echo # End of 10.6 tests
 

--- a/mysql-test/main/lotofstack.result
+++ b/mysql-test/main/lotofstack.result
@@ -104,3 +104,14 @@ drop table t3|
 #
 SELECT ST_GeomFromText(CONCAT(REPEAT('GEOMETRYCOLLECTION(',5000),'POINT(1 1)',REPEAT(')',5000)));
 # End of 10.6 tests
+#
+# MDEV-39813 ST_GeomFromGeoJSON does not control recursion depth
+#
+set @len = 3000;
+SELECT ST_GeomFromGeoJSON(
+concat(
+repeat('{"type":"GeometryCollection", "geometries":[', @len),
+'{"type":"Point","coordinates":[0,0]}',
+repeat(']}', @len)
+)) as exp;
+# End of 12.3 tests

--- a/mysql-test/main/lotofstack.test
+++ b/mysql-test/main/lotofstack.test
@@ -148,3 +148,21 @@ SELECT ST_GeomFromText(CONCAT(REPEAT('GEOMETRYCOLLECTION(',5000),'POINT(1 1)',RE
 --enable_result_log
 
 --echo # End of 10.6 tests
+
+
+--echo #
+--echo # MDEV-39813 ST_GeomFromGeoJSON does not control recursion depth
+--echo #
+
+set @len = 3000;
+--disable_result_log
+--error ER_STACK_OVERRUN_NEED_MORE
+SELECT ST_GeomFromGeoJSON(
+  concat(
+    repeat('{"type":"GeometryCollection", "geometries":[', @len),
+    '{"type":"Point","coordinates":[0,0]}',
+    repeat(']}', @len)
+  )) as exp;
+--enable_result_log
+
+--echo # End of 12.3 tests

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -587,8 +587,10 @@ Geometry *Geometry::create_from_json(Geometry_buffer *buffer,
   uint key_len;
   int fcoll_type_found= 0, feature_type_found= 0;
 
+  if (check_stack_overrun(current_thd, STACK_MIN_SIZE , NULL))
+    return NULL;
+
   const uint32_t *killed_ptr= (uint32_t *) je->killed_ptr;
-  int stack_p;
 
   if (json_read_value(je))
     goto err_return;
@@ -754,10 +756,8 @@ handle_feature_collection:
 
 create_geom:
 
-  stack_p= je->stack_p;
   json_scan_start(je, je->s.cs, coord_start, je->s.str_end);
   je->killed_ptr= killed_ptr;
-  je->stack_p= stack_p;
 
   if (res->reserve(1 + 4, 512))
     goto err_return;
@@ -771,10 +771,8 @@ create_geom:
   return result;
 
 handle_geometry_key:
-  stack_p= je->stack_p;
   json_scan_start(je, je->s.cs, geometry_start, je->s.str_end);
   je->killed_ptr= killed_ptr;
-  je->stack_p= stack_p;
   return create_from_json(buffer, je, er_on_3D, res);
 
 err_return:


### PR DESCRIPTION
Using stack_p wasn't a portable concept in 12.3 when JSON parsing got unlimited depth. To let ST_GeomFromGeoJSON as a recursive function, needed because object order of "type" may be after the "geometries", some stack checking was required.

Use the check_stack_depth function to allow excessively deep GeoJSON objects to error.

@mariadb-RuchaDeodhar , I'm after a concept approval. To run reliably I'm going to move this test to the thread_stack_overun.test that @vaintroub added in 10.11 (#5320) that hasn't yet been merged up.

The 10.6/10.11 fix for this bug is going to change the stack_p, killed_ptr and json_scan_start  but what is clear is that 12.3 requires a stack overrun check.