### PR TITLE
Json valid normalize preserve names

### DIFF
--- a/include/json_lib.h
+++ b/include/json_lib.h
@@ -443,8 +443,10 @@ int json_locate_key(const char *js, const char *js_end,
                     const char **key_start, const char **key_end,
                     int *comma_pos);
 
-int json_normalize(json_engine_t *je, DYNAMIC_STRING *result,
+int json_normalize(DYNAMIC_STRING *result,
                    const char *s, size_t size, CHARSET_INFO *cs);
+int json_normalize_engine(json_engine_t *je, DYNAMIC_STRING *result,
+                          const char *s, size_t size, CHARSET_INFO *cs);
 
 int json_skip_array_and_count(json_engine_t *j, int* n_item);
 

--- a/include/json_lib.h
+++ b/include/json_lib.h
@@ -435,8 +435,9 @@ int json_get_path_next(json_engine_t *je, json_path_t *p);
 int json_path_compare(const json_path_t *a, const json_path_t *b,
                       enum json_value_types vt, const int* array_size_counter);
 
-int json_valid(json_engine_t *je, const char *js, size_t js_len,
-               CHARSET_INFO *cs);
+int json_valid(const char *js, size_t js_len, CHARSET_INFO *cs);
+int json_valid_engine(json_engine_t *je, const char *js, size_t js_len,
+                      CHARSET_INFO *cs);
 
 int json_locate_key(const char *js, const char *js_end,
                     const char *kname,

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -600,7 +600,7 @@ bool Item_func_json_valid::val_bool()
   JSON_DO_PAUSE_EXECUTION(thd, 0.0002);
   je.killed_ptr= (uint32_t *) &thd->killed;
 
-  if (json_valid(&je, js->ptr(), js->length(), js->charset()))
+  if (json_valid_engine(&je, js->ptr(), js->length(), js->charset()))
     return true;
   /* Sql_condition::WARN_LEVEL_WARN becomes an error in check constraints */
   report_json_error_ex(js->ptr(), &je, func_name(), 0, Sql_condition::WARN_LEVEL_NOTE);

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -650,11 +650,11 @@ bool Item_func_json_equals::val_bool()
   JSON_DO_PAUSE_EXECUTION(thd, 0.0002);
   je.killed_ptr= (uint32_t *) &thd->killed;
 
-  if (json_normalize(&je, &a_res, a->ptr(), a->length(), a->charset()))
+  if (json_normalize_engine(&je, &a_res, a->ptr(), a->length(), a->charset()))
     goto return_null;
 
   arg_num++;
-  if (json_normalize(&je, &b_res, b->ptr(), b->length(), b->charset()))
+  if (json_normalize_engine(&je, &b_res, b->ptr(), b->length(), b->charset()))
     goto return_null;
 
   result= strcmp(a_res.str, b_res.str) ? 0 : 1;
@@ -4620,9 +4620,9 @@ String *Item_func_json_normalize::val_str(String *buf)
   JSON_DO_PAUSE_EXECUTION(thd, 0.0002);
   je.killed_ptr= (uint32_t *) &thd->killed;
 
-  if (json_normalize(&je, &normalized_json,
-                     raw_json->ptr(), raw_json->length(),
-                     raw_json->charset()))
+  if (json_normalize_engine(&je, &normalized_json,
+                            raw_json->ptr(), raw_json->length(),
+                            raw_json->charset()))
     goto null_return;
 
   buf->length(0);
@@ -4840,13 +4840,13 @@ int compare_nested_object(json_engine_t *js, json_engine_t *value)
   { 
     goto error;
   }
-  if (json_normalize(&je, &a_res, a.ptr(), a.length(), value->s.cs))
+  if (json_normalize_engine(&je, &a_res, a.ptr(), a.length(), value->s.cs))
   {
     value->s.error= je.s.error;
     value->s.c_str= je.s.c_str;
     goto error;
   }
-  if (json_normalize(&je, &b_res, b.ptr(), b.length(), value->s.cs))
+  if (json_normalize_engine(&je, &b_res, b.ptr(), b.length(), value->s.cs))
   {
     js->s.error= je.s.error;
     js->s.c_str= je.s.c_str;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -1847,13 +1847,7 @@ class User_table_json: public User_table
     if (!value_type && string)
       json.append('"');
     json.append(value_start, res->end() - value_start);
-#ifndef DBUG_OFF
-    {
-      json_engine_t je;
-      je.killed_ptr= nullptr;
-      DBUG_ASSERT(json_valid(&je, json.ptr(), json.length(), json.charset()));
-    }
-#endif
+    DBUG_ASSERT(json_valid(json.ptr(), json.length(), json.charset()));
     m_table->field[2]->store(json.ptr(), json.length(), json.charset());
     return value_type;
   }

--- a/strings/json_lib.c
+++ b/strings/json_lib.c
@@ -2043,7 +2043,7 @@ enum json_types json_get_object_nkey(const char *js __attribute__((unused)),
   @retval 1 - success, json is well-formed
   @retval 0 - error, json is invalid
 */
-int json_valid(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *cs)
+int json_valid_engine(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *cs)
 {
   volatile const uint32_t *killed_ptr= je->killed_ptr;
   json_scan_start(je, cs, (const uchar *) js, (const uchar *) js + js_len);
@@ -2052,6 +2052,13 @@ int json_valid(json_engine_t *je, const char *js, size_t js_len, CHARSET_INFO *c
   return je->s.error == 0;
 }
 
+int json_valid(const char *js, size_t js_len, CHARSET_INFO *cs)
+{
+  json_engine_t je;
+  json_scan_start(&je, cs, (const uchar *) js, (const uchar *) js + js_len);
+  while (json_scan_next(&je) == 0) /* no-op */ ;
+  return je.s.error == 0;
+}
 
 /*
   Expects the JSON object as an js argument, and the key name.

--- a/strings/json_normalize.c
+++ b/strings/json_normalize.c
@@ -828,7 +828,7 @@ json_normalize_engine(json_engine_t *je, DYNAMIC_STRING *result,
   }
 
 
-  if (!json_valid(je, in, in_size, &my_charset_utf8mb4_bin))
+  if (!json_valid_engine(je, in, in_size, &my_charset_utf8mb4_bin))
   {
     err= 1;
     goto json_normalize_end;

--- a/strings/json_normalize.c
+++ b/strings/json_normalize.c
@@ -784,8 +784,8 @@ json_norm_build(json_engine_t *je, struct json_norm_value *root,
 
 
 int
-json_normalize(json_engine_t *je, DYNAMIC_STRING *result,
-               const char *s, size_t size, CHARSET_INFO *cs)
+json_normalize_engine(json_engine_t *je, DYNAMIC_STRING *result,
+                      const char *s, size_t size, CHARSET_INFO *cs)
 {
   int err= 0;
   uint convert_err= 0;
@@ -857,3 +857,12 @@ json_normalize_end:
 }
 
 
+int
+json_normalize(DYNAMIC_STRING *result,
+               const char *s, size_t size, CHARSET_INFO *cs)
+{
+  json_engine_t je;
+
+  memset(&je, 0x00, sizeof(je));
+  return json_normalize_engine(&je, result, s, size, cs);
+}

--- a/unittest/json_lib/json_normalize-t.c
+++ b/unittest/json_lib/json_normalize-t.c
@@ -25,13 +25,12 @@ check_json_normalize(const char *in, const char *expected)
 {
   int err;
   DYNAMIC_STRING result;
-  json_engine_t je= {0};
+
   CHARSET_INFO *cs= &my_charset_utf8mb4_general_ci;
 
-  je.killed_ptr= NULL;
   init_dynamic_string(&result, NULL, 0, 0);
 
-  err= json_normalize(&je, &result, in, strlen(in), cs);
+  err= json_normalize(&result, in, strlen(in), cs);
 
   ok(err == 0, "normalize err?");
 
@@ -47,29 +46,26 @@ static void
 test_json_normalize_invalid(void)
 {
   DYNAMIC_STRING result;
-  json_engine_t je= {0};
+
   CHARSET_INFO *cs= &my_charset_utf8mb4_general_ci;
 
   init_dynamic_string(&result, NULL, 0, 0);
-  ok(json_normalize(&je, &result, STRING_WITH_LEN(""), cs) != 0,
+  ok(json_normalize(&result, STRING_WITH_LEN(""), cs) != 0,
      "expected normalized error");
   dynstr_free(&result);
 
-  memset(&je, 0, sizeof(je));
   init_dynamic_string(&result, NULL, 0, 0);
-  ok(json_normalize(&je, &result, STRING_WITH_LEN("["), cs) != 0,
+  ok(json_normalize(&result, STRING_WITH_LEN("["), cs) != 0,
      "expected normalized error");
   dynstr_free(&result);
 
-  memset(&je, 0, sizeof(je));
   init_dynamic_string(&result, NULL, 0, 0);
-  ok(json_normalize(&je, &result, STRING_WITH_LEN("}"), cs) != 0,
+  ok(json_normalize(&result, STRING_WITH_LEN("}"), cs) != 0,
      "expected normalized error");
   dynstr_free(&result);
 
-  memset(&je, 0, sizeof(je));
   init_dynamic_string(&result, NULL, 0, 0);
-  ok(json_normalize(&je, &result, NULL, 0, cs) != 0,
+  ok(json_normalize(&result, NULL, 0, cs) != 0,
      "expected normalized error");
   dynstr_free(&result);
 }
@@ -204,19 +200,17 @@ test_json_normalize_non_utf8(void)
   const char utf8[]= { 0x22, 0xC3, 0x8A, 0x22, 0x00 };
   const char latin[] = { 0x22, 0xCA, 0x22, 0x00 };
   DYNAMIC_STRING result;
-  json_engine_t je= {0};
   CHARSET_INFO *cs_utf8= &my_charset_utf8mb4_bin;
   CHARSET_INFO *cs_latin= &my_charset_latin1;
 
   init_dynamic_string(&result, NULL, 0, 0);
-  err= json_normalize(&je, &result, utf8, strlen(utf8), cs_utf8);
+  err= json_normalize(&result, utf8, strlen(utf8), cs_utf8);
   ok(err == 0, "normalize err?");
   ok((strcmp(utf8, result.str) == 0), "utf8 round trip");
   dynstr_free(&result);
 
-  memset(&je, 0, sizeof(je));
   init_dynamic_string(&result, NULL, 0, 0);
-  err= json_normalize(&je, &result, latin, strlen(latin), cs_latin);
+  err= json_normalize(&result, latin, strlen(latin), cs_latin);
   ok(err == 0, "normalize err?");
   ok((strcmp(utf8, result.str) == 0), "latin to utf8 round trip");
   dynstr_free(&result);


### PR DESCRIPTION
Columnstore compatibility in 11.4+ of these function names needs to occur.

To prevent a merge requiring a function name change, we backport the compatibility to 10.11.