### PR TITLE
MDEV-39490 Inline the disabled fast path of Opt_trace_start::init()

### DIFF
--- a/sql/opt_trace.cc
+++ b/sql/opt_trace.cc
@@ -485,22 +485,21 @@ void Opt_trace_context::end()
 }
 
 
-void Opt_trace_start::init(THD *thd,
-                           TABLE_LIST *tbl,
-                           enum enum_sql_command sql_command,
-                           List<set_var_base> *set_vars,
-                           const char *query,
-                           size_t query_length,
-                           const CHARSET_INFO *query_charset)
+/*
+  Slow path of Opt_trace_start::init(): reached only when optimizer trace is
+  enabled (the FLAG_ENABLED test is done inline by the caller in opt_trace.h).
+  It applies the remaining traceability conditions and, if they hold, starts
+  the trace context.
+*/
+void Opt_trace_start::init_traceable(THD *thd,
+                                     TABLE_LIST *tbl,
+                                     enum enum_sql_command sql_command,
+                                     List<set_var_base> *set_vars,
+                                     const char *query,
+                                     size_t query_length,
+                                     const CHARSET_INFO *query_charset)
 {
-  /*
-    if optimizer trace is enabled and the statment we have is traceable,
-    then we start the context.
-  */
-  const ulonglong var= thd->variables.optimizer_trace;
-  traceable= FALSE;
-  if (unlikely(var & Opt_trace_context::FLAG_ENABLED) &&
-      sql_command_can_be_traced(sql_command) &&
+  if (sql_command_can_be_traced(sql_command) &&
       !list_has_optimizer_trace_table(tbl) &&
       !sets_var_optimizer_trace(sql_command, set_vars) &&
       !thd->system_thread &&

--- a/sql/opt_trace.h
+++ b/sql/opt_trace.h
@@ -77,16 +77,39 @@ class Opt_trace_start
  public:
   Opt_trace_start(THD *thd_arg): ctx(&thd_arg->opt_trace), traceable(false) {}
 
+  /*
+    Fast path for the common case where optimizer trace is disabled: this
+    inlines at the call site so a non-traced statement pays only a flag load
+    and a predicted-not-taken branch, instead of an out-of-line call with a
+    full prologue/epilogue. The actual context setup lives in init_traceable().
+  */
   void init(THD *thd, TABLE_LIST *tbl,
             enum enum_sql_command sql_command,
             List<set_var_base> *set_vars,
             const char *query,
             size_t query_length,
-            const CHARSET_INFO *query_charset);
+            const CHARSET_INFO *query_charset)
+  {
+    /*
+      traceable was set false by the constructor; assert that invariant
+      instead of re-storing it, so the disabled hot path stays store-free.
+    */
+    DBUG_ASSERT(!traceable);
+    if (unlikely(thd->variables.optimizer_trace & Opt_trace_context::FLAG_ENABLED))
+      init_traceable(thd, tbl, sql_command, set_vars, query, query_length,
+                     query_charset);
+  }
 
   ~Opt_trace_start();
 
  private:
+  void init_traceable(THD *thd, TABLE_LIST *tbl,
+                      enum enum_sql_command sql_command,
+                      List<set_var_base> *set_vars,
+                      const char *query,
+                      size_t query_length,
+                      const CHARSET_INFO *query_charset);
+
   Opt_trace_context *const ctx;
   /*
     True: the query will be traced


### PR DESCRIPTION
Optimizer trace is disabled by default, yet init() was out of line, so every statement paid a call plus a full prologue/epilogue only to test FLAG_ENABLED and return.

Move the FLAG_ENABLED test into an inline init() so the disabled path collapses to a flag load and a predicted-not-taken branch. The enabled path setup stays out of line in the new init_traceable(). Behaviour and the init() signature are unchanged.