### PR TITLE
MDEV-39530 Collation mix issue after update

### DIFF
--- a/mysql-test/main/ctype_collate.result
+++ b/mysql-test/main/ctype_collate.result
@@ -808,3 +808,25 @@ ts
 2024-01-26 21:38:02
 drop table t1;
 # End of 10.6 tests
+#
+# MDEV-39530: Collation mix issue after update
+#
+# Reproduce the environment from the report: character_set_collations
+# maps utf8mb3 to utf8mb3_uca1400_ai_ci and the connection uses that
+# collation.
+SET NAMES utf8mb3 COLLATE utf8mb3_uca1400_ai_ci;
+SELECT @@character_set_collations, @@collation_connection;
+@@character_set_collations	@@collation_connection
+utf8mb3=utf8mb3_uca1400_ai_ci,ucs2=ucs2_uca1400_ai_ci,utf8mb4=utf8mb4_uca1400_ai_ci,utf16=utf16_uca1400_ai_ci,utf32=utf32_uca1400_ai_ci	utf8mb3_uca1400_ai_ci
+CREATE TABLE file (
+`ID` int(10) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`Path` varchar(800) NOT NULL DEFAULT ''
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+INSERT INTO file VALUES (1,"text");
+# This query used to work in 11.4 but raises
+# ER_CANT_AGGREGATE_2COLLATIONS in 12.1+
+SELECT IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2);
+IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2)
+2
+DROP TABLE file;
+# End of 12.3 tests

--- a/mysql-test/main/ctype_collate.test
+++ b/mysql-test/main/ctype_collate.test
@@ -378,3 +378,28 @@ select * from t1 order by ts collate utf8_bin;
 drop table t1;
 
 --echo # End of 10.6 tests
+
+--echo #
+--echo # MDEV-39530: Collation mix issue after update
+--echo #
+
+--echo # Reproduce the environment from the report: character_set_collations
+--echo # maps utf8mb3 to utf8mb3_uca1400_ai_ci and the connection uses that
+--echo # collation.
+SET NAMES utf8mb3 COLLATE utf8mb3_uca1400_ai_ci;
+SELECT @@character_set_collations, @@collation_connection;
+
+CREATE TABLE file (
+  `ID` int(10) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `Path` varchar(800) NOT NULL DEFAULT ''
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+INSERT INTO file VALUES (1,"text");
+
+--echo # This query used to work in 11.4 but raises
+--echo # ER_CANT_AGGREGATE_2COLLATIONS in 12.1+
+SELECT IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2);
+
+DROP TABLE file;
+
+--echo # End of 12.3 tests

--- a/mysql-test/main/user_var.result
+++ b/mysql-test/main/user_var.result
@@ -162,13 +162,13 @@ collation(@a:=_latin2'test')
 latin2_general_ci
 select coercibility(@a:=_latin2'test');
 coercibility(@a:=_latin2'test')
-6
+5
 select collation(@a:=_latin2'test' collate latin2_bin);
 collation(@a:=_latin2'test' collate latin2_bin)
 latin2_bin
 select coercibility(@a:=_latin2'test' collate latin2_bin);
 coercibility(@a:=_latin2'test' collate latin2_bin)
-6
+5
 select (@a:=_latin2'test' collate latin2_bin) = _latin2'TEST';
 (@a:=_latin2'test' collate latin2_bin) = _latin2'TEST'
 0

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4840,9 +4840,17 @@ bool Item_func_set_user_var::fix_fields(THD *thd, Item **ref)
   if (!m_var_entry->charset() || !null_item)
     m_var_entry->set_charset(args[0]->collation.derivation == DERIVATION_NUMERIC ?
                              &my_charset_numeric : args[0]->collation.collation);
