### PR TITLE
MDEV-27561 Fix uninitialized memory in DES_ENCRYPT

### DIFF
--- a/mysql-test/main/func_des_encrypt.result
+++ b/mysql-test/main/func_des_encrypt.result
@@ -110,3 +110,10 @@ hex(des_encrypt('a'))
 #
 # End of 10.10 tests
 #
+#
+# MDEV-27561: Valgrind/MSAN errors in Item_func_des_encrypt::val_str
+#
+SELECT VARIANCE(0), HEX(DES_ENCRYPT('foo', ExtractValue('<foo></foo>', '/foo')));
+VARIANCE(0)	HEX(DES_ENCRYPT('foo', ExtractValue('<foo></foo>', '/foo')))
+0.0000	FFD41F3FDEBD4F0F62
+# End of 10.11 tests

--- a/mysql-test/main/func_des_encrypt.test
+++ b/mysql-test/main/func_des_encrypt.test
@@ -79,3 +79,12 @@ select hex(des_encrypt('a'));
 --echo #
 --echo # End of 10.10 tests
 --echo #
+
+
+--echo #
+--echo # MDEV-27561: Valgrind/MSAN errors in Item_func_des_encrypt::val_str
+--echo #
+
+SELECT VARIANCE(0), HEX(DES_ENCRYPT('foo', ExtractValue('<foo></foo>', '/foo')));
+
+--echo # End of 10.11 tests

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -786,13 +786,15 @@ String *Item_func_des_encrypt::val_str(String *str)
   }
   else
   {
-    String *keystr= args[1]->val_str(str);
+    String key_value;
+    String *keystr= args[1]->val_str(&key_value);
     if (!keystr)
       goto error;
     key_number=127;				// User key string
 
     /* We make good 24-byte (168 bit) key from given plaintext key with MD5 */
     bzero((char*) &ivec,sizeof(ivec));
+    bzero((char*) &keyblock,sizeof(keyblock));
     if (!EVP_BytesToKey(EVP_des_ede3_cbc(),EVP_md5(),NULL,
 		   (uchar*) keystr->ptr(), (int) keystr->length(),
 		   1, (uchar*) &keyblock,ivec))
@@ -897,11 +899,13 @@ String *Item_func_des_decrypt::val_str(String *str)
   else
   {
     // We make good 24-byte (168 bit) key from given plaintext key with MD5
-    String *keystr= args[1]->val_str(str);
+    String key_value;
+    String *keystr= args[1]->val_str(&key_value);
     if (!keystr)
       goto error;
 
     bzero((char*) &ivec,sizeof(ivec));
+    bzero((char*) &keyblock,sizeof(keyblock));
     if (!EVP_BytesToKey(EVP_des_ede3_cbc(),EVP_md5(),NULL,
 		   (uchar*) keystr->ptr(),(int) keystr->length(),
 		   1,(uchar*) &keyblock,ivec))


### PR DESCRIPTION
Initialize keyblock to zero before EVP_BytesToKey to prevent ununitialized access later in DES_set_key_unchecked()