### PR TITLE
MDEV-37859 mysqltest hex() fails on string arguments

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -6271,9 +6271,9 @@ void func_oct(Expression_value args[], int count, Expression_value *result)
   @param[out] result Expression_value to store result
 
   @details
-    Converts a number to hexadecimal representation.
     HEX(N) returns a string representation of the hexadecimal value of N.
     This is equivalent to CONV(N, 10, 16).
+    HEX(str) returns a hexadecimal representation of the bytes of str.
 
   @note Dies if argument count != 1
 */
@@ -6283,7 +6283,15 @@ void func_hex(Expression_value args[], int count, Expression_value *result)
   if (count != 1)
     die("hex() expects 1 argument, got %d", count);
 
-  convert_base_helper(args[0].to_string(), 10, 16, result);
+  if (args[0].is_numeric)
+    convert_base_helper(args[0].to_string(), 10, 16, result);
+  else
+  {
+    My_string str= args[0].to_string();
+    My_string hex_str;
+    hex_str.set_hex(str.ptr(), str.length());
+    result->set_string(hex_str.ptr(), hex_str.length());
+  }
 }
 
 

--- a/mysql-test/main/mysqltest_string_functions.result
+++ b/mysql-test/main/mysqltest_string_functions.result
@@ -1116,4 +1116,11 @@ insert(upper('hello world'), 7, 5, lower('MARIADB')) -> HELLO mariadb
 concat_ws(' ', upper('hello'), lower('WORLD')) -> HELLO world
 ifnull(nullif('same', 'same'), 'default') -> default
 coalesce(nullif('test', 'test'), 'backup') -> backup
+#
+# MDEV-37859: Mysqltest hex() not working for string values
+#
+hex("abc") -> 616263
+hex("255") -> 323535
+hex('') -> 
 # Expression evaluation string functions tests completed successfully
+# End of 10.6 tests

--- a/mysql-test/main/mysqltest_string_functions.test
+++ b/mysql-test/main/mysqltest_string_functions.test
@@ -2128,4 +2128,19 @@ let $result5 = $(ifnull(nullif('same', 'same'), 'default'));
 let $result6 = $(coalesce(nullif('test', 'test'), 'backup'));
 --echo coalesce(nullif('test', 'test'), 'backup') -> $result6
 
+--echo #
+--echo # MDEV-37859: Mysqltest hex() not working for string values
+--echo #
+
+let $hex_str1 = $(hex("abc"));
+--echo hex("abc") -> $hex_str1
+
+let $hex_str2 = $(hex("255"));
+--echo hex("255") -> $hex_str2
+
+let $hex_str3 = $(hex(''));
+--echo hex('') -> $hex_str3
+
 --echo # Expression evaluation string functions tests completed successfully
+
+--echo # End of 10.6 tests


### PR DESCRIPTION
`func_hex()` passed every argument through `convert_base_helper()`, which parses the argument as a base 10 number. A string argument therefore died with "invalid number 'abc' for base 10" instead of being converted.

`HEX()` is the only one of the base conversion functions that accepts a string. In the server `BIN()` and `OCT()` are built as `Item_func_conv()` with fixed bases and are numeric only, while `HEX()` has a dedicated Item with a separate string path, because `HEX()` is the counterpart of `UNHEX()` and has to serialise bytes.

Dispatch on the argument type: numeric arguments keep the existing `CONV(N, 10, 16)` behaviour, string arguments are converted byte by byte with `String::set_hex()`, which is the same call the server uses in `Item_func_hex::val_str_ascii_from_val_str()`.