### PR TITLE
MDEV-40385 use-of-uninitialized-value in Binary_string::c_ptr()

### DIFF
--- a/mysql-test/main/func_kdf.result
+++ b/mysql-test/main/func_kdf.result
@@ -161,3 +161,25 @@ ERROR 42000: Incorrect parameter count in the call to native function 'kdf'
 #
 # End of 11.3 tests
 #
+#
+# MDEV-40385 use-of-uninitialized-value in Binary_string::c_ptr()
+#
+SELECT KDF('','',1000,256);
+KDF('','',1000,256)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: '256' in function kdf.
+SELECT KDF('secret','salt',1000,999);
+KDF('secret','salt',1000,999)
+NULL
+Warnings:
+Warning	3047	Invalid argument error: '999' in function kdf.
+SELECT KDF('secret','salt',1000,'pbkdf2_hmac') IS NOT NULL;
+KDF('secret','salt',1000,'pbkdf2_hmac') IS NOT NULL
+1
+SELECT KDF('secret','salt') IS NOT NULL;
+KDF('secret','salt') IS NOT NULL
+1
+#
+# End of 11.4 tests
+#

--- a/mysql-test/main/func_kdf.test
+++ b/mysql-test/main/func_kdf.test
@@ -62,3 +62,17 @@ select kdf();
 --echo # End of 11.3 tests
 --echo #
 
+--echo #
+--echo # MDEV-40385 use-of-uninitialized-value in Binary_string::c_ptr()
+--echo #
+# MSAN only: this test verifies the fix behaviorally (warning + NULL); the
+# uninitialized read itself is only observable under an MSAN build.
+SELECT KDF('','',1000,256);
+SELECT KDF('secret','salt',1000,999);
+SELECT KDF('secret','salt',1000,'pbkdf2_hmac') IS NOT NULL;
+SELECT KDF('secret','salt') IS NOT NULL;
+
+--echo #
+--echo # End of 11.4 tests
+--echo #
+

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -521,9 +521,9 @@ String *Item_func_kdf::val_str(String *buf)
   {
     if (String *s= args[3]->val_str(buf))
     {
-      if (strcasecmp(s->c_ptr(), "hkdf") == 0)
+      if (strcasecmp(s->c_ptr_safe(), "hkdf") == 0)
         use_hkdf= true;
-      else if (strcasecmp(s->c_ptr(), "pbkdf2_hmac") != 0)
+      else if (strcasecmp(s->c_ptr_safe(), "pbkdf2_hmac") != 0)
       {
         invalid_argument_error(func_name(), ErrConvStringQ(s).ptr());
         goto ret_null;


### PR DESCRIPTION
# Description

`SELECT KDF('','',1000,256)` triggered an MSAN *use-of-uninitialized-value*
report originating in `Binary_string::c_ptr()` (`sql/sql_string.h`) reached from
`Item_func_kdf::val_str()` (`sql/item_strfunc.cc`).

In `Item_func_kdf::val_str(String *buf)` the optional 4th argument (`kdf_name`)
was evaluated into the **shared result buffer** `buf` and then read as a C
string:

```cpp
if (String *s= args[3]->val_str(buf))      // buf == the shared result buffer
{
  if (strcasecmp(s->c_ptr(), "hkdf") == 0)
  ...
```

The issue is when `args[3]` is an integer literal (here `256`), `Item_int::val_str()` writes the digits `"256"` (length 3) into the buffer, and `String::alloc()` intentionally skips reallocation when the buffer is already large enough — so the buffer stays non-`alloced` and is left **without a trailing NUL**.

`c_ptr()` then executes:

```cpp
if (unlikely(!alloced && !Ptr[str_length]))   // reads Ptr[3]
  return Ptr;
```

Because the buffer is not `alloced`, `c_ptr()` first *reads* `Ptr[str_length]`
(i.e. `buf[3]`) to decide whether a terminator already exists. That byte is
validly addressable (the buffer is large) but was never initialized, so MSAN
flags a use-of-uninitialized-value. Valgrind does not flag it because that stack
byte was typically written by an earlier call frame; only MSAN re-poisons the
stack scope, which is why the report is MSAN-only.

## Fix

`sql/item_strfunc.cc`, `Item_func_kdf::val_str()`:
- Use `s->c_ptr_safe()` instead of `s->c_ptr()`. `c_ptr_safe()` never reads
  `Ptr[str_length]`; it writes the terminator (or reallocates), removing the
  uninitialized read regardless of the buffer's `alloced` state.

Behaviour is unchanged for callers: a non-matching `kdf_name` still yields the
`ER_STD_INVALID_ARGUMENT` warning and `NULL`, and valid names (`pbkdf2_hmac`,
`hkdf`) still work.

## Release Notes

Resolved uninitialized read deficiency in `Binary_string::c_ptr()` via `item_func_kdf::val_str()`.

## How can this PR be tested?

Because this stray read is harmless without a sanitizer, related MTR tests need to be run on an MSAN build to observe regression. Run MTR on an MSAN build by adding build flag`-DWITH_MSAN=ON` (clang), which requires MSAN-instrumented system
libraries — see
https://mariadb.com/kb/en/compile-and-using-mariadb-with-sanitizers-asan-ubsan-tsan-msan/

The following test and result files were added as regression tests:
- `mysql-test/main/mdev40385.test`
- `mysql-test/main/mdev40385.result`

## Basing the PR against the correct MariaDB version

Based against `11.4`, the oldest maintained LTS affected. The JIRA MSAN matrix
shows `10.6` and `10.11` as unaffected because the `KDF()` function does not
exist there; the defect is present from `11.4` onward.

## Copyright

All new code of the whole pull request, including one or several files that are
either new files or modified ones, are contributed under the BSD-new license. I
am contributing on behalf of my employer Amazon Web Services, Inc.