### PR TITLE
MDEV-40489: main.set_password view-protocol incompatibilities

### DIFF
--- a/mysql-test/main/set_password.result
+++ b/mysql-test/main/set_password.result
@@ -58,7 +58,6 @@ current_user()
 oldpassold@localhost
 disconnect con;
 connection default;
-flush privileges;
 connect con,localhost,natauth,test,;
 select current_user();
 current_user()
@@ -140,7 +139,6 @@ current_user()
 oldpassold@localhost
 disconnect con;
 connection default;
-flush privileges;
 connect con,localhost,natauth,test2,;
 select current_user();
 current_user()

--- a/mysql-test/main/set_password.test
+++ b/mysql-test/main/set_password.test
@@ -45,6 +45,7 @@ select current_user();
 --connect(con,localhost,newpassnat,test,)
 select current_user();
 --disconnect con
+--disable_view_protocol
 --connect(con,localhost,oldauth,test,,,,auth=mysql_old_password:mysql_native_password)
 select current_user();
 --disconnect con
@@ -54,10 +55,9 @@ select current_user();
 --connect(con,localhost,oldpassold,test,,,,auth=mysql_old_password:mysql_native_password)
 select current_user();
 --disconnect con
+--enable_view_protocol
 
 --connection default
-
-flush privileges;
 
 --connect(con,localhost,natauth,test,)
 select current_user();
@@ -68,6 +68,7 @@ select current_user();
 --connect(con,localhost,newpassnat,test,)
 select current_user();
 --disconnect con
+--disable_view_protocol
 --connect(con,localhost,oldauth,test,,,,auth=mysql_old_password:mysql_native_password)
 select current_user();
 --disconnect con
@@ -77,6 +78,7 @@ select current_user();
 --connect(con,localhost,oldpassold,test,,,,auth=mysql_old_password:mysql_native_password)
 select current_user();
 --disconnect con
+--enable_view_protocol
 
 --connection default
 
@@ -111,8 +113,6 @@ select current_user();
 --disconnect con
 
 --connection default
-
-flush privileges;
 
 --connect(con,localhost,natauth,test2,)
 select current_user();


### PR DESCRIPTION
with auth=mysql_old_password:mysql_native_password,

so disable sections.

Remove two unneeded "flush privileges" from test.

This is a connector 3.4 difference compared to 3.3