### PR TITLE
MDEV-40384: innodb_gis.geometry fails on replay

### DIFF
--- a/mysql-test/include/opt_context_replay_innodb.inc
+++ b/mysql-test/include/opt_context_replay_innodb.inc
@@ -22,6 +22,11 @@ insert into t1 select seq, seq from seq_1_to_100;
 
 analyze table t1;
 
+set optimizer_record_context=ON;
+select count(*) from t1;
+--source include/opt_context_list_sys_vars.inc
+set optimizer_record_context=OFF;
+
 let $explain_query= explain format= json select * from t1 a,
     t1 b where a.c1 < 3 and b.c1 < 33;
 

--- a/mysql-test/main/opt_context_replay_innodb_comp.result
+++ b/mysql-test/main/opt_context_replay_innodb_comp.result
@@ -41,6 +41,97 @@ analyze table t1;
 Table	Op	Msg_type	Msg_text
 db1.t1	analyze	status	Engine-independent statistics collected
 db1.t1	analyze	status	OK
+set optimizer_record_context=ON;
+select count(*) from t1;
+count(*)
+100
+set @set_stmts=
+(select REGEXP_SUBSTR(context, '(SET .*)([\n\r].*)*(?=(CREATE DATABASE))')
+AS set_stmt from information_schema.optimizer_context);
+select @set_stmts;
+@set_stmts
+SET NAMES utf8mb4;
+
+SET GLOBAL InnoDB.OPTIMIZER_DISK_READ_COST=10.24;
+SET GLOBAL InnoDB.OPTIMIZER_INDEX_BLOCK_COPY_COST=0.0356;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_COPY_COST=0.015685;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_LOOKUP_COST=0.79112;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_NEXT_FIND_COST=0.099;
+SET GLOBAL InnoDB.OPTIMIZER_DISK_READ_RATIO=0.02;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_COPY_COST=0.06087;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_LOOKUP_COST=0.76597;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_NEXT_FIND_COST=0.07013;
+SET GLOBAL InnoDB.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL InnoDB.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET GLOBAL heap.OPTIMIZER_DISK_READ_COST=0;
+SET GLOBAL heap.OPTIMIZER_INDEX_BLOCK_COPY_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL heap.OPTIMIZER_KEY_COPY_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_LOOKUP_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_NEXT_FIND_COST=0;
+SET GLOBAL heap.OPTIMIZER_DISK_READ_RATIO=0;
+SET GLOBAL heap.OPTIMIZER_ROW_COPY_COST=0.002334;
+SET GLOBAL heap.OPTIMIZER_ROW_LOOKUP_COST=0;
+SET GLOBAL heap.OPTIMIZER_ROW_NEXT_FIND_COST=0.0080166;
+SET GLOBAL heap.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL heap.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET GLOBAL temp_table.OPTIMIZER_DISK_READ_COST=10.24;
+SET GLOBAL temp_table.OPTIMIZER_INDEX_BLOCK_COPY_COST=0.0356;
+SET GLOBAL temp_table.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL temp_table.OPTIMIZER_KEY_COPY_COST=0.015685;
+SET GLOBAL temp_table.OPTIMIZER_KEY_LOOKUP_COST=0.435777;
+SET GLOBAL temp_table.OPTIMIZER_KEY_NEXT_FIND_COST=0.082347;
+SET GLOBAL temp_table.OPTIMIZER_DISK_READ_RATIO=0.02;
+SET GLOBAL temp_table.OPTIMIZER_ROW_COPY_COST=0.060866;
+SET GLOBAL temp_table.OPTIMIZER_ROW_LOOKUP_COST=0.130839;
+SET GLOBAL temp_table.OPTIMIZER_ROW_NEXT_FIND_COST=0.045916;
+SET GLOBAL temp_table.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL temp_table.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET group_concat_max_len=1048576;
+SET in_predicate_conversion_threshold=1000;
+SET innodb_strict_mode='ON';
+SET join_buffer_size=262144;
+SET join_cache_level=2;
+SET max_heap_table_size=1048576;
+SET note_verbosity='basic,explain';
+SET old_mode='UTF8_IS_UTF8MB3';
+SET optimizer_adjust_secondary_key_costs=0;
+SET GLOBAL optimizer_disk_read_cost=10.240000;
+SET GLOBAL optimizer_disk_read_ratio=0.020000;
+SET optimizer_extra_pruning_depth=8;
+SET GLOBAL optimizer_index_block_copy_cost=0.035600;
+SET optimizer_join_limit_pref_ratio=0;
+SET GLOBAL optimizer_key_compare_cost=0.011361;
+SET GLOBAL optimizer_key_copy_cost=0.015685;
+SET GLOBAL optimizer_key_lookup_cost=0.435777;
+SET GLOBAL optimizer_key_next_find_cost=0.082347;
+SET optimizer_max_sel_arg_weight=32000;
+SET optimizer_max_sel_args=16000;
+SET optimizer_prune_level=2;
+SET GLOBAL optimizer_row_copy_cost=0.060866;
+SET GLOBAL optimizer_row_lookup_cost=0.130839;
+SET GLOBAL optimizer_row_next_find_cost=0.045916;
+SET GLOBAL optimizer_rowid_compare_cost=0.002653;
+SET GLOBAL optimizer_rowid_copy_cost=0.002653;
+SET optimizer_scan_setup_cost=10.000000;
+SET optimizer_search_depth=62;
+SET optimizer_selectivity_sampling_limit=100;
+SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
+SET optimizer_trace='enabled=off';
+SET optimizer_trace_max_mem_size=1048576;
+SET optimizer_use_condition_selectivity=4;
+SET optimizer_where_cost=0.032000;
+SET sort_buffer_size=262144;
+SET sql_buffer_result='OFF';
+SET sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+SET standard_compliant_cte='ON';
+SET time_zone='REPLACED';
+SET timestamp=REPLACED;
+## version='REPLACED';
+## version_source_revision='REPLACED';
+
+set optimizer_record_context=OFF;
 set optimizer_replay_context= "";
 explain format= json select * from t1 a,
 t1 b where a.c1 < 3 and b.c1 < 33

