### PR TITLE
MDEV-39750 ExtractValue does not control recursion depth - fix failing test.

### DIFF
--- a/mysql-test/main/lotofstack.result
+++ b/mysql-test/main/lotofstack.result
@@ -99,3 +99,10 @@ drop procedure bug10100pd|
 drop procedure bug10100pc|
 drop view v1|
 drop table t3|
+#
+# MDEV-39750 ExtractValue does not control recursion depth.
+#
+SELECT ExtractValue('<a/>', REPEAT('(', 100000));
+ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
+SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
+ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.

--- a/mysql-test/main/lotofstack.test
+++ b/mysql-test/main/lotofstack.test
@@ -131,3 +131,16 @@ drop procedure bug10100pc|
 drop view v1|
 drop table t3|
 delimiter ;|
+
+--echo #
+--echo # MDEV-39750 ExtractValue does not control recursion depth.
+--echo #
+
+--replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
+--error ER_STACK_OVERRUN_NEED_MORE
+SELECT ExtractValue('<a/>', REPEAT('(', 100000));
+
+--replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
+--error ER_STACK_OVERRUN_NEED_MORE
+SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
+

--- a/mysql-test/main/xml.result
+++ b/mysql-test/main/xml.result
@@ -1414,11 +1414,4 @@ ExtractValue(@xml, '/employee/dt3')
 NULL
 Warnings:
 Warning	1525	Incorrect XML value: 'parse error at line 10 pos 27: unexpected END-OF-INPUT'
-#
-# MDEV-39750 ExtractValue does not control recursion depth.
-#
-SELECT ExtractValue('<a/>', REPEAT('(', 100000));
-ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
-SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
-ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
 # End of 10.6 tests

--- a/mysql-test/main/xml.test
+++ b/mysql-test/main/xml.test
@@ -899,17 +899,5 @@ set @xml= '<?xml version="1.0"?>
 
 SELECT ExtractValue(@xml, '/employee/dt3');
 
---echo #
---echo # MDEV-39750 ExtractValue does not control recursion depth.
---echo #
-
---replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
---error ER_STACK_OVERRUN_NEED_MORE
-SELECT ExtractValue('<a/>', REPEAT('(', 100000));
-
---replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
---error ER_STACK_OVERRUN_NEED_MORE
-SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
-
 --echo # End of 10.6 tests
 


### PR DESCRIPTION
Stack exhaustive test shouldn't be ran with the ASAN/UBSAN. So it moved to the lotofstack.test that checks necessary conditions.