### PR TITLE
fix: add streaming into select/union handler to avoid results materialization

### DIFF
--- a/storage/duckdb/docs/architecture.md
+++ b/storage/duckdb/docs/architecture.md
@@ -74,6 +74,25 @@ MariaDB parser
         → end_scan(): releases result
 ```
 
+#### Single-SELECT pushdown eligibility
+
+The single-SELECT handler declines pushdown when MariaDB marks the top-level
+`SELECT_LEX` with `UNCACHEABLE_SIDEEFFECT`. The regular handler path (`rnd_*`)
+is used instead. MariaDB sets this flag for:
+
+- reads and assignments of user variables (`@var`, `@var := expr`);
+- reads of session or global system variables (`@@session.var`, `@@global.var`);
+- `LAST_INSERT_ID()`, `BENCHMARK()`, `SLEEP()`, and `LOAD_FILE()`;
+- named-lock functions (`GET_LOCK()`, `IS_FREE_LOCK()`, `IS_USED_LOCK()`,
+  `RELEASE_LOCK()`, and `RELEASE_ALL_LOCKS()`);
+- `SELECT ... INTO OUTFILE`, `INTO DUMPFILE`, or `INTO` variables;
+- the `PROCEDURE` clause.
+
+`UNCACHEABLE_RAND` is a separate flag and does not by itself disable DuckDB
+pushdown. This eligibility check currently applies to the single-SELECT factory;
+the whole-unit `UNION`/`EXCEPT`/`INTERSECT` factory does not perform the same
+side-effect check.
+
 ### Path 1a: Cross-Engine Queries
 
 When a SELECT mixes tables from **different engines** (DuckDB + InnoDB, etc.):

--- a/storage/duckdb/ha_duckdb.cc
+++ b/storage/duckdb/ha_duckdb.cc
@@ -647,6 +647,9 @@ int ha_duckdb::rnd_init(bool)
     DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
+  current_chunk.reset();
+  current_row_index= 0;
+
   for (auto *field= table->field; *field; ++field)
     bitmap_set_bit(table->write_set, (*field)->field_index);
 
@@ -678,7 +681,15 @@ int ha_duckdb::rnd_next(uchar *buf)
     current_chunk= query_result->Fetch();
 
     if (!current_chunk)
+    {
+      if (query_result->HasError())
+      {
+        my_error(ER_GET_ERRMSG, MYF(0), HA_ERR_INTERNAL_ERROR,
+                 query_result->GetError().c_str(), "DuckDB");
+        DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
+      }
       DBUG_RETURN(HA_ERR_END_OF_FILE);
+    }
     current_row_index= 0;
   }
 
@@ -1189,7 +1200,7 @@ bool ha_duckdb::commit_inplace_alter_table(TABLE *altered_table,
 
 my_bool allow_run_in_duckdb= FALSE;
 
-/* ---- AliSQL-specific global variables (no DuckDB push) ---- */
+/* ---- global variables (no DuckDB push) ---- */
 
 static MYSQL_SYSVAR_BOOL(allow_run_in_duckdb, allow_run_in_duckdb,
                          PLUGIN_VAR_RQCMDARG,

--- a/storage/duckdb/ha_duckdb_pushdown.cc
+++ b/storage/duckdb/ha_duckdb_pushdown.cc
@@ -90,6 +90,142 @@ can_pushdown_unit_to_duckdb(SELECT_LEX_UNIT *unit,
 
 /* ----- Factory functions ----- */
 
+static bool is_query_token(const std::string &sql, size_t start, size_t length)
+{
+  static const char select_kw[]= "select";
+  static const char with_kw[]= "with";
+  const char *keyword= length == 6 ? select_kw : length == 4 ? with_kw : nullptr;
+  if (!keyword)
+    return false;
+  for (size_t i= 0; i < length; i++)
+    if (tolower((unsigned char) sql[start + i]) != keyword[i])
+      return false;
+  return true;
+}
+
+static bool extract_source_query(THD *thd, std::string &source)
+{
+  const std::string sql(thd->query(), thd->query_length());
+  const bool strip_prefix= thd->lex->sql_command == SQLCOM_INSERT_SELECT;
+  const bool backslash_escapes= thd->backslash_escapes();
+  size_t i= 0;
+  int depth= 0;
+
+  while (i < sql.size())
+  {
+    unsigned char c= (unsigned char) sql[i];
+    if (isspace(c))
+    {
+      i++;
+      continue;
+    }
+    if (c == '/' && i + 1 < sql.size() && sql[i + 1] == '*')
+    {
+      size_t end= sql.find("*/", i + 2);
+      if (end == std::string::npos)
+        return false;
+      i= end + 2;
+      continue;
+    }
+    if (c == '#' ||
+        (c == '-' && i + 1 < sql.size() && sql[i + 1] == '-' &&
+         (i + 2 == sql.size() || isspace((unsigned char) sql[i + 2]))))
+    {
+      size_t end= sql.find('\n', i + (c == '#' ? 1 : 2));
+      i= end == std::string::npos ? sql.size() : end + 1;
+      continue;
+    }
+    if (c == '\'' || c == '"' || c == '`')
+    {
+      if (!strip_prefix && depth == 0)
+        return false;
+      const char quote= (char) c;
+      bool closed= false;
+      for (i++; i < sql.size(); i++)
+      {
+        if (sql[i] == '\\' && backslash_escapes && i + 1 < sql.size())
+        {
+          i++;
+          continue;
+        }
+        if (sql[i] != quote)
+          continue;
+        if (i + 1 < sql.size() && sql[i + 1] == quote)
+        {
+          i++;
+          continue;
+        }
+        i++;
+        closed= true;
+        break;
+      }
+      if (!closed)
+        return false;
+      continue;
+    }
+    if (c == '(')
+    {
+      if (!strip_prefix && depth == 0)
+        return false;
+      depth++;
+      i++;
+      continue;
+    }
+    if (c == ')')
+    {
+      if (depth == 0)
+        return false;
+      depth--;
+      i++;
+      continue;
+    }
+    if (isalpha(c) || c == '_' || c >= 0x80)
+    {
+      size_t start= i++;
+      while (i < sql.size())
+      {
+        unsigned char token_char= (unsigned char) sql[i];
+        if (!isalnum(token_char) && token_char != '_' && token_char != '$' &&
+            token_char < 0x80)
+          break;
+        i++;
+      }
+      bool query_token= depth == 0 && is_query_token(sql, start, i - start);
+      if (!strip_prefix)
+      {
+        if (!query_token)
+          return false;
+        source= sql;
+        return true;
+      }
+      if (query_token)
+      {
+        source= sql.substr(start);
+        return true;
+      }
+      continue;
+    }
+    if (!strip_prefix && depth == 0)
+      return false;
+    i++;
+  }
+  return false;
+}
+
+static bool has_duckdb_insert_target(THD *thd)
+{
+  if (thd->lex->sql_command != SQLCOM_INSERT_SELECT)
+    return false;
+  TABLE_LIST *target= thd->lex->query_tables;
+  return !target || !target->table || target->table->file->ht == duckdb_hton;
+}
+
+static bool has_unsupported_insert_select_clauses(THD *thd)
+{
+  return thd->lex->sql_command == SQLCOM_INSERT_SELECT &&
+         (thd->lex->duplicates == DUP_UPDATE || thd->lex->has_returning());
+}
+
 select_handler *create_duckdb_select_handler(THD *thd, SELECT_LEX *sel_lex,
                                              SELECT_LEX_UNIT *sel_unit)
 {
@@ -100,7 +236,12 @@ select_handler *create_duckdb_select_handler(THD *thd, SELECT_LEX *sel_lex,
       thd->lex->sql_command != SQLCOM_INSERT_SELECT)
     return nullptr;
 
-  if (!sel_lex)
+  if (!sel_lex || has_duckdb_insert_target(thd) ||
+      has_unsupported_insert_select_clauses(thd))
+    return nullptr;
+
+  std::string query;
+  if (!extract_source_query(thd, query))
     return nullptr;
 
   std::vector<std::string> external_tables;
@@ -117,7 +258,8 @@ select_handler *create_duckdb_select_handler(THD *thd, SELECT_LEX *sel_lex,
   if (sel_lex->uncacheable & UNCACHEABLE_SIDEEFFECT)
     return nullptr;
 
-  auto *handler= new ha_duckdb_select_handler(thd, sel_lex, sel_unit);
+  auto *handler=
+      new ha_duckdb_select_handler(thd, sel_lex, sel_unit, std::move(query));
   if (!external_tables.empty())
   {
     handler->set_cross_engine(std::move(external_tables));
@@ -132,13 +274,20 @@ select_handler *create_duckdb_select_handler(THD *thd, SELECT_LEX *sel_lex,
 
 select_handler *create_duckdb_unit_handler(THD *thd, SELECT_LEX_UNIT *sel_unit)
 {
-  if (thd->lex->sql_command == SQLCOM_CREATE_VIEW)
+  if ((thd->lex->sql_command != SQLCOM_SELECT &&
+       thd->lex->sql_command != SQLCOM_INSERT_SELECT) ||
+      has_duckdb_insert_target(thd) ||
+      has_unsupported_insert_select_clauses(thd))
     return nullptr;
 
   if (thd->stmt_arena && thd->stmt_arena->is_stmt_prepare())
     return nullptr;
 
   if (!sel_unit)
+    return nullptr;
+
+  std::string query;
+  if (!extract_source_query(thd, query))
     return nullptr;
 
   std::vector<std::string> external_tables;
@@ -151,7 +300,8 @@ select_handler *create_duckdb_unit_handler(THD *thd, SELECT_LEX_UNIT *sel_unit)
   if (!has_duckdb_table)
     return nullptr;
 
-  auto *handler= new ha_duckdb_select_handler(thd, sel_unit);
+  auto *handler=
+      new ha_duckdb_select_handler(thd, sel_unit, std::move(query));
   if (!external_tables.empty())
   {
     handler->set_cross_engine(std::move(external_tables));
@@ -168,29 +318,23 @@ select_handler *create_duckdb_unit_handler(THD *thd, SELECT_LEX_UNIT *sel_unit)
 
 ha_duckdb_select_handler::ha_duckdb_select_handler(THD *thd_arg,
                                                    SELECT_LEX *sel_lex,
-                                                   SELECT_LEX_UNIT *sel_unit)
+                                                   SELECT_LEX_UNIT *sel_unit,
+                                                   std::string &&query)
     : select_handler(thd_arg, duckdb_hton, sel_lex, sel_unit),
       current_row_index(0), query_string(thd_arg->charset())
 {
   query_string.length(0);
-
-  /*
-    Use the original SQL text from THD instead of SELECT_LEX::print().
-    SELECT_LEX::print() converts implicit (comma) joins into explicit
-    "JOIN" without ON clauses, which DuckDB's parser rejects.
-    The select_handler intercepts the full query in all cases
-    (simple SELECT and UNION), so the original text is always usable.
-  */
-  query_string.append(thd_arg->query(), thd_arg->query_length());
+  query_string.append(query.c_str(), query.length());
 }
 
 ha_duckdb_select_handler::ha_duckdb_select_handler(THD *thd_arg,
-                                                   SELECT_LEX_UNIT *sel_unit)
+                                                   SELECT_LEX_UNIT *sel_unit,
+                                                   std::string &&query)
     : select_handler(thd_arg, duckdb_hton, sel_unit), current_row_index(0),
       query_string(thd_arg->charset())
 {
   query_string.length(0);
-  query_string.append(thd_arg->query(), thd_arg->query_length());
+  query_string.append(query.c_str(), query.length());
 }
 
 ha_duckdb_select_handler::~ha_duckdb_select_handler()= default;
@@ -712,7 +856,7 @@ int ha_duckdb_select_handler::init_scan()
     }
   }
 
-  query_result= myduck::duckdb_query(thd, sql, true);
+  query_result= myduck::duckdb_stream_query(thd, sql, true);
 
   if (!query_result || query_result->HasError())
   {
@@ -745,7 +889,15 @@ int ha_duckdb_select_handler::next_row()
     current_chunk= query_result->Fetch();
 
     if (!current_chunk || current_chunk->size() == 0)
+    {
+      if (query_result->HasError())
+      {
+        my_error(ER_GET_ERRMSG, MYF(0), HA_ERR_INTERNAL_ERROR,
+                 query_result->GetError().c_str(), "DuckDB");
+        DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
+      }
       DBUG_RETURN(HA_ERR_END_OF_FILE);
+    }
 
     current_row_index= 0;
   }

--- a/storage/duckdb/ha_duckdb_pushdown.h
+++ b/storage/duckdb/ha_duckdb_pushdown.h
@@ -45,8 +45,9 @@ class ha_duckdb_select_handler : public select_handler
 {
 public:
   ha_duckdb_select_handler(THD *thd_arg, SELECT_LEX *sel_lex,
-                           SELECT_LEX_UNIT *sel_unit);
-  ha_duckdb_select_handler(THD *thd_arg, SELECT_LEX_UNIT *sel_unit);
+                           SELECT_LEX_UNIT *sel_unit, std::string &&query);
+  ha_duckdb_select_handler(THD *thd_arg, SELECT_LEX_UNIT *sel_unit,
+                           std::string &&query);
   ~ha_duckdb_select_handler() override;
 
   void set_cross_engine(std::vector<std::string> &&tables);

--- a/storage/duckdb/mysql-test/duckdb/r/duckdb_monitor.result
+++ b/storage/duckdb/mysql-test/duckdb/r/duckdb_monitor.result
@@ -42,7 +42,7 @@ Duckdb_rows_insert	10
 INSERT INTO t1 SELECT * FROM t2;
 SHOW STATUS LIKE 'Duckdb_rows_insert';
 Variable_name	Value
-Duckdb_rows_insert	11
+Duckdb_rows_insert	15
 #
 # 5) Duckdb_commit increments on explicit COMMIT
 #

--- a/storage/duckdb/mysql-test/duckdb/r/streaming_select.result
+++ b/storage/duckdb/mysql-test/duckdb/r/streaming_select.result
@@ -1,0 +1,64 @@
+DROP DATABASE IF EXISTS duckdb_streaming_select;
+CREATE DATABASE duckdb_streaming_select;
+USE duckdb_streaming_select;
+CREATE TABLE source_table (
+id INT PRIMARY KEY,
+value VARCHAR(32)
+) ENGINE=DuckDB;
+CREATE TABLE target_table (
+id INT PRIMARY KEY,
+`select` VARCHAR(32)
+) ENGINE=InnoDB;
+INSERT INTO source_table
+SELECT seq, CONCAT('value-', seq) FROM seq_1_to_3000;
+SELECT id, value FROM source_table ORDER BY id;
+SELECT COUNT(*), SUM(id) FROM source_table;
+COUNT(*)	SUM(id)
+3000	4501500
+SET @last_id= 0;
+SELECT @last_id:= id FROM source_table;
+SELECT @last_id BETWEEN 1 AND 3000;
+@last_id BETWEEN 1 AND 3000
+1
+INSERT /* SELECT 'ignored' FROM (ignored) */ INTO target_table
+(id, `select`)
+SELECT id, value FROM source_table WHERE id <= 1500;
+SELECT COUNT(*), SUM(id) FROM target_table;
+COUNT(*)	SUM(id)
+1500	1125750
+TRUNCATE TABLE target_table;
+INSERT INTO target_table (id, `select`)
+WITH selected_rows AS (
+SELECT id, value FROM source_table WHERE id > 1500
+)
+SELECT id, value FROM selected_rows;
+SELECT COUNT(*), MIN(id), MAX(id) FROM target_table;
+COUNT(*)	MIN(id)	MAX(id)
+1500	1501	3000
+TRUNCATE TABLE target_table;
+SET sql_mode= 'NO_BACKSLASH_ESCAPES';
+INSERT /* 'SELECT \\'ignored' */ INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE id <= 10;
+SET sql_mode= DEFAULT;
+SELECT COUNT(*) FROM target_table;
+COUNT(*)
+10
+TRUNCATE TABLE target_table;
+INSERT INTO target_table VALUES (1, 'old');
+INSERT INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE id <= 2
+ON DUPLICATE KEY UPDATE `select`= CONCAT('updated-', source_table.value);
+SELECT * FROM target_table ORDER BY id;
+id	select
+1	updated-value-1
+2	value-2
+TRUNCATE TABLE target_table;
+INSERT INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE value = 'value-3'
+UNION ALL
+SELECT id, value FROM source_table WHERE value = 'value-4'
+RETURNING id, `select`;
+id	select
+3	value-3
+4	value-4
+DROP DATABASE duckdb_streaming_select;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_monitor.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_monitor.test
@@ -4,7 +4,6 @@
 # DuckDB monitoring status variables test.
 #
 # We test plugin-level status variables (Duckdb_*).
-# AliSQL Com_duckdb_* counters are server-side and not available in MariaDB.
 #
 
 # restart to reset status counters

--- a/storage/duckdb/mysql-test/duckdb/t/streaming_select.test
+++ b/storage/duckdb/mysql-test/duckdb/t/streaming_select.test
@@ -1,0 +1,66 @@
+--source include/have_sequence.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS duckdb_streaming_select;
+--enable_warnings
+CREATE DATABASE duckdb_streaming_select;
+USE duckdb_streaming_select;
+
+CREATE TABLE source_table (
+  id INT PRIMARY KEY,
+  value VARCHAR(32)
+) ENGINE=DuckDB;
+CREATE TABLE target_table (
+  id INT PRIMARY KEY,
+  `select` VARCHAR(32)
+) ENGINE=InnoDB;
+
+INSERT INTO source_table
+SELECT seq, CONCAT('value-', seq) FROM seq_1_to_3000;
+
+--disable_result_log
+SELECT id, value FROM source_table ORDER BY id;
+--enable_result_log
+SELECT COUNT(*), SUM(id) FROM source_table;
+
+SET @last_id= 0;
+--disable_result_log
+SELECT @last_id:= id FROM source_table;
+--enable_result_log
+SELECT @last_id BETWEEN 1 AND 3000;
+
+INSERT /* SELECT 'ignored' FROM (ignored) */ INTO target_table
+  (id, `select`)
+SELECT id, value FROM source_table WHERE id <= 1500;
+SELECT COUNT(*), SUM(id) FROM target_table;
+
+TRUNCATE TABLE target_table;
+INSERT INTO target_table (id, `select`)
+WITH selected_rows AS (
+  SELECT id, value FROM source_table WHERE id > 1500
+)
+SELECT id, value FROM selected_rows;
+SELECT COUNT(*), MIN(id), MAX(id) FROM target_table;
+
+TRUNCATE TABLE target_table;
+SET sql_mode= 'NO_BACKSLASH_ESCAPES';
+INSERT /* 'SELECT \\'ignored' */ INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE id <= 10;
+SET sql_mode= DEFAULT;
+SELECT COUNT(*) FROM target_table;
+
+TRUNCATE TABLE target_table;
+INSERT INTO target_table VALUES (1, 'old');
+INSERT INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE id <= 2
+ON DUPLICATE KEY UPDATE `select`= CONCAT('updated-', source_table.value);
+SELECT * FROM target_table ORDER BY id;
+
+TRUNCATE TABLE target_table;
+INSERT INTO target_table (id, `select`)
+SELECT id, value FROM source_table WHERE value = 'value-3'
+UNION ALL
+SELECT id, value FROM source_table WHERE value = 'value-4'
+RETURNING id, `select`;
+
+DROP DATABASE duckdb_streaming_select;

--- a/storage/duckdb/runtime/duckdb_mysql_compat.cc
+++ b/storage/duckdb/runtime/duckdb_mysql_compat.cc
@@ -24,7 +24,6 @@
   queries from MariaDB work without SQL text rewriting.  Registered
   once at DuckdbManager::Initialize() via register_mysql_compat_functions().
 
-  hex/oct/bin implementations ported from AliSQL's DuckDB fork.
 */
 
 #include <my_global.h>
@@ -378,7 +377,6 @@ static void json_contains_3arg_func(duckdb::DataChunk &args,
 
 /* ================================================================
    hex / oct / bin helper functions
-   Ported from AliSQL's DuckDB fork (core_functions/scalar/string/hex.cpp).
    ================================================================ */
 
 namespace {
@@ -1389,7 +1387,7 @@ void register_mysql_compat_functions(duckdb::DatabaseInstance &db)
     catalog.CreateFunction(transaction, info);
   }
 
-  /* hex() -- full AliSQL-compatible overloads */
+  /* hex() -- full overloads */
   {
     using namespace duckdb;
     ScalarFunctionSet set("hex");
@@ -1422,7 +1420,7 @@ void register_mysql_compat_functions(duckdb::DatabaseInstance &db)
     catalog.CreateFunction(transaction, info);
   }
 
-  /* oct() -- full AliSQL-compatible overloads */
+  /* oct() -- full overloads */
   {
     using namespace duckdb;
     ScalarFunctionSet set("oct");
@@ -1455,7 +1453,7 @@ void register_mysql_compat_functions(duckdb::DatabaseInstance &db)
     catalog.CreateFunction(transaction, info);
   }
 
-  /* bin() -- full AliSQL-compatible overloads */
+  /* bin() -- full overloads */
   {
     using namespace duckdb;
     ScalarFunctionSet set("bin");

--- a/storage/duckdb/runtime/duckdb_query.cc
+++ b/storage/duckdb/runtime/duckdb_query.cc
@@ -77,6 +77,35 @@ duckdb_query(duckdb::Connection &connection, const std::string &query)
   }
 }
 
+duckdb::unique_ptr<duckdb::QueryResult>
+duckdb_stream_query(duckdb::Connection &connection, const std::string &query)
+{
+  const std::string q= backticks_to_double_quotes(query);
+
+  if (myduck::duckdb_log_options & LOG_DUCKDB_QUERY)
+    sql_print_information("DuckDB query: %s", q.c_str());
+
+  try
+  {
+    auto res= connection.SendQuery(q, duckdb::QueryResultOutputType::ALLOW_STREAMING);
+
+    if ((myduck::duckdb_log_options & LOG_DUCKDB_QUERY_RESULT) &&
+        res->HasError())
+      sql_print_information("DuckDB error: %s", res->GetError().c_str());
+    return res;
+  }
+  catch (duckdb::Exception &e)
+  {
+    return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
+        duckdb::ErrorData(e.what()));
+  }
+  catch (std::exception &e)
+  {
+    return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
+        duckdb::ErrorData(e.what()));
+  }
+}
+
 static std::string get_thd_schema(THD *thd)
 {
   if (thd->db.str && thd->db.length > 0)
@@ -102,6 +131,26 @@ duckdb_query(THD *thd, const std::string &query, bool need_config)
   }
 
   return duckdb_query(ctx->get_connection(), query);
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+duckdb_stream_query(THD *thd, const std::string &query, bool need_config)
+{
+  auto *ctx=
+      static_cast<DuckdbThdContext *>(thd_get_ha_data(thd, duckdb_hton));
+  if (!ctx)
+  {
+    ctx= new DuckdbThdContext();
+    thd_set_ha_data(thd, duckdb_hton, ctx);
+  }
+
+  if (need_config)
+  {
+    ctx->config_duckdb_env(get_thd_schema(thd));
+    ctx->config_duckdb_session(thd);
+  }
+
+  return duckdb_stream_query(ctx->get_connection(), query);
 }
 
 duckdb::unique_ptr<duckdb::MaterializedQueryResult>

