### PR TITLE
MDEV-40585 Assertion `(data_len == 0) == (data_ptr == ((void *)0))' fails in hp_flush_unaliased_blob_free

### DIFF
--- a/mysql-test/suite/heap/blob_empty_compressed.result
+++ b/mysql-test/suite/heap/blob_empty_compressed.result
@@ -1,0 +1,69 @@
+#
+# Writing an empty COMPRESSED blob into a HEAP table right after a
+# delete or update parked the old row's blob chain for deferred free.
+#
+# Field_blob_compressed::store() leaves a stale non-NULL data pointer
+# in the record buffer when storing a zero-length value, unlike plain
+# Field_blob::store() which zeroes the whole pack.  The engine must
+# decide everything from the stored length and never trust the pointer
+# of a zero-length blob.
+#
+#
+# REPLACE over an existing row (delete + re-insert path)
+#
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+DROP TABLE t;
+#
+# DELETE followed by INSERT of an empty compressed blob
+#
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+DELETE FROM t;
+INSERT INTO t VALUES (2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+2	0
+DROP TABLE t;
+#
+# INSERT ON DUPLICATE KEY UPDATE (update parks, next insert flushes)
+#
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+INSERT INTO t VALUES (1,''),(2,'')
+ON DUPLICATE KEY UPDATE b = VALUES(b);
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+DROP TABLE t;
+#
+# Two blob columns: one parked chain adopted by a non-empty value,
+# the other column written empty in the same statement
+#
+CREATE TABLE t (id INT PRIMARY KEY, b1 TEXT COMPRESSED, b2 TEXT COMPRESSED)
+ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo','bar');
+REPLACE INTO t VALUES (1,'','quux'),(2,'','');
+SELECT id, LENGTH(b1), LENGTH(b2) FROM t ORDER BY id;
+id	LENGTH(b1)	LENGTH(b2)
+1	0	4
+2	0	0
+DROP TABLE t;
+#
+# Plain TEXT control: empty value stores a NULL pointer, must keep
+# working the same way
+#
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+DROP TABLE t;

--- a/mysql-test/suite/heap/blob_empty_compressed.test
+++ b/mysql-test/suite/heap/blob_empty_compressed.test
@@ -1,0 +1,60 @@
+--echo #
+--echo # Writing an empty COMPRESSED blob into a HEAP table right after a
+--echo # delete or update parked the old row's blob chain for deferred free.
+--echo #
+--echo # Field_blob_compressed::store() leaves a stale non-NULL data pointer
+--echo # in the record buffer when storing a zero-length value, unlike plain
+--echo # Field_blob::store() which zeroes the whole pack.  The engine must
+--echo # decide everything from the stored length and never trust the pointer
+--echo # of a zero-length blob.
+--echo #
+
+--echo #
+--echo # REPLACE over an existing row (delete + re-insert path)
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+DROP TABLE t;
+
+--echo #
+--echo # DELETE followed by INSERT of an empty compressed blob
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+DELETE FROM t;
+INSERT INTO t VALUES (2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+DROP TABLE t;
+
+--echo #
+--echo # INSERT ON DUPLICATE KEY UPDATE (update parks, next insert flushes)
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+INSERT INTO t VALUES (1,''),(2,'')
+  ON DUPLICATE KEY UPDATE b = VALUES(b);
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+DROP TABLE t;
+
+--echo #
+--echo # Two blob columns: one parked chain adopted by a non-empty value,
+--echo # the other column written empty in the same statement
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b1 TEXT COMPRESSED, b2 TEXT COMPRESSED)
+  ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo','bar');
+REPLACE INTO t VALUES (1,'','quux'),(2,'','');
+SELECT id, LENGTH(b1), LENGTH(b2) FROM t ORDER BY id;
+DROP TABLE t;
+
+--echo #
+--echo # Plain TEXT control: empty value stores a NULL pointer, must keep
+--echo # working the same way
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+DROP TABLE t;

--- a/mysql-test/suite/heap/blob_empty_repl.result
+++ b/mysql-test/suite/heap/blob_empty_repl.result
@@ -1,0 +1,49 @@
+include/master-slave.inc
+[connection master]
+#
+# Row-based replication of an empty blob into a HEAP table.
+#
+# Field_blob::unpack() points a zero-length blob at the replication
+# event buffer instead of storing a NULL pointer, so the applier hands
+# the engine a record with LENGTH() = 0 and a non-NULL data pointer
+# even for a plain, uncompressed column.  The engine must decide
+# everything from the stored length when it redeems blob chains parked
+# by the delete or update earlier in the same event group.
+#
+#
+# REPLACE (delete + re-insert events)
+#
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+connection slave;
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+connection master;
+#
+# INSERT ON DUPLICATE KEY UPDATE (update event parks, write event
+# flushes)
+#
+CREATE TABLE t2 (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t2 VALUES (1,'foo');
+INSERT INTO t2 VALUES (1,''),(2,'')
+ON DUPLICATE KEY UPDATE b = VALUES(b);
+SELECT id, LENGTH(b) FROM t2 ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+connection slave;
+SELECT id, LENGTH(b) FROM t2 ORDER BY id;
+id	LENGTH(b)
+1	0
+2	0
+connection master;
+DROP TABLE t, t2;
+connection slave;
+include/rpl_end.inc

--- a/mysql-test/suite/heap/blob_empty_repl.test
+++ b/mysql-test/suite/heap/blob_empty_repl.test
@@ -1,0 +1,44 @@
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+--echo #
+--echo # Row-based replication of an empty blob into a HEAP table.
+--echo #
+--echo # Field_blob::unpack() points a zero-length blob at the replication
+--echo # event buffer instead of storing a NULL pointer, so the applier hands
+--echo # the engine a record with LENGTH() = 0 and a non-NULL data pointer
+--echo # even for a plain, uncompressed column.  The engine must decide
+--echo # everything from the stored length when it redeems blob chains parked
+--echo # by the delete or update earlier in the same event group.
+--echo #
+
+--echo #
+--echo # REPLACE (delete + re-insert events)
+--echo #
+CREATE TABLE t (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t VALUES (1,'foo');
+REPLACE INTO t VALUES (1,''),(2,'');
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+
+--sync_slave_with_master
+SELECT id, LENGTH(b) FROM t ORDER BY id;
+--connection master
+
+--echo #
+--echo # INSERT ON DUPLICATE KEY UPDATE (update event parks, write event
+--echo # flushes)
+--echo #
+CREATE TABLE t2 (id INT PRIMARY KEY, b TEXT) ENGINE=HEAP;
+INSERT INTO t2 VALUES (1,'foo');
+INSERT INTO t2 VALUES (1,''),(2,'')
+  ON DUPLICATE KEY UPDATE b = VALUES(b);
+SELECT id, LENGTH(b) FROM t2 ORDER BY id;
+
+--sync_slave_with_master
+SELECT id, LENGTH(b) FROM t2 ORDER BY id;
+--connection master
+
+DROP TABLE t, t2;
+--sync_slave_with_master
+
+--source include/rpl_end.inc

--- a/storage/heap/hp_blob.c
+++ b/storage/heap/hp_blob.c
@@ -194,13 +194,18 @@ void hp_flush_unaliased_blob_free(HP_INFO *info, const uchar *record)
     data_len= hp_blob_length(desc, record);
     memcpy(&data_ptr, record + desc->offset + desc->packlength,
            sizeof(data_ptr));
-    DBUG_ASSERT((data_len == 0) == (data_ptr == NULL));
+    DBUG_ASSERT(data_len == 0 || data_ptr != NULL);
 
     /*
       Test the length, not the pointer: hp_write_blobs() decides the same
       question the same way, and the two have to agree on which columns can
       source a parked chain.  A column they disagreed about would leave a
       chain parked that nothing will ever adopt.
+
+      The pointer of a zero-length blob is not necessarily NULL: the SQL
+      layer leaves a stale non-NULL pointer behind when storing an empty
+      compressed value (Field_blob_compressed::store) and when applying a
+      row-based replication event (Field_blob::unpack).
     */
     if (data_len != 0 && hp_blob_sources_chain(share, data_ptr, *chain_pos))
     {


### PR DESCRIPTION
## MDEV-40585 Assertion `(data_len == 0) == (data_ptr == ((void *)0))' fails in hp_flush_unaliased_blob_free

