### PR TITLE
Disable rpl_parallel_multi_domain_xa

### DIFF
--- a/mysql-test/suite/rpl/disabled.def
+++ b/mysql-test/suite/rpl/disabled.def
@@ -15,3 +15,4 @@ rpl_row_binlog_max_cache_size : MDEV-11092
 rpl_row_index_choice      : MDEV-11666
 rpl_auto_increment_update_failure  : disabled for now
 rpl_current_user          : waits for MDEV-22374 fix
+rpl_parallel_multi_domain_xa : (2026-07-24) Waits for MDEV-32020

--- a/mysql-test/suite/rpl/disabled.def
+++ b/mysql-test/suite/rpl/disabled.def
@@ -15,3 +15,4 @@ rpl_row_binlog_max_cache_size : MDEV-11092
 rpl_row_index_choice      : MDEV-11666
 rpl_auto_increment_update_failure  : disabled for now
 rpl_current_user          : waits for MDEV-22374 fix
+rpl_parallel_multi_domain_xa : (2026-07-24) MDEV-34104: waits for MDEV-32020


### PR DESCRIPTION
MDEV-34104 describes why this test fails. It was filed 2 years ago, but the fix is complex, and we keep this failing test around hurting all other development. The fix is planned, once finished, we can re-enable this test.