+  /*
+    A user variable assignment (e.g. @p:=expr) must expose the same collation
+    derivation as reading the variable back with Item_func_get_user_var, which
+    uses DERIVATION_USERVAR (see MDEV-35041). Using DERIVATION_COERCIBLE here
+    made the assignment as strong as a string literal, causing "Illegal mix of
+    collations" conflicts against literals that carry the (possibly different)
+    connection collation (MDEV-39530).
+  */
   collation.set(m_var_entry->charset(),
                 args[0]->collation.derivation == DERIVATION_NUMERIC ?
-                DERIVATION_NUMERIC : DERIVATION_COERCIBLE);
+                DERIVATION_NUMERIC : DERIVATION_USERVAR);
   switch (args[0]->result_type()) {
   case STRING_RESULT:
   case TIME_RESULT:


### PR DESCRIPTION
## Description

`SELECT IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2);` fails with `ER_CANT_AGGREGATE_2COLLATIONS` ("Illegal mix of collations") when then connection collation (`utf8mb3_uca1400_ai_ci`, the post-MDEV-25829 default) differs from the column collation (`utf8mb3_unicode_ci`). The query worked in 11.4.

### Root cause

The comparison `(@p := subquery) != ""` forces the `!=` operator to pick a single collation for both operands. Every string expression carries two attributes that drive this decision:

- a **collation**, and
- a **derivation** (a.k.a. coercibility) that expresses how strongly that collation
  is attached to the value. Lower numeric derivation = stronger.

For the failing query the two operands are:

| Operand | Collation | Derivation (coercibility) | Source |
|---|---|---|---|
| `@p := (SELECT f.Path ...)` | `utf8mb3_unicode_ci` | `DERIVATION_COERCIBLE` (6) | inherited from column `Path` |
| `""` (empty string literal) | `utf8mb3_uca1400_ai_ci` | `DERIVATION_COERCIBLE` (6) | inherited from `collation_connection` |


Here both operands sit at `DERIVATION_COERCIBLE` (6) with *different* collations, so aggregation fails and the error is raised.


### Fix

Make `Item_func_set_user_var` use `DERIVATION_USERVAR` so that assigning a user variable has the same derivation as reading it back, keeping it weaker than a literal. With the assignment at level 5 and the literal at level 6, the operands are now at *different* levels, so aggregation simply coerces the empty string to the variable's collation and returns a result — regardless of the connection collation.

## Release Notes

N/A

## How can this PR be tested?

Execute the `main.user_var_collation` test in `mysql-test-run`. It sets a connection collation that differs from the column collation and runs the reporter's query.

### Before this change:

The query raised an error instead of returning a result:

```
SELECT IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2);
ERROR 1267 (HY000): Illegal mix of collations (utf8mb3_unicode_ci,COERCIBLE) and (utf8mb3_uca1400_ai_ci,COERCIBLE) for operation '<>'
```

### After this change:

The query returns the expected result, matching 11.4 behavior:

```
SELECT IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2);
IF((@p:=(SELECT f.Path FROM file f WHERE f.ID=1 AND f.Path REGEXP "^xx"))!="",1,2)
2
```

The coercibility of a user variable assignment now matches reading it back
(both `DERIVATION_USERVAR`), reflected in the updated `main.user_var` result:

```
select coercibility(@a:=_latin2'test');
coercibility(@a:=_latin2'test')
-6
+5
```

`main.user_var_collation`, `main.user_var`, and the `ctype_*` / `main.variables` suites all pass:

```
main.user_var                            [ pass ]
main.ctype_utf8                          [ pass ]
main.ctype_utf8mb4                       [ pass ]
main.ctype_latin1                        [ pass ]
main.ctype_ucs                           [ pass ]
main.ctype_collate                       [ pass ]
main.ctype_utf8mb3_uca1400_ai_ci         [ pass ]
main.variables                           [ pass ]
main.user_var_collation                  [ pass ]
Completed: All tests were successful.
```
`main` suite passed without failure relevant to this change.

## Basing the PR against the correct MariaDB version

- [x] _This is a bug fix, and the PR is based against the branch 12.3._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.