### PR TITLE
MENT-2593: Infer: MEMORY_LEAK_C in mariabackup

### DIFF
--- a/extra/mariabackup/backup_copy.cc
+++ b/extra/mariabackup/backup_copy.cc
@@ -1534,13 +1534,17 @@ ibx_copy_incremental_over_full()
 
 		if (directory_exists(ROCKSDB_BACKUP_DIR, false)) {
 			if (my_rmtree(ROCKSDB_BACKUP_DIR, MYF(0))) {
-				die("Can't remove " ROCKSDB_BACKUP_DIR);
+				msg("Can't remove " ROCKSDB_BACKUP_DIR);
+				ret = false;
+				goto cleanup;
 			}
 		}
 		snprintf(path, sizeof(path), "%s/" ROCKSDB_BACKUP_DIR, xtrabackup_incremental_dir);
 		if (directory_exists(path, false)) {
 			if (my_mkdir(ROCKSDB_BACKUP_DIR, 0777, MYF(0))) {
-				die("my_mkdir failed for " ROCKSDB_BACKUP_DIR);
+				msg("my_mkdir failed for " ROCKSDB_BACKUP_DIR);
+				ret = false;
+				goto cleanup;
 			}
 			ds_data->copy_or_move_dir(path, ROCKSDB_BACKUP_DIR, true, true);
 		}


### PR DESCRIPTION
Replace die() with proper error handling to avoid memory leaks when RocksDB backup directory operations fail.