### PR TITLE
MDEV-38722 server crash hp_rec_key_cmp

### DIFF
--- a/mysql-test/main/intersect_all.result
+++ b/mysql-test/main/intersect_all.result
@@ -1030,3 +1030,69 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 NULL	UNIT RESULT	<unit1,2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
 drop tables t1, t2;
 set sql_mode= default;
+#
+# MDEV-38722 server crash hp_rec_key_cmp
+#
+# original reproducer (used to crash), returns a single row
+SELECT 1 INTERSECT SELECT 1 UNION ALL SELECT 1 EXCEPT ALL SELECT 1;
+1
+1
+CREATE TABLE t1 (i INT);
+INSERT INTO t1 VALUES (1),(1),(2),(3);
+CREATE TABLE t2 (i INT);
+INSERT INTO t2 VALUES (1),(2),(2);
+CREATE TABLE t3 (i INT);
+INSERT INTO t3 VALUES (1),(3);
+SELECT i FROM t1 INTERSECT SELECT i FROM t3
+UNION ALL SELECT i FROM t2 EXCEPT ALL SELECT i FROM t3 ORDER BY i;
+i
+1
+2
+2
+(((SELECT i FROM t1) INTERSECT (SELECT i FROM t3)) UNION ALL (SELECT i FROM t2))
+EXCEPT ALL (SELECT i FROM t3) ORDER BY i;
+i
+1
+2
+2
+# trailing UNION ALL after the EXCEPT ALL
+SELECT i FROM t1 INTERSECT SELECT i FROM t2 UNION ALL SELECT i FROM t2
+EXCEPT ALL SELECT i FROM t3 UNION ALL SELECT i FROM t1 ORDER BY i;
+i
+1
+1
+1
+2
+2
+2
+2
+3
+((((SELECT i FROM t1) INTERSECT (SELECT i FROM t2)) UNION ALL (SELECT i FROM t2))
+EXCEPT ALL (SELECT i FROM t3)) UNION ALL (SELECT i FROM t1) ORDER BY i;
+i
+1
+1
+1
+2
+2
+2
+2
+3
+# a leading INTERSECT ALL keeps the operation extended while the last
+# INTERSECT DISTINCT node is the index-release point
+SELECT i FROM t1 INTERSECT ALL SELECT i FROM t2 INTERSECT SELECT i FROM t3
+UNION ALL SELECT i FROM t2 ORDER BY i;
+i
+1
+1
+2
+2
+(((SELECT i FROM t1) INTERSECT ALL (SELECT i FROM t2)) INTERSECT (SELECT i FROM t3))
+UNION ALL (SELECT i FROM t2) ORDER BY i;
+i
+1
+1
+2
+2
+DROP TABLE t1,t2,t3;
+# End of 10.6 tests

--- a/mysql-test/main/intersect_all.test
+++ b/mysql-test/main/intersect_all.test
@@ -392,3 +392,34 @@ select * from t1 intersect all (select * from t2 union values (1, 2));
 explain select * from t1 intersect all select * from t2 union values (1, 2);
 drop tables t1, t2;
 set sql_mode= default;
+
+--echo #
+--echo # MDEV-38722 server crash hp_rec_key_cmp
+--echo #
+--echo # original reproducer (used to crash), returns a single row
+SELECT 1 INTERSECT SELECT 1 UNION ALL SELECT 1 EXCEPT ALL SELECT 1;
+
+CREATE TABLE t1 (i INT);
+INSERT INTO t1 VALUES (1),(1),(2),(3);
+CREATE TABLE t2 (i INT);
+INSERT INTO t2 VALUES (1),(2),(2);
+CREATE TABLE t3 (i INT);
+INSERT INTO t3 VALUES (1),(3);
+SELECT i FROM t1 INTERSECT SELECT i FROM t3
+  UNION ALL SELECT i FROM t2 EXCEPT ALL SELECT i FROM t3 ORDER BY i;
+(((SELECT i FROM t1) INTERSECT (SELECT i FROM t3)) UNION ALL (SELECT i FROM t2))
+  EXCEPT ALL (SELECT i FROM t3) ORDER BY i;
+--echo # trailing UNION ALL after the EXCEPT ALL
+SELECT i FROM t1 INTERSECT SELECT i FROM t2 UNION ALL SELECT i FROM t2
+  EXCEPT ALL SELECT i FROM t3 UNION ALL SELECT i FROM t1 ORDER BY i;
+((((SELECT i FROM t1) INTERSECT (SELECT i FROM t2)) UNION ALL (SELECT i FROM t2))
+  EXCEPT ALL (SELECT i FROM t3)) UNION ALL (SELECT i FROM t1) ORDER BY i;
+--echo # a leading INTERSECT ALL keeps the operation extended while the last
+--echo # INTERSECT DISTINCT node is the index-release point
+SELECT i FROM t1 INTERSECT ALL SELECT i FROM t2 INTERSECT SELECT i FROM t3
+  UNION ALL SELECT i FROM t2 ORDER BY i;
+(((SELECT i FROM t1) INTERSECT ALL (SELECT i FROM t2)) INTERSECT (SELECT i FROM t3))
+  UNION ALL (SELECT i FROM t2) ORDER BY i;
+DROP TABLE t1,t2,t3;
+
+--echo # End of 10.6 tests

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -781,10 +781,22 @@ bool select_unit_ext::send_eof()
                         next_sl &&
                         next_sl->get_linkage() == INTERSECT_TYPE &&
                         !next_sl->distinct;
