### PR TITLE
MDEV-40099: MSAN: use-of-uninitialized-value in `TABLE::delete_row<true>(bool)`

### DIFF
--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -149,3 +149,20 @@ drop table t1;
 #
 # End of 10.5 tests
 #
+#
+# MDEV-40099: MSAN: use-of-uninitialized-value in int `TABLE::delete_row<true>(bool)`
+#
+set @old_mode= @@sql_mode;
+set sql_mode='';
+create table t1 (c1 int key) engine=myisam with system versioning;
+insert into t1 () values ();
+Warnings:
+Warning	1364	Field 'c1' doesn't have a default value
+replace delayed into t1 () values ();
+drop table t1;
+create table t1 (c1 int key) engine=myisam with system versioning;
+insert into t1 (c1) values (1);
+replace delayed into t1 (c1) values (1);
+drop table t1;
+set sql_mode=@old_mode;
+# End of 10.11 tests

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -174,4 +174,27 @@ drop table t1;
 --echo # End of 10.5 tests
 --echo #
 
+--echo #
+--echo # MDEV-40099: MSAN: use-of-uninitialized-value in int `TABLE::delete_row<true>(bool)`
+--echo #
+
+set @old_mode= @@sql_mode;
+
+set sql_mode='';
+create table t1 (c1 int key) engine=myisam with system versioning;
+insert into t1 () values ();
+--disable_warnings
+replace delayed into t1 () values ();
+--enable_warnings
+drop table t1;
+
+create table t1 (c1 int key) engine=myisam with system versioning;
+insert into t1 (c1) values (1);
+replace delayed into t1 (c1) values (1);
+drop table t1;
+
+set sql_mode=@old_mode;
+
+--echo # End of 10.11 tests
+
 --source suite/versioning/common_finish.inc

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2610,6 +2610,7 @@ public:
     thd.lex->current_select= lex->current_select;
     thd.lex->sql_command= lex->sql_command;        // For innodb::store_lock()
     thd.lex->duplicates= lex->duplicates;
+    thd.lex->vers_conditions= lex->vers_conditions; // For TABLE::delete_row()
     /*
       Prevent changes to global.lock_wait_timeout from affecting
       delayed insert threads as any timeouts in delayed inserts


### PR DESCRIPTION
fixes [MDEV-40099](https://jira.mariadb.org/browse/MDEV-40099)

### Problem:
`REPLACE DELAYED` into a system-versioned table read an uninitialized `lex->vers_conditions.delete_history` in `TABLE::delete_row()`.

`Delayed_insert` has its own `THD`, and hence its own `LEX`, of which the constructor copies only a few fields from the parser `LEX.vers_conditions` was not copied, so it stayed uninitialized. It is read when a `REPLACE` resolves a duplicate on a versioned table.

### Fix:
Copy `vers_conditions` from the parser `LEX` in the `Delayed_insert` constructor.