### PR TITLE
MDEV-17613 Read sole now-partition for non-historical versioned query

### DIFF
--- a/mysql-test/suite/versioning/r/partition,heap.rdiff
+++ b/mysql-test/suite/versioning/r/partition,heap.rdiff
@@ -1,5 +1,5 @@
---- partition.result	2024-07-19 08:48:17.680094893 +0200
-+++ partition,heap.result	2024-07-19 11:32:08.570439183 +0200
+--- partition.result
++++ partition,heap.reject
 @@ -2244,85 +2244,6 @@
  (PARTITION `p0` HISTORY ENGINE = X,
   PARTITION `pn` CURRENT ENGINE = X)
@@ -221,3 +221,19 @@
  # INSERT .. ON DUPLICATE KEY UPDATE (ODKU)
  set timestamp= unix_timestamp('2000-01-01 00:00:00');
  create or replace table t1 (x int primary key) with system versioning
+@@ -3657,13 +3450,13 @@
+ delete from t1 where id = 1;
+ select * from t1;
+ id
+-0
+ 2
++0
+ # Below there should be: Select tables optimized away
+ # (except heap combination)
+ explain extended select max(id) from t1;
+ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+-1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Select tables optimized away
++1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
+ Warnings:
+ Note	1003	select max(`test`.`t1`.`id`) AS `max(id)` from `test`.`t1`
+ drop tables t1;

--- a/mysql-test/suite/versioning/r/partition,heap.rdiff
+++ b/mysql-test/suite/versioning/r/partition,heap.rdiff
@@ -221,14 +221,7 @@
  # INSERT .. ON DUPLICATE KEY UPDATE (ODKU)
  set timestamp= unix_timestamp('2000-01-01 00:00:00');
  create or replace table t1 (x int primary key) with system versioning
-@@ -3657,13 +3450,13 @@
- delete from t1 where id = 1;
- select * from t1;
- id
--0
- 2
-+0
- # Below there should be: Select tables optimized away
+@@ -3663,7 +3456,7 @@
  # (except heap combination)
  explain extended select max(id) from t1;
  id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -385,10 +385,10 @@ set timestamp=unix_timestamp('2001-02-04 10:30:10');
 update t1 set i=6 where i=5;
 select subpartition_name, partition_description, table_rows from information_schema.partitions where table_schema='test' and table_name='t1';
 subpartition_name	partition_description	table_rows
-p1sp0	2001-02-04 00:00:00	1
-p1sp1	2001-02-04 00:00:00	0
 p0sp0	2001-02-05 00:00:00	1
 p0sp1	2001-02-05 00:00:00	1
+p1sp0	2001-02-04 00:00:00	1
+p1sp1	2001-02-04 00:00:00	0
 p2sp0	2001-02-06 00:00:00	0
 p2sp1	2001-02-06 00:00:00	0
 pnsp0	CURRENT	0
@@ -398,8 +398,8 @@ i
 1
 select * from t1 partition (p0);
 i
-5
 2
+5
 select * from t1 partition (p2);
 i
 alter table t1 rebuild partition p0, p1, p2;
@@ -408,8 +408,8 @@ i
 1
 select * from t1 partition (p0);
 i
-5
 2
+5
 select * from t1 partition (p2);
 i
 ## pruning check
@@ -2216,9 +2216,9 @@ t1	CREATE TABLE `t1` (
  PARTITION `pn` CURRENT ENGINE = X)
 select * from t1;
 x
-3
 13
 23
+3
 select * from t1 for system_time all order by x;
 x
 3

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -421,7 +421,7 @@ i
 6
 explain partitions select * from t1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	pn_pnsp0,pn_pnsp1	ALL	NULL	NULL	NULL	NULL	#	Using where
+1	SIMPLE	t1	pn_pnsp0,pn_pnsp1	ALL	NULL	NULL	NULL	NULL	#	
 explain partitions select * from t1 for system_time as of '2001-02-04 10:20:30';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	p0_p0sp0,p0_p0sp1,p2_p2sp0,p2_p2sp1,pn_pnsp0,pn_pnsp1	ALL	NULL	NULL	NULL	NULL	#	Using where
@@ -3641,5 +3641,59 @@ Table	Op	Msg_type	Msg_text
 test.t	repair	status	OK
 drop table t;
 set timestamp=default;