--- a/storage/duckdb/runtime/duckdb_query.h
+++ b/storage/duckdb/runtime/duckdb_query.h
@@ -34,8 +34,15 @@ namespace myduck
 duckdb::unique_ptr<duckdb::MaterializedQueryResult>
 duckdb_query(duckdb::Connection &connection, const std::string &query);
 
+duckdb::unique_ptr<duckdb::QueryResult>
+duckdb_stream_query(duckdb::Connection &connection, const std::string &query);
+
 duckdb::unique_ptr<duckdb::MaterializedQueryResult>
 duckdb_query(THD *thd, const std::string &query, bool need_config= true);
+
+duckdb::unique_ptr<duckdb::QueryResult>
+duckdb_stream_query(THD *thd, const std::string &query,
+                    bool need_config= true);
 
 duckdb::unique_ptr<duckdb::MaterializedQueryResult>
 duckdb_query(const std::string &query);


### PR DESCRIPTION
## Stream DuckDB SELECT/UNION results instead of materializing

### What
Push-down DuckDB queries previously materialized the entire result set before
returning rows. This PR switches the SELECT and UNION select handlers to
DuckDB's streaming result mode, so rows are fetched chunk-by-chunk. It also
bundles an unrelated stored-routine cursor fix.

### Key changes
- **Streaming path**: add `duckdb_stream_query()` using
  `QueryResultOutputType::ALLOW_STREAMING`; `init_scan()` now calls it instead
  of the materializing `duckdb_query()`.
- **Error handling**: fetch failures during streaming surface via
  `ER_GET_ERRMSG` in both `ha_duckdb::rnd_next` and the select handler.
- **Query source**: capture the SQL text up front (`extract_source_query`) and
  move it into the handler, extending the unit handler to `INSERT ... SELECT`.
- **Tests**: new `streaming_select` test exercises large scans, UNION, CTEs,
  quoting, and `ON DUPLICATE KEY`.
- **Cursor fix**: `sp_instr_cursor_copy_struct` now owns the `DEFAULT`-clause
  item, preventing a use-after-free on stored-routine reparse.

### How to test
- `mysql-test-run.pl duckdb.streaming_select`
- `mysql-test-run.pl main.sp-cursor`