### PR TITLE
MDEV-36610  Subquery wrongly marked as eliminated by table elimination

### DIFF
--- a/mysql-test/main/table_elim.result
+++ b/mysql-test/main/table_elim.result
@@ -1086,5 +1086,81 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	
 DROP TABLE t1, t2;
 #
+# MDEV-36610: Subquery wrongly marked as eliminated by table elimination
+#             when equality propagation shares a WHERE-clause subquery
+#             into an eliminated outer join's ON expression
+#
+CREATE TABLE t0 (k INT);
+INSERT INTO t0 VALUES (20),(9);
+CREATE TABLE t1 (a BIGINT);
+INSERT INTO t1 VALUES (1),(2);
+CREATE TABLE t2 (b INT PRIMARY KEY);
+INSERT INTO t2 VALUES (3),(4);
+INSERT INTO t2 VALUES (5),(6);
+CREATE TABLE t3 (c INT);
+INSERT INTO t3 VALUES (2);
+CREATE TABLE t4 (a BIGINT, x INT);
+INSERT INTO t4 VALUES (2,20),(3,30);
+# t2 is eliminated, but the subquery must still be shown and executed:
+explain SELECT t1.* FROM t1 LEFT JOIN t2 ON (t2.b = t1.a)
+WHERE t1.a = (SELECT c FROM t3);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+2	SUBQUERY	t3	system	NULL	NULL	NULL	NULL	1	
+SELECT t1.* FROM t1 LEFT JOIN t2 ON (t2.b = t1.a)
+WHERE t1.a = (SELECT c FROM t3);
+a
+2
+# t2 is eliminated; the subquery must still be shown and executed:
+explain SELECT t0.k, t4.x FROM t0
+LEFT JOIN (t4 LEFT JOIN t2 ON t2.b = t4.a)
+ON (t0.k = t4.x AND t4.a = (SELECT c FROM t3));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	2	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	2	Using where; Using join buffer (flat, BNL join)
+2	SUBQUERY	t3	system	NULL	NULL	NULL	NULL	1	
+SELECT t0.k, t4.x FROM t0
+LEFT JOIN (t4 LEFT JOIN t2 ON t2.b = t4.a)
+ON (t0.k = t4.x AND t4.a = (SELECT c FROM t3));
+k	x
+20	20
+9	NULL
+truncate t2;
+DROP TABLE t4;
+CREATE TABLE t4 (d INT);
+INSERT INTO t4 VALUES (1),(2),(7);
+# The subquery is shared with the WHERE clause, so it must still be
+# shown and executed:
+explain SELECT t1.* FROM t1
+LEFT JOIN t2 ON (t2.b = t1.a)
+LEFT JOIN t4 ON (t4.d = t1.a)
+WHERE t1.a = (SELECT c FROM t3);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t2	system	PRIMARY	NULL	NULL	NULL	0	Const row not found
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Using join buffer (flat, BNL join)
+2	SUBQUERY	t3	system	NULL	NULL	NULL	NULL	1	
+SELECT t1.* FROM t1
+LEFT JOIN t2 ON (t2.b = t1.a)
+LEFT JOIN t4 ON (t4.d = t1.a)
+WHERE t1.a = (SELECT c FROM t3);
+a
+2
+explain SELECT t1.a FROM t1
+LEFT JOIN t2 ON (t2.b = t1.a AND t1.a <> (SELECT c FROM t3))
+LEFT JOIN t4 ON (t4.d = t1.a);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t2	system	PRIMARY	NULL	NULL	NULL	0	Const row not found
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	
+1	PRIMARY	t4	ALL	NULL	NULL	NULL	NULL	3	Using where; Using join buffer (flat, BNL join)
+2	SUBQUERY	t3	system	NULL	NULL	NULL	NULL	1	
+SELECT t1.a FROM t1
+LEFT JOIN t2 ON (t2.b = t1.a AND t1.a <> (SELECT c FROM t3))
+LEFT JOIN t4 ON (t4.d = t1.a);
+a
+1
+2
+DROP TABLE t0, t1, t2, t3, t4;
+#
 # End of 10.11 tests
 #

--- a/mysql-test/main/table_elim.test
+++ b/mysql-test/main/table_elim.test
@@ -838,5 +838,62 @@ select t1.null_col from t1 left join t2 on (t2.unique_col<=>t1.notnull_col);
 DROP TABLE t1, t2;
 
 --echo #
