### PR TITLE
MDEV-37865: IF() function is returning incorrect error

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -5543,7 +5543,7 @@ static void primary(Expression_value *result, const char **s)
     enum func_type func_type= get_expr_function_type(start,
                                                      end - start);
     if (func_type == FUNC_UNKNOWN)
-      die("Syntax error: Unknown function");
+      die("Syntax error: Unknown function '%.*s'", (int) (end - start), start);
 
     *s= end + 1; // skip '('
     handle_expr_function_call(func_type, result, s);
@@ -5990,47 +5990,48 @@ static void expr(Expression_value *result, const char **s)
 
 static struct {
   const char *name;
+  size_t length;
   enum func_type type;
 } function_table[]= {
     // Numeric functions
-    {"abs", FUNC_ABS},
-    {"bin", FUNC_BIN},
-    {"conv", FUNC_CONV},
-    {"hex", FUNC_HEX},
-    {"oct", FUNC_OCT},
+    {STRING_WITH_LEN("abs"), FUNC_ABS},
+    {STRING_WITH_LEN("bin"), FUNC_BIN},
+    {STRING_WITH_LEN("conv"), FUNC_CONV},
+    {STRING_WITH_LEN("hex"), FUNC_HEX},
+    {STRING_WITH_LEN("oct"), FUNC_OCT},
     // String functions
-    {"concat", FUNC_CONCAT},
-    {"concat_ws", FUNC_CONCAT_WS},
-    {"greatest", FUNC_GREATEST},
-    {"insert", FUNC_INSERT},
-    {"instr", FUNC_INSTR},
-    {"lcase", FUNC_LOWER},
-    {"least", FUNC_LEAST},
-    {"length", FUNC_LENGTH},
-    {"locate", FUNC_LOCATE},
-    {"lower", FUNC_LOWER},
-    {"lpad", FUNC_LPAD},
-    {"ltrim", FUNC_LTRIM},
-    {"repeat", FUNC_REPEAT},
-    {"replace", FUNC_REPLACE},
-    {"reverse", FUNC_REVERSE},
-    {"rpad", FUNC_RPAD},
-    {"rtrim", FUNC_RTRIM},
-    {"substr", FUNC_SUBSTR},
-    {"substring", FUNC_SUBSTR},
-    {"substring_index", FUNC_SUBSTR_IDX},
-    {"trim", FUNC_TRIM},
-    {"ucase", FUNC_UPPER},
-    {"upper", FUNC_UPPER},
+    {STRING_WITH_LEN("concat"), FUNC_CONCAT},
+    {STRING_WITH_LEN("concat_ws"), FUNC_CONCAT_WS},
+    {STRING_WITH_LEN("greatest"), FUNC_GREATEST},
+    {STRING_WITH_LEN("insert"), FUNC_INSERT},
+    {STRING_WITH_LEN("instr"), FUNC_INSTR},
+    {STRING_WITH_LEN("lcase"), FUNC_LOWER},
+    {STRING_WITH_LEN("least"), FUNC_LEAST},
+    {STRING_WITH_LEN("length"), FUNC_LENGTH},
+    {STRING_WITH_LEN("locate"), FUNC_LOCATE},
+    {STRING_WITH_LEN("lower"), FUNC_LOWER},
+    {STRING_WITH_LEN("lpad"), FUNC_LPAD},
+    {STRING_WITH_LEN("ltrim"), FUNC_LTRIM},
+    {STRING_WITH_LEN("repeat"), FUNC_REPEAT},
+    {STRING_WITH_LEN("replace"), FUNC_REPLACE},
+    {STRING_WITH_LEN("reverse"), FUNC_REVERSE},
+    {STRING_WITH_LEN("rpad"), FUNC_RPAD},
+    {STRING_WITH_LEN("rtrim"), FUNC_RTRIM},
+    {STRING_WITH_LEN("substr"), FUNC_SUBSTR},
+    {STRING_WITH_LEN("substring"), FUNC_SUBSTR},
+    {STRING_WITH_LEN("substring_index"), FUNC_SUBSTR_IDX},
+    {STRING_WITH_LEN("trim"), FUNC_TRIM},
+    {STRING_WITH_LEN("ucase"), FUNC_UPPER},
+    {STRING_WITH_LEN("upper"), FUNC_UPPER},
     // Regexp functions
-    {"regexp_instr", FUNC_REGEXP_INSTR},
-    {"regexp_replace", FUNC_REGEXP_REPLACE},
-    {"regexp_substr", FUNC_REGEXP_SUBSTR},
+    {STRING_WITH_LEN("regexp_instr"), FUNC_REGEXP_INSTR},
+    {STRING_WITH_LEN("regexp_replace"), FUNC_REGEXP_REPLACE},
+    {STRING_WITH_LEN("regexp_substr"), FUNC_REGEXP_SUBSTR},
     // Null functions
-    {"coalesce", FUNC_COALESCE},
-    {"ifnull", FUNC_IFNULL},
-    {"nullif", FUNC_NULLIF},
-    {NULL, FUNC_UNKNOWN}
+    {STRING_WITH_LEN("coalesce"), FUNC_COALESCE},
+    {STRING_WITH_LEN("ifnull"), FUNC_IFNULL},
+    {STRING_WITH_LEN("nullif"), FUNC_NULLIF},
+    {NULL, 0, FUNC_UNKNOWN}
 };
 
 
