### PR TITLE
MDEV-38384 : Galera test failure on MDEV-37366

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-37366.result
+++ b/mysql-test/suite/galera/r/MDEV-37366.result
@@ -1,9 +1,17 @@
 connection node_2;
 connection node_1;
 connection node_1;
-connection node_2;
-connection node_1;
+SET SESSION auto_increment_increment=2;
+SET SESSION auto_increment_offset=1;
 SET SESSION binlog_row_image=minimal;
+SELECT VARIABLE_NAME, SESSION_VALUE, GLOBAL_VALUE FROM
+INFORMATION_SCHEMA.SYSTEM_VARIABLES WHERE VARIABLE_NAME IN
+('auto_increment_increment','auto_increment_offset','binlog_row_image')
+ORDER BY VARIABLE_NAME;
+VARIABLE_NAME	SESSION_VALUE	GLOBAL_VALUE
+AUTO_INCREMENT_INCREMENT	2	2
+AUTO_INCREMENT_OFFSET	1	1
+BINLOG_ROW_IMAGE	MINIMAL	FULL
 CREATE SEQUENCE `seq_test` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB;
 SHOW CREATE TABLE seq_test;
 Table	Create Table
@@ -24,4 +32,12 @@ SELECT NEXT VALUE FOR seq_test;
 NEXT VALUE FOR seq_test
 3
 connection node_2;
+SELECT VARIABLE_VALUE AS expect_2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+expect_2
+2
+SELECT VARIABLE_VALUE expect_Primary FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+expect_Primary
+Primary
 DROP SEQUENCE seq_test;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-37366.test
+++ b/mysql-test/suite/galera/t/MDEV-37366.test
@@ -3,28 +3,22 @@
 # Failed 'SELECT NEXT VALUE' on applier node.
 #
 --source include/galera_cluster.inc
---source include/have_innodb.inc
---source include/big_test.inc
 --source include/have_log_bin.inc
+--source include/have_perfschema.inc
 
-#
-# Save original auto_increment_offset values.
-#
---let $node_1=node_1
---let $node_2=node_2
---source ../galera/include/auto_increment_offset_save.inc
-
-#
-# Verify there are two nodes in galera cluster.
-#
 --connection node_1
---let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
---source include/wait_condition.inc
-
 #
 # Create a sequence table on node1.
 #
+SET SESSION auto_increment_increment=2;
+SET SESSION auto_increment_offset=1;
 SET SESSION binlog_row_image=minimal;
+
+SELECT VARIABLE_NAME, SESSION_VALUE, GLOBAL_VALUE FROM
+ INFORMATION_SCHEMA.SYSTEM_VARIABLES WHERE VARIABLE_NAME IN
+ ('auto_increment_increment','auto_increment_offset','binlog_row_image')
+ ORDER BY VARIABLE_NAME;
+
 CREATE SEQUENCE `seq_test` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB;
 SHOW CREATE TABLE seq_test;
 
@@ -35,19 +29,18 @@ SHOW CREATE TABLE seq_test;
 SELECT NEXT VALUE FOR seq_test;
 SELECT NEXT VALUE FOR seq_test;
 --enable_ps_protocol
-
-#
-# Verify there are two nodes in galera cluster.
-#
---let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
---source include/wait_condition.inc
-
 #
 # Cleanup
 #
 --connection node_2
+#
+# Verify that node_2 has remained on cluster
+#
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+SELECT VARIABLE_VALUE AS expect_2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+SELECT VARIABLE_VALUE expect_Primary FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 
 DROP SEQUENCE seq_test;
 
-# Restore original variable values.
---source ../galera/include/auto_increment_offset_restore.inc
+--source include/galera_end.inc


### PR DESCRIPTION
Test failed because auto-increment variable values for the servers where not explicitly set. Fixed by setting auto-increment values explicitly on test case. Test case changes only.