+#
+# MDEV-17613 Read sole now-partition for non-historical versioned query
+#
+create table t1 (
+id int,
+ts timestamp(6) generated always as row start invisible,
+te timestamp(6) generated always as row end invisible,
+primary key (id, te),
+period for system_time (ts, te)
+) with system versioning
+partition by system_time interval 1 month (
+partition p0 history, partition p1 history, partition pcur current);
+insert t1 values (1), (2), (0);
+delete from t1 where id = 1;
+select * from t1;
+id
+0
+2
+# Below there should be: Select tables optimized away
+# (except heap combination)
+explain extended select max(id) from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Select tables optimized away
+Warnings:
+Note	1003	select max(`test`.`t1`.`id`) AS `max(id)` from `test`.`t1`
+drop tables t1;
+# Corner cases: outer and sysvar-set FOR SYSTEM_TIME
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+create or replace table t1 (id int)
+with system versioning
+partition by system_time interval 1 hour
+starts timestamp'2000-01-01 00:00:00' (
+partition p0 history,
+partition p1 history,
+partition pn current);
+insert into t1 values (1);
+set timestamp= unix_timestamp('2000-01-01 01:30:00');
+update t1 set id= 2;
+# implicit query reads only the current partition (id=2):
+select id from t1;
+id
+2
+# outer FOR SYSTEM_TIME must propagate into derived t1 and read history (id=1):
+select * from (select id from t1) for system_time as of timestamp'2000-01-01 01:00:00' as dt;
+id
+1
+# system_versioning_asof must be honored and read history (id=1):
+set system_versioning_asof= '2000-01-01 01:00:00';
+select id from t1;
+id
+1
+set system_versioning_asof= default;
+set timestamp= default;
+drop table t1;
 # End of 10.11 tests
 set global innodb_stats_persistent= @save_persistent;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -2868,6 +2868,52 @@ repair table t;
 drop table t;
 set timestamp=default;
 
+--echo #
+--echo # MDEV-17613 Read sole now-partition for non-historical versioned query
+--echo #
+create table t1 (
+  id int,
+  ts timestamp(6) generated always as row start invisible,
+  te timestamp(6) generated always as row end invisible,
+  primary key (id, te),
+  period for system_time (ts, te)
+) with system versioning
+partition by system_time interval 1 month (
+  partition p0 history, partition p1 history, partition pcur current);
+
+
+insert t1 values (1), (2), (0);
+delete from t1 where id = 1;
+select * from t1;
+--echo # Below there should be: Select tables optimized away
+--echo # (except heap combination)
+explain extended select max(id) from t1;
+
+drop tables t1;
+
+--echo # Corner cases: outer and sysvar-set FOR SYSTEM_TIME
+set timestamp= unix_timestamp('2000-01-01 00:00:00');
+create or replace table t1 (id int)
+with system versioning
+partition by system_time interval 1 hour
+starts timestamp'2000-01-01 00:00:00' (
+  partition p0 history,
+  partition p1 history,
+  partition pn current);
+insert into t1 values (1);
+set timestamp= unix_timestamp('2000-01-01 01:30:00');
+update t1 set id= 2;
+--echo # implicit query reads only the current partition (id=2):
+select id from t1;
+--echo # outer FOR SYSTEM_TIME must propagate into derived t1 and read history (id=1):
+select * from (select id from t1) for system_time as of timestamp'2000-01-01 01:00:00' as dt;
+--echo # system_versioning_asof must be honored and read history (id=1):
+set system_versioning_asof= '2000-01-01 01:00:00';
+select id from t1;
+set system_versioning_asof= default;
+set timestamp= default;
+drop table t1;
+
 --echo # End of 10.11 tests
 
 set global innodb_stats_persistent= @save_persistent;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -26,14 +26,17 @@ partition by range columns (x) (
     partition p1 values less than (1000));
 
 insert into t1 values (3), (300);
+--sorted_result
 select * from t1;
 select * from t1 partition (p0);
 select * from t1 partition (p1);
 
 delete from t1;
+--sorted_result
 select * from t1;
 select * from t1 partition (p0);
 select * from t1 partition (p1);
+--sorted_result
 select * from t1 for system_time all;
 select * from t1 partition (p0) for system_time all;
 select * from t1 partition (p1) for system_time all;
