### PR TITLE
MDEV-37000 disable optimization for Aria remove_key() on affected MSVC

### DIFF
--- a/mysql-test/main/mdev-37000.result
+++ b/mysql-test/main/mdev-37000.result
@@ -1,0 +1,8 @@
+#
+# MDEV-37000 Deleting a row from Aria table results to 'Index is corrupt'
+#
+CREATE OR REPLACE TABLE t (a INT, b CHAR(8) NOT NULL, KEY(b)) ENGINE=Aria DEFAULT CHARSET=utf8;
+INSERT INTO t VALUES (1,'20070101'), (2,'20070101');
+DELETE FROM t LIMIT 2;
+DROP TABLE t;
+# End of 10.6 tests

--- a/mysql-test/main/mdev-37000.test
+++ b/mysql-test/main/mdev-37000.test
@@ -1,0 +1,9 @@
+--echo #
+--echo # MDEV-37000 Deleting a row from Aria table results to 'Index is corrupt'
+--echo #
+CREATE OR REPLACE TABLE t (a INT, b CHAR(8) NOT NULL, KEY(b)) ENGINE=Aria DEFAULT CHARSET=utf8;
+INSERT INTO t VALUES (1,'20070101'), (2,'20070101');
+DELETE FROM t LIMIT 2;
+DROP TABLE t;
+
+--echo # End of 10.6 tests

--- a/storage/maria/ma_delete.c
+++ b/storage/maria/ma_delete.c
@@ -1335,6 +1335,9 @@ err:
   @retval #  How many chars was removed
 */
 
+#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930 && _MSC_VER < 1951
+#pragma optimize("g", off)
+#endif
 static uint remove_key(MARIA_KEYDEF *keyinfo, uint page_flag, uint nod_flag,
 		       uchar *keypos, uchar *lastkey,
 		       uchar *page_end, my_off_t *next_block,
@@ -1475,6 +1478,9 @@ static uint remove_key(MARIA_KEYDEF *keyinfo, uint page_flag, uint nod_flag,
   DBUG_RETURN((uint) s_length);
 } /* remove_key */
 
+#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930 && _MSC_VER < 1951
+#pragma optimize("", on)
+#endif
 
 /****************************************************************************
   Logging of redos

--- a/storage/myisam/mi_delete.c
+++ b/storage/myisam/mi_delete.c
@@ -767,7 +767,7 @@ err:
 	  returns how many chars was removed or 0 on error
 	*/
 
-#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930
+#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930 && _MSC_VER < 1951
 #pragma optimize("g", off)
 #endif
 
@@ -896,6 +896,6 @@ static uint remove_key(MI_KEYDEF *keyinfo, uint nod_flag,
   DBUG_RETURN((uint) s_length);
 } /* remove_key */
 
-#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930
+#if defined(_MSC_VER) && defined(_M_X64) && _MSC_VER >= 1930 && _MSC_VER < 1951
 #pragma optimize("",on)
 #endif


### PR DESCRIPTION
The Aria remove_key() helper can miscompile in x64 MSVC builds when optimization is enabled, leading to 'Index is corrupt' during DELETE.

Apply the same #pragma optimize("g", off) workaround already used in MyISAM, and limit it to _MSC_VER >= 1930 && _MSC_VER < 1951.

The upper bound for affected MSVC is just the newest MSVC version in VS2026, where the bug is no longer reproducible. Also, MSVC release notes https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes list multiple fixes for 19.50 x64 optimizer and codegen bugs.