@@ -7546,7 +7547,8 @@ enum func_type get_expr_function_type(const char *name, size_t len)
 {
   for (int i= 0; function_table[i].name; ++i)
   {
-    if (!strncasecmp(function_table[i].name, name, len))
+    if (function_table[i].length == len &&
+        !strncasecmp(function_table[i].name, name, len))
       return function_table[i].type;
   }
   return FUNC_UNKNOWN;

--- a/mysql-test/main/mysqltest_expression_evaluation.result
+++ b/mysql-test/main/mysqltest_expression_evaluation.result
@@ -505,4 +505,11 @@ mysqltest: At line 1: Evaluation error: Modulo by zero
 # Test case: Overflow
 mysqltest: At line 1: Range error: 18446744073709551616 value out of range for Integer type
 mysqltest: At line 1: Range error: 18446744073709551616 value out of range for Integer type
+#
+# MDEV-37865: IF() function is returning incorrect error
+#
+# Test case: unknown function name that is a prefix of a known one
+mysqltest: At line 1: Syntax error: Unknown function 'if'
+mysqltest: At line 1: Syntax error: Unknown function 'l'
 # Expression evaluation tests completed successfully
+# End of 10.6 tests

--- a/mysql-test/main/mysqltest_expression_evaluation.test
+++ b/mysql-test/main/mysqltest_expression_evaluation.test
@@ -894,4 +894,17 @@ let $large_xor = $(0x7FFFFFFFFFFFFFFF ^ 0x7FFFFFFFFFFFFFFE);
 --error 1
 --exec echo "let \$a = \$(-18446744073709551616);" | $MYSQL_TEST 2>&1
 
+--echo #
+--echo # MDEV-37865: IF() function is returning incorrect error
+--echo #
+
+--echo # Test case: unknown function name that is a prefix of a known one
+--error 1
+--exec echo "let \$a = \$(if(null, 'fallback', 'actual'));" | $MYSQL_TEST 2>&1
+
+--error 1
+--exec echo "let \$a = \$(l('AB'));" | $MYSQL_TEST 2>&1
+
 --echo # Expression evaluation tests completed successfully
+
+--echo # End of 10.6 tests


### PR DESCRIPTION
`get_expr_function_type()` compared a parsed function name against `function_table[]` using `strncasecmp()` bounded by the length of the parsed name. The comparison stopped at that length and never checked that the table entry ended there, so any name that is a prefix of a known function resolved to that function.

"if" matched "ifnull" and produced a misleading arity error. Names that prefixed a function with a compatible signature were worse and dispatched silently: `l("AB")` ran `lcase()`,`t("  x  ")` ran `trim()`. A typo in a test script ran a different function and the test still passed.

Store each entry's length in `function_table[]` with `STRING_WITH_LEN()` and require it to match the parsed length. Report the unmatched name in the "Unknown function" error.