@@ -140,6 +143,7 @@ alter table t1 drop partition p1;
 --error ER_VERS_WRONG_PARTS
 alter table t1 drop partition p0;
 
+--sorted_result
 select x from t1;
 
 --echo # rename works
@@ -216,6 +220,7 @@ update t1 set x = x + 1;
 
 --source suite/versioning/wait_system_clock.inc
 
+--sorted_result
 execute select_p0;
 execute select_pn;
 
@@ -251,11 +256,14 @@ show create table t1;
 alter table t1 drop partition non_existent;
 
 insert into t1 values (1), (2), (3), (4), (5), (6);
+--sorted_result
 select * from t1 partition (pn);
 delete from t1 where x < 4;
 delete from t1;
 --echo # You see warning above ^
+--sorted_result
 select * from t1 partition (p0);
+--sorted_result
 select * from t1 partition (p1);
 
 insert into t1 values (7), (8);
@@ -288,13 +296,17 @@ set @ts=(select partition_description from information_schema.partitions
   where table_schema='test' and table_name='t1' and partition_name='p0');
 
 alter table t1 add column b int;
+--sorted_result
 select partition_name,partition_ordinal_position,partition_method,timediff(partition_description, @ts) from information_schema.partitions where table_schema='test' and table_name='t1';
 alter table t1 add partition (partition p1 history, partition p2 history);
+--sorted_result
 select partition_name,partition_ordinal_position,partition_method,timediff(partition_description, @ts) from information_schema.partitions where table_schema='test' and table_name='t1';
 alter table t1 drop partition p0;
+--sorted_result
 select partition_name,partition_ordinal_position,partition_method,timediff(partition_description, @ts) from information_schema.partitions where table_schema='test' and table_name='t1';
 --error ER_VERS_DROP_PARTITION_INTERVAL
 alter table t1 drop partition p2;
+--sorted_result
 select partition_name,partition_ordinal_position,partition_method,timediff(partition_description, @ts) from information_schema.partitions where table_schema='test' and table_name='t1';
 
 #
@@ -310,7 +322,9 @@ insert t1 values (1); delete from t1;
 set timestamp=unix_timestamp('2001-02-04 10:20:50');
 insert t1 values (2); delete from t1;
 
+--sorted_result
 select subpartition_name, partition_description, table_rows from information_schema.partitions where table_schema='test' and table_name='t1';
+--sorted_result
 select * from t1 partition (p1);
 
 set timestamp=unix_timestamp('2001-02-04 10:20:55');
@@ -320,13 +334,16 @@ insert t1 values (4),(5);
 set timestamp=unix_timestamp('2001-02-04 10:30:10');
 update t1 set i=6 where i=5;
 
+--sorted_result
 select subpartition_name, partition_description, table_rows from information_schema.partitions where table_schema='test' and table_name='t1';
 select * from t1 partition (p1);
+--sorted_result
 select * from t1 partition (p0);
 select * from t1 partition (p2);
 
 alter table t1 rebuild partition p0, p1, p2;
 select * from t1 partition (p1);
+--sorted_result
 select * from t1 partition (p0);
 select * from t1 partition (p2);
 
@@ -466,6 +483,7 @@ set timestamp= unix_timestamp('2001-01-01 00:00:02');
 update t1 set i= i + 1;
 
 select *, row_end from t1 partition (p0);
+--sorted_result
 select *, row_end from t1 partition (p1);
 
 set timestamp= unix_timestamp('2000-01-01 00:00:00');
@@ -484,6 +502,7 @@ update t1 set i= i + 1;
 set timestamp= unix_timestamp('2000-01-04 00:00:01');
 update t1 set i= i + 1;
 
+--sorted_result
 select *, row_end from t1 partition (p0);
 select *, row_end from t1 partition (p1);
 
@@ -519,7 +538,9 @@ subpartition by key (x)
 subpartitions 2;
 
 insert into t1 (x) values (1), (2), (3), (4), (5);
+--sorted_result
 select * from t1 partition (pnsp0);
+--sorted_result
 select * from t1 partition (pnsp1);
 
 delete from t1 where x < 3;
@@ -529,6 +550,7 @@ delete from t1;
 --echo # You see warning above ^ (no matter if nothing was deleted)
 select * from t1 partition (p0sp0);
 select * from t1 partition (p0sp1);
