### PR TITLE
MDEV-40204: Unexpected Linux AIO errors drop the tablespace/subsequent reads fatal

### DIFF
--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -665,17 +665,26 @@ bool buf_dblwr_t::flush_buffered_writes(const ulint size) noexcept
   if (multi_batch)
   {
     fil_system.sys_space->reacquire();
-    os_aio(request, write_buf,
-           os_offset_t{block1.page_no()} << srv_page_size_shift,
-           size << srv_page_size_shift);
-    os_aio(request, write_buf + (size << srv_page_size_shift),
-           os_offset_t{block2.page_no()} << srv_page_size_shift,
-           (old_first_free - size) << srv_page_size_shift);
+    if (os_aio(request, write_buf,
+               os_offset_t{block1.page_no()} << srv_page_size_shift,
+               size << srv_page_size_shift) != DB_SUCCESS
+        || os_aio(request, write_buf + (size << srv_page_size_shift),
+                  os_offset_t{block2.page_no()} << srv_page_size_shift,
+                  (old_first_free - size) << srv_page_size_shift)
+           != DB_SUCCESS)
+    {
+      mysql_mutex_lock(&mutex); // callers assume false has the mutex locked
+      return false;
+    }
   }
   else
-    os_aio(request, write_buf,
-           os_offset_t{block1.page_no()} << srv_page_size_shift,
-           old_first_free << srv_page_size_shift);
+    if (os_aio(request, write_buf,
+               os_offset_t{block1.page_no()} << srv_page_size_shift,
+               old_first_free << srv_page_size_shift) != DB_SUCCESS)
+    {
+      mysql_mutex_lock(&mutex);
+      return false;
+    }
   return true;
 }
 
@@ -759,8 +768,13 @@ void buf_dblwr_t::flush_buffered_writes_completed(const IORequest &request)
     ut_ad(!e.request.node->space->full_crc32() ||
           !buf_page_is_corrupted(true, static_cast<const byte*>(frame),
                                  e.request.node->space->flags));
-    e.request.node->space->io(e.request, bpage->physical_offset(), e_size,
-                              frame, bpage);
+    fil_io_t fil= e.request.node->space->io(e.request,
+                                            bpage->physical_offset(), e_size,
+                                            frame, bpage);
+    if (fil.err != DB_SUCCESS)
+    {
+      // TODO, or cry
+    }
   }
 }
 

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -989,9 +989,11 @@ uint32_t fil_space_t::flush_freed(bool writable) noexcept
     {
       written+= range.last - range.first + 1;
       reacquire();
-      io(IORequest(IORequest::PUNCH_RANGE),
-         os_offset_t{range.first} * physical,
-         (range.last - range.first + 1) * physical, nullptr);
+      fil_io_t fio= io(IORequest(IORequest::PUNCH_RANGE),
+                       os_offset_t{range.first} * physical,
+                       (range.last - range.first + 1) * physical, nullptr);
+      if (fio.err != DB_SUCCESS)
+        continue; /* result of io had to be used */
     }
   }
   else
@@ -1002,8 +1004,10 @@ uint32_t fil_space_t::flush_freed(bool writable) noexcept
       for (os_offset_t i= range.first; i <= range.last; i++)
       {
         reacquire();
-        io(IORequest(IORequest::WRITE_ASYNC), i * physical, physical,
-           const_cast<byte*>(field_ref_zero));
+        fil_io_t fio= io(IORequest(IORequest::WRITE_ASYNC), i * physical, physical,
+                         const_cast<byte*>(field_ref_zero));
+        if (fio.err != DB_SUCCESS)
+          continue; /* result of io had to be used */
       }
     }
   }

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1185,6 +1185,7 @@ fil_space_t *fil_space_t::get_for_write(uint32_t id) noexcept
   return space;
 }
 
+MY_ATTRIBUTE((warn_unused_result))
 /** Start writing out pages for a tablespace.
 @param id   tablespace identifier
 @return tablespace and number of pages written */

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -855,8 +855,10 @@ bool buf_page_t::flush(fil_space_t *space) noexcept
       log_write_up_to(lsn, true);
     ut_ad(space->is_temporary() || !space->full_crc32() ||
           !buf_page_is_corrupted(true, write_frame, space->flags));
-    space->io(IORequest{type, this, slot}, physical_offset(), size,
-              write_frame, this);
+    fil_io_t fio= space->io(IORequest{type, this, slot}, physical_offset(), size,
+                            write_frame, this);
+    if (fio.err != DB_SUCCESS)
+      return false;
   }
   else
     buf_dblwr.add_to_batch(IORequest{this, slot, space->chain.start, type},

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2781,7 +2781,7 @@ release:
 		}
 		ut_ad(fil_validate_skip());
 	}
-	if (err != DB_SUCCESS) {
+	else if (err != DB_SUCCESS) {
 		goto release;
 	}
 func_exit:

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -998,6 +998,7 @@ public:
   @param buf      the data to be read or written
   @param bpage    buffer block (for type.is_async() completion callback)
   @return status and file descriptor */
+  MY_ATTRIBUTE((warn_unused_result))
   fil_io_t io(const IORequest &type, os_offset_t offset, size_t len,
               void *buf, buf_page_t *bpage= nullptr) noexcept;
   /** Flush pending writes from the file system cache to the file. */

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -994,6 +994,7 @@ void os_fake_read(const IORequest &type, os_offset_t offset) noexcept;
 @param n		number of bytes
 @retval DB_SUCCESS if request was queued successfully
 @retval DB_IO_ERROR on I/O error */
+MY_ATTRIBUTE((warn_unused_result))
 dberr_t os_aio(const IORequest &type, void *buf, os_offset_t offset, size_t n)
   noexcept;
 

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3356,7 +3356,6 @@ func_exit:
 					     ? "aio read" : "aio write",
 					     false);
 		err = DB_IO_ERROR;
-		type.node->space->release();
 	}
 
 	goto func_exit;

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3352,9 +3352,13 @@ func_exit:
 
 	if (srv_thread_pool->submit_io(cb)) {
 		slots->release(cb);
-		os_file_handle_error_no_exit(type.node->name, type.is_read()
-					     ? "aio read" : "aio write",
-					     false);
+		const char *op= type.is_read() ? "aio read" : "aio write";
+		os_file_handle_error_no_exit(type.node->name, op, false);
+		sql_print_error("InnoDB: Tried to %s %zu bytes at offset %" PRIu64
+				" of file %s(file descriptor %d), buffer=%p, "
+				" but error %d instead",
+				op, n, offset, type.node->name,
+				type.node->handle.m_file, buf, errno);
 		err = DB_IO_ERROR;
 	}
 

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -671,6 +671,7 @@ handle_new_error:
 	case DB_INTERRUPTED:
 	case DB_CANT_CREATE_GEOMETRY_OBJECT:
 	case DB_TABLE_NOT_FOUND:
+	case DB_TABLESPACE_DELETED:
 	case DB_DECRYPTION_FAILED:
 	case DB_COMPUTE_VALUE_FAILED:
 	rollback_to_savept:


### PR DESCRIPTION
When a tablespace is dropped for any internal reason, the reading of that tables results in a DB_TABLESPACE_DELETED error.

The default handling of this error is a fatal case.

The implementation is changes to handle the DB_TABLESPACE_DELETED just like a table error DB_TABLE_NOT_FOUND to cleanup, log error, but continue.