### PR TITLE
MDEV-33843: Server crashes by stack-overflow with UPDATEXML

### DIFF
--- a/mysql-test/main/xml.result
+++ b/mysql-test/main/xml.result
@@ -1320,13 +1320,10 @@ f
 foo
 <b></b>
 #
-# Start of 10.5 tests
+# End of 10.5 tests
 #
 #
-# Start of 10.6 tests
-#
-#
-# MDEV-39210 ExtractValue/UpdateXML crash
+# ExtractValue/UpdateXML crash
 #
 SELECT ExtractValue('<!a/><!b/>', '/a');
 ExtractValue('<!a/><!b/>', '/a')
@@ -1421,4 +1418,12 @@ SELECT ExtractValue('<a/>', REPEAT('(', 100000));
 ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
 SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
 ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
-# End of 10.6 tests
+#
+# Start of 10.6 tests
+#
+#
+# MDEV-33843: Server crashes by stack-overflow with UPDATEXML
+#
+SELECT UPDATEXML(NULL, REPEAT('(', 100000), 1);
+ERROR HY000: Thread stack overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed. Consider increasing the thread_stack system variable.
+# End of 10.6 test

--- a/mysql-test/main/xml.test
+++ b/mysql-test/main/xml.test
@@ -822,15 +822,11 @@ DROP TABLE t1;
 SELECT 'foo' AS f UNION SELECT BINARY( UpdateXML('<a></a>', '/a', '<b></b>')) AS f;
 
 --echo #
---echo # Start of 10.5 tests
+--echo # End of 10.5 tests
 --echo #
 
 --echo #
---echo # Start of 10.6 tests
---echo #
-
---echo #
---echo # MDEV-39210 ExtractValue/UpdateXML crash
+--echo # ExtractValue/UpdateXML crash
 --echo #
 
 #view protocol generates additional warning
@@ -911,5 +907,16 @@ SELECT ExtractValue('<a/>', REPEAT('(', 100000));
 --error ER_STACK_OVERRUN_NEED_MORE
 SELECT ExtractValue('<a/>', REPEAT('/n', 100000));
 
---echo # End of 10.6 tests
+--echo #
+--echo # Start of 10.6 tests
+--echo #
 
+--echo #
+--echo # MDEV-33843: Server crashes by stack-overflow with UPDATEXML
+--echo #
+
+--replace_regex /overrun:  [0-9]* bytes used of a [0-9]* byte stack, and [0-9]* bytes needed/overrun:  'used bytes' used of a 'available' byte stack, and 'X' bytes needed/
+--error ER_STACK_OVERRUN_NEED_MORE
+SELECT UPDATEXML(NULL, REPEAT('(', 100000), 1);
+
+--echo # End of 10.6 test

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -25,7 +25,8 @@
 #include "set_var.h"
 #include "my_xml.h"
 #include "sp_pcontext.h"
-#include "sql_parse.h"                          // THD
+#include "sql_class.h"                          // THD
+#include "sql_parse.h"                          // for check_stack_overrun
 
 /*
   TODO: future development directions:
@@ -2210,9 +2211,19 @@ static int my_xpath_parse_FilterExpr(MY_XPATH *xpath)
   RETURN
     1 - success
     0 - failure
+
+  Please note: There is non-standard returning here to
+               simplify processing in the parser.
 */
 static int my_xpath_parse_OrExpr(MY_XPATH *xpath)
 {
+  /*
+     Check for stack ovver run because it might call itself and
+     result in stack overflow. Return error if thats the case.
+  */
+  if (check_stack_overrun(current_thd, STACK_MIN_SIZE , NULL))
+    return 0;
+
   if (!my_xpath_parse_AndExpr(xpath))
     return 0;
 


### PR DESCRIPTION
Analysis:
The stack size if insufficient and there is no stack overrun check.

Fix:
Add stack overrun check.