### PR TITLE
MDEV-40388 Optimizer context records unusable DDL for SEQUENCE tables

### DIFF
--- a/mysql-test/main/opt_trace_store_ddls_sequence.result
+++ b/mysql-test/main/opt_trace_store_ddls_sequence.result
@@ -1,0 +1,47 @@
+#
+# MDEV-40388: sequence.simple fails on replay
+#
+# Auto-generated SEQUENCE-engine tables (seq_<from>_to_<to>[_step_<step>])
+# are discovered by the engine from their name and cannot be recreated
+# with an explicit CREATE TABLE. Their DDL must therefore NOT be recorded
+# into the optimizer trace, otherwise replaying the recorded context
+# fails with "Table '...' already exists".
+#
+create database db1;
+use db1;
+create table t1 (a int, b int);
+insert into t1 values (1,2),(2,3);
+set optimizer_trace=1;
+set optimizer_record_context=ON;
+#
+# A query over an auto-generated sequence table only.
+# No ddl should be recorded for the sequence table.
+#
+explain select * from seq_15_to_1_step_12345;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	seq_15_to_1_step_12345	ALL	NULL	NULL	NULL	NULL	1	
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl'))
+from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+ddl
+#
+# A query joining a regular table with a sequence table.
+# Only the regular table t1 should have its ddl recorded.
+#
+select t1.a from t1, seq_1_to_10 where t1.a = seq;
+a
+1
+2
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl'))
+from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+ddl
+CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+set optimizer_record_context=OFF;
+set optimizer_trace=0;
+drop database db1;

--- a/mysql-test/main/opt_trace_store_ddls_sequence.test
+++ b/mysql-test/main/opt_trace_store_ddls_sequence.test
@@ -1,0 +1,46 @@
+--source include/not_embedded.inc
+--source include/have_sequence.inc
+--source include/no_view_protocol.inc
+
+--echo #
+--echo # MDEV-40388: sequence.simple fails on replay
+--echo #
+--echo # Auto-generated SEQUENCE-engine tables (seq_<from>_to_<to>[_step_<step>])
+--echo # are discovered by the engine from their name and cannot be recreated
+--echo # with an explicit CREATE TABLE. Their DDL must therefore NOT be recorded
+--echo # into the optimizer trace, otherwise replaying the recorded context
+--echo # fails with "Table '...' already exists".
+--echo #
+
+create database db1;
+use db1;
+create table t1 (a int, b int);
+insert into t1 values (1,2),(2,3);
+
+set optimizer_trace=1;
+set optimizer_record_context=ON;
+
+--echo #
+--echo # A query over an auto-generated sequence table only.
+--echo # No ddl should be recorded for the sequence table.
+--echo #
+explain select * from seq_15_to_1_step_12345;
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl'))
+            from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+
+--echo #
+--echo # A query joining a regular table with a sequence table.
+--echo # Only the regular table t1 should have its ddl recorded.
+--echo #
+select t1.a from t1, seq_1_to_10 where t1.a = seq;
+set @ddls= (select json_detailed(json_extract(trace, '$**.ddl'))
+            from information_schema.optimizer_trace);
+select ddl
+from json_table(@ddls, '$[*]' columns(ddl text path '$')) as jt;
+
+set optimizer_record_context=OFF;
+set optimizer_trace=0;
+
+drop database db1;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1926,6 +1926,7 @@ handlerton *ha_default_tmp_handlerton(THD *thd);
 #define HTON_ALTER_NOT_SUPPORTED     (1 << 1) //Engine does not support alter
 #define HTON_CAN_RECREATE            (1 << 2) //Delete all is used for truncate
 #define HTON_HIDDEN                  (1 << 3) //Engine does not appear in lists
+#define HTON_TABLE_EXISTS_BY_NAME    (1 << 4) //Tables auto-discovered from name; reject CREATE TABLE (e.g. SEQUENCE)
 #define HTON_NOT_USER_SELECTABLE     (1 << 5)
 #define HTON_TEMPORARY_NOT_SUPPORTED (1 << 6) //Having temporary tables not supported
 #define HTON_SUPPORT_LOG_TABLES      (1 << 7) //Engine supports log tables

--- a/sql/opt_trace_ddl_info.cc
+++ b/sql/opt_trace_ddl_info.cc
@@ -62,6 +62,7 @@ static const uchar *get_rec_key(const void *entry_, size_t *length,
      - INFORMATION_SCHEMA tables
      - Tables in PERFORMANCE_SCHEMA and mysql database
      - Internal temporary ("work") tables
+     - Tables auto-discovered from their name (e.g. SEQUENCE), which reject CREATE TABLE
 */
 static bool is_base_table(TABLE_LIST *tbl)
 {
@@ -73,7 +74,9 @@ static bool is_base_table(TABLE_LIST *tbl)
      get_table_category(tbl->get_db_name(), tbl->get_table_name()) ==
        TABLE_CATEGORY_USER &&
      tbl->table->s->tmp_table != INTERNAL_TMP_TABLE &&
-     tbl->table->s->tmp_table != SYSTEM_TMP_TABLE);
+     tbl->table->s->tmp_table != SYSTEM_TMP_TABLE &&
+     !(tbl->table->s->db_type() &&
+       (tbl->table->s->db_type()->flags & HTON_TABLE_EXISTS_BY_NAME)));
 }
 
 static bool dump_record_to_trace(THD *thd, DDL_Key *ddl_key, String *stmt)