--- a/mysql-test/main/opt_context_replay_innodb_pref.result
+++ b/mysql-test/main/opt_context_replay_innodb_pref.result
@@ -41,6 +41,97 @@ analyze table t1;
 Table	Op	Msg_type	Msg_text
 db1.t1	analyze	status	Engine-independent statistics collected
 db1.t1	analyze	status	OK
+set optimizer_record_context=ON;
+select count(*) from t1;
+count(*)
+100
+set @set_stmts=
+(select REGEXP_SUBSTR(context, '(SET .*)([\n\r].*)*(?=(CREATE DATABASE))')
+AS set_stmt from information_schema.optimizer_context);
+select @set_stmts;
+@set_stmts
+SET NAMES utf8mb4;
+
+SET GLOBAL InnoDB.OPTIMIZER_DISK_READ_COST=10.24;
+SET GLOBAL InnoDB.OPTIMIZER_INDEX_BLOCK_COPY_COST=0.0356;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_COPY_COST=0.015685;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_LOOKUP_COST=0.79112;
+SET GLOBAL InnoDB.OPTIMIZER_KEY_NEXT_FIND_COST=0.099;
+SET GLOBAL InnoDB.OPTIMIZER_DISK_READ_RATIO=0.02;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_COPY_COST=0.06087;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_LOOKUP_COST=0.76597;
+SET GLOBAL InnoDB.OPTIMIZER_ROW_NEXT_FIND_COST=0.07013;
+SET GLOBAL InnoDB.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL InnoDB.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET GLOBAL heap.OPTIMIZER_DISK_READ_COST=0;
+SET GLOBAL heap.OPTIMIZER_INDEX_BLOCK_COPY_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL heap.OPTIMIZER_KEY_COPY_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_LOOKUP_COST=0;
+SET GLOBAL heap.OPTIMIZER_KEY_NEXT_FIND_COST=0;
+SET GLOBAL heap.OPTIMIZER_DISK_READ_RATIO=0;
+SET GLOBAL heap.OPTIMIZER_ROW_COPY_COST=0.002334;
+SET GLOBAL heap.OPTIMIZER_ROW_LOOKUP_COST=0;
+SET GLOBAL heap.OPTIMIZER_ROW_NEXT_FIND_COST=0.0080166;
+SET GLOBAL heap.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL heap.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET GLOBAL temp_table.OPTIMIZER_DISK_READ_COST=10.24;
+SET GLOBAL temp_table.OPTIMIZER_INDEX_BLOCK_COPY_COST=0.0356;
+SET GLOBAL temp_table.OPTIMIZER_KEY_COMPARE_COST=0.011361;
+SET GLOBAL temp_table.OPTIMIZER_KEY_COPY_COST=0.015685;
+SET GLOBAL temp_table.OPTIMIZER_KEY_LOOKUP_COST=0.435777;
+SET GLOBAL temp_table.OPTIMIZER_KEY_NEXT_FIND_COST=0.082347;
+SET GLOBAL temp_table.OPTIMIZER_DISK_READ_RATIO=0.02;
+SET GLOBAL temp_table.OPTIMIZER_ROW_COPY_COST=0.060866;
+SET GLOBAL temp_table.OPTIMIZER_ROW_LOOKUP_COST=0.130839;
+SET GLOBAL temp_table.OPTIMIZER_ROW_NEXT_FIND_COST=0.045916;
+SET GLOBAL temp_table.OPTIMIZER_ROWID_COMPARE_COST=0.002653;
+SET GLOBAL temp_table.OPTIMIZER_ROWID_COPY_COST=0.002653;
+SET group_concat_max_len=1048576;
+SET in_predicate_conversion_threshold=1000;
+SET innodb_strict_mode='ON';
+SET join_buffer_size=262144;
+SET join_cache_level=2;
+SET max_heap_table_size=1048576;
+SET note_verbosity='basic,explain';
+SET old_mode='UTF8_IS_UTF8MB3';
+SET optimizer_adjust_secondary_key_costs=0;
+SET GLOBAL optimizer_disk_read_cost=10.240000;
+SET GLOBAL optimizer_disk_read_ratio=0.020000;
+SET optimizer_extra_pruning_depth=8;
+SET GLOBAL optimizer_index_block_copy_cost=0.035600;
+SET optimizer_join_limit_pref_ratio=0;
+SET GLOBAL optimizer_key_compare_cost=0.011361;
+SET GLOBAL optimizer_key_copy_cost=0.015685;
+SET GLOBAL optimizer_key_lookup_cost=0.435777;
+SET GLOBAL optimizer_key_next_find_cost=0.082347;
+SET optimizer_max_sel_arg_weight=32000;
+SET optimizer_max_sel_args=16000;
+SET optimizer_prune_level=2;
+SET GLOBAL optimizer_row_copy_cost=0.060866;
+SET GLOBAL optimizer_row_lookup_cost=0.130839;
+SET GLOBAL optimizer_row_next_find_cost=0.045916;
+SET GLOBAL optimizer_rowid_compare_cost=0.002653;
+SET GLOBAL optimizer_rowid_copy_cost=0.002653;
+SET optimizer_scan_setup_cost=10.000000;
+SET optimizer_search_depth=62;
+SET optimizer_selectivity_sampling_limit=100;
+SET optimizer_switch='index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,duplicateweedout=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=on,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on,condition_pushdown_for_subquery=on,rowid_filter=on,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=on,cset_narrowing=on,sargable_casefold=on';
+SET optimizer_trace='enabled=off';
+SET optimizer_trace_max_mem_size=1048576;
+SET optimizer_use_condition_selectivity=4;
+SET optimizer_where_cost=0.032000;
+SET sort_buffer_size=262144;
+SET sql_buffer_result='OFF';
+SET sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+SET standard_compliant_cte='ON';
+SET time_zone='REPLACED';
+SET timestamp=REPLACED;
+## version='REPLACED';
+## version_source_revision='REPLACED';
+
+set optimizer_record_context=OFF;
 set optimizer_replay_context= "";
 explain format= json select * from t1 a,
 t1 b where a.c1 < 3 and b.c1 < 33

