### PR TITLE
MDEV-39522 Query with UNION fails in Oracle sql_mode with ER_BAD_FIELD_ERROR/ER_UNKNOWN_TABLE

### DIFF
--- a/mysql-test/main/intersect_all.result
+++ b/mysql-test/main/intersect_all.result
@@ -1023,13 +1023,12 @@ NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL
 set sql_mode= 'oracle';
 explain SELECT * from t3 union select * from u3 intersect all select * from i3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	2	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	no matching row in const table
 3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	no matching row in const table
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
-5	INTERSECT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	no matching row in const table
-NULL	INTERSECT RESULT	<intersect4,5>	ALL	NULL	NULL	NULL	NULL	NULL	
+4	INTERSECT	i3	system	NULL	NULL	NULL	NULL	0	Const row not found
+NULL	INTERSECT RESULT	<intersect1,4>	ALL	NULL	NULL	NULL	NULL	NULL	
 select x from t3 union select x from u3 intersect select x from i3;
 x
 SELECT x from t3 union select x from u3 intersect all select x from i3;
@@ -1153,23 +1152,22 @@ a	b
 2	3
 explain select * from t1 intersect all select * from t2 union values (1, 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	8	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	7	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	7	
 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	7	
 3	INTERSECT	t2	ALL	NULL	NULL	NULL	NULL	7	
 NULL	INTERSECT RESULT	<intersect2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
-5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,5>	ALL	NULL	NULL	NULL	NULL	NULL	
+4	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,4>	ALL	NULL	NULL	NULL	NULL	NULL	
 show create view v1;
 View	Create View	character_set_client	collation_connection
-v1	CREATE VIEW "v1" AS select "__6"."a" AS "a","__6"."b" AS "b" from (select "__4"."a" AS "a","__4"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__4" union values (1,2)) "__6"	latin1	latin1_swedish_ci
+v1	CREATE VIEW "v1" AS select "__5"."a" AS "a","__5"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__5" union values (1,2)	latin1	latin1_swedish_ci
 select * from v1;
 a	b
 1	2
 2	3
 show create view v2;
 View	Create View	character_set_client	collation_connection
-v2	CREATE VIEW "v2" AS select "__7"."a" AS "a","__7"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" union select "__5"."1" AS "1","__5"."2" AS "2" from (select "__6"."1" AS "1","__6"."2" AS "2" from (values (1,2) intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__6") "__5") "__7"	latin1	latin1_swedish_ci
+v2	CREATE VIEW "v2" AS select "t1"."a" AS "a","t1"."b" AS "b" from "t1" union select "__5"."1" AS "1","__5"."2" AS "2" from (values (1,2) intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__5"	latin1	latin1_swedish_ci
 select * from v2;
 a	b
 1	2
@@ -1178,7 +1176,7 @@ a	b
 create view v3 as select * from t1 union values (1, 2) intersect all select * from t2;
 show create view v3;
 View	Create View	character_set_client	collation_connection
-v3	CREATE VIEW "v3" AS select "__6"."a" AS "a","__6"."b" AS "b" from (select "__8"."a" AS "a","__8"."b" AS "b" from (select "__4"."a" AS "a","__4"."b" AS "b" from (select "__6"."a" AS "a","__6"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" union values (1,2)) "__6") "__4" intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__8") "__6"	latin1	latin1_swedish_ci
+v3	CREATE VIEW "v3" AS select "__5"."a" AS "a","__5"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" union values (1,2)) "__5" intersect all select "t2"."a" AS "a","t2"."b" AS "b" from "t2"	latin1	latin1_swedish_ci
 select * from v3;
 a	b
 1	2
@@ -1255,20 +1253,19 @@ set sql_mode= 'oracle';
 create view v2 as select * from t1 except all select * from t2 intersect all values (1, 2);
 show create view v2;
 View	Create View	character_set_client	collation_connection
-v2	CREATE VIEW "v2" AS select "__6"."a" AS "a","__6"."b" AS "b" from (select "__8"."a" AS "a","__8"."b" AS "b" from (select "__4"."a" AS "a","__4"."b" AS "b" from (select "__6"."a" AS "a","__6"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" except all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__6") "__4" intersect all values (1,2)) "__8") "__6"	latin1	latin1_swedish_ci
+v2	CREATE VIEW "v2" AS select "__5"."a" AS "a","__5"."b" AS "b" from (select "t1"."a" AS "a","t1"."b" AS "b" from "t1" except all select "t2"."a" AS "a","t2"."b" AS "b" from "t2") "__5" intersect all values (1,2)	latin1	latin1_swedish_ci
 select * from v2;
 a	b
 1	2
 drop view v2;
 EXPLAIN select * from t1 except all select * from t2 intersect all values (1, 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	2	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	4	
 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	4	
 3	EXCEPT	t2	ALL	NULL	NULL	NULL	NULL	2	
 NULL	EXCEPT RESULT	<except2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
-5	INTERSECT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	INTERSECT RESULT	<intersect4,5>	ALL	NULL	NULL	NULL	NULL	NULL	
+4	INTERSECT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	INTERSECT RESULT	<intersect1,4>	ALL	NULL	NULL	NULL	NULL	NULL	
 select * from t2 union all select * from t2;
 a	b
 1	2

--- a/mysql-test/main/set_operation_oracle.result
+++ b/mysql-test/main/set_operation_oracle.result
@@ -12,18 +12,17 @@ a	b
 explain extended
 (select a,b from t1) union (select c,d from t2) intersect (select e,f from t3) union (select 4,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+1	PRIMARY	<derived5>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	UNION	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-5	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
-NULL	INTERSECT RESULT	<intersect4,5>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union6,7>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+4	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
+NULL	INTERSECT RESULT	<intersect5,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+6	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,6>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__7"."a" AS "a","__7"."b" AS "b" from (/* select#6 */ select "__5"."a" AS "a","__5"."b" AS "b" from (/* select#4 */ select "__3"."a" AS "a","__3"."b" AS "b" from ((/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1") union (/* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2")) "__3" intersect (/* select#5 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3")) "__5" union (/* select#7 */ select 4 AS "4",4 AS "4")) "__7"
+Note	1003	/* select#1 */ select "__6"."a" AS "a","__6"."b" AS "b" from (/* select#5 */ select "__4"."a" AS "a","__4"."b" AS "b" from ((/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1") union (/* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2")) "__4" intersect (/* select#4 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3")) "__6" union (/* select#6 */ select 4 AS "4",4 AS "4")
 (select e,f from t3) intersect (select c,d from t2) union (select a,b from t1) union (select 4,4);
 e	f
 3	3
@@ -33,18 +32,15 @@ e	f
 explain extended
 (select e,f from t3) intersect (select c,d from t2) union (select a,b from t1) union (select 4,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
 2	DERIVED	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	INTERSECT	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
 NULL	INTERSECT RESULT	<intersect2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-5	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
-NULL	UNION RESULT	<union4,5>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union6,7>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+4	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,4,5>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__7"."e" AS "e","__7"."f" AS "f" from (/* select#6 */ select "__5"."e" AS "e","__5"."f" AS "f" from (/* select#4 */ select "__3"."e" AS "e","__3"."f" AS "f" from ((/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") intersect (/* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2")) "__3" union (/* select#5 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1")) "__5" union (/* select#7 */ select 4 AS "4",4 AS "4")) "__7"
+Note	1003	/* select#1 */ select "__4"."e" AS "e","__4"."f" AS "f" from ((/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") intersect (/* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2")) "__4" union (/* select#4 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1") union (/* select#5 */ select 4 AS "4",4 AS "4")
 create table t12(c1 int);
 insert into t12 values(1);
 insert into t12 values(2);
@@ -76,16 +72,15 @@ a	b
 explain extended
 select a,b from t1 union all select c,d from t2 intersect select e,f from t3 union all select 4,'4' from dual;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+1	PRIMARY	<derived5>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	UNION	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
-5	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
-NULL	INTERSECT RESULT	<intersect4,5>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
+NULL	INTERSECT RESULT	<intersect5,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+6	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__7"."a" AS "a","__7"."b" AS "b" from (/* select#6 */ select "__5"."a" AS "a","__5"."b" AS "b" from (/* select#4 */ select "__3"."a" AS "a","__3"."b" AS "b" from (/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__3" intersect /* select#5 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") "__5" union all /* select#7 */ select 4 AS "4",'4' AS "4") "__7"
+Note	1003	/* select#1 */ select "__6"."a" AS "a","__6"."b" AS "b" from (/* select#5 */ select "__4"."a" AS "a","__4"."b" AS "b" from (/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__4" intersect /* select#4 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") "__6" union all /* select#6 */ select 4 AS "4",'4' AS "4"
 select a,b from t1 union all select c,d from t2 intersect all select e,f from t3 union all select 4,'4' from dual;
 a	b
 3	3
@@ -93,16 +88,15 @@ a	b
 explain extended
 select a,b from t1 union all select c,d from t2 intersect all select e,f from t3 union all select 4,'4' from dual;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
+1	PRIMARY	<derived5>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	
 2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	UNION	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
-5	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
-NULL	INTERSECT RESULT	<intersect4,5>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	INTERSECT	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
+NULL	INTERSECT RESULT	<intersect5,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+6	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__7"."a" AS "a","__7"."b" AS "b" from (/* select#6 */ select "__5"."a" AS "a","__5"."b" AS "b" from (/* select#4 */ select "__3"."a" AS "a","__3"."b" AS "b" from (/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__3" intersect all /* select#5 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") "__5" union all /* select#7 */ select 4 AS "4",'4' AS "4") "__7"
+Note	1003	/* select#1 */ select "__6"."a" AS "a","__6"."b" AS "b" from (/* select#5 */ select "__4"."a" AS "a","__4"."b" AS "b" from (/* select#2 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__4" intersect all /* select#4 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3") "__6" union all /* select#6 */ select 4 AS "4",'4' AS "4"
 select e,f from t3 intersect select c,d from t2 union all select a,b from t1 union all select 4,'4' from dual;
 e	f
 3	3
@@ -112,16 +106,14 @@ e	f
 explain extended
 select e,f from t3 intersect select c,d from t2 union all select a,b from t1 union all select 4,'4' from dual;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
 2	DERIVED	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	INTERSECT	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
 NULL	INTERSECT RESULT	<intersect2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-5	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__7"."e" AS "e","__7"."f" AS "f" from (/* select#6 */ select "__5"."e" AS "e","__5"."f" AS "f" from (/* select#4 */ select "__3"."e" AS "e","__3"."f" AS "f" from (/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3" intersect /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__3" union all /* select#5 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1") "__5" union all /* select#7 */ select 4 AS "4",'4' AS "4") "__7"
+Note	1003	/* select#1 */ select "__4"."e" AS "e","__4"."f" AS "f" from (/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3" intersect /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__4" union all /* select#4 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#5 */ select 4 AS "4",'4' AS "4"
 select e,f from t3 intersect all select c,d from t2 union all select a,b from t1 union all select 4,'4' from dual;
 e	f
 3	3
@@ -131,16 +123,14 @@ e	f
 explain extended
 select e,f from t3 intersect all select c,d from t2 union all select a,b from t1 union all select 4,'4' from dual;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived6>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-6	DERIVED	<derived4>	ALL	NULL	NULL	NULL	NULL	4	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
 2	DERIVED	t3	ALL	NULL	NULL	NULL	NULL	2	100.00	
 3	INTERSECT	t2	ALL	NULL	NULL	NULL	NULL	2	100.00	
 NULL	INTERSECT RESULT	<intersect2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
-5	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
-7	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	UNION	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	
+5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__7"."e" AS "e","__7"."f" AS "f" from (/* select#6 */ select "__5"."e" AS "e","__5"."f" AS "f" from (/* select#4 */ select "__3"."e" AS "e","__3"."f" AS "f" from (/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3" intersect all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__3" union all /* select#5 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1") "__5" union all /* select#7 */ select 4 AS "4",'4' AS "4") "__7"
+Note	1003	/* select#1 */ select "__4"."e" AS "e","__4"."f" AS "f" from (/* select#2 */ select "test"."t3"."e" AS "e","test"."t3"."f" AS "f" from "test"."t3" intersect all /* select#3 */ select "test"."t2"."c" AS "c","test"."t2"."d" AS "d" from "test"."t2") "__4" union all /* select#4 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" union all /* select#5 */ select 4 AS "4",'4' AS "4"
 set SQL_MODE=default;
 drop table t1,t2,t3;
 set SQL_MODE=oracle;
@@ -174,10 +164,10 @@ bar
 set sql_mode=oracle;
 show create view v;
 View	Create View	character_set_client	collation_connection
-v	CREATE VIEW "v" AS select "__4"."a" AS "a" from (select 'foo' AS "a" union select 'bar' AS "a") "__4"	latin1	latin1_swedish_ci
+v	CREATE VIEW "v" AS select 'foo' AS "a" union select 'bar' AS "a"	latin1	latin1_swedish_ci
 show create view v2;
 View	Create View	character_set_client	collation_connection
-v2	CREATE VIEW "v2" AS select "__4"."a" AS "a","__4"."b" AS "b" from (select 'foo' AS "a",'baz' AS "b" union select 'bar' AS "a",'qux' AS "b") "__4"	latin1	latin1_swedish_ci
+v2	CREATE VIEW "v2" AS select 'foo' AS "a",'baz' AS "b" union select 'bar' AS "a",'qux' AS "b"	latin1	latin1_swedish_ci
 select a from v;
 a
 foo
@@ -198,5 +188,37 @@ drop view v;
 drop view v2;
 drop view v3;
 drop view v4;
+set sql_mode=default;
+#
+# MDEV-39522 Query with UNION fails in Oracle sql_mode with ER_BAD_FIELD_ERROR/ER_UNKNOWN_TABLE
+#
+set sql_mode='oracle';
+create table t1 (id varchar(10));
+select 1 from t1 where exists (select 1 from dual union select 1 from dual  where t1.id=1);
+1
+drop table t1;
+set sql_mode=default;
+# ansi:   1 union (2 intersect 2) = {1,2}
+select 1 a union select 2 intersect select 2;
+a
+1
+2
+set sql_mode='oracle';
+# oracle:   (1 union 2) intersect 2 = {2}
+select 1 a union select 2 intersect select 2;
+a
+2
+# recursive CTE with set operator wraps nothing (anchor preserved)
+with recursive c(n) as
+(
+select 1 from dual
+union all
+select n+1 from c where n < 3
+)
+select * from c;
+n
+1
+2
+3
 set sql_mode=default;
 # End of 10.11 tests

--- a/mysql-test/main/set_operation_oracle.test
+++ b/mysql-test/main/set_operation_oracle.test
@@ -100,4 +100,31 @@ drop view v3;
 drop view v4;
 set sql_mode=default;
 
+--echo #
+--echo # MDEV-39522 Query with UNION fails in Oracle sql_mode with ER_BAD_FIELD_ERROR/ER_UNKNOWN_TABLE
+--echo #
+set sql_mode='oracle';
+create table t1 (id varchar(10));
+select 1 from t1 where exists (select 1 from dual union select 1 from dual  where t1.id=1);
+drop table t1;
+set sql_mode=default;
+
+--echo # ansi:   1 union (2 intersect 2) = {1,2}
+select 1 a union select 2 intersect select 2;
+set sql_mode='oracle';
+--echo # oracle:   (1 union 2) intersect 2 = {2}
+--disable_service_connection
+select 1 a union select 2 intersect select 2;
+--enable_service_connection
+
+--echo # recursive CTE with set operator wraps nothing (anchor preserved)
+with recursive c(n) as
+(
+  select 1 from dual
+  union all
+  select n+1 from c where n < 3
+)
+select * from c;
+set sql_mode=default;
+
 --echo # End of 10.11 tests

--- a/mysql-test/suite/compat/oracle/r/empty_string_literal.result
+++ b/mysql-test/suite/compat/oracle/r/empty_string_literal.result
@@ -156,7 +156,7 @@ c1	c2
 1	one
 SHOW CREATE VIEW v1;
 View	Create View	character_set_client	collation_connection
-v1	CREATE VIEW "v1" AS select "__4"."c1" AS "c1","__4"."c2" AS "c2" from (select "__5"."c1" AS "c1","__5"."c2" AS "c2" from (select "t1"."c1" AS "c1","t1"."c2" AS "c2" from "t1" union select "t1"."c1" AS "c1",NULL AS "NULL" from "t1") "__5") "__4" order by 1,2	cp1250	latin2_general_ci
+v1	CREATE VIEW "v1" AS select "t1"."c1" AS "c1","t1"."c2" AS "c2" from "t1" union select "t1"."c1" AS "c1",NULL AS "NULL" from "t1" order by 1,2	cp1250	latin2_general_ci
 DROP VIEW v1;
 DROP TABLE t1;
 EXPLAIN EXTENDED SELECT '';

--- a/mysql-test/suite/compat/oracle/r/table_value_constr.result
+++ b/mysql-test/suite/compat/oracle/r/table_value_constr.result
@@ -774,24 +774,23 @@ explain extended select * from t1
 where a in (values (1) union select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
+4	DEPENDENT SUBQUERY	<derived2>	ref	key0	key0	4	func	2	100.00	
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+3	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((values (1) union /* select#3 */ select 2 AS "2") "__4") where "__4"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union /* select#3 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2))))
 explain extended select * from t1
 where a in (select * from (values (1)) as tvc_0 union 
 select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	<derived3>	ref	key0	key0	4	func	2	100.00	
 3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0" union /* select#4 */ select 2 AS "2") "__5") where "__5"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union /* select#4 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2))))
 # IN-subquery with VALUES structure(s) : UNION with VALUES on the second place
 select * from t1
 where a in (select 2 union values (1));
@@ -810,24 +809,23 @@ explain extended select * from t1
 where a in (select 2 union values (1));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	<derived3>	ref	key0	key0	4	func	2	100.00	
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 2 AS "2" union values (1)) "__4") where "__4"."2" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2) union /* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 explain extended select * from t1
 where a in (select 2 union 
 select * from (values (1)) tvc_0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	DEPENDENT UNION	<derived4>	ref	key0	key0	4	func	2	100.00	
 4	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 2 AS "2" union /* select#3 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0") "__5") where "__5"."2" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2) union /* select#3 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 # IN-subquery with VALUES structure(s) : UNION ALL
 select * from t1
 where a in (values (1) union all select b from t1);
@@ -848,22 +846,21 @@ explain extended select * from t1
 where a in (values (1) union all select b from t1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	5	test.t1.a	2	100.00	FirstMatch(t1)
+4	DEPENDENT SUBQUERY	<derived2>	ref	key0	key0	4	func	2	100.00	
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	
+3	DEPENDENT UNION	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((values (1) union all /* select#3 */ select "test"."t1"."b" AS "b" from "test"."t1") "__4") where "__4"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union all /* select#3 */ select "test"."t1"."b" from "test"."t1" where <cache>("test"."t1"."a") = "test"."t1"."b")))
 explain extended select * from t1
 where a in (select * from (values (1)) as tvc_0 union all 
 select b from t1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	5	test.t1.a	2	100.00	FirstMatch(t1)
-2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	<derived3>	ref	key0	key0	4	func	2	100.00	
 3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	
+4	DEPENDENT UNION	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0" union all /* select#4 */ select "test"."t1"."b" AS "b" from "test"."t1") "__5") where "__5"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union all /* select#4 */ select "test"."t1"."b" from "test"."t1" where <cache>("test"."t1"."a") = "test"."t1"."b")))
 # NOT IN subquery with VALUES structure(s) : simple case
 select * from t1 
 where a not in (values (1),(2));
@@ -911,24 +908,23 @@ explain extended select * from t1
 where a not in (values (1) union select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-4	DEPENDENT SUBQUERY	<derived2>	index_subquery	key0	key0	4	func	1	100.00	Using where; Full scan on NULL key
+4	DEPENDENT SUBQUERY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+3	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(<index_lookup>(<cache>("test"."t1"."a") in (temporary) on key0 where trigcond(<cache>("test"."t1"."a") = "__4"."1")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") = "tvc_0"."1") union /* select#3 */ select 2 having trigcond(<cache>("test"."t1"."a") = <ref_null_helper>(2)))))
 explain extended select * from t1
 where a not in (select * from (values (1)) as tvc_0 union 
 select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-5	DEPENDENT SUBQUERY	<derived2>	index_subquery	key0	key0	4	func	1	100.00	Using where; Full scan on NULL key
-2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
 3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(<index_lookup>(<cache>("test"."t1"."a") in (temporary) on key0 where trigcond(<cache>("test"."t1"."a") = "__5"."1")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") = "tvc_0"."1") union /* select#4 */ select 2 having trigcond(<cache>("test"."t1"."a") = <ref_null_helper>(2)))))
 # NOT IN subquery with VALUES structure(s) : UNION with VALUES on the second place
 select * from t1
 where a not in (select 2 union values (1));
@@ -947,24 +943,23 @@ explain extended select * from t1
 where a not in (select 2 union values (1));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-4	DEPENDENT SUBQUERY	<derived2>	index_subquery	key0	key0	4	func	1	100.00	Using where; Full scan on NULL key
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(<index_lookup>(<cache>("test"."t1"."a") in (temporary) on key0 where trigcond(<cache>("test"."t1"."a") = "__4"."2")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having trigcond(<cache>("test"."t1"."a") = <ref_null_helper>(2)) union /* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") = "tvc_0"."1"))))
 explain extended select * from t1
 where a not in (select 2 union 
 select * from (values (1)) as tvc_0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-5	DEPENDENT SUBQUERY	<derived2>	index_subquery	key0	key0	4	func	1	100.00	Using where; Full scan on NULL key
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	DEPENDENT UNION	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
 4	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(<index_lookup>(<cache>("test"."t1"."a") in (temporary) on key0 where trigcond(<cache>("test"."t1"."a") = "__5"."2")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where !<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having trigcond(<cache>("test"."t1"."a") = <ref_null_helper>(2)) union /* select#3 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") = "tvc_0"."1"))))
 # ANY-subquery with VALUES structure(s) : simple case
 select * from t1 
 where a = any (values (1),(2));
@@ -1014,24 +1009,23 @@ explain extended select * from t1
 where a = any (values (1) union select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
+4	DEPENDENT SUBQUERY	<derived2>	ref	key0	key0	4	func	2	100.00	
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+3	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((values (1) union /* select#3 */ select 2 AS "2") "__4") where "__4"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union /* select#3 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2))))
 explain extended select * from t1
 where a = any (select * from (values (1)) as tvc_0 union 
 select 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	<derived3>	ref	key0	key0	4	func	2	100.00	
 3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0" union /* select#4 */ select 2 AS "2") "__5") where "__5"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1" union /* select#4 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2))))
 # ANY-subquery with VALUES structure(s) : UNION with VALUES on the second place
 select * from t1
 where a = any (select 2 union values (1));
@@ -1050,24 +1044,23 @@ explain extended select * from t1
 where a = any (select 2 union values (1));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	<derived3>	ref	key0	key0	4	func	2	100.00	
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 2 AS "2" union values (1)) "__4") where "__4"."2" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2) union /* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 explain extended select * from t1
 where a = any (select 2 union 
 select * from (values (1)) as tvc_0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	DEPENDENT UNION	<derived4>	ref	key0	key0	4	func	2	100.00	
 4	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 2 AS "2" union /* select#3 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0") "__5") where "__5"."2" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 2 having <cache>("test"."t1"."a") = <ref_null_helper>(2) union /* select#3 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 # ALL-subquery with VALUES structure(s) : simple case
 select * from t1 
 where a = all (values (1));
@@ -1113,22 +1106,21 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
 4	DEPENDENT SUBQUERY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+3	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <not>(<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "__4"."1" from (values (1) union /* select#3 */ select 1 AS "1") "__4" where trigcond(<cache>("test"."t1"."a") <> "__4"."1")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <not>(<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") <> "tvc_0"."1") union /* select#3 */ select 1 having trigcond(<cache>("test"."t1"."a") <> <ref_null_helper>(1))))))
 explain extended select * from t1
 where a = all (select * from (values (1)) as tvc_0 union 
 select 1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-5	DEPENDENT SUBQUERY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
-2	DERIVED	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	<derived3>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
 3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <not>(<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#5 */ select "__5"."1" from (/* select#2 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0" union /* select#4 */ select 1 AS "1") "__5" where trigcond(<cache>("test"."t1"."a") <> "__5"."1")))))
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <not>(<expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select "tvc_0"."1" from (values (1)) "tvc_0" where trigcond(<cache>("test"."t1"."a") <> "tvc_0"."1") union /* select#4 */ select 1 having trigcond(<cache>("test"."t1"."a") <> <ref_null_helper>(1))))))
 # ALL-subquery with VALUES structure(s) : UNION with VALUES on the second place
 select * from t1
 where a = any (select 1 union values (1));
@@ -1145,24 +1137,23 @@ explain extended select * from t1
 where a = any (select 1 union values (1));
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+4	DEPENDENT UNION	<derived3>	ref	key0	key0	4	func	2	100.00	
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 1 AS "1" union values (1)) "__4") where "__4"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 1 having <cache>("test"."t1"."a") = <ref_null_helper>(1) union /* select#4 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 explain extended select * from t1
 where a = any (select 1 union 
 select * from (values (1)) as tvc_0);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	6	100.00	Using where
-1	PRIMARY	<derived2>	ref	key0	key0	4	test.t1.a	1	100.00	FirstMatch(t1)
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	<derived4>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	DEPENDENT UNION	<derived4>	ref	key0	key0	4	func	2	100.00	
 4	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" semi join ((/* select#2 */ select 1 AS "1" union /* select#3 */ select "tvc_0"."1" AS "1" from (values (1)) "tvc_0") "__5") where "__5"."1" = "test"."t1"."a"
