### PR TITLE
MDEV-40387: perfschema.misc fails on replay

### DIFF
--- a/mysql-test/suite/perfschema/t/misc.test
+++ b/mysql-test/suite/perfschema/t/misc.test
@@ -5,6 +5,7 @@
 --source include/have_perfschema.inc
 --source include/have_innodb.inc
 --source include/no_protocol.inc
+--disable_replay testfile performance schema tables context is not captured
 
 #
 # Bug#12790483 OBJECTS_SUMMARY_GLOBAL_BY_TYPE AND RENAME TABLE


### PR DESCRIPTION
Disable the testfile, as we don't capture context for performance schema tables.