### PR TITLE
MDEV-40390: compat/oracle.sp-package fails on replay

### DIFF
--- a/mysql-test/suite/compat/oracle/t/sp-package.test
+++ b/mysql-test/suite/compat/oracle/t/sp-package.test
@@ -1,4 +1,5 @@
 --source include/default_charset.inc
+--disable_replay testfile Don't support UDFs
 
 SET sql_mode=ORACLE;
 


### PR DESCRIPTION
UDFs are not yet supported in replay mode.

So, disabling test compat/oracle.sp-package