### PR TITLE
MDEV-39050: Improve error message for missing table share in GetTableShare()

### DIFF
--- a/storage/connect/mysql-test/connect/r/unknown_db.result
+++ b/storage/connect/mysql-test/connect/r/unknown_db.result
@@ -1,0 +1,28 @@
+#
+# MDEV-39050 ConnectSE: improve table discovery error message when local database doesn't exist
+#
+DROP DATABASE IF EXISTS unknown_connect_db;
+Warnings:
+Note	1008	Can't drop database 'unknown_connect_db'; database doesn't exist
+CREATE TABLE t1 (id INT NOT NULL, name VARCHAR(32));
+INSERT INTO t1 VALUES (1, 'foo'), (2, 'bar');
+#
+# TABLE_TYPE=PROXY with DBNAME pointing to a non-existent database
+# should produce "Unknown database" instead of a generic discovery error
+#
+CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=PROXY TABNAME='t1' DBNAME='unknown_connect_db';
+ERROR HY000: Unknown database 'unknown_connect_db'
+#
+# Once the database and source table exist, discovery should succeed
+#
+CREATE DATABASE unknown_connect_db;
+CREATE TABLE unknown_connect_db.t1 (id INT NOT NULL, name VARCHAR(32));
+INSERT INTO unknown_connect_db.t1 VALUES (3, 'baz');
+CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=PROXY TABNAME='t1' DBNAME='unknown_connect_db';
+SELECT * FROM t2 ORDER BY id;
+id	name
+3	baz
+DROP TABLE t2;
+DROP TABLE t1;
+DROP TABLE unknown_connect_db.t1;
+DROP DATABASE unknown_connect_db;

--- a/storage/connect/mysql-test/connect/t/unknown_db.test
+++ b/storage/connect/mysql-test/connect/t/unknown_db.test
@@ -1,0 +1,37 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # MDEV-39050 ConnectSE: improve table discovery error message when local database doesn't exist
+--echo #
+
+# Ensure the test database does not exist
+DROP DATABASE IF EXISTS unknown_connect_db;
+
+# Create a source table to proxy
+CREATE TABLE t1 (id INT NOT NULL, name VARCHAR(32));
+INSERT INTO t1 VALUES (1, 'foo'), (2, 'bar');
+
+--echo #
+--echo # TABLE_TYPE=PROXY with DBNAME pointing to a non-existent database
+--echo # should produce "Unknown database" instead of a generic discovery error
+--echo #
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=PROXY TABNAME='t1' DBNAME='unknown_connect_db';
+
+--echo #
+--echo # Once the database and source table exist, discovery should succeed
+--echo #
+
+CREATE DATABASE unknown_connect_db;
+CREATE TABLE unknown_connect_db.t1 (id INT NOT NULL, name VARCHAR(32));
+INSERT INTO unknown_connect_db.t1 VALUES (3, 'baz');
+
+CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=PROXY TABNAME='t1' DBNAME='unknown_connect_db';
+SELECT * FROM t2 ORDER BY id;
+
+# Cleanup
+DROP TABLE t2;
+DROP TABLE t1;
+DROP TABLE unknown_connect_db.t1;
+DROP DATABASE unknown_connect_db;

--- a/storage/connect/tabutil.cpp
+++ b/storage/connect/tabutil.cpp
@@ -14,6 +14,7 @@
 #include "sql_class.h"
 #include "table.h"
 #include "field.h"
+#include "sql_db.h"
 #if defined(_WIN32)
 #include <stdlib.h>
 #include <stdio.h>
@@ -109,7 +110,12 @@ TABLE_SHARE *GetTableShare(PGLOBAL g, THD *thd, const char *db,
     if (thd->is_error())
       thd->clear_error();  // Avoid stopping info commands
 
-    snprintf(g->Message, sizeof(g->Message), "Error %d opening share", s->error);
+    if (s->error == OPEN_FRM_OPEN_ERROR && s->open_errno == ENOENT &&
+        check_db_dir_existence(db))
+      snprintf(g->Message, sizeof(g->Message), "Unknown database '%s'", db);
+    else
+      snprintf(g->Message, sizeof(g->Message), "Error %d opening share", s->error);
+
     free_table_share(s);
     return NULL;
   } // endif open_table_def


### PR DESCRIPTION
Handle the case in tabutil.cpp where GetTableShare() must report an error after open_table_def() has already failed.
open_table_def() stores the underlying system error in s->open_errno before returning, so if opening the .frm file fails with ENOENT, that information is preserved on the share. We use these recorded values to determine the most appropriate error message:
1. s->error == OPEN_FRM_OPEN_ERROR indicates the table definition file failed to open.
2. s->open_errno == ENOENT indicates the failure was due to a "not found" condition.
3. check_db_dir_existence(db) then distinguishes whether the missing path corresponds to an unknown database, versus a generic open/share error.