Debug-only regression from the MDEV-40523 chain-adoption fix. `hp_flush_unaliased_blob_free()` asserted that a zero-length blob in the record buffer carries a `NULL` data pointer. The SQL layer does not guarantee that direction of the invariant.

```sql
CREATE TABLE t (id INT PRIMARY KEY, b TEXT COMPRESSED) ENGINE=HEAP;
INSERT INTO t VALUES (1,'foo');
REPLACE INTO t VALUES (1,''),(2,'');   -- asserts on a debug build
```

### Cause

Two producers leave `(length = 0, ptr != NULL)` in the record buffer:

- **`Field_blob_compressed::store()`** of a zero-length value allocates its scratch `String` first and then stores `(length = 0, ptr = value.ptr())`, leaving a stale non-`NULL` pointer. Plain `Field_blob::store()` zeroes the whole pack instead, which is why an uncompressed column does not reproduce this through SQL.
- **`Field_blob::unpack()`** points a zero-length blob at the row-based replication event buffer, so the applier trips the same assertion on a slave-side `HEAP` table with a plain, uncompressed column.

The assertion evaluates only for a column whose old chain was parked for deferred free, so the failing statement must both park a chain and write a zero-length blob: `REPLACE` over an existing row, `INSERT ... ON DUPLICATE KEY UPDATE`, or one replicated row-event group doing the same. A delete and an insert in separate statements redeem the parking through the record-less `hp_flush_pending_blob_free_impl()` and are unaffected.

Release builds are unaffected and store no wrong data: every decision in the engine -- in `hp_write_blobs()`, in the release path of `hp_flush_unaliased_blob_free()`, and in `heap_update()` -- tests the stored length and never the pointer, and `hp_write_blobs()` zeroes the stored pointer for a zero-length column. The `hp_update.c` comment already documented that stale zero-length SQL-layer pointers exist.

### Fix

Keep the direction that is guaranteed, a non-empty blob must have a data pointer, and drop the reverse implication:

```c
DBUG_ASSERT(data_len == 0 || data_ptr != NULL);
```

### Tests

`heap.blob_empty_compressed` covers the SQL paths: the `REPLACE` repro, `DELETE` followed by `INSERT` of an empty value in separate statements (statement-boundary flush), `INSERT ... ON DUPLICATE KEY UPDATE`, two compressed columns where one parked chain is adopted while the other is written empty in the same statement, and a plain `TEXT` control. The result files verify data, not just survival: empty blobs read back as `LENGTH() = 0` and the adopted column keeps its value.

`heap.blob_empty_repl` covers the applier producer with a plain, uncompressed column: a replicated `REPLACE` (delete + write events) and a replicated `ON DUPLICATE KEY UPDATE` (update event parks, write event flushes), with slave contents checked against the master. The slave asserted on both before the fix.

Both tests were written before the fix and verified to fail against it. The tests need no debug build to run; on a release build they remain functional coverage of the empty-blob paths.

### Verification

- `heap` suite: 39/39.
- HEAP unit tests (ctest): 9/9.