+--sorted_result
 select * from t1 partition (p1sp0);
 select * from t1 partition (p1sp1);
 
@@ -873,6 +895,7 @@ create or replace table t1 (
 insert into t1 (x) values (1), (2), (3), (4);
 update t1 set a= 'foo' limit 3;
 update t1 set a= 'bar' limit 4;
+--sorted_result
 select * from t1;
 drop table t1;
 
@@ -930,6 +953,7 @@ create or replace table t1 (pk int primary key, f int) engine=innodb
         partition by key() partitions 2;
 insert into t1 values (1,10),(2,20);
 --echo # expected to hit same partition
+--sorted_result
 select * from t1 partition (p0);
 alter table t1 drop system versioning;
 
@@ -1130,17 +1154,20 @@ replace into t1 select seq from seq_1_to_70;
 # Puts 60 rows into p1
 replace into t1 select seq from seq_1_to_60;
 
+--sorted_result
 select partition_name, table_rows
 from information_schema.partitions
 where table_name = 't1';
 rollback;
 
+--sorted_result
 select partition_name, table_rows
 from information_schema.partitions
 where table_name = 't1';
 
 # Should put 10 rows into the empty partition p0
 replace into t1 select seq from seq_1_to_10;
+--sorted_result
 select partition_name, table_rows
 from information_schema.partitions
 where table_name = 't1';
@@ -1622,6 +1649,7 @@ starts '2000-01-01 00:00:00';
 --replace_result $default_engine DEFAULT_ENGINE
 show create table t1;
 select * from t1 partition (p0);
+--sorted_result
 select * from t1 partition (p1);
 select * from t1 partition (p2);
 select * from t1 partition (pn);
@@ -1637,6 +1665,7 @@ update t1 set x= x + 1;
 update t1 set x= x + 1;
 --echo # You see warning above ^
 select * from t1 partition (p0);
+--sorted_result
 select * from t1 partition (p1);
 select * from t1 partition (p2);
 select * from t1 partition (p3);
@@ -1791,6 +1820,7 @@ select * from tp1 for system_time all;
 
 --replace_result $default_engine X ' PAGE_CHECKSUM=1' ''
 show create table t1;
+--sorted_result
 select * from t1;
 select * from t1 for system_time all order by x;
 
@@ -2645,6 +2675,7 @@ insert into t1 (a,row_start,row_end) values
 ('p1',                   '2021-09-30', '2021-10-01 10:00:00'),
 ('overflows, so also p1','2021-09-30', '2021-10-10 10:00:00'),
 ('pn, current',          '2021-09-30', '2038-01-19 03:14:07.999999');
+--sorted_result
 select table_name,partition_name,partition_ordinal_position,partition_method,partition_description,table_rows
 from information_schema.partitions where table_schema='test';
 drop table t1;
@@ -2787,6 +2818,7 @@ update t1 set x= 3;
 
 --echo # CREATE result: row 1 got into p1
 select *, row_start, row_end from t1 partition (p0);
+--sorted_result
 select *, row_start, row_end from t1 partition (p1);
 flush tables;
 --echo # For CREATE pruning is affected by current timestamp, but SELECT works
@@ -2806,6 +2838,7 @@ partition by system_time interval 1 hour (
 
 --echo # ALTER result: row 1 got into p1
 Select *, row_start, row_end from t1 partition (p0);
+--sorted_result
 Select *, row_start, row_end from t1 partition (p1);
 flush tables;
 Explain partitions select * from t1 for system_time as of '2000-01-01 00:59:59';
@@ -2884,6 +2917,7 @@ partition by system_time interval 1 month (
 
 insert t1 values (1), (2), (0);
 delete from t1 where id = 1;
+--sorted_result
 select * from t1;
 --echo # Below there should be: Select tables optimized away
 --echo # (except heap combination)

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -1644,9 +1644,8 @@ public:
   ha_rows part_records(partition_element *part_elem)
   {
     DBUG_ASSERT(m_part_info);
-    uint32 sub_factor= m_part_info->num_subparts ? m_part_info->num_subparts : 1;
-    uint32 part_id= part_elem->id * sub_factor;
-    uint32 part_id_end= part_id + sub_factor;
+    uint32 part_id_end;
+    uint32 part_id= part_elem->bitmap_range(m_part_info->num_subparts, part_id_end);
     DBUG_ASSERT(part_id_end <= m_tot_parts);
     ha_rows part_recs= 0;
     for (; part_id < part_id_end; ++part_id)

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -4007,7 +4007,6 @@ static int find_used_partitions_imerge(PART_PRUNE_PARAM *ppar,
                                        SEL_IMERGE *imerge);
 static int find_used_partitions_imerge_list(PART_PRUNE_PARAM *ppar,
                                             List<SEL_IMERGE> &merges);
-static void mark_all_partitions_as_used(partition_info *part_info);
 
 #ifndef DBUG_OFF
 static void print_partitioning_index(KEY_PART *parts, KEY_PART *parts_end);
@@ -4024,13 +4023,28 @@ static void dbug_print_singlepoint_range(SEL_ARG **start, uint num);
   @param      table          Table to perform partition pruning for
   @param      pprune_cond    Condition to use for partition pruning
   
+  @param[in]  part_info->read_partitions
+              Candidate partitions to scan; normally all locked partitions,
+              but possibly already restricted (e.g. to the current partition
+              of a versioned table)
+
+  @param[out] part_info->read_partitions
+              Narrowed to the partitions that may hold records matching the
+              condition; never widened
+
   @note This function assumes that lock_partitions are setup when it
   is invoked. The function analyzes the condition, finds partitions that
   need to be used to retrieve the records that match the condition, and 
   marks them as used by setting appropriate bit in part_info->read_partitions
-  In the worst case all partitions are marked as used. If the table is not
-  yet locked, it will also unset bits in part_info->lock_partitions that is
-  not set in read_partitions.
+  If the table is not yet locked, it will also unset bits in
+  part_info->lock_partitions that is not set in read_partitions.
+
+  The matching set is computed independently of the incoming
+  read_partitions/lock_partitions: the analysis walks the whole partition
+  list (or only the value interval derived from the condition for
+  range-capable partitioning), and the result is then intersected into
+  read_partitions. A restriction already present in read_partitions
+  therefore narrows the outcome but does not reduce the pruning work.
 
   This function returns promptly if called for non-partitioned table.
 
@@ -4049,10 +4063,7 @@ bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond)
     DBUG_RETURN(FALSE); /* not a partitioned table */
   
   if (!pprune_cond)
-  {
-    mark_all_partitions_as_used(part_info);
     DBUG_RETURN(FALSE);
-  }
   
   PART_PRUNE_PARAM prune_param;
   MEM_ROOT alloc;
@@ -4068,7 +4079,6 @@ bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond)
 
   if (create_partition_index_description(&prune_param))
   {
-    mark_all_partitions_as_used(part_info);
     free_root(&alloc,MYF(0));		// Return memory & allocator
     DBUG_RETURN(FALSE);
   }
@@ -4170,11 +4180,10 @@ bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond)
 
 all_used:
   retval= FALSE; // some partitions are used
-  mark_all_partitions_as_used(prune_param.part_info);
   goto all_used_end;
 end:
-  bitmap_copy(&prune_param.part_info->read_partitions,
-              &prune_param.parts_bitmap);
+  bitmap_intersect(&prune_param.part_info->read_partitions,
+                   &prune_param.parts_bitmap);
 all_used_end:
   dbug_tmp_restore_column_maps(&table->read_set, &table->write_set, old_sets);
   thd->no_errors=0;
@@ -4839,13 +4848,6 @@ pop_and_go_right:
   return (left_res || right_res || res);
 }
  
