### PR TITLE
MDEV-37167 Nested BEGINs (4600+) cause a segmentation fault

### DIFF
--- a/mysql-test/main/parser.result
+++ b/mysql-test/main/parser.result
@@ -2277,4 +2277,51 @@ select 1b from test.1a;
 select select.1c from test.select;
 1c
 drop table 1a, `select`;
+#
+# MDEV-37167 Nested BEGINs (4600+) cause a segmentation fault
+#
+#
+# Unclosed BEGINs
+#
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 1
+#
+# Well-formed deep routine
+#
+DROP PROCEDURE p2;
+#
+# Same, with variables, so the contexts are not empty
+#
+DROP PROCEDURE p3;
+#
+# A deep FUNCTION tears down the same way
+#
+DROP FUNCTION f1;
+#
+# Invoking a deep routine must not crash. It is rejected with
+# ER_STACK_OVERRUN_NEED_MORE when the frame does not fit the thread
+# stack, which depends on the build, so both outcomes are accepted.
+#
+CALL p4();
+DROP PROCEDURE p4;
+#
+# Nested scopes must still resolve correctly
+#
+CREATE PROCEDURE p5()
+BEGIN
+DECLARE a INT DEFAULT 1;
+BEGIN
+DECLARE b INT DEFAULT 2;
+BEGIN
+DECLARE c INT DEFAULT 3;
+SELECT a + b + c AS total;
+END;
+END;
+END$$
+CALL p5();
+total
+6
+DROP PROCEDURE p5;
+SELECT 'Server is alive' AS state;
+state
+Server is alive
 # End of 10.11 tests

--- a/mysql-test/main/parser.test
+++ b/mysql-test/main/parser.test
@@ -2078,4 +2078,78 @@ select select.1c from test.select;
 
 drop table 1a, `select`;
 
