### PR TITLE
MDEV-40447: Cap HEAP block allocations derived from the memory ceiling

### DIFF
--- a/mysql-test/main/tmp_table_heap_alloc.result
+++ b/mysql-test/main/tmp_table_heap_alloc.result
@@ -1,0 +1,36 @@
+connect  con1,localhost,root,,test;
+connection con1;
+CREATE TABLE t1 (a INT, b TEXT);
+INSERT INTO t1 VALUES (1,REPEAT('a',100)), (2,REPEAT('b',100)),
+(3,REPEAT('c',100)), (4,REPEAT('d',100));
+#
+# Materialization with a blob distinct key under a 4GB ceiling
+#
+SET SESSION tmp_memory_table_size = 4294967296;
+SET SESSION max_heap_table_size = 4294967296;
+FLUSH STATUS;
+SELECT DISTINCT b FROM t1;
+SET SESSION tmp_memory_table_size = DEFAULT;
+SET SESSION max_heap_table_size = DEFAULT;
+SELECT CAST(VARIABLE_VALUE AS UNSIGNED) < 67108864 AS distinct_alloc_bounded
+FROM information_schema.SESSION_STATUS
+WHERE VARIABLE_NAME = 'MAX_MEMORY_USED';
+distinct_alloc_bounded
+1
+#
+# I_S materialization (SHOW FULL COLUMNS) under a 4GB ceiling
+#
+SET SESSION tmp_memory_table_size = 4294967296;
+SET SESSION max_heap_table_size = 4294967296;
+FLUSH STATUS;
+SHOW FULL COLUMNS FROM t1;
+SET SESSION tmp_memory_table_size = DEFAULT;
+SET SESSION max_heap_table_size = DEFAULT;
+SELECT CAST(VARIABLE_VALUE AS UNSIGNED) < 67108864 AS show_columns_alloc_bounded
+FROM information_schema.SESSION_STATUS
+WHERE VARIABLE_NAME = 'MAX_MEMORY_USED';
+show_columns_alloc_bounded
+1
+connection default;
+disconnect con1;
+DROP TABLE t1;

--- a/mysql-test/main/tmp_table_heap_alloc.test
+++ b/mysql-test/main/tmp_table_heap_alloc.test
@@ -1,0 +1,52 @@
+# Internal HEAP temporary tables derive max_records from the memory
+# ceiling (tmp_memory_table_size), and the first HP_BLOCK allocation
+# used to be sized at max_records/16 records.  With a large ceiling a
+# small materialization (SELECT DISTINCT, SHOW ... FROM) allocated a
+# multi-hundred-MB block per statement, served by mmap and unmapped on
+# drop, causing mmap_lock contention.  Block allocations from a
+# ceiling-derived max_records are now capped, so session memory use for
+# a small materialization must stay bounded regardless of the ceiling.
+
+--source include/have_64bit.inc
+--source include/not_embedded.inc
+
+connect (con1,localhost,root,,test);
+connection con1;
+
+CREATE TABLE t1 (a INT, b TEXT);
+INSERT INTO t1 VALUES (1,REPEAT('a',100)), (2,REPEAT('b',100)),
+                      (3,REPEAT('c',100)), (4,REPEAT('d',100));
+
+--echo #
+--echo # Materialization with a blob distinct key under a 4GB ceiling
+--echo #
+SET SESSION tmp_memory_table_size = 4294967296;
+SET SESSION max_heap_table_size = 4294967296;
+FLUSH STATUS;
+--disable_result_log
+SELECT DISTINCT b FROM t1;
+--enable_result_log
+SET SESSION tmp_memory_table_size = DEFAULT;
+SET SESSION max_heap_table_size = DEFAULT;
+SELECT CAST(VARIABLE_VALUE AS UNSIGNED) < 67108864 AS distinct_alloc_bounded
+  FROM information_schema.SESSION_STATUS
+ WHERE VARIABLE_NAME = 'MAX_MEMORY_USED';
+
+--echo #
+--echo # I_S materialization (SHOW FULL COLUMNS) under a 4GB ceiling
+--echo #
+SET SESSION tmp_memory_table_size = 4294967296;
+SET SESSION max_heap_table_size = 4294967296;
+FLUSH STATUS;
+--disable_result_log
+SHOW FULL COLUMNS FROM t1;
+--enable_result_log
+SET SESSION tmp_memory_table_size = DEFAULT;
+SET SESSION max_heap_table_size = DEFAULT;
+SELECT CAST(VARIABLE_VALUE AS UNSIGNED) < 67108864 AS show_columns_alloc_bounded
+  FROM information_schema.SESSION_STATUS
+ WHERE VARIABLE_NAME = 'MAX_MEMORY_USED';
+
+connection default;
+disconnect con1;
+DROP TABLE t1;

