### PR TITLE
MDEV-38075: Make sysV init script check for actual function presence

### DIFF
--- a/support-files/mysql.server.sh
+++ b/support-files/mysql.server.sh
@@ -100,11 +100,19 @@ fi
 
 if test -f $init_functions; then
   . $init_functions
-else
+fi
+
+# Newer Red Hat releases no longer define these functions in
+# /etc/init.d/functions (or anywhere else), so provide fallbacks whenever
+# they are still undefined.
+if ! command -v log_success_msg >/dev/null 2>&1; then
   log_success_msg()
   {
     echo " SUCCESS! $@"
   }
+fi
+
+if ! command -v log_failure_msg >/dev/null 2>&1; then
   log_failure_msg()
   {
     echo " ERROR! $@"


### PR DESCRIPTION
fixes [MDEV-38075](https://jira.mariadb.org/browse/MDEV-38075)

### Problem:
The current implementation of the sysvinit script only creates `log_success_msg()` and `log_failure_msg()` fallback functions when not finding an `/etc/init.d/functions` file to include.

Newer RHEL releases do not define those functions in that file anymore.

### Fix:
Check if the functions are defined and provide fallback functions if they are not defined.