--- a/storage/sequence/sequence.cc
+++ b/storage/sequence/sequence.cc
@@ -531,6 +531,7 @@ static int init(void *p)
   hton->drop_table= drop_table;
   hton->discover_table= discover_table;
   hton->discover_table_existence= discover_table_existence;
+  hton->flags|= HTON_TABLE_EXISTS_BY_NAME;
   hton->commit= hton->rollback= [](THD *, bool) { return 0; };
   hton->savepoint_set= hton->savepoint_rollback= hton->savepoint_release=
     [](THD *, void *) { return 0; };


### PR DESCRIPTION
# Description

#### This is a draft PR including MTR regression test and example of adding flag to identify sequence tables, in case it may be of use.

With `optimizer_record_context` enabled, the optimizer trace records a
`CREATE TABLE` statement for every base table referenced by a
SELECT/INSERT/DELETE/UPDATE query, so that an Optimizer Context Replay server
(MDEV-39368) can recreate the query's context. The recording code emitted a
`CREATE TABLE ... ENGINE=SEQUENCE` for the auto-generated SEQUENCE-engine
helper tables (`seq_<from>_to_<to>[_step_<step>]`).

Replaying that DDL fails:

```
ERROR 1050 (42S01): Table 'seq_15_to_1_step_12345' already exists
```

The SEQUENCE engine discovers such tables purely from their name pattern — the
table exists the moment it is referenced and can never be created with an
explicit `CREATE TABLE` (`ha_seq::create()` returns `HA_ERR_WRONG_COMMAND`), so
the recorded DDL is unusable on replay.

## Root cause

`is_base_table()` in `sql/opt_trace_ddl_info.cc` records the DDL of every table
in the `TABLE_CATEGORY_USER` category. It did not exclude engines that determine
a table's existence from its name alone, so SEQUENCE tables were treated like
ordinary base tables and their (unusable) DDL was recorded.

## Fix

- `sql/handler.h`: add a handlerton capability flag
  `HTON_TABLE_EXISTS_BY_NAME (1 << 4)`. An engine sets it to declare that its
  tables are discovered from the table name alone and cannot be created with an
  explicit `CREATE TABLE`.
- `storage/sequence/sequence.cc`: the SEQUENCE storage engine sets
  `HTON_TABLE_EXISTS_BY_NAME` in its `init()`.
- `sql/opt_trace_ddl_info.cc`: `is_base_table()` now also returns `false` when
  the table's engine has `HTON_TABLE_EXISTS_BY_NAME` set, so no DDL is recorded
  for such tables. All other base tables (InnoDB, MyISAM, views, ...) are
  unaffected.

Using a declared handlerton flag (rather than inferring the property from the
engine's `discover_table_existence` hook) states the intent explicitly and is
opt-in: only engines that set the flag are skipped. The flag occupies a
previously unused bit and defaults to 0 (handlertons are zero-filled at
allocation), so no other engine's behaviour changes. `PERFORMANCE_SCHEMA` tables
remain excluded earlier in `is_base_table()` by the table-category check.

## How this PR Can Be Tested

New MTR test `main.opt_trace_store_ddls_sequence`:

- A query over `seq_15_to_1_step_12345` records no DDL (the `list_ddls` array is
  empty).
- A join of a regular MyISAM table `t1` with `seq_1_to_10` records the DDL for
  `t1` only, confirming normal tables are still captured while the sequence
  table is skipped.

Verification performed on a Debug build of `main`:

- Unfixed base: `main.opt_trace_store_ddls_sequence` fails — the trace records
  `CREATE TABLE ... ENGINE=SEQUENCE` for both `seq_15_to_1_step_12345` and
  `seq_1_to_10`, matching the JIRA report.
- With this fix: `main.opt_trace_store_ddls_sequence` passes.
- Regression: `main.opt_trace_store_ddls` (pre-existing), `sequence.simple`, and
  `sequence.group_by` all pass.

## Basing the PR against the correct MariaDB version

Based on `main`. The optimizer-context-recording feature (`opt_trace_ddl_info.cc`,
`optimizer_record_context`) is not present in any released LTS (10.6, 10.11,
11.4, 11.8); it lives only on `main`, so there is no older affected branch to
base on.

## Release Notes

The optimizer context (`optimizer_record_context`) no longer records an
unusable `CREATE TABLE ... ENGINE=SEQUENCE` statement for auto-generated
SEQUENCE tables, so recorded contexts referencing sequence tables can be
replayed.

All new code of the whole pull request, including one or several files that are
either new files or modified ones, are contributed under the BSD-new license. I
am contributing on behalf of my employer Amazon Web Services, Inc.