--- a/storage/heap/CMakeLists.txt
+++ b/storage/heap/CMakeLists.txt
@@ -32,7 +32,7 @@ IF(WITH_UNIT_TESTS)
   TARGET_LINK_LIBRARIES(hp_test1 heap mysys dbug strings)
   ADD_EXECUTABLE(hp_test2 hp_test2.c)
   TARGET_LINK_LIBRARIES(hp_test2 heap mysys dbug strings)
-  MY_ADD_TESTS(hp_test_hash hp_test_scan hp_test_freelist hp_test_concurrent LINK_LIBRARIES heap mysys dbug strings)
+  MY_ADD_TESTS(hp_test_hash hp_test_scan hp_test_freelist hp_test_concurrent hp_test_block_size LINK_LIBRARIES heap mysys dbug strings)
 
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/sql
                       ${CMAKE_SOURCE_DIR}/include)

--- a/storage/heap/hp_create.c
+++ b/storage/heap/hp_create.c
@@ -29,6 +29,23 @@ static void init_block(HP_BLOCK *block, size_t reclength, ulong min_records,
 */
 static const int heap_allocation_parts= 16;
 
+/*
+  Upper bound for a block allocation derived from max_records.
+  max_records is usually computed from the table memory ceiling
+  (max_heap_table_size or tmp_memory_table_size), not from an estimate of
+  the expected number of rows, so with a large ceiling max_records /
+  heap_allocation_parts can yield allocations of hundreds of MB even for
+  tables that will only ever hold a few rows.  Blocks above a few MB are
+  served by mmap() and unmapped on free by common malloc implementations
+  (never recycled), so short-lived tables (per-statement internal
+  temporary tables) would pay mmap/munmap, page fault-in/zeroing and
+  process-wide mmap_lock serialization on every statement.  4MB is
+  recycled from the allocator's free lists by all mainstream mallocs
+  (glibc, jemalloc, tcmalloc, mimalloc) and is large enough to keep
+  typical blob values in a single continuation run (zero-copy reads).
+*/
+static const ulong heap_max_allocation_block= 4*1024*1024;
+
 /* min block allocation */
 static const ulong heap_min_allocation_block= 16384;
 
@@ -360,9 +377,10 @@ ha_rows hp_rows_in_memory(size_t reclength, size_t index_size,
 static void init_block(HP_BLOCK *block, size_t reclength, ulong min_records,
 		       ulong max_records)
 {
-  ulong i,records_in_block;
+  ulong i,records_in_block,cap_records;
   ulong recbuffer= (ulong) MY_ALIGN(reclength, sizeof(uchar*));
   ulong extra;
+  ulong requested_min_records= min_records;
   ulonglong memory_needed;
   size_t alloc_size;
 
@@ -393,6 +411,17 @@ static void init_block(HP_BLOCK *block, size_t reclength, ulong min_records,
     heap_allocation_parts)
   */
   extra= sizeof(HP_PTRS) + MALLOC_OVERHEAD;
+
+  /*
+    Cap block allocations derived from max_records at
+    heap_max_allocation_block.  Only an explicit min_records from the
+    caller (CREATE TABLE ... MIN_ROWS) is a real row count expectation
+    and may pre-size beyond the cap; the 1000-row default min_records
+    is a heuristic and must not override the cap.
+  */
+  cap_records= (heap_max_allocation_block - extra) / recbuffer;
+  if (records_in_block > cap_records)
+    records_in_block= MY_MAX(requested_min_records, cap_records);
 
   /* We don't want too few blocks per row either */
   if (records_in_block < 10)

--- a/storage/heap/hp_test_block_size-t.c
+++ b/storage/heap/hp_test_block_size-t.c
@@ -1,0 +1,442 @@
+/*
+   Unit tests for HP_BLOCK allocation sizing in init_block().
+
+   A HEAP table's max_records is normally derived from the memory
+   ceiling (max_heap_table_size / tmp_memory_table_size), not from any
+   estimate of how many rows the table will hold.  The first (and every)
+   block used to be sized as max_records/heap_allocation_parts records,
+   so a large ceiling produced a multi-hundred-MB allocation on the
+   first row write even for a table holding a handful of rows.  Such
+   allocations are served by mmap and unmapped on free, causing
+   per-statement mmap/munmap churn and mmap_lock contention for
+   create-and-drop temporary tables.
+
+   These tests verify:
+   - the ceiling-derived block size is capped so it stays in the range
+     that memory allocators recycle without returning pages to the OS;
+   - an explicit min_records pre-sizing hint (CREATE TABLE ... MIN_ROWS)
+     still overrides the cap;
+   - small tables are sized exactly as before;
+   - a capped table remains fully functional past the first block.
+*/
+
+#include <my_global.h>
+#include <my_sys.h>
+#include <m_string.h>
+#include <tap.h>
+#include "heap.h"
+#include "heapdef.h"
+
+#define REC_LENGTH   100
+#define INT_OFFSET   1
+
+/* Largest block allocation init_block() may produce from a
+   ceiling-derived max_records (heap_max_allocation_block) */
+#define BLOCK_SIZE_CAP (4*1024*1024)
+
+static void build_record(uchar *rec, int32 int_val)
+{
+  memset(rec, 0, REC_LENGTH);
+  int4store(rec + INT_OFFSET, int_val);
+}
+
+
+static int create_table(const char *name, uint keys, uint reclength,
+                        ulong min_records, ulong max_records,
+                        HP_KEYDEF *keydef, HP_SHARE **share)
+{
+  HP_CREATE_INFO ci;
+  my_bool unused;
+
+  memset(&ci, 0, sizeof(ci));
+  ci.keys=           keys;
+  ci.keydef=         keydef;
+  ci.reclength=      reclength;
+  ci.max_records=    max_records;
+  ci.min_records=    min_records;
+  ci.max_table_size= 17179869184ULL;            /* 16G ceiling */
+
+  return heap_create(name, &ci, share, &unused);
+}
+
+
+static void init_int_keydef(HP_KEYDEF *keydef, HA_KEYSEG *keyseg)
+{
+  memset(keyseg, 0, sizeof(*keyseg));
+  keyseg->type=    HA_KEYTYPE_BINARY;
+  keyseg->start=   INT_OFFSET;
+  keyseg->length=  4;
+  keyseg->charset= &my_charset_bin;
+
+  memset(keydef, 0, sizeof(*keydef));
+  keydef->keysegs=   1;
+  keydef->seg=       keyseg;
+  keydef->algorithm= HA_KEY_ALG_HASH;
+  keydef->flag=      HA_NOSAME;
+  keydef->length=    4;
+}
+
+
+/*
+  Test: ceiling-derived max_records must not inflate block allocations.
+
+  max_records = 100M simulates a multi-GB memory ceiling divided by the
+  per-row size.  Without the cap the record block came out at
+  max_records/16 * recbuffer ~ 650MB (rounded up to 1GB) and the hash
+  key block at max_records/16 * sizeof(HASH_INFO) ~ 200MB+.  Both must
+  stay within BLOCK_SIZE_CAP.
+
+  The table must also remain fully functional across the first-block
+  boundary: with recbuffer = 104 a capped block holds ~40K records, so
+  writing 45K rows exercises hp_get_new_block() beyond the first block
+  at the capped geometry.
+*/
+
+static void test_huge_max_records_capped(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  ulong i;
+  ulong write_failures= 0;
+  const ulong rows= 45000;
+
+  init_int_keydef(&keydef, &keyseg);
+
+  if (create_table("test_block_cap", 1, REC_LENGTH, 0, 100000000UL, &keydef,
+                   &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(8, "setup failed");
+    return;
+  }
+  ok(1, "created table with max_records=100M");
+
+  ok(share->block.alloc_size <= BLOCK_SIZE_CAP,
+     "record block alloc_size capped (got %zu, cap %d)",
+     share->block.alloc_size, BLOCK_SIZE_CAP);
+
+  ok(share->keydef[0].block.alloc_size <= BLOCK_SIZE_CAP,
+     "hash key block alloc_size capped (got %zu, cap %d)",
+     share->keydef[0].block.alloc_size, BLOCK_SIZE_CAP);
+
+  ok(share->block.records_in_block >= 10,
+     "capped block still holds >= 10 records (got %lu)",
+     share->block.records_in_block);
+
+  if (!(info= heap_open("test_block_cap", 2)))
+  {
+    ok(0, "heap_open failed: %d", my_errno);
+    skip(4, "open failed");
+    return;
+  }
+  heap_extra(info, HA_EXTRA_NO_READCHECK);
+
+  for (i= 0; i < rows; i++)
+  {
+    build_record(rec, (int32) i);
+    if (heap_write(info, rec))
+      write_failures++;
+  }
+  ok(write_failures == 0, "wrote %lu rows without error (%lu failures)",
+     rows, write_failures);
+
+  ok(share->block.last_allocated > share->block.records_in_block,
+     "writes crossed the first block boundary "
+     "(last_allocated %lu, records_in_block %lu)",
+     share->block.last_allocated, share->block.records_in_block);
+
+  {
+    uchar key[4];
+    uchar read_buf[REC_LENGTH];
+    int4store(key, 12345);
+    ok(heap_rkey(info, read_buf, 0, key, 4, HA_READ_KEY_EXACT) == 0,
+       "read row 12345 back via hash key");
+    ok(sint4korr(read_buf + INT_OFFSET) == 12345,
+       "row 12345 content matches");
+  }
+
+  ok(heap_check_heap(info, 0) == 0,
+     "heap_check_heap validates multi-block capped table");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test: keyless table (the I_S/SHOW materialization shape) is capped.
+*/
+
+static void test_huge_max_records_keyless_capped(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_cap_nokey", 0, REC_LENGTH, 0, 100000000UL,
+                   NULL, &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created keyless table with max_records=100M");
+
+  ok(share->block.alloc_size <= BLOCK_SIZE_CAP,
+     "record block alloc_size capped (got %zu, cap %d)",
+     share->block.alloc_size, BLOCK_SIZE_CAP);
+
+  if ((info= heap_open("test_block_cap_nokey", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: an explicit min_records hint (CREATE TABLE ... MIN_ROWS) is a
+  user request to pre-size the table and must override the cap.
+  1M records * recbuffer 104 ~ 104MB, rounded up to 128MB.
+*/
+
+static void test_min_records_overrides_cap(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_minrows", 0, REC_LENGTH, 1000000UL,
+                   100000000UL, NULL, &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created table with min_records=1M");
+
+  ok(share->block.alloc_size > BLOCK_SIZE_CAP,
+     "min_records pre-sizing overrides the cap (got %zu)",
+     share->block.alloc_size);
+
+  if ((info= heap_open("test_block_minrows", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: small tables keep their historical sizing (the cap must be a
+  pure upper bound and never change small-table behavior).
+  max_records=1000: block memory = max(62 * 104 + extra, 16384) = 16K.
+*/
+
+static void test_small_table_sizing_unchanged(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_small", 0, REC_LENGTH, 0, 1000UL, NULL,
+                   &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created table with max_records=1000");
+
+  ok(share->block.alloc_size <= 16384,
+     "small table block stays at heap_min_allocation_block (got %zu)",
+     share->block.alloc_size);
+
+  if ((info= heap_open("test_block_small", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: wide rows must not defeat the cap through the defaulted
+  min_records.
+
+  When the caller passes min_records=0 (every internal temporary
+  table), init_block() defaults it to 1000 ("optimize for 1000 rows").
+  That heuristic default is not a user pre-sizing request and must not
+  override the cap the way an explicit MIN_ROWS does.  Once recbuffer
+  exceeds heap_max_allocation_block/1000 (~4KB), cap_records drops
+  below 1000 and the defaulted value takes over: 8KB rows give
+  1000 * 8KB ~ 8MB, rounded up to a 16MB block.  Capped, the block must
+  stay within BLOCK_SIZE_CAP (511 records * 8KB fits exactly).
+  max_records = 2M simulates a 16GB ceiling divided by the row size.
+*/
+
+static void test_wide_row_capped(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_wide", 0, 8192, 0, 2097152UL, NULL, &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created keyless table with reclength=8K, max_records=2M");
+
+  ok(share->block.alloc_size <= BLOCK_SIZE_CAP,
+     "8K-row block alloc_size capped (got %zu, cap %d)",
+     share->block.alloc_size, BLOCK_SIZE_CAP);
+
+  if ((info= heap_open("test_block_wide", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: rows near the 64KB row-size limit (a single max-width table
+  materialized into a tmp table) are capped too.  Uncapped, the
+  defaulted min_records of 1000 gives 1000 * 64KB ~ 64MB, rounded up
+  to a 128MB block.  Capped: 63 records * 64KB fits in 4MB.
+  max_records = 262144 simulates a 16GB ceiling / 64KB rows.
+*/
+
+static void test_very_wide_row_capped(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_vwide", 0, 65535, 0, 262144UL, NULL, &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created keyless table with reclength=64K, max_records=256K");
+
+  ok(share->block.alloc_size <= BLOCK_SIZE_CAP,
+     "64K-row block alloc_size capped (got %zu, cap %d)",
+     share->block.alloc_size, BLOCK_SIZE_CAP);
+
+  if ((info= heap_open("test_block_vwide", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: a row wider than the cap itself cannot honor the cap
+  (cap_records = 0); the 10-records-per-block floor takes over and the
+  block degrades to 10 * recbuffer, NOT to the defaulted 1000-record
+  geometry.  5MB rows: floor gives 10 * 5MB = 50MB rounded up to 64MB;
+  the defaulted min_records would give 1000 * 5MB ~ 5GB, clamped to
+  INT_MAX32 and rounded to a 2GB block.
+  max_records = 3276 simulates a 16GB ceiling / 5MB rows.
+*/
+
+static void test_row_wider_than_cap(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  const uint row_5mb= 5*1024*1024;
+
+  if (create_table("test_block_hugerow", 0, row_5mb, 0, 3276UL, NULL,
+                   &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(2, "setup failed");
+    return;
+  }
+  ok(1, "created keyless table with reclength=5M, max_records=3276");
+
+  ok(share->block.alloc_size <= 64*1024*1024,
+     "block for rows wider than the cap degrades to the 10-record floor "
+     "(got %zu)", share->block.alloc_size);
+
+  ok(share->block.records_in_block >= 10,
+     "block still holds >= 10 records (got %lu)",
+     share->block.records_in_block);
+
+  if ((info= heap_open("test_block_hugerow", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+/*
+  Test: an explicit min_records equal to the 1000-row default still
+  overrides the cap for wide rows.  This pins down the distinction the
+  cap must make: explicit MIN_ROWS pre-sizes past the cap, the
+  defaulted 1000 does not.  1000 records * 8KB ~ 8MB > cap.
+*/
+
+static void test_explicit_min_records_wide_row(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+
+  if (create_table("test_block_wide_minrows", 0, 8192, 1000UL, 2097152UL,
+                   NULL, &share))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(1, "setup failed");
+    return;
+  }
+  ok(1, "created 8K-row table with explicit min_records=1000");
+
+  ok(share->block.alloc_size > BLOCK_SIZE_CAP,
+     "explicit min_records pre-sizing overrides the cap for wide rows "
+     "(got %zu)", share->block.alloc_size);
+
+  if ((info= heap_open("test_block_wide_minrows", 2)))
+  {
+    heap_drop_table(info);
+    heap_close(info);
+  }
+}
+
+
+int main(int argc __attribute__((unused)),
+         char **argv __attribute__((unused)))
+{
+  MY_INIT("hp_test_block_size");
+  plan(24);
+
+  diag("Test 1: ceiling-derived max_records capped (keyed table)");
+  test_huge_max_records_capped();
+
+  diag("Test 2: ceiling-derived max_records capped (keyless table)");
+  test_huge_max_records_keyless_capped();
+
+  diag("Test 3: min_records pre-sizing hint overrides cap");
+  test_min_records_overrides_cap();
+
+  diag("Test 4: small table sizing unchanged");
+  test_small_table_sizing_unchanged();
+
+  diag("Test 5: wide rows (8K) capped despite defaulted min_records");
+  test_wide_row_capped();
+
+  diag("Test 6: very wide rows (64K) capped despite defaulted min_records");
+  test_very_wide_row_capped();
+
+  diag("Test 7: rows wider than the cap degrade to the 10-record floor");
+  test_row_wider_than_cap();
+
+  diag("Test 8: explicit min_records still overrides cap for wide rows");
+  test_explicit_min_records_wide_row();
+
+  my_end(0);
+  return exit_status();
+}


### PR DESCRIPTION
## MDEV-40447: HEAP initial block allocation is sized from max_records, causing per-statement giant mmap/munmap and mmap_lock contention with large tmp_table_size

**JIRA**: [MDEV-40447](https://jira.mariadb.org/browse/MDEV-40447)

### Problem

`init_block()` sizes every `HP_BLOCK` allocation as `max_records / heap_allocation_parts` records, and `max_records` is computed from the table memory ceiling (`max_heap_table_size` / `tmp_memory_table_size`), not from any estimate of the expected number of rows. With `tmp_table_size=16G` the **first row written** to an internal temporary table allocates a 256MB..2GB block (per-key `HASH_INFO` blocks are inflated the same way), which common malloc implementations serve with `mmap()` and unmap again when the table is dropped.

For create-and-drop-per-statement tables (`SHOW`/`INFORMATION_SCHEMA` materializations, `DISTINCT`/`GROUP BY` temporary tables) every statement then pays page fault-in and zeroing, page-table teardown with TLB-shootdown IPIs, and process-wide `mmap_lock` serialization. On a `SHOW FULL COLUMNS` loop workload (ORM/admin-tool startup pattern) with `tmp_table_size=16G`:

| threads | baseline QPS | affected QPS | delta |
|---------|-------------|--------------|-------|
| 16 | 297.14 | 191.52 | -36% |
| 64 | 360.10 | 180.21 | -50% |
| 128 | 328.79 | 132.32 | -60% |

The sizing heuristic predates MDEV-38975, but blob-bearing I_S temporary tables newly qualify for HEAP since then, which exposed it to this workload. With default-sized `tmp_table_size` the same workload is a 1.55x **win** for HEAP -- the block sizing, not the blob support, is the problem.

### Fix

Cap ceiling-derived block allocations at `heap_max_allocation_block` (4MB):

1. 4MB stays within the range that mainstream allocators (glibc, jemalloc, tcmalloc, mimalloc) recycle from their free lists instead of returning to the kernel on free, so per-statement blocks are reused with no syscalls at steady state. The nearest boundary is jemalloc's `oversize_threshold` (8MB, eagerly purged above); glibc's dynamic mmap threshold adapts up to 32MB.
2. 4MB keeps typical blob values (up to ~1MB) in a single continuation run, preserving zero-copy blob reads.
3. At the default `tmp_table_size` (16MB) blocks come out at 1-2MB, so default-configuration sizing is **unchanged**; the cap only binds for ceilings above ~64MB.

An explicit `min_records` (`CREATE TABLE ... MIN_ROWS=N`) is a real row count expectation and still pre-sizes beyond the cap. The cap compares against the **caller-supplied** `min_records`, not the defaulted "optimize for 1000 rows" value: for rows wider than ~4KB (`heap_max_allocation_block / 1000`) the 1000-row default exceeds `cap_records` and would otherwise silently override the cap (8KB rows -> 8MB blocks, 64KB rows -> 64MB blocks, and a row wider than the cap itself -> an `INT_MAX32`-clamped 1GB block). Wide internal tmp-table rows are reachable without `MIN_ROWS`: oversized fields become out-of-row blobs, but many inline columns (multi-table joins with `DISTINCT`/`GROUP BY`, wide `CHAR` columns) can sum past 4KB. Rows wider than the cap itself cannot honor it and degrade to the existing 10-records-per-block floor (e.g. 5MB rows -> 64MB blocks), which is as close to the cap as a block that must hold a few whole rows can get. Tables larger than 4MB simply allocate more 4MB blocks (the 128-ary `HP_PTRS` block tree accommodates this with no depth issues).

### Tests

- `storage/heap/hp_test_block_size-t.c` (new unit test): record and hash-key block `alloc_size` cap with ceiling-derived `max_records` (keyed and keyless: 1GB/256MB before, 4MB after), `MIN_ROWS` override preserved (128MB block), small-table sizing byte-identical, and full functionality across the first-block boundary at capped geometry (45K rows, key reads, `heap_check_heap`).
- Wide-row scenarios in the same unit test: the cap holds for 8KB rows (8MB before, 4MB after) and 64KB rows (64MB before, 4MB after) despite the defaulted `min_records`; rows wider than the cap (5MB) degrade to the 10-record floor (64MB block) instead of the defaulted 1000-record geometry (1GB before); an explicit `min_records=1000` still overrides the cap for 8KB rows.
- `mysql-test/main/tmp_table_heap_alloc.test` (new): `Max_memory_used` stays bounded when a small `SELECT DISTINCT` on a TEXT column and a `SHOW FULL COLUMNS` materialize under a 4GB ceiling. Both tests were verified to fail before the fix and pass after, unmodified.
- Regressions green: all `storage/heap` unit tests, full `heap` MTR suite (27 tests), `main.group_by`, `main.distinct`, `main.count_distinct`, `main.derived`, `main.show_check`, `main.information_schema`, `main.type_blob`, `main.tmp_table_*`, blob tests.