+Note	1003	/* select#1 */ select "test"."t1"."a" AS "a","test"."t1"."b" AS "b" from "test"."t1" where <expr_cache><"test"."t1"."a">(<in_optimizer>("test"."t1"."a",<exists>(/* select#2 */ select 1 having <cache>("test"."t1"."a") = <ref_null_helper>(1) union /* select#3 */ select "tvc_0"."1" from (values (1)) "tvc_0" where <cache>("test"."t1"."a") = "tvc_0"."1")))
 # prepare statement that uses VALUES structure(s): single VALUES structure
 prepare stmt1 from '
 values (1,2);
@@ -1330,28 +1321,25 @@ select 1,2
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	
 explain
 values (1,2),(3,4)
 union
 select 1,2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	
 explain
 values (5,6)
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	
 explain format=json
 select 1,2
 union
@@ -1359,44 +1347,29 @@ values (1,2),(3,4);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 2,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain format=json
@@ -1406,44 +1379,29 @@ select 1,2;
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 2,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain format=json
@@ -1453,44 +1411,29 @@ values (1,2),(3,4);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 3,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain
@@ -1500,13 +1443,10 @@ values (3,4)
 union
 values (1,2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	3	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
-5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,5>	ALL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
 explain format=json
 select 1,2
 union
@@ -1516,78 +1456,38 @@ values (1,2);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived4>",
-          "access_type": "ALL",
-          "rows": 3,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union4,5>",
-                "access_type": "ALL",
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 4,
-                      "nested_loop": [
-                        {
-                          "table": {
-                            "table_name": "<derived2>",
-                            "access_type": "ALL",
-                            "rows": 2,
-                            "filtered": 100,
-                            "materialized": {
-                              "query_block": {
-                                "union_result": {
-                                  "table_name": "<union2,3>",
-                                  "access_type": "ALL",
-                                  "query_specifications": [
-                                    {
-                                      "query_block": {
-                                        "select_id": 2,
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "query_block": {
-                                        "select_id": 3,
-                                        "operation": "UNION",
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 5,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2,3>",
+      "access_type": "ALL",
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 3,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 # explain query that uses VALUES structure(s): UNION ALL with VALUES structure(s)
@@ -1596,26 +1496,23 @@ select 1,2
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	
 explain
 values (1,2),(3,4)
 union all
 select 1,2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 explain
 values (1,2)
 union all
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 explain format=json
 values (1,2),(3,4)
 union all
@@ -1623,42 +1520,27 @@ select 1,2;
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 2,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain format=json
@@ -1668,44 +1550,29 @@ values (1,2),(3,4);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 2,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain format=json
@@ -1715,42 +1582,27 @@ values (1,2),(3,4);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "rows": 3,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 explain
@@ -1760,11 +1612,9 @@ values (3,4)
 union all
 values (1,2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	3	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 explain format=json
 select 1,2
 union all
@@ -1774,74 +1624,36 @@ values (1,2);
 EXPLAIN
 {
   "query_block": {
-    "select_id": 1,
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived4>",
-          "access_type": "ALL",
-          "rows": 3,
-          "filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 4,
-                      "nested_loop": [
-                        {
-                          "table": {
-                            "table_name": "<derived2>",
-                            "access_type": "ALL",
-                            "rows": 2,
-                            "filtered": 100,
-                            "materialized": {
-                              "query_block": {
-                                "union_result": {
-                                  "query_specifications": [
-                                    {
-                                      "query_block": {
-                                        "select_id": 2,
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "query_block": {
-                                        "select_id": 3,
-                                        "operation": "UNION",
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 5,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 3,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 # analyze query that uses VALUES structure(s): single VALUES structure
@@ -1877,28 +1689,25 @@ select 1,2
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	2.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
 analyze
 values (1,2),(3,4)
 union
 select 1,2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	2.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
 analyze
 values (5,6)
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	3.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	3.00	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	3.00	NULL	NULL	
 analyze format=json
 select 1,2
 union
@@ -1909,53 +1718,31 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 2,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "r_loops": 1,
-                "r_rows": 2,
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "r_rows": 2,
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze format=json
@@ -1968,53 +1755,31 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 2,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "r_loops": 1,
-                "r_rows": 2,
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "r_rows": 2,
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze format=json
@@ -2027,53 +1792,31 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 3,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "r_loops": 1,
-                "r_rows": 3,
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "r_rows": 3,
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze
@@ -2083,13 +1826,10 @@ values (3,4)
 union
 values (1,2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	3	2.00	100.00	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	2.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
-5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,5>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
+NULL	UNION RESULT	<union1,2,3>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
 analyze format=json
 select 1,2
 union
@@ -2102,96 +1842,40 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived4>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 2,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union4,5>",
-                "access_type": "ALL",
-                "r_loops": 1,
-                "r_rows": 2,
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 4,
-                      "r_loops": 1,
-                      "r_total_time_ms": "REPLACED",
-                      "nested_loop": [
-                        {
-                          "table": {
-                            "table_name": "<derived2>",
-                            "access_type": "ALL",
-                            "r_loops": 1,
-                            "rows": 2,
-                            "r_rows": 2,
-                            "r_table_time_ms": "REPLACED",
-                            "r_other_time_ms": "REPLACED",
-                            "filtered": 100,
-                            "r_filtered": 100,
-                            "materialized": {
-                              "query_block": {
-                                "union_result": {
-                                  "table_name": "<union2,3>",
-                                  "access_type": "ALL",
-                                  "r_loops": 1,
-                                  "r_rows": 2,
-                                  "query_specifications": [
-                                    {
-                                      "query_block": {
-                                        "select_id": 2,
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "query_block": {
-                                        "select_id": 3,
-                                        "operation": "UNION",
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 5,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2,3>",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "r_rows": 2,
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 3,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 # analyze query that uses VALUES structure(s): UNION ALL with VALUES structure(s)
@@ -2200,26 +1884,23 @@ select 1,2
 union
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	2.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	2.00	NULL	NULL	
 analyze
 values (1,2),(3,4)
 union all
 select 1,2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	3.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 analyze
 values (1,2)
 union all
 values (1,2),(3,4);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	3.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 analyze format=json
 values (1,2),(3,4)
 union all
@@ -2230,49 +1911,27 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 3,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze format=json
@@ -2285,53 +1944,31 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 2,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "table_name": "<union2,3>",
-                "access_type": "ALL",
-                "r_loops": 1,
-                "r_rows": 2,
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "table_name": "<union1,2>",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "r_rows": 2,
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze format=json
@@ -2344,49 +1981,27 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived2>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 3,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 2,
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 3,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 analyze
@@ -2396,11 +2011,9 @@ values (3,4)
 union all
 values (1,2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	<derived4>	ALL	NULL	NULL	NULL	NULL	3	3.00	100.00	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	2	2.00	100.00	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-5	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 analyze format=json
 select 1,2
 union all
@@ -2413,88 +2026,36 @@ ANALYZE
     "r_total_time_ms": "REPLACED"
   },
   "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "nested_loop": [
-      {
-        "table": {
-          "table_name": "<derived4>",
-          "access_type": "ALL",
-          "r_loops": 1,
-          "rows": 3,
-          "r_rows": 3,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
-          "filtered": 100,
-          "r_filtered": 100,
-          "materialized": {
-            "query_block": {
-              "union_result": {
-                "query_specifications": [
-                  {
-                    "query_block": {
-                      "select_id": 4,
-                      "r_loops": 1,
-                      "r_total_time_ms": "REPLACED",
-                      "nested_loop": [
-                        {
-                          "table": {
-                            "table_name": "<derived2>",
-                            "access_type": "ALL",
-                            "r_loops": 1,
-                            "rows": 2,
-                            "r_rows": 2,
-                            "r_table_time_ms": "REPLACED",
-                            "r_other_time_ms": "REPLACED",
-                            "filtered": 100,
-                            "r_filtered": 100,
-                            "materialized": {
-                              "query_block": {
-                                "union_result": {
-                                  "query_specifications": [
-                                    {
-                                      "query_block": {
-                                        "select_id": 2,
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "query_block": {
-                                        "select_id": 3,
-                                        "operation": "UNION",
-                                        "table": {
-                                          "message": "No tables used"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "query_block": {
-                      "select_id": 5,
-                      "operation": "UNION",
-                      "table": {
-                        "message": "No tables used"
-                      }
-                    }
-                  }
-                ]
-              }
+    "union_result": {
+      "query_specifications": [
+        {
+          "query_block": {
+            "select_id": 1,
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 2,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
+            }
+          }
+        },
+        {
+          "query_block": {
+            "select_id": 3,
+            "operation": "UNION",
+            "table": {
+              "message": "No tables used"
             }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 }
 # different number of values in TVC
@@ -2699,12 +2260,11 @@ select 2 union (values (5), (7), (1), (3), (4) limit 2);
 7
 explain extended select 2 union (values (5), (7), (1), (3), (4) limit 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."2" AS "2" from (/* select#2 */ select 2 AS "2" union (values (5),(7),(1),(3),(4) limit 2)) "__3"
+Note	1003	/* select#1 */ select 2 AS "2" union (values (5),(7),(1),(3),(4) limit 2)
 select 2 union (values (5), (7), (1), (3), (4) limit 2 offset 1);
 2
 2
@@ -2712,12 +2272,11 @@ select 2 union (values (5), (7), (1), (3), (4) limit 2 offset 1);
 1
 explain extended select 2 union (values (5), (7), (1), (3), (4) limit 2 offset 1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."2" AS "2" from (/* select#2 */ select 2 AS "2" union (values (5),(7),(1),(3),(4) limit 1,2)) "__3"
+Note	1003	/* select#1 */ select 2 AS "2" union (values (5),(7),(1),(3),(4) limit 1,2)
 select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2);
 2
 2
@@ -2725,13 +2284,12 @@ select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2);
 3
 explain extended select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	UNION	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."2" AS "2" from (/* select#2 */ select 2 AS "2" union (/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)) "__3"
+Note	1003	/* select#1 */ select 2 AS "2" union (/* select#3 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)
 select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2 offset 1);
 2
 2
@@ -2739,13 +2297,12 @@ select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2 offset 1);
 4
 explain extended select 2 union (values (5), (7), (1), (3), (4) order by 1 limit 2 offset 1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	100.00	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	UNION	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."2" AS "2" from (/* select#2 */ select 2 AS "2" union (/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,2)) "__3"
+Note	1003	/* select#1 */ select 2 AS "2" union (/* select#3 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,2)
 (values (5), (7), (1), (3), (4) limit 2) union select 2;
 5
 5
@@ -2753,12 +2310,11 @@ Note	1003	/* select#1 */ select "__3"."2" AS "2" from (/* select#2 */ select 2 A
 2
 explain extended (values (5), (7), (1), (3), (4) limit 2) union select 2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 2) union /* select#3 */ select 2 AS "2") "__3"
+Note	1003	(values (5),(7),(1),(3),(4) limit 2) union /* select#2 */ select 2 AS "2"
 (values (5), (7), (1), (3), (4) limit 2 offset 1) union select 2;
 5
 7
@@ -2766,12 +2322,11 @@ Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(
 2
 explain extended (values (5), (7), (1), (3), (4) limit 2 offset 1) union select 2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 1,2) union /* select#3 */ select 2 AS "2") "__3"
+Note	1003	(values (5),(7),(1),(3),(4) limit 1,2) union /* select#2 */ select 2 AS "2"
 (values (5), (7), (1), (3), (4) order by 1 limit 2) union select 2;
 5
 1
@@ -2779,13 +2334,12 @@ Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(
 2
 explain extended (values (5), (7), (1), (3), (4) order by 1 limit 2) union select 2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2) union /* select#3 */ select 2 AS "2") "__3"
+Note	1003	(/* select#1 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2) union /* select#2 */ select 2 AS "2"
 (values (5), (7), (1), (3), (4) order by 1 limit 2 offset 1) union select 2;
 5
 3
@@ -2793,13 +2347,12 @@ Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "t
 2
 explain extended (values (5), (7), (1), (3), (4) order by 1 limit 2 offset 1) union select 2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	3	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,2) union /* select#3 */ select 2 AS "2") "__3"
+Note	1003	(/* select#1 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,2) union /* select#2 */ select 2 AS "2"
 select 3 union all (values (5), (7), (1), (3), (4) limit 2 offset 3);
 3
 3
@@ -2807,11 +2360,10 @@ select 3 union all (values (5), (7), (1), (3), (4) limit 2 offset 3);
 4
 explain extended select 3 union all (values (5), (7), (1), (3), (4) limit 2 offset 3);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__3"."3" AS "3" from (/* select#2 */ select 3 AS "3" union all (values (5),(7),(1),(3),(4) limit 3,2)) "__3"
+Note	1003	/* select#1 */ select 3 AS "3" union all (values (5),(7),(1),(3),(4) limit 3,2)
 (values (5), (7), (1), (3), (4) limit 2 offset 3) union all select 3;
 5
 3
@@ -2819,11 +2371,10 @@ Note	1003	/* select#1 */ select "__3"."3" AS "3" from (/* select#2 */ select 3 A
 3
 explain extended (values (5), (7), (1), (3), (4) limit 2 offset 3) union all select 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 3,2) union all /* select#3 */ select 3 AS "3") "__3"
+Note	1003	(values (5),(7),(1),(3),(4) limit 3,2) union all /* select#2 */ select 3 AS "3"
 select 3 union all (values (5), (7), (1), (3), (4) order by 1 limit 2);
 3
 3
@@ -2831,13 +2382,12 @@ select 3 union all (values (5), (7), (1), (3), (4) order by 1 limit 2);
 3
 explain extended select 3 union all (values (5), (7), (1), (3), (4) order by 1 limit 2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	UNION	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."3" AS "3" from (/* select#2 */ select 3 AS "3" union all (/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)) "__3"
+Note	1003	/* select#1 */ select 3 AS "3" union all (/* select#3 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)
 (values (5), (7), (1), (3), (4) order by 1 limit 2) union all select 3;
 5
 1
@@ -2845,13 +2395,12 @@ Note	1003	/* select#1 */ select "__3"."3" AS "3" from (/* select#2 */ select 3 A
 3
 explain extended (values (5), (7), (1), (3), (4) order by 1 limit 2) union all select 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2) union all /* select#3 */ select 3 AS "3") "__3"
+Note	1003	(/* select#1 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2) union all /* select#2 */ select 3 AS "3"
 ( values (5), (7), (1), (3), (4) limit 2 offset 1 )
 union
 ( values (5), (7), (1), (3), (4) order by 1 limit 2 );
@@ -2863,13 +2412,12 @@ explain extended ( values (5), (7), (1), (3), (4) limit 2 offset 1 )
 union
 ( values (5), (7), (1), (3), (4) order by 1 limit 2 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	7	100.00	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	UNION	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 1,2) union (/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)) "__3"
+Note	1003	(values (5),(7),(1),(3),(4) limit 1,2) union (/* select#3 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)
 ( values (5), (7), (1), (3), (4) limit 2 offset 1 )
 union all
 ( values (5), (7), (1), (3), (4) order by 1 limit 2 );
@@ -2882,13 +2430,12 @@ explain extended ( values (5), (7), (1), (3), (4) limit 2 offset 1 )
 union all
 ( values (5), (7), (1), (3), (4) order by 1 limit 2 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	7	100.00	
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+3	UNION	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
 2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-4	UNION	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union2,4>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+NULL	UNION RESULT	<union1,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 1,2) union all (/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)) "__3"
+Note	1003	(values (5),(7),(1),(3),(4) limit 1,2) union all (/* select#3 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 2)
 (values (5), (7), (1), (3), (4) limit 2 offset 3) union all select 3 order by 1;
 5
 3
@@ -2896,11 +2443,11 @@ Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(
 4
 explain extended (values (5), (7), (1), (3), (4) limit 2 offset 3) union all select 3 order by 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 3,2) union all /* select#3 */ select 3 AS "3") "__3" order by 1
+Note	1003	(values (5),(7),(1),(3),(4) limit 3,2) union all /* select#2 */ select 3 AS "3" order by 1
 (values (5), (7), (1), (3), (4) order by 1 limit 3 offset 1) union all select 3 order by 1;
 5
 3
@@ -2909,13 +2456,12 @@ Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((values (5),(7),(1),(3),(
 5
 explain extended (values (5), (7), (1), (3), (4) order by 1 limit 3 offset 1) union all select 3 order by 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	Using filesort
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,3) union all /* select#3 */ select 3 AS "3") "__3" order by 1
+Note	1003	(/* select#1 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,3) union all /* select#2 */ select 3 AS "3" order by 1
 (values (5), (7), (1), (3), (4) order by 1 limit 3 offset 1) union all select 3
 order by 1 limit 2 offset 1;
 5
@@ -2924,13 +2470,12 @@ order by 1 limit 2 offset 1;
 explain extended (values (5), (7), (1), (3), (4) order by 1 limit 3 offset 1) union all select 3
 order by 1 limit 2 offset 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	4	100.00	Using filesort
-4	DERIVED	<derived2>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
-2	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-3	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
-NULL	UNION RESULT	<union4,3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	
+1	PRIMARY	<derived3>	ALL	NULL	NULL	NULL	NULL	5	100.00	Using filesort
+3	DERIVED	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+2	UNION	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+NULL	UNION RESULT	<union1,2>	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select "__3"."5" AS "5" from ((/* select#4 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,3) union all /* select#3 */ select 3 AS "3") "__3" order by 1 limit 1,2
+Note	1003	(/* select#1 */ select "tvc_0"."5" AS "5" from (values (5),(7),(1),(3),(4)) "tvc_0" order by 1 limit 1,3) union all /* select#2 */ select 3 AS "3" order by 1 limit 1,2
 values (5,90), (7,20), (1,70), (3,50), (4,10) order by 3;
 ERROR 42S22: Unknown column '3' in 'ORDER BY'
 create view v1 as values (5), (7), (1), (3), (4) order by 1 limit 2;
@@ -2948,7 +2493,7 @@ union
 ( values (5), (7), (1), (3), (4) order by 1 limit 2 );
 show create view v1;
 View	Create View	character_set_client	collation_connection
-v1	CREATE VIEW "v1" AS select "__4"."5" AS "5" from (select "__5"."5" AS "5" from ((values (5),(7),(1),(3),(4) limit 1,2) union (values (5),(7),(1),(3),(4) order by 1 limit 2)) "__5") "__4"	latin1	latin1_swedish_ci
+v1	CREATE VIEW "v1" AS (values (5),(7),(1),(3),(4) limit 1,2) union (values (5),(7),(1),(3),(4) order by 1 limit 2)	latin1	latin1_swedish_ci
 select * from v1;
 5
 7

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -6524,14 +6524,15 @@ SELECT_LEX *LEX::create_priority_nest(SELECT_LEX *first_in_nest, SELECT_LEX *att
     wrapper->set_linkage_and_distinct(wr_unit_type, wr_distinct);
     if (attach_to)
     {
-      wrapper->first_nested= attach_to->first_nested;
+      /* wraps whole prefix -> wrapper heads a fresh chain */
+      bool wraps_whole_prefix= (attach_to->first_nested == first_in_nest);
+      wrapper->first_nested= wraps_whole_prefix ? wrapper
+                                                : attach_to->first_nested;
       wrapper->set_master_unit(attach_to->master_unit());
       attach_to->link_neighbour(wrapper);
     }
     else
-    {
       wrapper->first_nested= wrapper;
-    }
   }
   DBUG_RETURN(wrapper);
 }
@@ -10498,30 +10499,11 @@ SELECT_LEX_UNIT *LEX::parsed_select_expr_start(SELECT_LEX *s1, SELECT_LEX *s2,
   sel1->link_neighbour(sel2);
   sel2->set_linkage_and_distinct(unit_type, distinct);
   sel2->first_nested= sel1->first_nested= sel1;
-  const bool oracle= (thd->variables.sql_mode & IS_OR_WAS_ORACLE);
-  if (oracle &&
-      /*
-         Recursive CTE must have anchor defined as non-recursive set attached
-         via UNION, such anchor would be lost in wrapping. But in recursive CTE
-         all set operations either distinct or non-distinct
-         (see ER_NOT_SUPPORTED_YET limitation in st_select_lex_unit::prepare()),
-         so explicit prioritization via wrapping is not required.
-
-         Test: compat/oracle.func_concat
-      */
-      !(curr_with_clause && curr_with_clause->with_recursive) &&
-      !(sel1= create_priority_nest(sel1, NULL)))
-  {
-      return NULL;
-  }
   res= create_unit(sel1);
   if (res == NULL)
     return NULL;
   res->pre_last_parse= sel1;
-  if (oracle)
-    push_select(sel1);
-  else
-    push_select(res->fake_select_lex);
+  push_select(res->fake_select_lex);
   return res;
 }
 
@@ -10535,7 +10517,38 @@ SELECT_LEX_UNIT *LEX::parsed_select_expr_cont(SELECT_LEX_UNIT *unit,
   SELECT_LEX *sel1= s2;
   SELECT_LEX *last= unit->pre_last_parse->next_select();
 
-  int cmp= oracle? 0 : cmp_unit_op(unit_type, last->get_linkage());
+  int cmp;
+  if (oracle)
+  {
+    if (unit_type != last->get_linkage())
+    {
+      /*
+        Oracle: equal-priority, left-to-right. Wrap whole prefix on op change.
+        Recursive CTEs use a single operator, so never wrap here (anchor kept).
+      */
+      SELECT_LEX *first_in_nest= unit->first_select();
+      last->cut_next();
+      if ((last= create_priority_nest(first_in_nest, NULL)) == NULL)
+        return NULL;
+      /*
+        Order matters: register_select_chain() re-points unit->slave at the
+        wrapper. Only then can fix_distinct()/reset_distinct() scan the new
+        outer chain instead of the pre-wrap selects that now belong to the
+        derived table's inner unit. Otherwise union_distinct is left pointing
+        into the inner unit (stale, non-NULL). Since optimize_bag_operation()
+        is skipped in Oracle mode, that value survives to execution and makes
+        the outer result temp table de-duplicating (MY_TEST(union_distinct)),
+        dropping rows that a trailing UNION ALL must keep.
+      */
+      unit->register_select_chain(last);
+      unit->fix_distinct();
+    }
+    cmp= 0;
+  }
+  else
+  {
+    cmp= cmp_unit_op(unit_type, last->get_linkage());
+  }
   if (cmp == 0)
   {
     sel1->first_nested= last->first_nested;


### PR DESCRIPTION
MDEV-37325 unconditionally wrapped union subqueries in derived tables,
breaking name resolution of outer-scope/correlated references inside
the unions (producing ER_UNKNOWN_TABLE errors).

Delay the wrap until a following operator has a different linkage.
In Oracle mode all set operators share one priority and bind
left-to-right, so wrapping the accumulated prefix on each operator
change enforces it. This also corrects the row multiplicity of mixed
set operations toward left-to-right order.

create_priority_nest(): when the nest covers the whole prefix, point
the wrapper's first_nested at itself. Cut the prefix with
cut_next() before wrapping and re-register it on the outer unit;

Aleksey Midenkov:

In Oracle mode optimize_bag_operation() returns early, so union_distinct is
never recomputed and the stale value reaches execution.
Register the wrapper first, then run fix_distinct(): reset_distinct() now
scans the new outer chain (the wrapper alone) and correctly leaves
union_distinct NULL; a following DISTINCT operand re-establishes it.
