### PR TITLE
MDEV-40175: JSON_VALID (postfix)

### DIFF
--- a/include/json_lib.h
+++ b/include/json_lib.h
@@ -435,8 +435,9 @@ int json_get_path_next(json_engine_t *je, json_path_t *p);
 int json_path_compare(const json_path_t *a, const json_path_t *b,
                       enum json_value_types vt, const int* array_size_counter);
 
-int json_valid(json_engine_t *je, const char *js, size_t js_len,
-               CHARSET_INFO *cs);
+int json_valid(const char *js, size_t js_len, CHARSET_INFO *cs);
+int json_valid_engine(json_engine_t *je, const char *js, size_t js_len,
+                      CHARSET_INFO *cs);
 
 int json_locate_key(const char *js, const char *js_end,
                     const char *kname,

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -605,7 +605,7 @@ bool Item_func_json_valid::val_bool()
   JSON_DO_PAUSE_EXECUTION(thd, 0.0002);
   je.killed_ptr= (uint32_t *) &thd->killed;
 
-  if (json_valid(&je, js->ptr(), js->length(), js->charset()))
+  if (json_valid_engine(&je, js->ptr(), js->length(), js->charset()))
     return true;
   /* Sql_condition::WARN_LEVEL_WARN becomes an error in check constraints */
   report_json_error_ex(js->ptr(), &je, func_name(), 0, Sql_condition::WARN_LEVEL_NOTE);

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -1840,13 +1840,7 @@ class User_table_json: public User_table
     if (!value_type && string)
       json.append('"');
     json.append(value_start, res->end() - value_start);
-#ifndef DBUG_OFF
-    {
-      json_engine_t je;
-      je.killed_ptr= nullptr;
-      DBUG_ASSERT(json_valid(&je, json.ptr(), json.length(), json.charset()));
-    }
-#endif
+    DBUG_ASSERT(json_valid(json.ptr(), json.length(), json.charset()));
     m_table->field[2]->store(json.ptr(), json.length(), json.charset());
     return value_type;
   }

--- a/strings/json_lib.c
+++ b/strings/json_lib.c
@@ -2043,7 +2043,7 @@ enum json_types json_get_object_nkey(const char *js __attribute__((unused)),
   @retval 1 - success, json is well-formed
   @retval 0 - error, json is invalid
 */
-int json_valid(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *cs)
+int json_valid_engine(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *cs)
 {
   volatile const uint32_t *killed_ptr= je->killed_ptr;
   json_scan_start(je, cs, (const uchar *) js, (const uchar *) js + js_len);
@@ -2052,6 +2052,13 @@ int json_valid(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *c
   return je->s.error == 0;
 }
 
+int json_valid(const char *js, size_t js_len, CHARSET_INFO *cs)
+{
+  json_engine_t je;
+  json_scan_start(&je, cs, (const uchar *) js, (const uchar *) js + js_len);
+  while (json_scan_next(&je) == 0) /* no-op */ ;
+  return je.s.error == 0;
+}
 
 /*
   Expects the JSON object as an js argument, and the key name.

--- a/strings/json_normalize.c
+++ b/strings/json_normalize.c
@@ -828,7 +828,7 @@ json_normalize_engine(json_engine_t *je, DYNAMIC_STRING *result,
   }
 
 
-  if (!json_valid(je, in, in_size, &my_charset_utf8mb4_bin))
+  if (!json_valid_engine(je, in, in_size, &my_charset_utf8mb4_bin))
   {
     err= 1;
     goto json_normalize_end;


### PR DESCRIPTION
a90779098b8683bcf87201e21f1c6d21abdbb56d changed the interface to the json_valid to take a json_engine_t so that it could be interupted and so that warnings could become visible.

On merge from that 10.11 to 11.4 it was discovered that the ColumnStore engine uses this interface.

Restored the original json_valid function exactly
how ColumnStore expects this and added renamed
the function with json_engine_t to be json_valid_engine.

This follows the same convention as in the commit
a90779098b8683bcf87201e21f1c6d21abdbb56d that was
for json_normalize, that ColumnStore also used.