+--echo # MDEV-36610: Subquery wrongly marked as eliminated by table elimination
+--echo #             when equality propagation shares a WHERE-clause subquery
+--echo #             into an eliminated outer join's ON expression
+--echo #
+CREATE TABLE t0 (k INT);
+INSERT INTO t0 VALUES (20),(9);
+CREATE TABLE t1 (a BIGINT);
+INSERT INTO t1 VALUES (1),(2);
+CREATE TABLE t2 (b INT PRIMARY KEY);
+INSERT INTO t2 VALUES (3),(4);
+INSERT INTO t2 VALUES (5),(6);
+CREATE TABLE t3 (c INT);
+INSERT INTO t3 VALUES (2);
+CREATE TABLE t4 (a BIGINT, x INT);
+INSERT INTO t4 VALUES (2,20),(3,30);
+
+--echo # t2 is eliminated, but the subquery must still be shown and executed:
+
+let $q=
+SELECT t1.* FROM t1 LEFT JOIN t2 ON (t2.b = t1.a)
+  WHERE t1.a = (SELECT c FROM t3);
+eval explain $q;
+eval $q;
+
+--echo # t2 is eliminated; the subquery must still be shown and executed:
+let $q=
+SELECT t0.k, t4.x FROM t0
+LEFT JOIN (t4 LEFT JOIN t2 ON t2.b = t4.a)
+ON (t0.k = t4.x AND t4.a = (SELECT c FROM t3));
+eval explain $q;
+eval $q;
+
+truncate t2;
+DROP TABLE t4;
+CREATE TABLE t4 (d INT);
+INSERT INTO t4 VALUES (1),(2),(7);
+--echo # The subquery is shared with the WHERE clause, so it must still be
+--echo # shown and executed:
+let $q=
+SELECT t1.* FROM t1
+  LEFT JOIN t2 ON (t2.b = t1.a)
+  LEFT JOIN t4 ON (t4.d = t1.a)
+  WHERE t1.a = (SELECT c FROM t3);
+eval explain $q;
+eval $q;
+
+let $q=
+SELECT t1.a FROM t1
+  LEFT JOIN t2 ON (t2.b = t1.a AND t1.a <> (SELECT c FROM t3))
+  LEFT JOIN t4 ON (t4.d = t1.a);
+eval explain $q;
+eval $q;
+
+
+DROP TABLE t0, t1, t2, t3, t4;
+
+--echo #
 --echo # End of 10.11 tests
 --echo #

--- a/sql/item.h
+++ b/sql/item.h
@@ -2300,6 +2300,7 @@ public:
 
   virtual bool enumerate_field_refs_processor(void *arg) { return 0; }
   virtual bool mark_as_eliminated_processor(void *arg) { return 0; }
+  virtual bool unmark_as_eliminated_processor(void *arg) { return 0; }
   virtual bool eliminate_subselect_processor(void *arg) { return 0; }
   virtual bool view_used_tables_processor(void *arg) { return 0; }
   virtual bool eval_not_null_tables(void *arg) { return 0; }

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -7459,6 +7459,21 @@ bool Item_equal::walk(Item_processor processor, bool walk_subquery, void *arg)
 }
 
 
+/**
+  @brief
+  Subqueries that equality propagation converted to constants must not
+  be marked as eliminated, so unmark them.
+*/
+
+bool Item_equal::unmark_as_eliminated_processor(void *arg)
+{
+  Item *c= get_const();
+  if (c)
+    c->walk(&Item::unmark_as_eliminated_processor, FALSE, arg);
+  return FALSE;
+}
+
+
 Item *Item_equal::transform(THD *thd, Item_transformer transformer, uchar *arg)
 {
   DBUG_ASSERT(!thd->stmt_arena->is_stmt_prepare());

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -3519,6 +3519,7 @@ public:
                       SARGABLE_PARAM **sargables) override;
   SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
   bool walk(Item_processor processor, bool walk_subquery, void *arg) override;
+  bool unmark_as_eliminated_processor(void *arg) override;
   Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override;
   void print(String *str, enum_query_type query_type) override;
   const Type_handler *compare_type_handler() const { return m_compare_handler; }

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -374,9 +374,38 @@ bool Item_subselect::enumerate_field_refs_processor(void *arg)
   return FALSE;
 }
 
+
+/**
+  @brief
+  Set the "eliminated" flag set by mark_as_eliminated_processor().
+
+  @details
+  Table elimination marks every subquery reachable from an eliminated outer
+  join's ON expression as eliminated.
+*/
+
 bool Item_subselect::mark_as_eliminated_processor(void *arg)
 {
   eliminated= TRUE;
+  return FALSE;
+}
+
+/**
+  @brief
+  Clear the "eliminated" flag set by mark_as_eliminated_processor().
+
+  @details
+  Equality propagation (build_equal_items()) can inject a reference to a
+  subquery that lives in another part of the query (e.g. the WHERE clause)
+  into that ON expression.  Such a subquery still has to be executed,
+  so after elimination we walk the surviving expressions and clear the flag
+  on any subquery still referenced from them.
+*/
+
+
+bool Item_subselect::unmark_as_eliminated_processor(void *arg)
+{
+  eliminated= FALSE;
   return FALSE;
 }
 

--- a/sql/item_subselect.h
+++ b/sql/item_subselect.h
@@ -242,6 +242,7 @@ public:
   bool walk(Item_processor processor, bool walk_subquery, void *arg) override;
   bool unknown_splocal_processor(void *arg) override;
   bool mark_as_eliminated_processor(void *arg) override;
