### PR TITLE
MDEV-40448 HEAP unique hash duplicate rejection re-hashes the full key value

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -143,6 +143,17 @@ typedef struct st_hp_blob_desc
   uint packlength;   /* 1, 2, 3, or 4: length prefix size */
 } HP_BLOB_DESC;
 
+/*
+  Bits for HP_SHARE::state_changed, modeled on the state.changed bitmaps
+  of Maria and MyISAM (see storage/maria/maria_def.h).  A table marked
+  crashed refuses every read and write with HA_ERR_CRASHED until it is
+  re-created or emptied (hp_clear()).
+*/
+#define HEAP_STATE_CRASHED 1U
+
+#define heap_mark_crashed(share) ((share)->state_changed|= HEAP_STATE_CRASHED)
+#define heap_is_crashed(share)   ((share)->state_changed & HEAP_STATE_CRASHED)
+
 typedef struct st_heap_share
 {
   HP_BLOCK block;
@@ -160,6 +171,7 @@ typedef struct st_heap_share
   uint reclength;			/* Length of one record */
   uint visible;     /* Offset to the flags byte (active/deleted/continuation) */
   uint changed;
+  uint state_changed;                   /* Bitmap of HEAP_STATE_* flags */
   uint keys,max_key_length;
   uint currently_disabled_keys;    /* saved value from "keys" when disabled */
   uint open_count;

--- a/include/my_tree.h
+++ b/include/my_tree.h
@@ -48,6 +48,8 @@ typedef uint32 element_count;
 typedef int (*tree_walk_action)(void *,element_count,void *);
 
 typedef enum { free_init, free_free, free_end } TREE_FREE;
+typedef enum { TREE_ERROR_NONE, TREE_ERROR_OOM, TREE_ERROR_DUP_KEY }
+TREE_ERROR;
 typedef int (*tree_element_free)(void*, TREE_FREE, void *);
 
 typedef struct st_tree_element {
@@ -70,6 +72,7 @@ typedef struct st_tree {
   tree_element_free free;
   myf my_flags;
   uint flag;
+  TREE_ERROR error;
 } TREE;
 
 	/* Functions on whole tree */

--- a/mysql-test/suite/heap/blob_update_key_rollback.result
+++ b/mysql-test/suite/heap/blob_update_key_rollback.result
@@ -1,0 +1,186 @@
+#
+# Index consistency after a failed UPDATE on a HEAP table with BLOB
+#
+# heap_update() moves changed key entries to the new key values
+# before writing the new blob chains.  When a blob chain write then
+# fails with "table is full", the key entries must be moved back to
+# the old values, otherwise the index refers to records whose
+# columns no longer match the indexed values.
+#
+SET @save_max_heap= @@max_heap_table_size;
+SET max_heap_table_size = 16384;
+#
+# Hash index: single-row UPDATE fails writing the new blob chain
+#
+CREATE TABLE t1 (
+id INT,
+k VARCHAR(20),
+b BLOB,
+KEY k1 (k)
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_10;
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 1;
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# The row must still be found through the index under the old value
+SELECT id, k, LENGTH(b) FROM t1 FORCE INDEX(k1) WHERE k = 'key1';
+id	k	LENGTH(b)
+1	key1	300
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+COUNT(*)
+0
+DROP TABLE t1;
+#
+# BTREE index: same failure, rb-tree entries must be restored
+#
+CREATE TABLE t1 (
+id INT,
+k VARCHAR(20),
+b BLOB,
+KEY k1 (k) USING BTREE
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_10;
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 1;
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT id, k, LENGTH(b) FROM t1 FORCE INDEX(k1) WHERE k = 'key1';
+id	k	LENGTH(b)
+1	key1	300
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+COUNT(*)
+0
+DROP TABLE t1;
+#
+# Two indexed columns changed by the same failing UPDATE:
+# entries in both indexes must be rolled back
+#
+CREATE TABLE t1 (
+id INT,
+k VARCHAR(20),
+m VARCHAR(20),
+b BLOB,
+KEY k1 (k),
+KEY k2 (m) USING BTREE
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), CONCAT('mem', seq),
+REPEAT('a', 300)
+FROM seq_1_to_10;
+UPDATE t1 SET k= 'moved', m= 'gone', b= REPEAT('z', 60000) WHERE id = 2;
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT id, k, m FROM t1 FORCE INDEX(k1) WHERE k = 'key2';
+id	k	m
+2	key2	mem2
+SELECT id, k, m FROM t1 FORCE INDEX(k2) WHERE m = 'mem2';
+id	k	m
+2	key2	mem2
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+COUNT(*)
+0
+SELECT COUNT(*) FROM t1 FORCE INDEX(k2) WHERE m = 'gone';
+COUNT(*)
+0
+DROP TABLE t1;
+#
+# A second index on a column the UPDATE does NOT touch must be left
+# alone by the rollback: only the changed key is moved back, the
+# unchanged key's entries stay put and keep finding the row.
+#
+CREATE TABLE t1 (
+id INT,
+k VARCHAR(20),
+fixed VARCHAR(20),
+b BLOB,
+KEY k1 (k),
+KEY k2 (fixed)
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), CONCAT('fix', seq),
+REPEAT('a', 300)
+FROM seq_1_to_10;
+# Only k and b change; 'fixed' is untouched
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 3;
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# Changed key rolled back to old value
+SELECT id, k, fixed FROM t1 FORCE INDEX(k1) WHERE k = 'key3';
+id	k	fixed
+3	key3	fix3
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+COUNT(*)
+0
+# Untouched key still resolves the row through its own index
+SELECT id, k, fixed FROM t1 FORCE INDEX(k2) WHERE fixed = 'fix3';
+id	k	fixed
+3	key3	fix3
+DROP TABLE t1;
+#
+# Multi-row UPDATE that fails part-way: rows updated before the
+# failure keep their new key values, the failing row keeps its old
+# ones, and every row must be reachable through the index by its
+# current key value
+#
+CREATE TABLE t1 (
+id INT,
+k VARCHAR(20),
+b BLOB,
+KEY k1 (k)
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_15;
+# Each row grows its blob; the table fills up after some rows
+UPDATE t1 SET k= CONCAT('new', id), b= REPEAT('z', 1500);
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# Every row must be found via the index under its current key value
+SELECT t.id FROM t1 t
+WHERE NOT EXISTS (SELECT 1 FROM t1 i FORCE INDEX(k1)
+WHERE i.k = t.k AND i.id = t.id)
+ORDER BY t.id;
+id
+# Old and new key values must partition the table, with the
+# failure hitting neither the first row nor after the last one.
+# The exact fill point depends on platform record layout, so only
+# the invariants are checked.
+SELECT COUNT(*) AS total,
+COUNT(IF(k LIKE 'new%', 1, NULL)) > 0 AS some_updated,
+COUNT(IF(k LIKE 'key%', 1, NULL)) > 0 AS some_old,
+COUNT(IF(k LIKE 'new%', 1, NULL)) +
+COUNT(IF(k LIKE 'key%', 1, NULL)) = COUNT(*) AS partitioned
+FROM t1;
+total	some_updated	some_old	partitioned
+15	1	1	1
+DROP TABLE t1;
+#
+# Table with no indexes at all: the failed blob write must leave the
+# record intact with nothing to roll back in the (empty) key set
+#
+CREATE TABLE t1 (
+id INT,
+b BLOB
+) ENGINE=HEAP;
+INSERT INTO t1 SELECT seq, REPEAT('a', 300) FROM seq_1_to_10;
+UPDATE t1 SET b= REPEAT('z', 60000) WHERE id = 1;
+ERROR HY000: The table 't1' is full
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT id, LENGTH(b) FROM t1 WHERE id = 1;
+id	LENGTH(b)
+1	300
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+10
+DROP TABLE t1;
+SET max_heap_table_size = @save_max_heap;

--- a/mysql-test/suite/heap/blob_update_key_rollback.test
+++ b/mysql-test/suite/heap/blob_update_key_rollback.test
@@ -1,0 +1,179 @@
+--source include/have_sequence.inc
+
+--echo #
+--echo # Index consistency after a failed UPDATE on a HEAP table with BLOB
+--echo #
+--echo # heap_update() moves changed key entries to the new key values
+--echo # before writing the new blob chains.  When a blob chain write then
+--echo # fails with "table is full", the key entries must be moved back to
+--echo # the old values, otherwise the index refers to records whose
+--echo # columns no longer match the indexed values.
+--echo #
+
+SET @save_max_heap= @@max_heap_table_size;
+SET max_heap_table_size = 16384;
+
+--echo #
+--echo # Hash index: single-row UPDATE fails writing the new blob chain
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  k VARCHAR(20),
+  b BLOB,
+  KEY k1 (k)
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_10;
+
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 1;
+
+CHECK TABLE t1;
+--echo # The row must still be found through the index under the old value
+SELECT id, k, LENGTH(b) FROM t1 FORCE INDEX(k1) WHERE k = 'key1';
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+DROP TABLE t1;
+
+--echo #
+--echo # BTREE index: same failure, rb-tree entries must be restored
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  k VARCHAR(20),
+  b BLOB,
+  KEY k1 (k) USING BTREE
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_10;
+
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 1;
+
+CHECK TABLE t1;
+SELECT id, k, LENGTH(b) FROM t1 FORCE INDEX(k1) WHERE k = 'key1';
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+DROP TABLE t1;
+
+--echo #
+--echo # Two indexed columns changed by the same failing UPDATE:
+--echo # entries in both indexes must be rolled back
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  k VARCHAR(20),
+  m VARCHAR(20),
+  b BLOB,
+  KEY k1 (k),
+  KEY k2 (m) USING BTREE
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), CONCAT('mem', seq),
+                      REPEAT('a', 300)
+FROM seq_1_to_10;
+
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET k= 'moved', m= 'gone', b= REPEAT('z', 60000) WHERE id = 2;
+
+CHECK TABLE t1;
+SELECT id, k, m FROM t1 FORCE INDEX(k1) WHERE k = 'key2';
+SELECT id, k, m FROM t1 FORCE INDEX(k2) WHERE m = 'mem2';
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+SELECT COUNT(*) FROM t1 FORCE INDEX(k2) WHERE m = 'gone';
+DROP TABLE t1;
+
+--echo #
+--echo # A second index on a column the UPDATE does NOT touch must be left
+--echo # alone by the rollback: only the changed key is moved back, the
+--echo # unchanged key's entries stay put and keep finding the row.
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  k VARCHAR(20),
+  fixed VARCHAR(20),
+  b BLOB,
+  KEY k1 (k),
+  KEY k2 (fixed)
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), CONCAT('fix', seq),
+                      REPEAT('a', 300)
+FROM seq_1_to_10;
+
+--echo # Only k and b change; 'fixed' is untouched
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET k= 'moved', b= REPEAT('z', 60000) WHERE id = 3;
+
+CHECK TABLE t1;
+--echo # Changed key rolled back to old value
+SELECT id, k, fixed FROM t1 FORCE INDEX(k1) WHERE k = 'key3';
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE k = 'moved';
+--echo # Untouched key still resolves the row through its own index
+SELECT id, k, fixed FROM t1 FORCE INDEX(k2) WHERE fixed = 'fix3';
+DROP TABLE t1;
+
+--echo #
+--echo # Multi-row UPDATE that fails part-way: rows updated before the
+--echo # failure keep their new key values, the failing row keeps its old
+--echo # ones, and every row must be reachable through the index by its
+--echo # current key value
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  k VARCHAR(20),
+  b BLOB,
+  KEY k1 (k)
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, CONCAT('key', seq), REPEAT('a', 300)
+FROM seq_1_to_15;
+
+--echo # Each row grows its blob; the table fills up after some rows
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET k= CONCAT('new', id), b= REPEAT('z', 1500);
+
+CHECK TABLE t1;
+--echo # Every row must be found via the index under its current key value
+SELECT t.id FROM t1 t
+WHERE NOT EXISTS (SELECT 1 FROM t1 i FORCE INDEX(k1)
+                  WHERE i.k = t.k AND i.id = t.id)
+ORDER BY t.id;
+--echo # Old and new key values must partition the table, with the
+--echo # failure hitting neither the first row nor after the last one.
+--echo # The exact fill point depends on platform record layout, so only
+--echo # the invariants are checked.
+SELECT COUNT(*) AS total,
+       COUNT(IF(k LIKE 'new%', 1, NULL)) > 0 AS some_updated,
+       COUNT(IF(k LIKE 'key%', 1, NULL)) > 0 AS some_old,
+       COUNT(IF(k LIKE 'new%', 1, NULL)) +
+       COUNT(IF(k LIKE 'key%', 1, NULL)) = COUNT(*) AS partitioned
+FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Table with no indexes at all: the failed blob write must leave the
+--echo # record intact with nothing to roll back in the (empty) key set
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  b BLOB
+) ENGINE=HEAP;
+
+INSERT INTO t1 SELECT seq, REPEAT('a', 300) FROM seq_1_to_10;
+
+--error ER_RECORD_FILE_FULL
+UPDATE t1 SET b= REPEAT('z', 60000) WHERE id = 1;
+
+CHECK TABLE t1;
+SELECT id, LENGTH(b) FROM t1 WHERE id = 1;
+SELECT COUNT(*) FROM t1;
+DROP TABLE t1;
+
+SET max_heap_table_size = @save_max_heap;

--- a/mysql-test/suite/heap/update_key_rollback.result
+++ b/mysql-test/suite/heap/update_key_rollback.result
@@ -1,0 +1,105 @@
+#
+# Index consistency after a failed UPDATE on a HEAP table
+#
+# heap_update() moves the changed key entries to their new key values
+# before it updates the record.  A failure raised after that has to
+# move them back.  An rb-tree node allocation failure used to be
+# reported as a duplicate key, and when the recovery itself cannot
+# restore a key the table is now marked crashed, so that no statement
+# can use an index that no longer describes the data.
+#
+# The keyword lists armed below always carry the inert
+# "heap_test_guard" keyword: the one-shot injection removes its own
+# keyword when it fires, and a keyword list that becomes empty while
+# debugging is on matches every keyword.
+#
+CALL mtr.add_suppression("Index for table .t1. is corrupt");
+#
+# The hash key k1 is moved to the new value, then the rb-tree node
+# allocation for k2 fails once: the failure is reported as out of
+# memory, not as a duplicate, and both keys are moved back
+#
+CREATE TABLE t1 (
+id INT,
+a INT,
+b INT,
+KEY k1 (a),
+KEY k2 (b) USING BTREE
+) ENGINE=HEAP;
+INSERT INTO t1 VALUES (1, 10, 100), (2, 20, 200);
+SET SESSION debug_dbug="+d,once_simulate_tree_insert_oom,heap_test_guard";
+UPDATE t1 SET a= 11, b= 101 WHERE id = 1;
+ERROR HY000: Out of memory.
+SET SESSION debug_dbug="";
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# Both indexes must still find the row under its unchanged values
+SELECT id, a, b FROM t1 FORCE INDEX(k1) WHERE a = 10;
+id	a	b
+1	10	100
+SELECT id, a, b FROM t1 FORCE INDEX(k2) WHERE b = 100;
+id	a	b
+1	10	100
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE a = 11;
+COUNT(*)
+0
+SELECT COUNT(*) FROM t1 FORCE INDEX(k2) WHERE b = 101;
+COUNT(*)
+0
+SELECT id, a, b FROM t1 ORDER BY id;
+id	a	b
+1	10	100
+2	20	200
+#
+# A duplicate key is still reported as a duplicate
+#
+CREATE TABLE t2 (
+id INT,
+a INT,
+UNIQUE KEY k1 (a) USING BTREE
+) ENGINE=HEAP;
+INSERT INTO t2 VALUES (1, 10), (2, 20);
+UPDATE t2 SET a= 20 WHERE id = 1;
+ERROR 23000: Duplicate entry '20' for key 'k1'
+CHECK TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	check	status	OK
+SELECT id, a FROM t2 ORDER BY id;
+id	a
+1	10
+2	20
+DROP TABLE t2;
+#
+# The allocation failure persists, so restoring the old k2 entry
+# fails as well: the already moved k1 no longer describes the
+# record, the table is marked crashed, and every read and write on
+# it is refused until it is emptied
+#
+SET SESSION debug_dbug="+d,simulate_tree_insert_oom,heap_test_guard";
+UPDATE t1 SET a= 11, b= 101 WHERE id = 1;
+ERROR HY000: Out of memory.
+SET SESSION debug_dbug="";
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	error	Corrupt
+SELECT id, a, b FROM t1 ORDER BY id;
+ERROR HY000: Index for table 't1' is corrupt; try to repair it
+SELECT id, a, b FROM t1 FORCE INDEX(k1) WHERE a = 10;
+ERROR HY000: Index for table 't1' is corrupt; try to repair it
+INSERT INTO t1 VALUES (3, 30, 300);
+ERROR HY000: Index for table 't1' is corrupt; try to repair it
+UPDATE t1 SET a= 12 WHERE id = 2;
+ERROR HY000: Index for table 't1' is corrupt; try to repair it
+DELETE FROM t1 WHERE id = 2;
+ERROR HY000: Index for table 't1' is corrupt; try to repair it
+# Emptying the table rebuilds the indexes from nothing
+TRUNCATE TABLE t1;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+INSERT INTO t1 VALUES (5, 50, 500);
+SELECT id, a, b FROM t1 FORCE INDEX(k2) WHERE b = 500;
+id	a	b
+5	50	500
+DROP TABLE t1;

--- a/mysql-test/suite/heap/update_key_rollback.test
+++ b/mysql-test/suite/heap/update_key_rollback.test
@@ -1,0 +1,99 @@
+--source include/have_debug.inc
+
+--echo #
+--echo # Index consistency after a failed UPDATE on a HEAP table
+--echo #
+--echo # heap_update() moves the changed key entries to their new key values
+--echo # before it updates the record.  A failure raised after that has to
+--echo # move them back.  An rb-tree node allocation failure used to be
+--echo # reported as a duplicate key, and when the recovery itself cannot
+--echo # restore a key the table is now marked crashed, so that no statement
+--echo # can use an index that no longer describes the data.
+--echo #
+--echo # The keyword lists armed below always carry the inert
+--echo # "heap_test_guard" keyword: the one-shot injection removes its own
+--echo # keyword when it fires, and a keyword list that becomes empty while
+--echo # debugging is on matches every keyword.
+--echo #
+
+CALL mtr.add_suppression("Index for table .t1. is corrupt");
+
+--echo #
+--echo # The hash key k1 is moved to the new value, then the rb-tree node
+--echo # allocation for k2 fails once: the failure is reported as out of
+--echo # memory, not as a duplicate, and both keys are moved back
+--echo #
+
+CREATE TABLE t1 (
+  id INT,
+  a INT,
+  b INT,
+  KEY k1 (a),
+  KEY k2 (b) USING BTREE
+) ENGINE=HEAP;
+
+INSERT INTO t1 VALUES (1, 10, 100), (2, 20, 200);
+
+SET SESSION debug_dbug="+d,once_simulate_tree_insert_oom,heap_test_guard";
+--error ER_OUT_OF_RESOURCES
+UPDATE t1 SET a= 11, b= 101 WHERE id = 1;
+SET SESSION debug_dbug="";
+
+CHECK TABLE t1;
+--echo # Both indexes must still find the row under its unchanged values
+SELECT id, a, b FROM t1 FORCE INDEX(k1) WHERE a = 10;
+SELECT id, a, b FROM t1 FORCE INDEX(k2) WHERE b = 100;
+SELECT COUNT(*) FROM t1 FORCE INDEX(k1) WHERE a = 11;
+SELECT COUNT(*) FROM t1 FORCE INDEX(k2) WHERE b = 101;
+SELECT id, a, b FROM t1 ORDER BY id;
+
+--echo #
+--echo # A duplicate key is still reported as a duplicate
+--echo #
+
+CREATE TABLE t2 (
+  id INT,
+  a INT,
+  UNIQUE KEY k1 (a) USING BTREE
+) ENGINE=HEAP;
+
+INSERT INTO t2 VALUES (1, 10), (2, 20);
+
+--error ER_DUP_ENTRY
+UPDATE t2 SET a= 20 WHERE id = 1;
+
+CHECK TABLE t2;
+SELECT id, a FROM t2 ORDER BY id;
+DROP TABLE t2;
+
+--echo #
+--echo # The allocation failure persists, so restoring the old k2 entry
+--echo # fails as well: the already moved k1 no longer describes the
+--echo # record, the table is marked crashed, and every read and write on
+--echo # it is refused until it is emptied
+--echo #
+
+SET SESSION debug_dbug="+d,simulate_tree_insert_oom,heap_test_guard";
+--error ER_OUT_OF_RESOURCES
+UPDATE t1 SET a= 11, b= 101 WHERE id = 1;
+SET SESSION debug_dbug="";
+
+CHECK TABLE t1;
+--error ER_NOT_KEYFILE
+SELECT id, a, b FROM t1 ORDER BY id;
+--error ER_NOT_KEYFILE
+SELECT id, a, b FROM t1 FORCE INDEX(k1) WHERE a = 10;
+--error ER_NOT_KEYFILE
+INSERT INTO t1 VALUES (3, 30, 300);
+--error ER_NOT_KEYFILE
+UPDATE t1 SET a= 12 WHERE id = 2;
+--error ER_NOT_KEYFILE
+DELETE FROM t1 WHERE id = 2;
+
+--echo # Emptying the table rebuilds the indexes from nothing
+TRUNCATE TABLE t1;
+CHECK TABLE t1;
+INSERT INTO t1 VALUES (5, 50, 500);
+SELECT id, a, b FROM t1 FORCE INDEX(k2) WHERE b = 500;
+
+DROP TABLE t1;

--- a/mysys/tree.c
+++ b/mysys/tree.c
@@ -106,6 +106,7 @@ void init_tree(TREE *tree, size_t default_alloc_size, size_t memory_limit,
   tree->custom_arg = custom_arg;
   tree->my_flags= my_flags;
   tree->flag= 0;
+  tree->error= TREE_ERROR_NONE;
   if (!free_element && size >= 0 &&
       ((uint) size <= sizeof(void*) || ((uint) size & (sizeof(void*)-1))))
   {
@@ -274,13 +275,35 @@ TREE_ELEMENT *tree_insert(TREE *tree, void *key, uint key_size,
     }
 
     key_size+=tree->size_of_element;
+    /*
+      Debug hooks that make this node allocation fail as if the allocator
+      had returned NULL.  "simulate_tree_insert_oom" fails every insert
+      until the caller disarms it; "once_simulate_tree_insert_oom" fails
+      only the next one and disarms itself.  Neither name may be a prefix
+      of the other: DBUG_SET() matches an existing list entry by prefix
+      and would merge into it instead of adding the keyword.
+    */
+    DBUG_EXECUTE_IF("once_simulate_tree_insert_oom",
+                    {
+                      DBUG_SET("-d,once_simulate_tree_insert_oom");
+                      tree->error= TREE_ERROR_OOM;
+                      return(NULL);
+                    });
+    DBUG_EXECUTE_IF("simulate_tree_insert_oom",
+                    {
+                      tree->error= TREE_ERROR_OOM;
+                      return(NULL);
+                    });
     if (tree->with_delete)
       element=(TREE_ELEMENT *) my_malloc(key_memory_TREE, alloc_size,
                                          MYF(tree->my_flags | MY_WME));
     else
       element=(TREE_ELEMENT *) alloc_root(&tree->mem_root,alloc_size);
     if (!element)
+    {
+      tree->error= TREE_ERROR_OOM;
       return(NULL);
+    }
     **parent=element;
     element->left=element->right= &null_element;
     if (!tree->offset_to_key)
@@ -303,7 +326,10 @@ TREE_ELEMENT *tree_insert(TREE *tree, void *key, uint key_size,
   else
   {
     if (tree->flag & TREE_NO_DUPS)
+    {
+      tree->error= TREE_ERROR_DUP_KEY;
       return(NULL);
+    }
     element->count++;
     /* Avoid a wrap over of the count. */
     if (! element->count)

--- a/storage/heap/CMakeLists.txt
+++ b/storage/heap/CMakeLists.txt
@@ -32,7 +32,8 @@ IF(WITH_UNIT_TESTS)
   TARGET_LINK_LIBRARIES(hp_test1 heap mysys dbug strings)
   ADD_EXECUTABLE(hp_test2 hp_test2.c)
   TARGET_LINK_LIBRARIES(hp_test2 heap mysys dbug strings)
-  MY_ADD_TESTS(hp_test_hash hp_test_scan hp_test_freelist hp_test_concurrent LINK_LIBRARIES heap mysys dbug strings)
+  MY_ADD_TESTS(hp_test_hash hp_test_scan hp_test_freelist hp_test_concurrent
+               hp_test_update LINK_LIBRARIES heap mysys dbug strings)
 
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/sql
                       ${CMAKE_SOURCE_DIR}/include)

--- a/storage/heap/CMakeLists.txt
+++ b/storage/heap/CMakeLists.txt
@@ -33,7 +33,8 @@ IF(WITH_UNIT_TESTS)
   ADD_EXECUTABLE(hp_test2 hp_test2.c)
   TARGET_LINK_LIBRARIES(hp_test2 heap mysys dbug strings)
   MY_ADD_TESTS(hp_test_hash hp_test_scan hp_test_freelist hp_test_concurrent
-               hp_test_update LINK_LIBRARIES heap mysys dbug strings)
+               hp_test_update hp_test_write_dup
+               LINK_LIBRARIES heap mysys dbug strings)
 
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/sql
                       ${CMAKE_SOURCE_DIR}/include)

--- a/storage/heap/_check.c
+++ b/storage/heap/_check.c
@@ -51,6 +51,9 @@ int heap_check_heap(const HP_INFO *info, my_bool print_status)
   uchar *current_ptr= info->current_ptr;
   DBUG_ENTER("heap_check_heap");
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(1);                     /* Already known to be damaged */
+
   for (error=key= 0 ; key < share->keys ; key++)
   {
     if (share->keydef[key].algorithm == HA_KEY_ALG_BTREE)

--- a/storage/heap/ha_heap.cc
+++ b/storage/heap/ha_heap.cc
@@ -528,7 +528,15 @@ int ha_heap::reset_auto_increment(ulonglong value)
 int ha_heap::external_lock(THD *thd, int lock_type)
 {
 #if !defined(DBUG_OFF) && defined(EXTRA_HEAP_DEBUG)
-  if (lock_type == F_UNLCK && file->s->changed && heap_check_heap(file, 0))
+  /*
+    A table already marked crashed is knowingly inconsistent; every data
+    access on it fails with HA_ERR_CRASHED, so re-detecting the damage
+    here would only raise a second error into a diagnostics area that
+    can already be OK (e.g. after UNLOCK TABLES) and fire the
+    Diagnostics_area assertion.
+  */
+  if (lock_type == F_UNLCK && file->s->changed &&
+      !heap_is_crashed(file->s) && heap_check_heap(file, 0))
     return HA_ERR_CRASHED;
 #endif
   if (lock_type == F_UNLCK)

--- a/storage/heap/hp_clear.c
+++ b/storage/heap/hp_clear.c
@@ -43,6 +43,7 @@ void hp_clear(HP_SHARE *info)
   info->data_length= 0;
   info->blength=1;
   info->changed=0;
+  info->state_changed=0;
   info->del_link=0;
   info->key_version++;
   info->file_version++;

--- a/storage/heap/hp_delete.c
+++ b/storage/heap/hp_delete.c
@@ -276,7 +276,23 @@ int hp_delete_key(HP_INFO *info, register HP_KEYDEF *keyinfo,
   last_ptr=0;
 
   /* Search after record with key */
-  rec_hash= hp_rec_hashnr(0, keyinfo, record);
+  if (flag && info->current_hash_ptr &&
+      info->current_hash_ptr->ptr_to_rec == recpos)
+  {
+    /*
+      The row was positioned via this key: flag means keyinfo is the
+      last used index, and current_hash_ptr is only ever set by
+      hp_search()/hp_search_next() on that index (scan and rnd-pos
+      paths clear it).  Every HASH_INFO entry stores the hash of its
+      own record's key, so the entry for recpos gives the hash of
+      'record' without re-scanning the key value (expensive for blob
+      keys).
+    */
+    rec_hash= info->current_hash_ptr->hash_of_key;
+    DBUG_ASSERT(rec_hash == hp_rec_hashnr(0, keyinfo, record));
+  }
+  else
+    rec_hash= hp_rec_hashnr(0, keyinfo, record);
   key_pos= hp_mask(rec_hash, blength, share->records + 1);
   pos= hp_find_hash(&keyinfo->block, key_pos);
 

--- a/storage/heap/hp_delete.c
+++ b/storage/heap/hp_delete.c
@@ -146,6 +146,8 @@ int heap_delete(HP_INFO *info, const uchar *record)
   DBUG_ENTER("heap_delete");
   DBUG_PRINT("enter",("info: %p  record: %p", info, record));
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   test_active(info);
   hp_flush_pending_blob_free(info);
 

--- a/storage/heap/hp_rfirst.c
+++ b/storage/heap/hp_rfirst.c
@@ -24,6 +24,8 @@ int heap_rfirst(HP_INFO *info, uchar *record, int inx)
   HP_KEYDEF *keyinfo = share->keydef + inx;
   
   DBUG_ENTER("heap_rfirst");
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   info->lastinx= inx;
   info->key_version= info->s->key_version;
 

--- a/storage/heap/hp_rfirst.c
+++ b/storage/heap/hp_rfirst.c
@@ -65,7 +65,14 @@ int heap_rfirst(HP_INFO *info, uchar *record, int inx)
   }
   else
   {
-    /* We can't scan a non existing key value with hash index */
+    /*
+      We can't scan a non existing key value with hash index.
+      lastinx was already retargeted to this key above; clear
+      current_hash_ptr so that it cannot be misread as belonging to
+      this key (hp_delete_key() reuses its cached hash when flag is
+      set and current_hash_ptr matches the record being deleted).
+    */
+    info->current_hash_ptr= 0;
     my_errno= HA_ERR_WRONG_COMMAND;
     DBUG_RETURN(my_errno);
   }

--- a/storage/heap/hp_rkey.c
+++ b/storage/heap/hp_rkey.c
@@ -25,6 +25,8 @@ int heap_rkey(HP_INFO *info, uchar *record, int inx, const uchar *key,
   DBUG_ENTER("heap_rkey");
   DBUG_PRINT("enter",("info: %p  inx: %d", info, inx));
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   if ((uint) inx >= share->keys)
   {
     DBUG_RETURN(my_errno= HA_ERR_WRONG_INDEX);

--- a/storage/heap/hp_rlast.c
+++ b/storage/heap/hp_rlast.c
@@ -25,6 +25,8 @@ int heap_rlast(HP_INFO *info, uchar *record, int inx)
   HP_KEYDEF *keyinfo= share->keydef + inx;
 
   DBUG_ENTER("heap_rlast");
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   info->lastinx= inx;
   info->key_version= info->s->key_version;
   if (keyinfo->algorithm == HA_KEY_ALG_BTREE)

--- a/storage/heap/hp_rlast.c
+++ b/storage/heap/hp_rlast.c
@@ -53,7 +53,14 @@ int heap_rlast(HP_INFO *info, uchar *record, int inx)
   }
   else
   {
-    /* We can't scan a non existing key value with hash index */
+    /*
+      We can't scan a non existing key value with hash index.
+      lastinx was already retargeted to this key above; clear
+      current_hash_ptr so that it cannot be misread as belonging to
+      this key (hp_delete_key() reuses its cached hash when flag is
+      set and current_hash_ptr matches the record being deleted).
+    */
+    info->current_hash_ptr= 0;
     my_errno= HA_ERR_WRONG_COMMAND;
     DBUG_RETURN(my_errno);
   }

--- a/storage/heap/hp_rnext.c
+++ b/storage/heap/hp_rnext.c
@@ -24,7 +24,9 @@ int heap_rnext(HP_INFO *info, uchar *record)
   HP_SHARE *share=info->s;
   HP_KEYDEF *keyinfo;
   DBUG_ENTER("heap_rnext");
-  
+
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   if (info->lastinx < 0)
     DBUG_RETURN(my_errno=HA_ERR_WRONG_INDEX);
 

--- a/storage/heap/hp_rprev.c
+++ b/storage/heap/hp_rprev.c
@@ -26,6 +26,8 @@ int heap_rprev(HP_INFO *info, uchar *record)
   HP_KEYDEF *keyinfo;
   DBUG_ENTER("heap_rprev");
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   if (info->lastinx < 0)
     DBUG_RETURN(my_errno=HA_ERR_WRONG_INDEX);
   keyinfo = share->keydef + info->lastinx;

--- a/storage/heap/hp_rrnd.c
+++ b/storage/heap/hp_rrnd.c
@@ -31,6 +31,8 @@ int heap_rrnd(register HP_INFO *info, uchar *record, uchar *pos)
   DBUG_ENTER("heap_rrnd");
   DBUG_PRINT("enter",("info: %p  pos: %p", info, pos));
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   info->lastinx= -1;
   if (!(info->current_ptr= pos))
   {

--- a/storage/heap/hp_rsame.c
+++ b/storage/heap/hp_rsame.c
@@ -31,6 +31,8 @@ int heap_rsame(register HP_INFO *info, uchar *record, int inx)
   HP_SHARE *share=info->s;
   DBUG_ENTER("heap_rsame");
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   test_active(info);
   if (info->current_ptr[share->visible])
   {

--- a/storage/heap/hp_scan.c
+++ b/storage/heap/hp_scan.c
@@ -28,6 +28,8 @@
 int heap_scan_init(register HP_INFO *info)
 {
   DBUG_ENTER("heap_scan_init");
+  if (heap_is_crashed(info->s))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   info->lastinx= -1;
   info->current_record= (ulong) ~0L;		/* No current record */
   info->update=0;
@@ -43,6 +45,8 @@ int heap_scan(register HP_INFO *info, uchar *record)
   ulong pos;
   DBUG_ENTER("heap_scan");
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   /*
     Scan boundary: total_records + deleted == block.last_allocated.
 

--- a/storage/heap/hp_test_update-t.c
+++ b/storage/heap/hp_test_update-t.c
@@ -1,0 +1,360 @@
+/*
+   Unit tests for the key recovery of heap_update().
+
+   heap_update() moves every changed key entry to its new key value before it
+   updates the record itself, so a failure raised afterwards leaves the index
+   describing a record image that is not in the table.  The recovery at the
+   err: label moves those entries back for the errors it knows how to recover
+   from, and marks the table crashed when it cannot restore a key, so that no
+   later statement can read from or write to an index that no longer
+   describes the data.
+
+   The failure used here - an rb-tree node allocation failure - is injected
+   with DBUG keywords inside tree_insert(), so these tests only run on debug
+   builds.  The keyword lists always carry the inert "heap_test_guard"
+   keyword: a keyword list that becomes empty while debugging is on matches
+   every keyword and would turn on all of the debug output.
+*/
+
+#include <my_global.h>
+#include <my_sys.h>
+#include <m_string.h>
+#include <tap.h>
+#include "heap.h"
+#include "heapdef.h"
+
+/*
+  Record layout: (null bitmap, int4 a, int4 b)
+    byte 0:     null bitmap
+    bytes 1-4:  a
+    bytes 5-8:  b
+*/
+#define REC_LENGTH  9
+#define A_OFFSET    1
+#define B_OFFSET    5
+
+/* Never a valid errkey value, so it shows whether errkey was written to */
+#define ERRKEY_UNSET (-2)
+
+/*
+  Everything below is driven by the injected failures, so a build without
+  DBUG has nothing to call it with.  The tests and the helpers only they use
+  are left out of such a build entirely, rather than only left uncalled,
+  which would warn about every one of them.
+*/
+#ifndef DBUG_OFF
+
+static void build_rec(uchar *rec, int32 a, int32 b)
+{
+  memset(rec, 0, REC_LENGTH);
+  int4store(rec + A_OFFSET, a);
+  int4store(rec + B_OFFSET, b);
+}
+
+
+/*
+  Create a table with 'keys' keys: key 0 over column a and key 1 over
+  column b.  Only key 0 can be made unique; the tests that need a
+  duplicate use a single key.
+*/
+
+static int create_and_open(const char *name, uint keys,
+                           enum ha_key_alg alg_a, enum ha_key_alg alg_b,
+                           uint flag_a, HP_SHARE **share, HP_INFO **info)
+{
+  HP_KEYDEF keydef[2];
+  HA_KEYSEG keyseg[2];
+  HP_CREATE_INFO ci;
+  my_bool unused;
+  uint i;
+
+  memset(keyseg, 0, sizeof(keyseg));
+  memset(keydef, 0, sizeof(keydef));
+  for (i= 0; i < 2; i++)
+  {
+    keyseg[i].type=    HA_KEYTYPE_BINARY;
+    keyseg[i].start=   i ? B_OFFSET : A_OFFSET;
+    keyseg[i].length=  4;
+    keyseg[i].charset= &my_charset_bin;
+
+    keydef[i].keysegs= 1;
+    keydef[i].seg=     &keyseg[i];
+    keydef[i].length=  4;
+  }
+  keydef[0].algorithm= alg_a;
+  keydef[0].flag=      flag_a;
+  keydef[1].algorithm= alg_b;
+
+  memset(&ci, 0, sizeof(ci));
+  ci.keys=           keys;
+  ci.keydef=         keydef;
+  ci.reclength=      REC_LENGTH;
+  ci.max_records=    1000;
+  ci.min_records=    10;
+  ci.max_table_size= 1024 * 1024;
+
+  if (heap_create(name, &ci, share, &unused))
+    return 1;
+  if (!(*info= heap_open(name, 2)))
+    return 1;
+  heap_extra(*info, HA_EXTRA_NO_READCHECK);
+  return 0;
+}
+
+
+static int position_on(HP_INFO *info, int keynr, int32 value, uchar *rec)
+{
+  uchar key[4];
+  int4store(key, value);
+  return heap_rkey(info, rec, keynr, key, (key_part_map) 1, HA_READ_KEY_EXACT);
+}
+
+
+static my_bool row_found(HP_INFO *info, int keynr, int32 value)
+{
+  uchar rec[REC_LENGTH];
+  return position_on(info, keynr, value, rec) == 0;
+}
+
+
+/*
+  Insert (1, 10) and (2, 20) and position on the first one through key 0.
+*/
+
+static int fill_and_position(HP_INFO *info, uchar *rec)
+{
+  build_rec(rec, 1, 10);
+  if (heap_write(info, rec))
+    return 1;
+  build_rec(rec, 2, 20);
+  if (heap_write(info, rec))
+    return 1;
+  build_rec(rec, 1, 10);
+  return position_on(info, 0, 1, rec) != 0;
+}
+
+
+/*
+  Test 1: a failed rb-tree node allocation is reported as such.
+
+  The key is not unique, so a duplicate cannot even occur, yet before the
+  fix the failure was reported as HA_ERR_FOUND_DUPP_KEY - with a fabricated
+  duplicate value and a key that has no uniqueness to violate.  The failure
+  is injected only once, so restoring the old key succeeds and the table
+  stays usable.
+*/
+
+static void test_rb_alloc_failure_is_oom(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  uchar rec[REC_LENGTH], new_rec[REC_LENGTH];
+  ulonglong index_length_before;
+  int error;
+
+  if (create_and_open("test_upd_oom", 1, HA_KEY_ALG_BTREE, HA_KEY_ALG_BTREE,
+                      0, &share, &info) ||
+      fill_and_position(info, rec))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(5, "setup failed");
+    return;
+  }
+
+  index_length_before= share->index_length;
+  build_rec(new_rec, 11, 10);
+  info->errkey= ERRKEY_UNSET;
+
+  DBUG_PUSH("d,once_simulate_tree_insert_oom,heap_test_guard");
+  error= heap_update(info, rec, new_rec);
+  DBUG_POP();
+
+  ok(error == HA_ERR_OUT_OF_MEM,
+     "allocation failure reported as out of memory, not as a duplicate "
+     "(got %d)", error);
+  ok(info->errkey == -1,
+     "errkey says no key error for a non-duplicate failure (got %d)",
+     info->errkey);
+  ok(share->index_length == index_length_before,
+     "index size unchanged after the recovery");
+  ok(!heap_is_crashed(share), "table not crashed: the recovery succeeded");
+  ok(heap_check_heap(info, 0) == 0, "index consistent after the recovery");
+  ok(row_found(info, 0, 1), "row still found through its old key value");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 2: a real duplicate is still reported as a duplicate.
+
+  Guards the classification above against reporting every rb-tree insert
+  failure as an allocation failure.
+*/
+
+static void test_rb_duplicate_still_reported(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  uchar rec[REC_LENGTH], new_rec[REC_LENGTH];
+  int error;
+
+  if (create_and_open("test_upd_dupp", 1, HA_KEY_ALG_BTREE, HA_KEY_ALG_BTREE,
+                      HA_NOSAME, &share, &info) ||
+      fill_and_position(info, rec))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(3, "setup failed");
+    return;
+  }
+
+  /* a=2 already exists on the second row */
+  build_rec(new_rec, 2, 10);
+  info->errkey= ERRKEY_UNSET;
+
+  error= heap_update(info, rec, new_rec);
+
+  ok(error == HA_ERR_FOUND_DUPP_KEY,
+     "duplicate key still reported as a duplicate (got %d)", error);
+  ok(info->errkey == 0, "errkey names the duplicate key (got %d)",
+     info->errkey);
+  ok(heap_check_heap(info, 0) == 0, "index consistent after the recovery");
+  ok(row_found(info, 0, 1), "row still found through its old key value");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 3: a key that was already moved is moved back.
+
+  Key 0 (hash) is moved to its new value before key 1 (rb-tree) fails, so
+  the recovery has to move key 0 back to the value the record still holds.
+*/
+
+static void test_earlier_key_is_moved_back(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  uchar rec[REC_LENGTH], new_rec[REC_LENGTH];
+  int error;
+
+  if (create_and_open("test_upd_earlier", 2, HA_KEY_ALG_HASH,
+                      HA_KEY_ALG_BTREE, 0, &share, &info) ||
+      fill_and_position(info, rec))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(4, "setup failed");
+    return;
+  }
+
+  build_rec(new_rec, 11, 110);
+
+  DBUG_PUSH("d,once_simulate_tree_insert_oom,heap_test_guard");
+  error= heap_update(info, rec, new_rec);
+  DBUG_POP();
+
+  ok(error == HA_ERR_OUT_OF_MEM, "update failed with out of memory (got %d)",
+     error);
+  ok(!heap_is_crashed(share), "table not crashed: the recovery succeeded");
+  ok(heap_check_heap(info, 0) == 0, "both indexes consistent after recovery");
+  ok(row_found(info, 0, 1), "hash key moved back to the old value");
+  ok(row_found(info, 1, 10), "rb-tree key holds the old value");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 4: a failed recovery marks the table crashed and shuts it down.
+
+  The allocation failure is left switched on, so restoring the old key 1
+  (rb-tree) entry fails as well.  The already moved key 0 (hash) then no
+  longer describes the record, so the table is marked crashed: every read
+  and write on it fails with HA_ERR_CRASHED and heap_check_heap() reports
+  it as damaged, until the table is emptied, which rebuilds the indexes
+  from nothing.
+*/
+
+static void test_failed_recovery_marks_crashed(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  uchar rec[REC_LENGTH], new_rec[REC_LENGTH];
+  int error;
+
+  if (create_and_open("test_upd_crashed", 2, HA_KEY_ALG_HASH,
+                      HA_KEY_ALG_BTREE, 0, &share, &info) ||
+      fill_and_position(info, rec))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(8, "setup failed");
+    return;
+  }
+
+  build_rec(new_rec, 11, 110);
+
+  DBUG_PUSH("d,simulate_tree_insert_oom,heap_test_guard");
+  error= heap_update(info, rec, new_rec);
+  DBUG_POP();
+
+  ok(error == HA_ERR_OUT_OF_MEM, "update failed with out of memory (got %d)",
+     error);
+  ok(heap_is_crashed(share),
+     "table marked crashed: one key could not be restored");
+  ok(heap_check_heap(info, 0) != 0, "heap_check_heap() reports the damage");
+
+  build_rec(rec, 1, 10);
+  build_rec(new_rec, 3, 30);
+  ok(heap_update(info, rec, new_rec) == HA_ERR_CRASHED,
+     "update on a crashed table is refused");
+  ok(!row_found(info, 0, 1) && my_errno == HA_ERR_CRASHED,
+     "key read on a crashed table is refused");
+  build_rec(rec, 4, 40);
+  ok(heap_write(info, rec) == HA_ERR_CRASHED,
+     "write on a crashed table is refused");
+  ok(heap_scan_init(info) == HA_ERR_CRASHED,
+     "scan on a crashed table is refused");
+
+  heap_clear(info);
+  ok(!heap_is_crashed(share), "emptying the table clears the crashed state");
+  build_rec(rec, 5, 50);
+  ok(heap_write(info, rec) == 0 && row_found(info, 0, 5),
+     "the emptied table accepts and finds rows again");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+#endif /* !DBUG_OFF */
+
+
+int main(int argc __attribute__((unused)),
+         char **argv __attribute__((unused)))
+{
+  MY_INIT("hp_test_update");
+
+#ifdef DBUG_OFF
+  skip_all("the failures under test are injected with DBUG keywords");
+#else
+  plan(24);
+
+  diag("Test 1: rb-tree allocation failure is not a duplicate key");
+  test_rb_alloc_failure_is_oom();
+
+  diag("Test 2: a real duplicate is still reported as a duplicate");
+  test_rb_duplicate_still_reported();
+
+  diag("Test 3: an already moved key is moved back");
+  test_earlier_key_is_moved_back();
+
+  diag("Test 4: a failed recovery marks the table crashed");
+  test_failed_recovery_marks_crashed();
+#endif
+
+  my_end(0);
+  return exit_status();
+}

--- a/storage/heap/hp_test_write_dup-t.c
+++ b/storage/heap/hp_test_write_dup-t.c
@@ -1,0 +1,844 @@
+/*
+   Unit tests for unique hash key duplicate rejection cost and rollback
+   correctness in the HEAP engine.
+
+   A hash index insert must hash the key value exactly once: the hash
+   selects the bucket, so it is computed unconditionally for every
+   insert.  Historically a *rejected duplicate* paid the full-value
+   hash twice: hp_write_key() hashed the key to insert it, and after
+   the duplicate was detected the caller invoked hp_delete_key() to
+   remove the just-inserted entry, which hashed the same key again to
+   locate the bucket.  For long key values (blob keys) the second scan
+   of the value dominates duplicate-heavy workloads such as
+   SELECT DISTINCT over blobs.
+
+   These tests wrap the key charset's hash_sort collation callback in
+   a counting shim so every full-value hash of key data is observable,
+   and assert:
+   - a successful insert costs exactly one full-value hash (the
+     duplicate probe must not add hashing);
+   - a rejected duplicate insert costs exactly one full-value hash;
+   - deleting or re-keying a row positioned via the same hash index
+     reuses the hash cached in the index entry instead of re-hashing;
+   plus rollback behavior: rejected inserts and updates leave the
+   table exactly as before, including multi-key rollback, NULL key
+   parts and non-unique keys.
+
+   Record layout (same as hp_test_helpers.h, plus a nullable variant):
+     byte 0:       null bitmap (1 byte, bit 2 = blob null)
+     bytes 1-4:    int4 field
+     bytes 5-6:    blob packlength=2 (length, little-endian)
+     bytes 7-14:   blob data pointer (portable_sizeof_char_ptr bytes)
+   reclength = 15
+*/
+
+#include <my_global.h>
+#include <my_sys.h>
+#include <m_string.h>
+#include <tap.h>
+#include "heap.h"
+#include "heapdef.h"
+
+#define REC_NULL_OFFSET 0
+#define INT_OFFSET      1
+#define BLOB_OFFSET     5
+#define BLOB_PACKLEN    2
+#define REC_LENGTH      15
+
+#define BLOB_KEY_LEN    (4 + portable_sizeof_char_ptr)
+
+/*
+  In builds where DBUG_ASSERT evaluates its expression (debug builds,
+  and DBUG_OFF builds compiled with DBUG_ASSERT_AS_PRINTF),
+  hp_delete_key() cross-checks the cached hash against a recomputed
+  one, which adds one counted hash_sort call per delete that takes the
+  cached-hash path.  The cached-path count assertions are therefore
+  only distinguishing when DBUG_ASSERT compiles to nothing; the
+  insert-path assertions distinguish in all builds.
+*/
+#if defined(DBUG_OFF) && !defined(DBUG_ASSERT_AS_PRINTF)
+#define DELETE_HASH_CHECK 0
+#else
+#define DELETE_HASH_CHECK 1
+#endif
+
+/*
+  Counting charset: a copy of latin1 whose collation handler routes
+  hash_sort through a wrapper that increments hash_calls.  Comparisons
+  (strnncollsp) are left untouched, so the counter isolates hashing.
+*/
+static struct charset_info_st counting_cs;
+static struct my_collation_handler_st counting_coll;
+static ulong hash_calls;
+static void (*real_hash_sort)(my_hasher_st *hasher, CHARSET_INFO *cs,
+                              const uchar *key, size_t len);
+
+static void counting_hash_sort(my_hasher_st *hasher, CHARSET_INFO *cs,
+                               const uchar *key, size_t len)
+{
+  hash_calls++;
+  real_hash_sort(hasher, cs, key, len);
+}
+
+static void init_counting_charset(void)
+{
+  counting_cs= my_charset_latin1;
+  counting_coll= *my_charset_latin1.coll;
+  real_hash_sort= counting_coll.hash_sort;
+  counting_coll.hash_sort= counting_hash_sort;
+  counting_cs.coll= &counting_coll;
+}
+
+
+static void build_record(uchar *rec, int32 int_val,
+                         const uchar *blob_data, uint16 blob_len,
+                         my_bool blob_is_null)
+{
+  memset(rec, 0, REC_LENGTH);
+  rec[REC_NULL_OFFSET]= blob_is_null ? 2 : 0;
+  int4store(rec + INT_OFFSET, int_val);
+  if (!blob_is_null)
+  {
+    int2store(rec + BLOB_OFFSET, blob_len);
+    memcpy(rec + BLOB_OFFSET + BLOB_PACKLEN, &blob_data, sizeof(blob_data));
+  }
+}
+
+
+/* Packed key for heap_rkey on the blob key: 4-byte length + pointer */
+static void build_blob_key(uchar *key, const uchar *data, uint32 len)
+{
+  memset(key, 0, BLOB_KEY_LEN);
+  int4store(key, len);
+  memcpy(key + 4, &data, sizeof(data));
+}
+
+
+static void init_blob_keyseg(HA_KEYSEG *seg, my_bool nullable)
+{
+  memset(seg, 0, sizeof(*seg));
+  seg->type=      HA_KEYTYPE_VARTEXT4;
+  seg->flag=      HA_BLOB_PART | HA_VAR_LENGTH_PART;
+  seg->start=     BLOB_OFFSET;
+  seg->length=    BLOB_KEY_LEN;
+  seg->bit_start= BLOB_PACKLEN;
+  seg->charset=   &counting_cs;
+  if (nullable)
+  {
+    seg->null_bit= 2;
+    seg->null_pos= REC_NULL_OFFSET;
+  }
+}
+
+
+static void init_int_keyseg(HA_KEYSEG *seg)
+{
+  memset(seg, 0, sizeof(*seg));
+  seg->type=    HA_KEYTYPE_BINARY;
+  seg->start=   INT_OFFSET;
+  seg->length=  4;
+  seg->charset= &my_charset_bin;
+}
+
+
+static void init_keydef(HP_KEYDEF *keydef, HA_KEYSEG *seg, uint length,
+                        uint8 flag)
+{
+  memset(keydef, 0, sizeof(*keydef));
+  keydef->keysegs=   1;
+  keydef->seg=       seg;
+  keydef->algorithm= HA_KEY_ALG_HASH;
+  keydef->flag=      flag;
+  keydef->length=    length;
+}
+
+
+static int create_and_open(const char *name, uint keys, HP_KEYDEF *keydef,
+                           HP_SHARE **share, HP_INFO **info)
+{
+  HP_CREATE_INFO ci;
+  HP_BLOB_DESC blob_desc;
+  my_bool unused;
+
+  blob_desc.offset=     BLOB_OFFSET;
+  blob_desc.packlength= BLOB_PACKLEN;
+
+  memset(&ci, 0, sizeof(ci));
+  ci.keys=           keys;
+  ci.keydef=         keydef;
+  ci.reclength=      REC_LENGTH;
+  ci.max_records=    0;
+  ci.min_records=    10;
+  ci.max_table_size= 64 * 1024 * 1024;
+  ci.blob_descs=     &blob_desc;
+  ci.blob_count=     1;
+
+  if (heap_create(name, &ci, share, &unused))
+    return 1;
+  if (!(*info= heap_open(name, 2)))
+    return 1;
+  heap_extra(*info, HA_EXTRA_NO_READCHECK);
+  return 0;
+}
+
+
+/*
+  Test 1: hashing cost of unique inserts and rejected duplicates.
+
+  Every insert must cost exactly one full-value hash: one for a
+  successful insert (probe + insert share the hash) and one for a
+  rejected duplicate (the undo delete that re-hashed the value must
+  not exist).  A rejected duplicate must leave the table unchanged
+  and usable.
+*/
+
+static void test_dup_insert_hash_cost(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  uchar blob_a[400], blob_b[400];
+  ulong i, dup_errors;
+
+  memset(blob_a, 'a', sizeof(blob_a));
+  memset(blob_b, 'b', sizeof(blob_b));
+
+  init_blob_keyseg(&keyseg, FALSE);
+  init_keydef(&keydef, &keyseg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_dup_cost", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(12, "setup failed");
+    return;
+  }
+  ok(1, "created table with unique blob hash key");
+
+  build_record(rec, 1, blob_a, sizeof(blob_a), FALSE);
+  hash_calls= 0;
+  ok(heap_write(info, rec) == 0, "insert first row");
+  ok(hash_calls == 1, "unique insert costs exactly one full-value hash "
+     "(got %lu)", hash_calls);
+
+  build_record(rec, 2, blob_a, sizeof(blob_a), FALSE);
+  hash_calls= 0;
+  ok(heap_write(info, rec) == HA_ERR_FOUND_DUPP_KEY,
+     "duplicate blob value rejected");
+  ok(hash_calls == 1, "rejected duplicate costs exactly one full-value hash "
+     "(got %lu)", hash_calls);
+  ok(info->errkey == 0, "errkey is the failing key (got %d)", info->errkey);
+  ok(share->records == 1, "table unchanged after rejection (records=%lu)",
+     (ulong) share->records);
+
+  build_record(rec, 3, blob_b, sizeof(blob_b), FALSE);
+  hash_calls= 0;
+  ok(heap_write(info, rec) == 0, "different value inserted after rejection");
+  ok(hash_calls == 1, "insert after rejection costs one hash (got %lu)",
+     hash_calls);
+  ok(share->records == 2, "records=2 after second insert");
+
+  dup_errors= 0;
+  hash_calls= 0;
+  for (i= 0; i < 50; i++)
+  {
+    build_record(rec, (int32) (100 + i), blob_a, sizeof(blob_a), FALSE);
+    if (heap_write(info, rec) == HA_ERR_FOUND_DUPP_KEY)
+      dup_errors++;
+  }
+  ok(dup_errors == 50, "all 50 repeated duplicates rejected (got %lu)",
+     dup_errors);
+  ok(hash_calls == 50, "50 rejections cost exactly 50 hashes (got %lu)",
+     hash_calls);
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 2: delete of a row positioned via the hash index must reuse the
+  hash cached in the index entry (heap_rkey already hashed the key to
+  find the row); delete of a row positioned via a table scan must fall
+  back to computing the hash once.
+*/
+
+static void test_delete_hash_cost(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_a[400], blob_b[400];
+
+  memset(blob_a, 'a', sizeof(blob_a));
+  memset(blob_b, 'b', sizeof(blob_b));
+
+  init_blob_keyseg(&keyseg, FALSE);
+  init_keydef(&keydef, &keyseg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_del_cost", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(11, "setup failed");
+    return;
+  }
+  ok(1, "created table");
+
+  build_record(rec, 1, blob_a, sizeof(blob_a), FALSE);
+  ok(heap_write(info, rec) == 0, "insert row a");
+  build_record(rec, 2, blob_b, sizeof(blob_b), FALSE);
+  ok(heap_write(info, rec) == 0, "insert row b");
+
+  /* Position row b via the hash index, then delete it */
+  build_blob_key(key, blob_b, sizeof(blob_b));
+  hash_calls= 0;
+  ok(heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) == 0,
+     "positioned row b via hash key");
+  ok(heap_delete(info, rec) == 0, "deleted row b");
+  ok(hash_calls == 1 + DELETE_HASH_CHECK,
+     "index-read + delete hash the key exactly once (got %lu)", hash_calls);
+  ok(share->records == 1, "one row left");
+
+  /* Position the remaining row via a scan: delete must still work */
+  heap_scan_init(info);
+  {
+    int found= 0;
+    while (heap_scan(info, rec) == 0)
+    {
+      found= 1;
+      break;
+    }
+    ok(found, "scan found remaining row");
+  }
+  hash_calls= 0;
+  ok(heap_delete(info, rec) == 0, "deleted scan-positioned row");
+  ok(hash_calls == 1,
+     "scan-positioned delete computes the hash once (got %lu)", hash_calls);
+  ok(share->records == 0, "table empty");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 3: update re-keying a row positioned via the hash index, and an
+  update rejected as duplicate.
+
+  A successful re-key must hash only the new key value (the old key's
+  hash is cached in the index entry).  A rejected update must restore
+  the old key and leave both rows intact.
+*/
+
+static void test_update_rekey_and_dup(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar oldrec[REC_LENGTH], newrec[REC_LENGTH], rec[REC_LENGTH];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_x[300], blob_y[300], blob_z[300];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+  memset(blob_y, 'y', sizeof(blob_y));
+  memset(blob_z, 'z', sizeof(blob_z));
+
+  init_blob_keyseg(&keyseg, FALSE);
+  init_keydef(&keydef, &keyseg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_upd_dup", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(15, "setup failed");
+    return;
+  }
+  ok(1, "created table");
+
+  build_record(rec, 1, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert row 1 (x)");
+  build_record(rec, 2, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_write(info, rec) == 0, "insert row 2 (y)");
+
+  /* Re-key row 2 from y to z, positioned via the index */
+  build_blob_key(key, blob_y, sizeof(blob_y));
+  ok(heap_rkey(info, oldrec, 0, key, 1, HA_READ_KEY_EXACT) == 0,
+     "positioned row 2 via hash key");
+  build_record(newrec, 2, blob_z, sizeof(blob_z), FALSE);
+  hash_calls= 0;
+  ok(heap_update(info, oldrec, newrec) == 0, "re-keyed row 2 from y to z");
+  ok(hash_calls == 1 + DELETE_HASH_CHECK,
+     "re-key hashes only the new key value (got %lu)", hash_calls);
+
+  build_blob_key(key, blob_z, sizeof(blob_z));
+  ok(heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) == 0,
+     "new key z finds the row");
+  ok(sint4korr(rec + INT_OFFSET) == 2, "row content preserved");
+  build_blob_key(key, blob_y, sizeof(blob_y));
+  ok(heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) != 0,
+     "old key y no longer finds a row");
+
+  /* Update row 2 to x: duplicate of row 1, must be rejected + rolled back */
+  build_blob_key(key, blob_z, sizeof(blob_z));
+  ok(heap_rkey(info, oldrec, 0, key, 1, HA_READ_KEY_EXACT) == 0,
+     "re-positioned row 2 via key z");
+  build_record(newrec, 2, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_update(info, oldrec, newrec) == HA_ERR_FOUND_DUPP_KEY,
+     "update to duplicate value rejected");
+  ok(info->errkey == 0, "errkey is the failing key (got %d)", info->errkey);
+  ok(share->records == 2, "both rows still present");
+
+  ok(heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) == 0,
+     "row 2 still reachable via key z after rejected update");
+  build_blob_key(key, blob_x, sizeof(blob_x));
+  ok(heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) == 0 &&
+     sint4korr(rec + INT_OFFSET) == 1,
+     "row 1 still reachable via key x");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 4: multi-key rollback.  When a later key detects a duplicate,
+  keys already written for the row must be removed again, and when the
+  first key detects the duplicate, later keys must never be touched.
+*/
+
+static void test_multikey_rollback(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef[2];
+  HA_KEYSEG int_seg, blob_seg;
+  uchar rec[REC_LENGTH];
+  uchar int_key[4];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_x[200], blob_y[200], blob_z[200], blob_w[200];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+  memset(blob_y, 'y', sizeof(blob_y));
+  memset(blob_z, 'z', sizeof(blob_z));
+  memset(blob_w, 'w', sizeof(blob_w));
+
+  init_int_keyseg(&int_seg);
+  init_keydef(&keydef[0], &int_seg, 4, HA_NOSAME);
+  init_blob_keyseg(&blob_seg, FALSE);
+  init_keydef(&keydef[1], &blob_seg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_multikey", 2, keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(13, "setup failed");
+    return;
+  }
+  ok(1, "created table with unique int + unique blob hash keys");
+
+  build_record(rec, 1, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (1, x)");
+  build_record(rec, 2, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (2, y)");
+
+  /* key 0 accepts 3, key 1 rejects y: key 0 must be rolled back */
+  build_record(rec, 3, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_write(info, rec) == HA_ERR_FOUND_DUPP_KEY,
+     "(3, y) rejected on blob key");
+  ok(info->errkey == 1, "errkey is the blob key (got %d)", info->errkey);
+  int4store(int_key, 3);
+  ok(heap_rkey(info, rec, 0, int_key, 1, HA_READ_KEY_EXACT) != 0,
+     "int key 3 rolled back");
+  build_record(rec, 3, blob_z, sizeof(blob_z), FALSE);
+  ok(heap_write(info, rec) == 0, "(3, z) inserted after rollback");
+  ok(share->records == 3, "records=3");
+
+  /* key 0 rejects 2 immediately: key 1 must never see w */
+  build_record(rec, 2, blob_w, sizeof(blob_w), FALSE);
+  ok(heap_write(info, rec) == HA_ERR_FOUND_DUPP_KEY,
+     "(2, w) rejected on int key");
+  ok(info->errkey == 0, "errkey is the int key (got %d)", info->errkey);
+  build_blob_key(key, blob_w, sizeof(blob_w));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) != 0,
+     "blob key w was never inserted");
+  build_record(rec, 4, blob_w, sizeof(blob_w), FALSE);
+  ok(heap_write(info, rec) == 0, "(4, w) inserted");
+  ok(share->records == 4, "records=4");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 5: multi-key update rollback.  An update that changes two
+  unique hash keys where the second key hits a duplicate must restore
+  both original key values: the failing key was never inserted (only
+  its old value is re-inserted), and the first key's new value must be
+  removed and its old value re-inserted.
+*/
+
+static void test_multikey_update_rollback(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef[2];
+  HA_KEYSEG int_seg, blob_seg;
+  uchar oldrec[REC_LENGTH], newrec[REC_LENGTH], rec[REC_LENGTH];
+  uchar int_key[4];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_x[200], blob_y[200];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+  memset(blob_y, 'y', sizeof(blob_y));
+
+  init_int_keyseg(&int_seg);
+  init_keydef(&keydef[0], &int_seg, 4, HA_NOSAME);
+  init_blob_keyseg(&blob_seg, FALSE);
+  init_keydef(&keydef[1], &blob_seg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_multikey_upd", 2, keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(11, "setup failed");
+    return;
+  }
+  ok(1, "created table with unique int + unique blob hash keys");
+
+  build_record(rec, 1, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (1, x)");
+  build_record(rec, 2, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (2, y)");
+
+  /* Update (1, x) to (3, y): int key 3 is written, blob key y dups */
+  int4store(int_key, 1);
+  ok(heap_rkey(info, oldrec, 0, int_key, 1, HA_READ_KEY_EXACT) == 0,
+     "positioned row (1, x) via int key");
+  build_record(newrec, 3, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_update(info, oldrec, newrec) == HA_ERR_FOUND_DUPP_KEY,
+     "update (1, x) -> (3, y) rejected on blob key");
+  ok(info->errkey == 1, "errkey is the blob key (got %d)", info->errkey);
+
+  int4store(int_key, 1);
+  ok(heap_rkey(info, rec, 0, int_key, 1, HA_READ_KEY_EXACT) == 0 &&
+     sint4korr(rec + INT_OFFSET) == 1,
+     "int key 1 restored after rollback");
+  int4store(int_key, 3);
+  ok(heap_rkey(info, rec, 0, int_key, 1, HA_READ_KEY_EXACT) != 0,
+     "int key 3 rolled back");
+  build_blob_key(key, blob_x, sizeof(blob_x));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) == 0 &&
+     sint4korr(rec + INT_OFFSET) == 1,
+     "blob key x restored after rollback");
+  build_blob_key(key, blob_y, sizeof(blob_y));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) == 0 &&
+     sint4korr(rec + INT_OFFSET) == 2,
+     "blob key y still finds row 2");
+
+  ok(share->records == 2, "records=2");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 6: delete after a rejected ordered read on a hash index.
+
+  heap_rfirst()/heap_rlast() retarget lastinx to the requested index
+  before discovering it is a hash index and failing with
+  HA_ERR_WRONG_COMMAND.  They must not leave current_hash_ptr pointing
+  into another key's hash block: hp_delete_key() trusts
+  current_hash_ptr's cached hash when the row was positioned via the
+  index it is deleting from, so a stale pointer from a different key
+  would send the bucket lookup to the wrong chain and fail with
+  HA_ERR_CRASHED.
+*/
+
+static void test_delete_after_rejected_ordered_read(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef[2];
+  HA_KEYSEG int_seg, blob_seg;
+  uchar rec[REC_LENGTH], readbuf[REC_LENGTH];
+  uchar int_key[4];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_x[200], blob_y[200];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+  memset(blob_y, 'y', sizeof(blob_y));
+
+  init_int_keyseg(&int_seg);
+  init_keydef(&keydef[0], &int_seg, 4, HA_NOSAME);
+  init_blob_keyseg(&blob_seg, FALSE);
+  init_keydef(&keydef[1], &blob_seg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_stale_cursor", 2, keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(13, "setup failed");
+    return;
+  }
+  ok(1, "created table with unique int + unique blob hash keys");
+
+  build_record(rec, 1, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (1, x)");
+  build_record(rec, 2, blob_y, sizeof(blob_y), FALSE);
+  ok(heap_write(info, rec) == 0, "insert (2, y)");
+
+  /* Position row 1 via the blob key, then poison lastinx via rfirst */
+  build_blob_key(key, blob_x, sizeof(blob_x));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) == 0,
+     "positioned row 1 via blob key");
+  ok(heap_rfirst(info, readbuf, 0) == HA_ERR_WRONG_COMMAND,
+     "rfirst on hash int key rejected");
+  ok(heap_delete(info, rec) == 0,
+     "delete succeeds after rejected rfirst retargeted lastinx");
+  ok(share->records == 1, "one row left");
+  build_blob_key(key, blob_x, sizeof(blob_x));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) != 0,
+     "deleted row unreachable via blob key");
+  int4store(int_key, 2);
+  ok(heap_rkey(info, rec, 0, int_key, 1, HA_READ_KEY_EXACT) == 0,
+     "row 2 still reachable via int key");
+
+  /* Same shape with heap_rlast */
+  build_blob_key(key, blob_y, sizeof(blob_y));
+  ok(heap_rkey(info, rec, 1, key, 1, HA_READ_KEY_EXACT) == 0,
+     "positioned row 2 via blob key");
+  ok(heap_rlast(info, readbuf, 0) == HA_ERR_WRONG_COMMAND,
+     "rlast on hash int key rejected");
+  ok(heap_delete(info, rec) == 0,
+     "delete succeeds after rejected rlast retargeted lastinx");
+  ok(share->records == 0, "table empty");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 7: NULL key parts never conflict on a unique key; non-NULL
+  duplicates in the same table are still rejected.
+*/
+
+static void test_null_parts(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  uchar blob_x[200];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+
+  init_blob_keyseg(&keyseg, TRUE);
+  init_keydef(&keydef, &keyseg, 1 + BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_null_parts", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(7, "setup failed");
+    return;
+  }
+  ok(1, "created table with nullable unique blob hash key");
+
+  build_record(rec, 1, NULL, 0, TRUE);
+  ok(heap_write(info, rec) == 0, "insert first NULL key");
+  hash_calls= 0;
+  build_record(rec, 2, NULL, 0, TRUE);
+  ok(heap_write(info, rec) == 0, "insert second NULL key (NULLs never dup)");
+  ok(hash_calls == 0, "NULL key value is never hashed (got %lu)", hash_calls);
+  ok(share->records == 2, "records=2");
+
+  build_record(rec, 3, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert non-NULL value");
+  build_record(rec, 4, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == HA_ERR_FOUND_DUPP_KEY,
+     "non-NULL duplicate still rejected");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 8: non-unique hash keys accept duplicates and never pay a
+  duplicate probe beyond the single insert hash.
+*/
+
+static void test_non_unique_dups(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  uchar blob_x[200];
+
+  memset(blob_x, 'x', sizeof(blob_x));
+
+  init_blob_keyseg(&keyseg, FALSE);
+  init_keydef(&keydef, &keyseg, BLOB_KEY_LEN, 0);
+
+  if (create_and_open("t_non_unique", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(5, "setup failed");
+    return;
+  }
+  ok(1, "created table with non-unique blob hash key");
+
+  hash_calls= 0;
+  build_record(rec, 1, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert value");
+  build_record(rec, 2, blob_x, sizeof(blob_x), FALSE);
+  ok(heap_write(info, rec) == 0, "insert same value again");
+  ok(hash_calls == 2, "two inserts cost two hashes (got %lu)", hash_calls);
+  ok(share->records == 2, "records=2");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+/*
+  Test 9: duplicate-heavy insert stream across many hash table splits,
+  then delete everything via index reads.
+
+  500 inserts of 173 distinct values: exactly 173 succeed, 327 are
+  rejected, and the total hashing cost is exactly 500 (one hash per
+  insert attempt, successful or not).  The table stays consistent
+  through the linear-hash splits interleaved with rejections.
+*/
+
+static void test_mixed_stress(void)
+{
+  HP_SHARE *share;
+  HP_INFO *info;
+  HP_KEYDEF keydef;
+  HA_KEYSEG keyseg;
+  uchar rec[REC_LENGTH];
+  uchar key[BLOB_KEY_LEN];
+  uchar blob_val[24];
+  ulong i, successes= 0, dups= 0, delete_failures= 0;
+  const ulong attempts= 500, distinct= 173;
+
+  init_blob_keyseg(&keyseg, FALSE);
+  init_keydef(&keydef, &keyseg, BLOB_KEY_LEN, HA_NOSAME);
+
+  if (create_and_open("t_stress", 1, &keydef, &share, &info))
+  {
+    ok(0, "setup failed: %d", my_errno);
+    skip(9, "setup failed");
+    return;
+  }
+  ok(1, "created table");
+
+  hash_calls= 0;
+  for (i= 0; i < attempts; i++)
+  {
+    int res;
+    memset(blob_val, 'v', sizeof(blob_val));
+    my_snprintf((char*) blob_val, sizeof(blob_val), "value-%03lu",
+                i % distinct);
+    build_record(rec, (int32) i, blob_val, sizeof(blob_val), FALSE);
+    res= heap_write(info, rec);
+    if (res == 0)
+      successes++;
+    else if (res == HA_ERR_FOUND_DUPP_KEY)
+      dups++;
+  }
+  ok(successes == distinct, "%lu distinct values inserted (got %lu)",
+     distinct, successes);
+  ok(dups == attempts - distinct, "%lu duplicates rejected (got %lu)",
+     attempts - distinct, dups);
+  ok(hash_calls == attempts,
+     "%lu insert attempts cost exactly %lu hashes (got %lu)",
+     attempts, attempts, hash_calls);
+  ok(share->records == distinct, "records=%lu", (ulong) share->records);
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK after inserts");
+
+  hash_calls= 0;
+  for (i= 0; i < distinct; i++)
+  {
+    memset(blob_val, 'v', sizeof(blob_val));
+    my_snprintf((char*) blob_val, sizeof(blob_val), "value-%03lu", i);
+    build_blob_key(key, blob_val, sizeof(blob_val));
+    if (heap_rkey(info, rec, 0, key, 1, HA_READ_KEY_EXACT) ||
+        heap_delete(info, rec))
+      delete_failures++;
+  }
+  ok(delete_failures == 0, "all %lu rows deleted via index reads (%lu failed)",
+     distinct, delete_failures);
+  ok(hash_calls == distinct * (1 + DELETE_HASH_CHECK),
+     "each index-read + delete hashes the key exactly once (got %lu)",
+     hash_calls);
+  ok(share->records == 0, "table empty");
+
+  ok(heap_check_heap(info, 0) == 0, "heap_check_heap OK after deletes");
+
+  heap_drop_table(info);
+  heap_close(info);
+}
+
+
+int main(int argc __attribute__((unused)),
+         char **argv __attribute__((unused)))
+{
+  MY_INIT("hp_test_write_dup");
+  plan(105);
+
+  init_counting_charset();
+
+  diag("Test 1: hashing cost of unique inserts and rejected duplicates");
+  test_dup_insert_hash_cost();
+
+  diag("Test 2: hashing cost of deletes (index- and scan-positioned)");
+  test_delete_hash_cost();
+
+  diag("Test 3: update re-key cost and update-to-duplicate rollback");
+  test_update_rekey_and_dup();
+
+  diag("Test 4: multi-key rollback on duplicate");
+  test_multikey_rollback();
+
+  diag("Test 5: multi-key update rollback on duplicate");
+  test_multikey_update_rollback();
+
+  diag("Test 6: delete after rejected rfirst/rlast on a hash index");
+  test_delete_after_rejected_ordered_read();
+
+  diag("Test 7: NULL key parts never conflict");
+  test_null_parts();
+
+  diag("Test 8: non-unique hash keys accept duplicates");
+  test_non_unique_dups();
+
+  diag("Test 9: duplicate-heavy stress across hash splits");
+  test_mixed_stress();
+
+  my_end(0);
+  return exit_status();
+}

--- a/storage/heap/hp_update.c
+++ b/storage/heap/hp_update.c
@@ -20,7 +20,7 @@
 
 int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
 {
-  HP_KEYDEF *keydef, *end, *p_lastinx;
+  HP_KEYDEF *keydef, *keydef_end, *p_lastinx;
   uchar *pos, *recovery_ptr;
   struct st_hp_hash_info *recovery_hash_ptr;
   my_bool auto_key_changed= 0, key_changed= 0;
@@ -41,7 +41,9 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
   recovery_hash_ptr= info->current_hash_ptr;
 
   p_lastinx= share->keydef + info->lastinx;
-  for (keydef= share->keydef, end= keydef + share->keys; keydef < end; keydef++)
+  for (keydef= share->keydef, keydef_end= keydef + share->keys;
+       keydef < keydef_end;
+       keydef++)
   {
     if (hp_rec_key_cmp(keydef, heap_new, old, NULL))
     {
@@ -253,20 +255,39 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
   DBUG_RETURN(0);
 
  err:
-  if (my_errno == HA_ERR_FOUND_DUPP_KEY)
+  info->errkey= -1;                             /* If not a key error */
+  if (my_errno == HA_ERR_FOUND_DUPP_KEY || my_errno == HA_ERR_OUT_OF_MEM ||
+      my_errno == ENOMEM || my_errno == HA_ERR_RECORD_FILE_FULL)
   {
-    info->errkey = (int) (keydef - share->keydef);
-    if (keydef->algorithm == HA_KEY_ALG_BTREE)
+    int org_error= my_errno;
+    if (keydef == keydef_end)
     {
-      /* we don't need to delete non-inserted key from rb-tree */
-      if ((*keydef->write_key)(info, keydef, old, pos))
-      {
-        if (++(share->records) == share->blength)
-	  share->blength+= share->blength;
-        DBUG_RETURN(my_errno);
-      }
+      /*
+        We got a failure after all key parts have been written, like
+        while writing blobs. Alternatively there are no keys.
+        Decrement keydef so that it points at the last key part or
+        before share->keydef.
+      */
+      DBUG_ASSERT(share->keydef);
       keydef--;
     }
+    else
+    {
+      /* keydef points to the last key that failed */
+      info->errkey = (int) (keydef - share->keydef);
+      if (keydef->algorithm == HA_KEY_ALG_BTREE)
+      {
+        /* we don't need to delete non-inserted key from rb-tree */
+        if ((*keydef->write_key)(info, keydef, old, pos))
+        {
+          if (++(share->records) == share->blength)
+            share->blength+= share->blength;
+          DBUG_RETURN(my_errno);
+        }
+        keydef--;
+      }
+    }
+    /* Restore all modified keys */
     while (keydef >= share->keydef)
     {
       if (hp_rec_key_cmp(keydef, heap_new, old, NULL))
@@ -279,6 +300,7 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
     }
     info->current_ptr= recovery_ptr;
     info->current_hash_ptr= recovery_hash_ptr;
+    my_errno= org_error;
   }
   if (++(share->records) == share->blength)
     share->blength+= share->blength;

--- a/storage/heap/hp_update.c
+++ b/storage/heap/hp_update.c
@@ -27,6 +27,8 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
   HP_SHARE *share= info->s;
   DBUG_ENTER("heap_update");
 
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
   test_active(info);
   hp_flush_pending_blob_free(info);
   pos=info->current_ptr;
@@ -274,12 +276,14 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
     else
     {
       /* keydef points to the last key that failed */
-      info->errkey = (int) (keydef - share->keydef);
+      if (org_error == HA_ERR_FOUND_DUPP_KEY)
+        info->errkey = (int) (keydef - share->keydef);
       if (keydef->algorithm == HA_KEY_ALG_BTREE)
       {
         /* we don't need to delete non-inserted key from rb-tree */
         if ((*keydef->write_key)(info, keydef, old, pos))
         {
+          heap_mark_crashed(share);
           if (++(share->records) == share->blength)
             share->blength+= share->blength;
           DBUG_RETURN(my_errno);
@@ -294,13 +298,26 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
       {
 	if ((*keydef->delete_key)(info, keydef, heap_new, pos, 0) ||
 	    (*keydef->write_key)(info, keydef, old, pos))
+	{
+	  heap_mark_crashed(share);
 	  break;
+	}
       }
       keydef--;
     }
     info->current_ptr= recovery_ptr;
     info->current_hash_ptr= recovery_hash_ptr;
     my_errno= org_error;
+  }
+  else
+  {
+    /*
+      An error we do not know how to recover from.  The changed keys have
+      been moved to the new values, or could not be removed from them,
+      while the record keeps the old ones, so the index no longer
+      describes the data.
+    */
+    heap_mark_crashed(share);
   }
   if (++(share->records) == share->blength)
     share->blength+= share->blength;

--- a/storage/heap/hp_update.c
+++ b/storage/heap/hp_update.c
@@ -278,18 +278,21 @@ int heap_update(HP_INFO *info, const uchar *old, const uchar *heap_new)
       /* keydef points to the last key that failed */
       if (org_error == HA_ERR_FOUND_DUPP_KEY)
         info->errkey = (int) (keydef - share->keydef);
-      if (keydef->algorithm == HA_KEY_ALG_BTREE)
+      /*
+        The failing key was never inserted: tree_insert() rejects
+        duplicates and fails allocation before linking the node, and
+        hash keys are probed for duplicates before insert.  Re-insert
+        the old key that was deleted just before the failed insert,
+        then roll back the previously updated keys.
+      */
+      if ((*keydef->write_key)(info, keydef, old, pos))
       {
-        /* we don't need to delete non-inserted key from rb-tree */
-        if ((*keydef->write_key)(info, keydef, old, pos))
-        {
-          heap_mark_crashed(share);
-          if (++(share->records) == share->blength)
-            share->blength+= share->blength;
-          DBUG_RETURN(my_errno);
-        }
-        keydef--;
+        heap_mark_crashed(share);
+        if (++(share->records) == share->blength)
+          share->blength+= share->blength;
+        DBUG_RETURN(my_errno);
       }
+      keydef--;
     }
     /* Restore all modified keys */
     while (keydef >= share->keydef)

--- a/storage/heap/hp_write.c
+++ b/storage/heap/hp_write.c
@@ -92,15 +92,12 @@ err:
     DBUG_PRINT("info",("Duplicate key: %d", (int) (keydef - share->keydef)));
   info->errkey= (int) (keydef - share->keydef);
   /*
-    We don't need to delete non-inserted key from rb-tree.  Also, if
-    we got ENOMEM, the key wasn't inserted, so don't try to delete it
-    either.  Otherwise for HASH index on HA_ERR_FOUND_DUPP_KEY the key
-    was inserted and we have to delete it.
+    The failing key was never inserted: tree_insert() rejects
+    duplicates and fails allocation before linking the node, hash keys
+    are probed for duplicates before insert, and on ENOMEM nothing was
+    added.  Roll back only the preceding keys.
   */
-  if (keydef->algorithm == HA_KEY_ALG_BTREE || my_errno == ENOMEM)
-  {
-    keydef--;
-  }
+  keydef--;
 
 err_delete_written_keys:
   while (keydef >= share->keydef)
@@ -338,8 +335,8 @@ uchar *next_free_record_pos(HP_SHARE *info)
   RETURN
     0  - OK
     -1 - Out of memory
-    HA_ERR_FOUND_DUPP_KEY - Duplicate record on unique key. The record was 
-    still added and the caller must call hp_delete_key for it.
+    HA_ERR_FOUND_DUPP_KEY - Duplicate record on unique key. Nothing was
+    inserted; the index is unchanged.
 */
 
 int hp_write_key(HP_INFO *info, HP_KEYDEF *keyinfo,
@@ -347,11 +344,41 @@ int hp_write_key(HP_INFO *info, HP_KEYDEF *keyinfo,
 {
   HP_SHARE *share = info->s;
   int flag;
-  ulong halfbuff,hashnr,first_index;
+  ulong halfbuff,hashnr,first_index,rec_hash;
   ulong UNINIT_VAR(hash_of_key), UNINIT_VAR(hash_of_key2);
   uchar *UNINIT_VAR(ptr_to_rec),*UNINIT_VAR(ptr_to_rec2);
   HASH_INFO *empty,*UNINIT_VAR(gpos),*UNINIT_VAR(gpos2),*pos;
   DBUG_ENTER("hp_write_key");
+
+  rec_hash= hp_rec_hashnr(0, keyinfo, record);
+
+  /*
+    Reject a duplicate before modifying the index, so that the caller
+    never has to undo the insert (the undo would hash the key value a
+    second time, which is expensive for blob keys).  The probe walks
+    the key's chain under the current mask comparing cached hashes;
+    the full value is compared only on a hash match.  Records with
+    equal hashes always share a bucket under any mask, so probing the
+    pre-insert chain finds any duplicate.
+  */
+  if ((keyinfo->flag & HA_NOSAME) && share->records &&
+      (!(keyinfo->flag & HA_NULL_PART_KEY) ||
+       !hp_if_null_in_key(keyinfo, record)))
+  {
+    ulong search_pos= hp_mask(rec_hash, share->blength, share->records);
+    pos= hp_find_hash(&keyinfo->block, search_pos);
+    /* Only entries whose home position is search_pos belong to the chain */
+    if (hp_mask(pos->hash_of_key, share->blength, share->records) ==
+        search_pos)
+    {
+      do
+      {
+        if (pos->hash_of_key == rec_hash &&
+            !hp_rec_key_cmp(keyinfo, record, pos->ptr_to_rec, info))
+          DBUG_RETURN(my_errno=HA_ERR_FOUND_DUPP_KEY);
+      } while ((pos= pos->next_key));
+    }
+  }
 
   flag=0;
   if (!(empty= hp_find_free_hash(share,&keyinfo->block,share->records)))
@@ -491,13 +518,12 @@ int hp_write_key(HP_INFO *info, HP_KEYDEF *keyinfo,
   }
   /* Check if we are at the empty position */
 
-  hash_of_key= hp_rec_hashnr(0, keyinfo, record);
   pos=hp_find_hash(&keyinfo->block,
-                   hp_mask(hash_of_key, share->blength, share->records + 1));
+                   hp_mask(rec_hash, share->blength, share->records + 1));
   if (pos == empty)
   {
     pos->ptr_to_rec=  recpos;
-    pos->hash_of_key= hash_of_key;
+    pos->hash_of_key= rec_hash;
     pos->next_key=    0;
     keyinfo->hash_buckets++;
   }
@@ -510,7 +536,7 @@ int hp_write_key(HP_INFO *info, HP_KEYDEF *keyinfo,
 			      share->blength, share->records + 1));
 
     pos->ptr_to_rec=  recpos;
-    pos->hash_of_key= hash_of_key;
+    pos->hash_of_key= rec_hash;
     if (pos == gpos)
       pos->next_key=empty;
     else
@@ -518,22 +544,6 @@ int hp_write_key(HP_INFO *info, HP_KEYDEF *keyinfo,
       keyinfo->hash_buckets++;
       pos->next_key= 0;
       hp_movelink(pos, gpos, empty);
-    }
-
-    /* Check if duplicated keys */
-    if ((keyinfo->flag & HA_NOSAME) && pos == gpos &&
-	(!(keyinfo->flag & HA_NULL_PART_KEY) ||
-	 !hp_if_null_in_key(keyinfo, record)))
-    {
-      pos=empty;
-      do
-      {
-	if (pos->hash_of_key == hash_of_key &&
-            ! hp_rec_key_cmp(keyinfo, record, pos->ptr_to_rec, info))
-	{
-	  DBUG_RETURN(my_errno=HA_ERR_FOUND_DUPP_KEY);
-	}
-      } while ((pos=pos->next_key));
     }
   }
   DBUG_RETURN(0);

--- a/storage/heap/hp_write.c
+++ b/storage/heap/hp_write.c
@@ -35,6 +35,8 @@ int heap_write(HP_INFO *info, const uchar *record)
   uchar *pos;
   HP_SHARE *share=info->s;
   DBUG_ENTER("heap_write");
+  if (heap_is_crashed(share))
+    DBUG_RETURN(my_errno= HA_ERR_CRASHED);
 #ifndef DBUG_OFF
   if (info->mode & O_RDONLY)
   {
@@ -123,11 +125,12 @@ err_delete_written_keys:
   Write a key to rb_tree-index 
 */
 
-int hp_rb_write_key(HP_INFO *info, HP_KEYDEF *keyinfo, const uchar *record, 
+int hp_rb_write_key(HP_INFO *info, HP_KEYDEF *keyinfo, const uchar *record,
 		    uchar *recpos)
 {
   heap_rb_param custom_arg;
   size_t old_allocated;
+  TREE_ELEMENT *element;
 
   custom_arg.keyseg= keyinfo->seg;
   custom_arg.key_length= hp_rb_make_key(keyinfo, info->recbuf, record, recpos);
@@ -142,10 +145,16 @@ int hp_rb_write_key(HP_INFO *info, HP_KEYDEF *keyinfo, const uchar *record,
     keyinfo->rb_tree.flag= 0;
   }
   old_allocated= keyinfo->rb_tree.allocated;
-  if (!tree_insert(&keyinfo->rb_tree, (void*)info->recbuf,
-		   custom_arg.key_length, &custom_arg))
+  element= tree_insert(&keyinfo->rb_tree, (void*) info->recbuf,
+                       custom_arg.key_length, &custom_arg);
+  if (!element)
   {
-    my_errno= HA_ERR_FOUND_DUPP_KEY;
+    if (keyinfo->rb_tree.error == TREE_ERROR_OOM)
+      my_errno= HA_ERR_OUT_OF_MEM;
+    else if (keyinfo->rb_tree.error == TREE_ERROR_DUP_KEY)
+      my_errno= HA_ERR_FOUND_DUPP_KEY;
+    else
+      my_errno= HA_ERR_INTERNAL_ERROR;
     return 1;
   }
   info->s->index_length+= (keyinfo->rb_tree.allocated-old_allocated);


### PR DESCRIPTION
JIRA: [MDEV-40448](https://jira.mariadb.org/browse/MDEV-40448)

## Problem

A rejected duplicate insert into a HEAP unique hash index paid the full-value key hash **twice**: `hp_write_key()` hashed the key to insert it (the documented contract was "the record was still added and the caller must call hp_delete_key for it"), and `hp_delete_key()` then hashed the same record again just to locate the bucket to unlink from. For long key values (BLOB keys, MDEV-38975) the second scan dominates duplicate-heavy workloads: `SELECT DISTINCT` over 20-50KB blob values (~80% duplicates) regressed 25-32% vs Aria tmp tables at low concurrency, with `my_uca_hash_sort_utf8mb4` doing 1.83x the hashing work for the identical query.

The hash caching added by `de1765fb64d` (`HASH_INFO::hash_of_key`) already made all chain surgery hash-free; the two full-value hashes per rejected row were the entire cost.

## Fix

1. **Probe before insert** (`hp_write_key()`): compute the hash once at the top; for `HA_NOSAME` keys without NULL key parts walk the key's chain under the pre-insert mask comparing cached `HASH_INFO::hash_of_key` values, comparing full key values only on a hash match. On a duplicate return `HA_ERR_FOUND_DUPP_KEY` with **nothing modified**; otherwise proceed with the linear-hash split and insertion reusing the already-computed hash. Records with equal full hashes share a bucket under any mask, so probing the pre-insert chain finds any duplicate. A successful insert costs exactly one full-value hash, as before; a rejected duplicate drops from two full hashes + insert + undo delete to one hash + compare, the same as a lookup.
2. **Error-path contract change**: `hp_write_key()` no longer inserts the key on a duplicate, so `heap_write()` rolls back only the preceding keys (unconditional `keydef--`, as for BTREE/ENOMEM), and `heap_update()`'s duplicate path now re-inserts the old key for the failing keydef for both algorithms (previously BTREE-only) before rolling back earlier keys.
3. **Delete-side hash reuse** (`hp_delete_key()`): when the row being deleted was positioned via the same hash index (`flag` set and `info->current_hash_ptr->ptr_to_rec == recpos`), take the hash from the index entry instead of re-scanning the key value; a `DBUG_ASSERT` cross-checks the cached hash in debug builds. This removes the remaining full-value hash from `DELETE`/`UPDATE` of rows located through the index (`heap_rkey()` already hashed the key).
4. **`heap_rfirst()`/`heap_rlast()`**: clear `info->current_hash_ptr` when rejecting a hash index with `HA_ERR_WRONG_COMMAND`. Both functions retarget `info->lastinx` before the algorithm check, so a stale `current_hash_ptr` from a previous search on a different key could otherwise satisfy the new cached-hash guard in `hp_delete_key()` and send the bucket lookup to the wrong chain (reachable through the heap API only; the SQL layer never issues ordered reads on hash indexes).

## Testing

New unit test `hp_test_write_dup-t` (105 assertions) wraps the key charset's `hash_sort` collation handler in a counting shim, asserting the **exact** number of full-value hashes for every operation: 1 per insert attempt (successful or rejected), 1 total for index-read + delete, 1 for an index-positioned re-key. Behavioral coverage: single- and multi-key rollback for INSERT and UPDATE duplicates, NULL key parts, non-unique keys, delete after rejected `heap_rfirst()`/`heap_rlast()`, and a 500-row duplicate-heavy stress across linear-hash splits (exactly 500 hashes; was 827 before the fix). All counting assertions were verified to fail before the fix and pass after, with the production code otherwise unchanged.

Full runs green on RelWithDebInfo and Debug: heap unit tests, `hp_test1`/`hp_test2`, MTR `suite/heap` (27/27), and main-suite distinct/group_by/count_distinct/derived/type_blob/temp_table/replace/insert_update/update/show_check/information_schema (14/14). The `DBUG_ASSERT` cross-check never fired.

## Benchmark

16 threads, 120s recorded runs, 8c/16t AMD 7840HS; `base` = preview-13.1 without MDEV-38975 (Aria tmp tables), `new` = unfixed, `fix` = this patch:

| test (QPS) | base | new | fix |
|---|---|---|---|
| `blob_case_c` | 4.65 | 3.36 (-28%) | **5.61** (+21% vs base, +67% vs new) |
| `blob_mixed` | 5.87 | 4.13 (-30%) | **6.92** (+18% vs base, +68% vs new) |

`hp_delete_key()` (38% inclusive before) is absent from the fixed profile; the low-concurrency regression becomes a win on top of the existing 2x+ high-concurrency wins.