+--echo #
+--echo # MDEV-37167 Nested BEGINs (4600+) cause a segmentation fault
+--echo #
+
+# Each nested BEGIN adds one sp_pcontext. Freeing them used to recurse once
+# per nesting level and overran the thread stack. Building the run-time frame
+# still recurses, but checks the stack now, and the depth where it gives up
+# follows thread_stack, so the invoking statements accept either outcome.
+
+--echo #
+--echo # Unclosed BEGINs
+--echo #
+--disable_query_log
+--error ER_PARSE_ERROR
+--eval CREATE PROCEDURE p1() $(repeat("BEGIN ", 6000))
+--enable_query_log
+
+--echo #
+--echo # Well-formed deep routine
+--echo #
+--disable_query_log
+--eval CREATE PROCEDURE p2() $(repeat("BEGIN ", 6000)) $(repeat("END; ", 5999)) END
+--enable_query_log
+DROP PROCEDURE p2;
+
+--echo #
+--echo # Same, with variables, so the contexts are not empty
+--echo #
+--disable_query_log
+--eval CREATE PROCEDURE p3() $(repeat("BEGIN DECLARE v INT DEFAULT 1; ", 2000)) $(repeat("END; ", 1999)) END
+--enable_query_log
+DROP PROCEDURE p3;
+
+--echo #
+--echo # A deep FUNCTION tears down the same way
+--echo #
+--disable_query_log
+--eval CREATE FUNCTION f1() RETURNS INT $(repeat("BEGIN ", 6000)) RETURN 1; $(repeat("END; ", 5999)) END
+--enable_query_log
+DROP FUNCTION f1;
+
+--echo #
+--echo # Invoking a deep routine must not crash. It is rejected with
+--echo # ER_STACK_OVERRUN_NEED_MORE when the frame does not fit the thread
+--echo # stack, which depends on the build, so both outcomes are accepted.
+--echo #
+--disable_query_log
+--eval CREATE PROCEDURE p4() $(repeat("BEGIN ", 6000)) $(repeat("END; ", 5999)) END
+--enable_query_log
+--error 0,ER_STACK_OVERRUN_NEED_MORE
+CALL p4();
+DROP PROCEDURE p4;
+
+--echo #
+--echo # Nested scopes must still resolve correctly
+--echo #
+DELIMITER $$;
+CREATE PROCEDURE p5()
+BEGIN
+  DECLARE a INT DEFAULT 1;
+  BEGIN
+    DECLARE b INT DEFAULT 2;
+    BEGIN
+      DECLARE c INT DEFAULT 3;
+      SELECT a + b + c AS total;
+    END;
+  END;
+END$$
+DELIMITER ;$$
+CALL p5();
+DROP PROCEDURE p5;
+
+SELECT 'Server is alive' AS state;
+
 --echo # End of 10.11 tests

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -586,6 +586,7 @@ sp_head::sp_head(MEM_ROOT *mem_root_arg, sp_package *parent,
    m_thd_root(NULL),
    m_thd(NULL),
    m_pcont(new (&main_mem_root) sp_pcontext()),
+   m_pcont_list(NULL),
    m_cont_level(0)
 {
   mem_root= &main_mem_root;
@@ -906,6 +907,17 @@ sp_head::~sp_head()
   for (uint ip = 0 ; (i = get_instr(ip)) ; ip++)
     delete i;
   delete_dynamic(&m_instr);
+
+  /*
+    Free the parse contexts iteratively, freeing them recursively overran
+    the thread stack on deeply nested BEGIN blocks.
+  */
+  for (sp_pcontext *ctx= m_pcont_list; ctx; )
+  {
+    sp_pcontext *next= ctx->m_next_pcont;
+    delete ctx;
+    ctx= next;
+  }
   delete m_pcont;
   free_items();
 
@@ -1849,7 +1861,8 @@ sp_rcontext *sp_head::rcontext_create(THD *thd, Field *ret_value,
 {
   DBUG_ASSERT(args);
   Row_definition_list defs;
-  m_pcont->retrieve_field_definitions(&defs);
+  if (m_pcont->retrieve_field_definitions(thd, &defs))
+    return NULL;
   if (defs.adjust_formal_params_to_actual_params(thd, args))
     return NULL;
   return rcontext_create(thd, ret_value, &defs, true);
@@ -1860,7 +1873,8 @@ sp_rcontext *sp_head::rcontext_create(THD *thd, Field *ret_value,
                                       Item **args, uint arg_count)
 {
   Row_definition_list defs;
-  m_pcont->retrieve_field_definitions(&defs);
+  if (m_pcont->retrieve_field_definitions(thd, &defs))
+    return NULL;
   if (defs.adjust_formal_params_to_actual_params(thd, args, arg_count))
     return NULL;
   return rcontext_create(thd, ret_value, &defs, true);
@@ -1965,8 +1979,8 @@ sp_head::execute_trigger(THD *thd,
   thd->set_n_backup_active_arena(&call_arena, &backup_arena);
 
   Row_definition_list defs;
-  m_pcont->retrieve_field_definitions(&defs);
-  if (!(nctx= rcontext_create(thd, NULL, &defs, false)))
+  if (m_pcont->retrieve_field_definitions(thd, &defs) ||
+      !(nctx= rcontext_create(thd, NULL, &defs, false)))
   {
     err_status= TRUE;
     goto err_with_cleanup;

--- a/sql/sp_head.h
+++ b/sql/sp_head.h
@@ -910,6 +910,16 @@ public:
   sp_pcontext *get_parse_context() { return m_pcont; }
 
   /*
+    Remember a parse context of this routine, so that ~sp_head frees the
+    whole tree iteratively instead of recursing down sp_pcontext's children
+  */
+  void remember_pcontext(sp_pcontext *ctx)
+  {
+    ctx->m_next_pcont= m_pcont_list;
+    m_pcont_list= ctx;
+  }
+
+  /*
     Check EXECUTE access:
     - in case of a standalone rotuine, for the routine itself
     - in case of a package routine, for the owner package body
@@ -929,6 +939,7 @@ protected:
   THD *m_thd;			///< Set if we have reset mem_root
 
   sp_pcontext *m_pcont;		///< Parse context
+  sp_pcontext *m_pcont_list;	///< Head of context list, freed by ~sp_head
   List<LEX> m_lex;		///< Temp. store for the other lex
   DYNAMIC_ARRAY m_instr;	///< The "instructions"
 

--- a/sql/sp_pcontext.cc
+++ b/sql/sp_pcontext.cc
@@ -23,6 +23,7 @@
 
 #include "sp_pcontext.h"
 #include "sp_head.h"
+#include "sql_parse.h"
 
 bool sp_condition_value::equals(const sp_condition_value *cv) const
 {
@@ -95,7 +96,7 @@ void sp_pcontext::init(uint var_offset,
 sp_pcontext::sp_pcontext()
   : Sql_alloc(),
   m_max_var_index(0), m_max_cursor_index(0),
-  m_parent(NULL), m_pboundary(0),
+  m_parent(NULL), m_next_pcont(NULL), m_pboundary(0),
   m_vars(PSI_INSTRUMENT_MEM), m_case_expr_ids(PSI_INSTRUMENT_MEM),
   m_conditions(PSI_INSTRUMENT_MEM), m_cursors(PSI_INSTRUMENT_MEM),
   m_handlers(PSI_INSTRUMENT_MEM), m_children(PSI_INSTRUMENT_MEM),
@@ -108,7 +109,7 @@ sp_pcontext::sp_pcontext()
 sp_pcontext::sp_pcontext(sp_pcontext *prev, sp_pcontext::enum_scope scope)
   : Sql_alloc(),
   m_max_var_index(0), m_max_cursor_index(0),
-  m_parent(prev), m_pboundary(0),
+  m_parent(prev), m_next_pcont(NULL), m_pboundary(0),
   m_vars(PSI_INSTRUMENT_MEM), m_case_expr_ids(PSI_INSTRUMENT_MEM),
   m_conditions(PSI_INSTRUMENT_MEM), m_cursors(PSI_INSTRUMENT_MEM),
   m_handlers(PSI_INSTRUMENT_MEM), m_children(PSI_INSTRUMENT_MEM),
@@ -120,19 +121,16 @@ sp_pcontext::sp_pcontext(sp_pcontext *prev, sp_pcontext::enum_scope scope)
 }
 
 
-sp_pcontext::~sp_pcontext()
-{
-  for (size_t i= 0; i < m_children.elements(); ++i)
-    delete m_children.at(i);
-}
-
-
-sp_pcontext *sp_pcontext::push_context(THD *thd, sp_pcontext::enum_scope scope)
+sp_pcontext *sp_pcontext::push_context(THD *thd, sp_head *sphead,
+                                       sp_pcontext::enum_scope scope)
 {
   sp_pcontext *child= new (thd->mem_root) sp_pcontext(this, scope);
 
   if (child)
+  {
     m_children.append(child);
+    sphead->remember_pcontext(child);
+  }
   return child;
 }
 
@@ -644,9 +642,12 @@ const sp_pcursor *sp_pcontext::find_cursor(const LEX_CSTRING *name,
 }
 
 
-void sp_pcontext::retrieve_field_definitions(
-  List<Spvar_definition> *field_def_lst) const
+bool sp_pcontext::retrieve_field_definitions(
+  THD *thd, List<Spvar_definition> *field_def_lst) const
 {
+  if (check_stack_overrun(thd, STACK_MIN_SIZE, NULL))
+    return true;
+
   size_t next_child_idx= 0;
   size_t next_variable_idx= 0;
 
@@ -656,15 +657,16 @@ void sp_pcontext::retrieve_field_definitions(
     {
       // No variables left, just retrieve the remaining children contexts
       for (size_t i= next_child_idx; i < m_children.elements(); ++i)
-        m_children.at(i)->retrieve_field_definitions(field_def_lst);
-      return;
+        if (m_children.at(i)->retrieve_field_definitions(thd, field_def_lst))
+          return true;
+      return false;
     }
     if (next_child_idx >= m_children.elements())
     {
       // No child contexts left, just retrieve the remaining variables
       for (size_t i= next_variable_idx; i < m_vars.elements(); ++i)
         field_def_lst->push_back(&m_vars.at(i)->field_def);
-      return;
+      return false;
     }
 
     sp_variable *next_variable= m_vars.at(next_variable_idx);
@@ -713,11 +715,13 @@ void sp_pcontext::retrieve_field_definitions(
       DBUG_ASSERT(next_child_idx + 1 < m_children.elements() ?
         next_child->after_last_variable_offset() <= next_variable->offset :
         next_child->after_last_variable_offset() == next_variable->offset);
-      next_child->retrieve_field_definitions(field_def_lst);
+      if (next_child->retrieve_field_definitions(thd, field_def_lst))
+        return true;
       next_child_idx++;
     }
   }
 
+  return false;
 }
 
 

--- a/sql/sp_pcontext.h
+++ b/sql/sp_pcontext.h
@@ -357,8 +357,12 @@ public:
 ///   - for error checking (e.g. to check correct number of parameters);
 ///   - to resolve SQL-handlers.
 
+class sp_head;
+
 class sp_pcontext : public Sql_alloc
 {
+  friend class sp_head;
+
 public:
   enum enum_scope
   {
@@ -398,15 +402,19 @@ public:
 
 public:
   sp_pcontext();
-  ~sp_pcontext();
 
+  /*
+    No destructor: sp_head owns the tree and frees it. Freeing the children
+    here recursed and overran the thread stack on deeply nested BEGIN blocks
+  */
 
   /// Create and push a new context in the tree.
 
-  /// @param thd   thread context.
-  /// @param scope scope of the new parsing context.
+  /// @param thd    thread context.
+  /// @param sphead the routine owning the tree, which remembers the new node.
+  /// @param scope  scope of the new parsing context.
   /// @return the node created.
-  sp_pcontext *push_context(THD *thd, enum_scope scope);
+  sp_pcontext *push_context(THD *thd, sp_head *sphead, enum_scope scope);
 
   /// Pop a node from the parsing context tree.
   /// @return the parent node.
@@ -503,8 +511,11 @@ public:
   /// Retrieve full type information about SP-variables in this parsing
   /// context and its children.
   ///
+  /// @param thd                thread context.
   /// @param field_def_lst[out] Container to store type information.
-  void retrieve_field_definitions(List<Spvar_definition> *field_def_lst) const;
+  /// @return true on error, in which case field_def_lst is incomplete.
+  bool retrieve_field_definitions(THD *thd,
+                                  List<Spvar_definition> *field_def_lst) const;
 
   /// Find SP-variable by name.
   ///
@@ -751,6 +762,9 @@ private:
 
   /// Parent context.
   sp_pcontext *m_parent;
+
+  /// Next context in the sp_head's single linked list of all contexts.
+  sp_pcontext *m_next_pcont;
 
   /// An index of the first SP-variable in this parsing context. The index
   /// belongs to a runtime table of SP-variables.

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -7385,7 +7385,7 @@ bool LEX::sp_handler_declaration_init(THD *thd, int type)
 {
   sp_handler *h= spcont->add_handler(thd, (sp_handler::enum_type) type);
 
-  spcont= spcont->push_context(thd, sp_pcontext::HANDLER_SCOPE);
+  spcont= spcont->push_context(thd, sphead, sp_pcontext::HANDLER_SCOPE);
 
   sp_instr_hpush_jump *i=
     new (thd->mem_root) sp_instr_hpush_jump(sphead->instructions(), spcont, h);
@@ -7436,7 +7436,7 @@ bool LEX::sp_handler_declaration_finalize(THD *thd, int type)
 void LEX::sp_block_init(THD *thd, const LEX_CSTRING *label)
 {
   spcont->push_label(thd, label, sphead->instructions(), sp_label::BEGIN);
-  spcont= spcont->push_context(thd, sp_pcontext::REGULAR_SCOPE);
+  spcont= spcont->push_context(thd, sphead, sp_pcontext::REGULAR_SCOPE);
 }
 
 


### PR DESCRIPTION
## Description
Each nested `BEGIN` adds one `sp_pcontext` to the routine's parse context tree. Building the tree costs no C stack, the parser is iterative, but two walks over the finished tree recursed once per nesting level and overran the thread stack.

`~sp_pcontext()` freed its children recursively. The root context now remembers every context of the tree in a list and frees them in a flat loop, so teardown depth is constant.

`retrieve_field_definitions()` descends the children from `sp_head::rcontext_create()` to build the run-time frame. It emits variables and child contexts in run-time offset order, so it stays recursive, but it now checks the stack and returns an error. All three callers, for procedures, functions and triggers, already had an error path. A routine too deeply nested to fit the thread stack is now rejected with `ER_STACK_OVERRUN_NEED_MORE` instead of crashing.

## How can this PR be tested?

```bash
./mtr main.mdev_37167
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*