--- a/sql/opt_context_store_replay.cc
+++ b/sql/opt_context_store_replay.cc
@@ -437,11 +437,11 @@ static bool get_create_table_stmt(THD *thd, TABLE_LIST *tbl, String *ddl)
 }
 
 /*
-  System variables that are related to the optimizer but
-  do not have "optimizer" in their name.
+  System variables that are required for the optimizer context,
+  but do not have "optimizer" in their name.
     TODO: include @@SQL_SELECT_LIMIT here.
 */
-static const char *opt_related_sys_vars[]=
+static const char *opt_ctx_sys_vars[]=
 {
   "join_cache_level",
   "join_buffer_size",
@@ -456,6 +456,7 @@ static const char *opt_related_sys_vars[]=
   "group_concat_max_len",
   "max_heap_table_size",
   "standard_compliant_cte",
+  "innodb_strict_mode",
   NULL
 };
 
@@ -465,8 +466,7 @@ static const char *read_only_info_sys_vars[]= {
 static const char *excluded_sys_vars[]= {"optimizer_replay_context",
                                          "optimizer_record_context", NULL};
 
-static bool is_optimizer_related_var(const char **sys_vars,
-                                     const char *var_name)
+static bool is_var_in_list(const char **sys_vars, const char *var_name)
 {
   for (uint i= 0; sys_vars[i] != NULL; i++)
   {
@@ -524,14 +524,14 @@ static void store_system_variables(THD *thd, String &script)
   for (SHOW_VAR *show_var= all_session_vars; show_var->name != NULL;
        show_var++)
   {
-    if (is_optimizer_related_var(excluded_sys_vars, show_var->name))
+    if (is_var_in_list(excluded_sys_vars, show_var->name))
       continue;
 
     bool is_informative_sys_var= false;
 
     if (strstr(show_var->name, "optimizer") != NULL ||
-        is_optimizer_related_var(opt_related_sys_vars, show_var->name) ||
-        (is_informative_sys_var= is_optimizer_related_var(
+        is_var_in_list(opt_ctx_sys_vars, show_var->name) ||
+        (is_informative_sys_var= is_var_in_list(
              read_only_info_sys_vars, show_var->name)))
     {
       sys_var *var= (sys_var *) show_var->value;


### PR DESCRIPTION
The test had innodb_strict_mode turned OFF, when running the test. But, in the replay, it was enabled, which caused the creation of tables with KEY_BLOCK_SIZE=16 fail.

Solution is to record the innodb_strict_mode variable in the context, so that it gets used during the replay.