### PR TITLE
MDEV-37224 Remove UBSAN limitation from MTR tests

### DIFF
--- a/mysql-test/suite/plugins/t/multiauth.test
+++ b/mysql-test/suite/plugins/t/multiauth.test
@@ -1,5 +1,3 @@
---source include/not_ubsan.inc
-
 let $REGEX_VERSION_ID=/$mysql_get_server_version/VERSION_ID/;
 let $REGEX_PASSWORD_LAST_CHANGED=/password_last_changed": [0-9]*/password_last_changed": #/;
 let $REGEX_GLOBAL_PRIV=$REGEX_PASSWORD_LAST_CHANGED $REGEX_VERSION_ID;

--- a/mysql-test/suite/sys_vars/t/thread_stack_basic.test
+++ b/mysql-test/suite/sys_vars/t/thread_stack_basic.test
@@ -1,20 +1,18 @@
 #
 # only global
 #
---source include/not_asan.inc
---source include/not_ubsan.inc
---source include/not_msan.inc
---replace_result 392192 299008
+# sizes per DEFAULT_THREAD_STACK in include/my_pthread.h
+--replace_result 11534336 299008 2097152 299008
 select @@global.thread_stack;
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 select @@session.thread_stack;
---replace_result 392192 299008
+--replace_result 11534336 299008 2097152 299008
 show global variables like 'thread_stack';
---replace_result 392192 299008
+--replace_result 11534336 299008 2097152 299008
 show session variables like 'thread_stack';
---replace_result 392192 299008
+--replace_result 11534336 299008 2097152 299008
 select * from information_schema.global_variables where variable_name='thread_stack';
---replace_result 392192 299008
+--replace_result 11534336 299008 2097152 299008
 select * from information_schema.session_variables where variable_name='thread_stack';
 
 #


### PR DESCRIPTION
There's no good reason why undefined behaviour is
acceptable in our codebase let alone having a test that triggers this.

The thread_stack_basic test because of compulation has a different stack size under UBSAN. With replace_results we can include all values of the default stack size in this test.

plugins.multiauth was added in 031f11717d9f before CONC-730 and MDEV-31379 corrected the ref10 implementaiton.