### PR TITLE
MDEV-40389: type_test.type_test_int8 fails on replay

### DIFF
--- a/plugin/type_test/mysql-test/type_test/type_test_double.test
+++ b/plugin/type_test/mysql-test/type_test/type_test_double.test
@@ -1,6 +1,7 @@
 --echo #
 --echo # MDEV-20016 Add MariaDB_DATA_TYPE_PLUGIN
 --echo #
+--disable_replay testfile plugins are not yet supported
 
 --vertical_results
 SELECT

--- a/plugin/type_test/mysql-test/type_test/type_test_int8.test
+++ b/plugin/type_test/mysql-test/type_test/type_test_int8.test
@@ -1,6 +1,7 @@
 --echo #
 --echo # MDEV-20016 Add MariaDB_DATA_TYPE_PLUGIN
 --echo #
+--disable_replay testfile plugins are not yet supported
 
 --vertical_results
 SELECT


### PR DESCRIPTION
plugins are not yet supported in replay mode.

So, disabling tests type_test.type_test_int8, and type_test.type_test_double to be run in replay-server mode