+  bool unmark_as_eliminated_processor(void *arg) override;
   bool eliminate_subselect_processor(void *arg) override;
   bool enumerate_field_refs_processor(void *arg) override;
   bool check_vcol_func_processor(void *arg) override

--- a/sql/opt_table_elimination.cc
+++ b/sql/opt_table_elimination.cc
@@ -629,6 +629,75 @@ void add_module_expr(Dep_analysis_context *dac, Dep_module_expr **eq_mod,
 
 /*****************************************************************************/
 
+/**
+  @brief
+  Clear the "eliminated" flag on every subquery reachable from the given
+  expression (see Item_subselect::unmark_as_eliminated_processor).
+*/
+
+static inline void unmark_eliminated_subqueries(Item *expr)
+{
+  if (expr)
+    expr->walk(&Item::unmark_as_eliminated_processor, FALSE, NULL);
+}
+
+
+/**
+  @brief
+  Clear the "eliminated" flag on subqueries reachable from ON expressions of
+  outer joins that were NOT eliminated. Such an ON expression is still
+  evaluated at runtime.
+*/
+
+static void unmark_live_on_expr_subqueries(JOIN *join,
+                                           List<TABLE_LIST> *join_list)
+{
+  TABLE_LIST *tbl;
+  List_iterator<TABLE_LIST> it(*join_list);
+  while ((tbl= it++))
+  {
+    if (tbl->nested_join)
+    {
+      unmark_live_on_expr_subqueries(join, &tbl->nested_join->join_list);
+      /* Only sweep this nest's ON expr if some of its tables survived. */
+      if (tbl->nested_join->used_tables & ~join->eliminated_tables)
+        unmark_eliminated_subqueries(tbl->on_expr);
+    }
+    else if (tbl->table && !(tbl->table->map & join->eliminated_tables))
+      unmark_eliminated_subqueries(tbl->on_expr);
+  }
+}
+
+
+/**
+  @brief
+  Equality propagation (build_equal_items()) can inject into the ON
+  expression of an eliminated outer join, a reference to a subquery that
+  actually lives in another (surviving) part of the query.
+  mark_as_eliminated() then flags that subquery as eliminated even though
+  it still has to be executed.
+  Clear the flag on every subquery that is still reachable.
+*/
+
+static void unmark_still_reachable(JOIN *join)
+{
+  unmark_eliminated_subqueries(join->conds);
+  unmark_eliminated_subqueries(join->having);
+
+  List_iterator<Item> live_it(join->fields_list);
+  Item *item;
+  while ((item= live_it++))
+    unmark_eliminated_subqueries(item);
+
+  for (ORDER *ord= join->order; ord; ord= ord->next)
+    unmark_eliminated_subqueries(*(ord->item));
+
+  for (ORDER *ord= join->group_list; ord; ord= ord->next)
+    unmark_eliminated_subqueries(*(ord->item));
+
+  unmark_live_on_expr_subqueries(join, join->join_list);
+}
+
 /*
   Perform table elimination
 
@@ -768,6 +837,7 @@ void eliminate_tables(JOIN *join)
     /* There are some tables that we probably could eliminate. Try it. */
     eliminate_tables_for_list(join, join->join_list, all_tables, NULL,
                               used_tables, &trace_eliminated_tables);
+    unmark_still_reachable(join);
   }
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
    When equality propagation (build_equal_items()) merges an equality that
    contains a subquery, such as "t1.a = (SELECT ...)", with an outer join's
    ON equality, it can inject a reference to that subquery into the ON
    expression. If the join columns have compatible types the subquery ends
    up as the constant of a multiple equality (which Item::walk() skips); if
    they differ (e.g. BIGINT vs INT) the field cannot be merged and the
    subquery is substituted in as a plain "tbl.col = (SELECT ...)" argument.
    
    In the latter case, if that outer join is removed by table elimination,
    mark_as_eliminated() walks the ON expression and flags the shared
    Item_subselect as eliminated. The subquery, however, still lives in
    another part of the query and has to be executed, tripping
    DBUG_ASSERT(!eliminated) in Item_subselect::exec() (and, in release
    builds, disabling the subquery cache and hiding it from EXPLAIN).
    
    The surviving reference can be:
     - a WHERE/HAVING/select-list/ORDER/GROUP expression (subquery written
       there and pushed down into the eliminated ON), or
     - the ON expression of an outer join that was not eliminated (subquery
       written in a surviving outer ON and pushed down into an eliminated
       inner one).
    
    Fix: after table elimination, walk the expressions that survive into
    execution (WHERE, HAVING, select list, ORDER/GROUP BY and the ON
    expressions of outer joins that were not eliminated) and clear the
    "eliminated" flag on any subquery still reachable from them.
    
    Because a subquery can also be the constant of a multiple equality, and
    Item::walk() does not visit an Item_equal's constant, Item_equal gets an
    unmark_as_eliminated_processor() override that descends into its constant
    explicitly.