-
-static void mark_all_partitions_as_used(partition_info *part_info)
-{
-  bitmap_copy(&(part_info->read_partitions),
-              &(part_info->lock_partitions));
-}
-
 
 /*
   Check if field types allow to construct partitioning index description

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -3928,7 +3928,7 @@ void store_key_image_to_rec(Field *field, uchar *ptr, uint len)
 struct st_part_prune_param;
 struct st_part_opt_info;
 
-typedef void (*mark_full_part_func)(partition_info*, uint32);
+typedef void (*mark_full_part_func)(struct st_part_prune_param*, uint32);
 
 /*
   Partition pruning operation context
@@ -3988,6 +3988,9 @@ typedef struct st_part_prune_param
 
   /* Iterator to be used to obtain the "current" set of used partitions */
   PARTITION_ITERATOR part_iter;
+
+  /* Initialized bitmap of read_partitions size */
+  MY_BITMAP parts_bitmap;
 
   /* Initialized bitmap of num_subparts size */
   MY_BITMAP subparts_bitmap;
@@ -4090,7 +4093,7 @@ bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond)
   thd->no_errors=1;				// Don't warn about NULL
   thd->mem_root=&alloc;
 
-  bitmap_clear_all(&part_info->read_partitions);
+  bitmap_clear_all(&prune_param.parts_bitmap);
 
   prune_param.key= prune_param.range_param.key_parts;
   SEL_TREE *tree;
