### PR TITLE
MDEV-17746: perfschema.dml_threads failed in buildbot with wrong errno

### DIFF
--- a/mysql-test/suite/perfschema/r/dml_threads.result
+++ b/mysql-test/suite/perfschema/r/dml_threads.result
@@ -9,7 +9,7 @@ update performance_schema.threads
 set thread_id=12;
 ERROR HY000: Invalid performance_schema usage
 update performance_schema.threads
-set thread_id=12 where PROCESSLIST_ID=connection_id();
+set thread_id=thread_id + 42 where PROCESSLIST_ID=connection_id();
 ERROR HY000: Invalid performance_schema usage
 update performance_schema.threads
 set instrumented= 'NO' where PROCESSLIST_ID=connection_id();

--- a/mysql-test/suite/perfschema/t/dml_threads.test
+++ b/mysql-test/suite/perfschema/t/dml_threads.test
@@ -21,7 +21,7 @@ update performance_schema.threads
 
 --error ER_WRONG_PERFSCHEMA_USAGE
 update performance_schema.threads
-  set thread_id=12 where PROCESSLIST_ID=connection_id();
+  set thread_id=thread_id + 42 where PROCESSLIST_ID=connection_id();
 
 update performance_schema.threads
   set instrumented= 'NO' where PROCESSLIST_ID=connection_id();


### PR DESCRIPTION
The test was trying to update the performance_schema.threads row for the current connection. And if that row was not found or was the same, there's nothing to update hence no update not allowed error.

MariaDB has a device to skip calling ha_update_row() if the old and the new records are identical.

The connection id is increasing by at least 2 for every test run. Eventually it will hit the constant 12 in the UPDATE and the server will not call ha_update_row() at all and won't get the error. This is not a bug: it's reasonable behavior.

Stablizied the test by changing the UPDATE value to thread_id
 + const.

Co-authored-by: Grok