### PR TITLE
MDEV-40427 lock_move_reorganize_page() early exit check is useful onl…

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2914,11 +2914,15 @@ lock_move_reorganize_page(
     UT_LIST_INIT(old_locks, &lock_t::trx_locks);
 
     const page_id_t id{block->page.id()};
+    /* Fast path for the early exit case, available only with lock elision. */
+#if !defined NO_ELISION && !defined SUX_LOCK_GENERIC
+    if (have_transactional_memory)
     {
       TMLockGuard g{lock_sys.rec_hash, id};
       if (!lock_sys_t::get_first(g.cell(), id))
         return;
     }
+#endif
 
     /* All record locks affected by a page reorganize belong to this
     single page and therefore live in a single lock_sys.rec_hash cell.


### PR DESCRIPTION
…y with lock elision

After MDEV-40128, the early exit check in lock_move_reorganize_page() is useful only with lock elision support.
This is because, when lock elision is not supported, TMLockGuard falls back to behave like LockGuard.
The same check would be done using LockGuard later, in any case. Hence, the early exit check can be skipped when lock elision is not supported.