### PR TITLE
MDEV-40243 Fix MEMORY_LEAK_C leaks in mariadb-dump  (rockdb tests)

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -5924,7 +5924,9 @@ static inline bool inner_refs_check(THD *thd,
                              enum_parsing_place place,
                              Item **reference)
 {
+#ifndef DBUG_OFF
   Item::Type ref_type= (*reference)->type();
+#endif
   if (!last_checked_context->select_lex->having_fix_field &&
       select->group_list.elements &&
       (place == SELECT_LIST || place == IN_HAVING))

--- a/storage/rocksdb/mysql-test/rocksdb/t/mysqldump.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/mysqldump.test
@@ -33,10 +33,10 @@ insert into r1 values (5,5,5,5,5,5,5,5);
 update r1 set value1=value1+100 where id1=1 and id2=1 and id3='1';
 
 --replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb --order-by-primary-desc --rocksdb_bulk_load test
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb --order-by-primary-desc --rocksdb_bulk_load test
 
 --replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb --order-by-primary-desc --rocksdb_bulk_load --rocksdb_bulk_load_allow_sk test
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb --order-by-primary-desc --rocksdb_bulk_load --rocksdb_bulk_load_allow_sk test
 
 rollback;
 
@@ -49,17 +49,17 @@ source include/search_pattern_in_file.inc;
 set @save_default_storage_engine=@@global.default_storage_engine;
 SET GLOBAL default_storage_engine=rocksdb;
 --replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key test
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key test
 source include/search_pattern_in_file.inc;
 
 # Sanity test mysqldump when the --innodb-stats-on-metadata is specified (no effect)
 --echo ==== mysqldump with --innodb-stats-on-metadata ====
 --replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --innodb-stats-on-metadata test
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --innodb-stats-on-metadata test
 
 # testing mysqldump work with statement based binary logging
 SET GLOBAL binlog_format=statement;
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key test > /dev/null
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key test > /dev/null
 SET GLOBAL binlog_format=row;
 
 drop table r1;

--- a/storage/rocksdb/mysql-test/rocksdb/t/mysqldump2.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/mysqldump2.test
@@ -29,7 +29,7 @@ let $restart_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect;
 
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_block_cache_add';
 
---exec ASAN_OPTIONS="detect_leaks=0" $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb test > /dev/null
+--exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 --print-ordering-key --rocksdb test > /dev/null
 
 # verifying block cache was not filled
 select case when variable_value - @a > 20 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_block_cache_add';


### PR DESCRIPTION
With memory leaks fixed in the rocksdb.mysqldump/mysqldump2 no longer need to run with leak detection disabled.

ref: 2217477fb8fc82f4921d9d13afcd24b1d86b34d6