@@ -4168,7 +4171,11 @@ bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond)
 all_used:
   retval= FALSE; // some partitions are used
   mark_all_partitions_as_used(prune_param.part_info);
+  goto all_used_end;
 end:
+  bitmap_copy(&prune_param.part_info->read_partitions,
+              &prune_param.parts_bitmap);
+all_used_end:
   dbug_tmp_restore_column_maps(&table->read_set, &table->write_set, old_sets);
   thd->no_errors=0;
   thd->mem_root= range_par->old_root;
@@ -4232,20 +4239,21 @@ static void store_selargs_to_rec(PART_PRUNE_PARAM *ppar, SEL_ARG **start,
 
 
 /* Mark a partition as used in the case when there are no subpartitions */
-static void mark_full_partition_used_no_parts(partition_info* part_info,
+static void mark_full_partition_used_no_parts(PART_PRUNE_PARAM *ppar,
                                               uint32 part_id)
 {
   DBUG_ENTER("mark_full_partition_used_no_parts");
   DBUG_PRINT("enter", ("Mark partition %u as used", part_id));
-  bitmap_set_bit(&part_info->read_partitions, part_id);
+  bitmap_set_bit(&ppar->parts_bitmap, part_id);
   DBUG_VOID_RETURN;
 }
 
 
 /* Mark a partition as used in the case when there are subpartitions */
-static void mark_full_partition_used_with_parts(partition_info *part_info,
+static void mark_full_partition_used_with_parts(PART_PRUNE_PARAM *ppar,
                                                 uint32 part_id)
 {
+  partition_info *part_info= ppar->part_info;
   uint32 start= part_id * part_info->num_subparts;
   uint32 end=   start + part_info->num_subparts; 
   DBUG_ENTER("mark_full_partition_used_with_parts");
@@ -4253,7 +4261,7 @@ static void mark_full_partition_used_with_parts(partition_info *part_info,
   for (; start != end; start++)
   {
     DBUG_PRINT("info", ("1:Mark subpartition %u as used", start));
-    bitmap_set_bit(&part_info->read_partitions, start);
+    bitmap_set_bit(&ppar->parts_bitmap, start);
   }
   DBUG_VOID_RETURN;
 }
@@ -4281,7 +4289,7 @@ static int find_used_partitions_imerge_list(PART_PRUNE_PARAM *ppar,
   MY_BITMAP all_merges;
   uint bitmap_bytes;
   my_bitmap_map *bitmap_buf;
-  uint n_bits= ppar->part_info->read_partitions.n_bits;
+  uint n_bits= ppar->parts_bitmap.n_bits;
   bitmap_bytes= bitmap_buffer_size(n_bits);
   if (!(bitmap_buf= (my_bitmap_map*) alloc_root(ppar->range_param.mem_root,
                                                 bitmap_bytes)))
@@ -4307,15 +4315,15 @@ static int find_used_partitions_imerge_list(PART_PRUNE_PARAM *ppar,
     }
 
     if (res != -1)
-      bitmap_intersect(&all_merges, &ppar->part_info->read_partitions);
+      bitmap_intersect(&all_merges, &ppar->parts_bitmap);
 
 
     if (bitmap_is_clear_all(&all_merges))
       return 0;
 
-    bitmap_clear_all(&ppar->part_info->read_partitions);
+    bitmap_clear_all(&ppar->parts_bitmap);
   }
-  memcpy(ppar->part_info->read_partitions.bitmap, all_merges.bitmap,
+  memcpy(ppar->parts_bitmap.bitmap, all_merges.bitmap,
          bitmap_bytes);
   return 1;
 }
@@ -4686,7 +4694,7 @@ int find_used_partitions(PART_PRUNE_PARAM *ppar, SEL_ARG *key_tree)
       {
         for (uint i= 0; i < ppar->part_info->num_subparts; i++)
           if (bitmap_is_set(&ppar->subparts_bitmap, i))
-            bitmap_set_bit(&ppar->part_info->read_partitions,
+            bitmap_set_bit(&ppar->parts_bitmap,
                            part_id * ppar->part_info->num_subparts + i);
       }
       goto pop_and_go_right;
@@ -4748,7 +4756,7 @@ int find_used_partitions(PART_PRUNE_PARAM *ppar, SEL_ARG *key_tree)
         while ((part_id= ppar->part_iter.get_next(&ppar->part_iter)) !=
                 NOT_A_PARTITION_ID)
         {
-          bitmap_set_bit(&part_info->read_partitions,
+          bitmap_set_bit(&ppar->parts_bitmap,
                          part_id * part_info->num_subparts + subpart_id);
         }
         res= 1; /* Some partitions were marked as used */
@@ -4803,7 +4811,7 @@ process_next_key_part:
       while ((part_id= ppar->part_iter.get_next(&ppar->part_iter)) !=
              NOT_A_PARTITION_ID)
       {
-        ppar->mark_full_partition_used(ppar->part_info, part_id);
+        ppar->mark_full_partition_used(ppar, part_id);
         found= TRUE;
       }
       res= MY_TEST(found);
@@ -4943,6 +4951,15 @@ static bool create_partition_index_description(PART_PRUNE_PARAM *ppar)
       !(ppar->is_subpart_keypart= (my_bool*)alloc_root(alloc, sizeof(my_bool)*
                                                            total_parts)))
     return TRUE;
+
+  {
+    my_bitmap_map *buf;
+    uint32 bufsize= bitmap_buffer_size(part_info->read_partitions.n_bits);
+    if (!(buf= (my_bitmap_map*) alloc_root(alloc, bufsize)))
+      return TRUE;
+    my_bitmap_init(&ppar->parts_bitmap, buf,
+                   part_info->read_partitions.n_bits);
+  }
  
   if (ppar->subpart_fields)
   {

--- a/sql/partition_element.h
+++ b/sql/partition_element.h
@@ -173,6 +173,19 @@ public:
     DBUG_ASSERT(ev->col_val_array);
     return ev->col_val_array[idx];
   }
+
+  /*
+    Leaf-bitmap (read/lock_partitions) range [bit_no, bit_no_end) covered by
+    this top-level partition: a single bit if not subpartitioned, num_subparts
+    bits otherwise.
+  */
+  uint32 bitmap_range(uint num_subparts, uint32 &bit_no_end) const
+  {
+    uint32 sub_factor= num_subparts ? num_subparts : 1;
+    uint32 first= id * sub_factor;
+    bit_no_end= first + sub_factor;
+    return first;
+  }
 };
 
 #endif /* PARTITION_ELEMENT_INCLUDED */

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -1031,10 +1031,9 @@ void partition_info::vers_check_limit(THD *thd)
     of partitions.
   */
 #ifndef DBUG_OFF
-  const uint32 sub_factor= num_subparts ? num_subparts : 1;
-  uint32 part_id= vers_info->hist_part->id * sub_factor;
-  const uint32 part_id_end __attribute__((unused)) = part_id + sub_factor;
-  DBUG_ASSERT(part_id_end <= num_parts * sub_factor);
+  uint32 part_id_end;
+  vers_info->hist_part->bitmap_range(num_subparts, part_id_end);
+  DBUG_ASSERT(part_id_end <= get_tot_partitions());
 #endif
 
   ha_partition *hp= (ha_partition*)(table->file);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -947,6 +947,7 @@ bool vers_select_conds_t::init_from_sysvar(THD *thd)
 {
   vers_asof_timestamp_t &in= thd->variables.vers_asof_timestamp;
   type= (vers_system_time_t) in.type;
+  orig_type= type;
   delete_history= false;
   start.unit= VERS_TIMESTAMP;
   if (type != SYSTEM_TIME_UNSPECIFIED && type != SYSTEM_TIME_ALL)
@@ -1237,22 +1238,23 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
     vers_select_conds_t &vers_conditions= table->vers_conditions;
 
 #ifdef WITH_PARTITION_STORAGE_ENGINE
-      /*
-        if the history is stored in partitions, then partitions
-        themselves are not versioned
-      */
-      if (table->partition_names && table->table->part_info->vers_info)
+    partition_info *part_info= table->table->part_info;
+    /*
+      if the history is stored in partitions, then partitions
+      themselves are not versioned
+    */
+    if (table->partition_names && part_info->vers_info)
+    {
+      /* If the history is stored in partitions, then partitions
+          themselves are not versioned. */
+      if (vers_conditions.was_set())
       {
-        /* If the history is stored in partitions, then partitions
-            themselves are not versioned. */
-        if (vers_conditions.was_set())
-        {
-          my_error(ER_VERS_QUERY_IN_PARTITION, MYF(0), table->alias.str);
-          DBUG_RETURN(-1);
-        }
-        else if (!vers_conditions.is_set())
-          vers_conditions.set_all();
+        my_error(ER_VERS_QUERY_IN_PARTITION, MYF(0), table->alias.str);
+        DBUG_RETURN(-1);
       }
+      else if (!vers_conditions.is_set())
+        vers_conditions.set_all();
+    }
 #endif
 
     if (outer_table && !vers_conditions.is_set())
@@ -1268,6 +1270,23 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
       if (vers_conditions.init_from_sysvar(thd))
         DBUG_RETURN(-1);
     }
+
+#ifdef WITH_PARTITION_STORAGE_ENGINE
+    if (part_info && part_info->vers_info &&
+        !table->partition_names &&
+        !vers_conditions.was_set())
+    {
+      /* Enable only now_part in read_partitions */
+      uint32 end;
+      const uint32 start= part_info->vers_info->now_part->bitmap_range(part_info->num_subparts, end);
+
+      bitmap_clear_all(&part_info->read_partitions);
+      for (uint32 i= start; i < end; i++)
+        bitmap_set_bit(&part_info->read_partitions, i);
+
+      vers_conditions.set_all();
+    }
+#endif
 
     if (vers_conditions.is_set())
     {

--- a/sql/table.h
+++ b/sql/table.h
@@ -2261,7 +2261,35 @@ public:
 
 struct vers_select_conds_t
 {
+  /*
+    Effective system-time selection used to build the actual row condition
+    (row_start/row_end predicate). is_set() tests it against SYSTEM_TIME_UNSPECIFIED.
+    set_all() forces it to SYSTEM_TIME_ALL in three situations:
+
+      1) once the row_start/row_end predicate for the requested time has been
+         generated and attached to the query - marking it applied so a later pass
+         or the next prepared-statement execution neither rebuilds nor re-applies
+         it (guarded by "if (type == SYSTEM_TIME_ALL) continue");
+
+      2) a versioned table whose history is stored in partitions is queried with
+         an explicit PARTITION(...) clause - the named partitions are read as-is,
+         without a versioning predicate;
+
+      3) the same kind of table queried implicitly (no FOR SYSTEM_TIME) -
+         read_partitions is narrowed to the now-partition, which takes the place
+         of the row_end predicate.
+
+    Because set_all() overwrites 'type', orig_type preserves what was actually
+    requested.
+  */
   vers_system_time_t type;
+  /*
+    Originally requested system-time selection, set by init() from an explicit
+    FOR SYSTEM_TIME clause or by init_from_sysvar() from @@system_versioning_asof.
+    Unlike 'type' it is NOT overwritten by set_all(), so it still reflects the
+    request after the predicate has been applied. Tested by was_set(); used by
+    print() to reconstruct the FOR SYSTEM_TIME clause.
+  */
   vers_system_time_t orig_type;
   bool used:1;
   bool delete_history:1;


### PR DESCRIPTION
    When a versioned table stores its history in partitions, an implicit
    query (no FOR SYSTEM_TIME) needs only current rows, which all live in the
    current partition. Restrict read_partitions to that partition in
    vers_setup_conds() instead of relying on a row_end condition.

    read_partitions is reset to all partitions every statement in
    open_table(), so this restriction must be re-applied on each execution.
    Guard it with !vers_conditions.was_set() rather than !is_set():
    set_all() sets type (flips is_set()) but not orig_type (was_set()), so
    is_set() would stay true across prepared-statement / stored-procedure
    re-executions and skip the restriction, leaving history partitions
    readable - rows matched then grow on each execute/call.

    EXPLAIN no longer shows "Using where" for such a query: correctness now
    comes from partition selection rather than a row_end filter.