+  /*
+    True at the last INTERSECT of an inline INTERSECT DISTINCT subsequence: the
+    records that did not match every operand (their intersect counter differs
+    from curr_step) must be dropped. Instead of a separate table scan this is
+    folded into the scan/unfold loops below, so the table is scanned only once
+    (MDEV-38722). When the subsequence is materialized in a derived table this
+    filtering is done by select_unit::send_eof() instead.
+  */
+  bool filter_intersect= curr_op_type == INTERSECT_DISTINCT &&
+                         !(next_sl &&
+                           next_sl->get_linkage() == INTERSECT_TYPE);
   bool need_unfold= disable_index_if_needed(curr_sl);
 
   if (((curr_sl->distinct && !is_next_distinct) ||
       curr_op_type == INTERSECT_ALL ||
+      filter_intersect ||
       is_next_intersect_all) &&
       !need_unfold)
   {
@@ -805,6 +817,13 @@ bool select_unit_ext::send_eof()
           break;
         }
         break;
+      }
+      if (filter_intersect && additional_cnt->val_int() != curr_step)
+      {
+        /* drop a record that did not match every INTERSECT operand */
+        if (unlikely(error= delete_record()))
+          break;
+        continue;
       }
       store_record(table, record[1]);
 
@@ -858,6 +877,13 @@ bool select_unit_ext::send_eof()
           break;
         }
         break;
+      }
+      if (filter_intersect && additional_cnt->val_int() != curr_step)
+      {
+        /* drop a record that did not match every INTERSECT operand */
+        if (unlikely(error= delete_record()))
+          break;
+        continue;
       }
       dup_cnt= (ha_rows)duplicate_cnt->val_int();
       /* delete record if not exist in the second operand */
@@ -1998,6 +2024,15 @@ void st_select_lex_unit::optimize_bag_operation(bool is_outer_distinct)
         if (prev_sl->distinct && prev_sl->is_set_op())
         {
           sl->distinct= true;
+          disable_index= sl;
+        }
+        else if (disable_index)
+        {
+          /*
+            EXCEPT ALL needs the unique index in select_unit_ext::send_data().
+            If the index would otherwise be released at an earlier node,
+            postpone the release until (at least) this operation.
+          */
           disable_index= sl;
         }
       }


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-38722

## Problem

In an extended set operation (`select_unit_ext`, used when `EXCEPT ALL` or
`INTERSECT ALL` is present) the HEAP unique index is released once, at the
node pointed to by `union_distinct`, assuming every operation after it is a
plain `UNION ALL` that can be unfolded. That does not hold for a trailing
`EXCEPT ALL`: `select_unit_ext::send_data()` still calls `find_unique_row()`
for it (only the `UNION ALL` branch checks `is_index_enabled`), so it
dereferenced the already released index and the server crashed in
`hp_rec_key_cmp()`.

Minimal reproducer:

```sql
SELECT 1 INTERSECT SELECT 1 UNION ALL SELECT 1 EXCEPT ALL SELECT 1;
```

## Fix

* `optimize_bag_operation()` postpones the index release past such a trailing
  `EXCEPT ALL`, so the index is available while it is executed.
* Keeping the index alive uncovered a second problem: a leading `INTERSECT`
  that stays inline in the extended operation left the rows that did not match
  every `INTERSECT` operand in the temporary table (the materialized case is
  handled by `select_unit::send_eof()`, the inline `select_unit_ext` override
  did not), producing a wrong multiset once the crash was gone.
  `select_unit_ext::send_eof()` already scans the temporary table (to reset the
  duplicate counter, fold `INTERSECT ALL` counters, or unfold), so the
  filtering of the non-matching `INTERSECT` records is folded into those loops
  (guarded by `filter_intersect`) and the table is still scanned only once.

## Test

Regression test added to `main/intersect_all.test`; verified the flat form
matches the parenthesized (materialized) form across the mixed cases, in
default and Oracle mode, with `--ps-protocol`/`--view-protocol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)