### PR TITLE
MDEV-40596 clang-23 reports unused global variables

### DIFF
--- a/mysys/thr_lock.c
+++ b/mysys/thr_lock.c
@@ -1651,7 +1651,6 @@ int lock_counts[]= {sizeof(test_0)/sizeof(struct st_test),
 static mysql_cond_t COND_thread_count;
 static mysql_mutex_t LOCK_thread_count;
 static uint thread_count;
-static ulong sum=0;
 
 #define MAX_LOCK_COUNT 8
 #define TEST_TIMEOUT 100000
@@ -1678,6 +1677,7 @@ static my_bool test_check_status(void* param __attribute__((unused)))
   return 0;
 }
 
+#include "my_cpu.h"
 
 static void *test_thread(void *arg)
 {
@@ -1711,7 +1711,7 @@ static void *test_thread(void *arg)
       {
 	ulong k;
 	for (k=0 ; k < (ulong) (tmp-2)*100000L ; k++)
-	  sum+=k;
+	  MY_RELAX_CPU();
       }
     }
     mysql_mutex_unlock(&LOCK_thread_count);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -868,8 +868,10 @@ static int cleanup_done;
 static ulong opt_specialflag;
 READ_ONLY_SYSVAR char *mysql_home_ptr;
 READ_ONLY_SYSVAR char *pidfile_name_ptr;
+#ifdef EMBEDDED_LIBRARY
 /** Initial command line arguments (count), after load_defaults().*/
 static int defaults_argc;
+#endif
 /**
   Initial command line arguments (arguments), after load_defaults().
   This memory is allocated by @c load_defaults() and should be freed
@@ -1538,7 +1540,6 @@ static void charset_error_reporter(enum loglevel level,
 C_MODE_END
 
 struct passwd *user_info;
-static pthread_t select_thread;
 #endif
 
 /* OS specific variables */
@@ -5781,7 +5782,6 @@ static void test_lc_time_sz()
 
 static void run_main_loop()
 {
-  select_thread=pthread_self();
   mysql_mutex_lock(&LOCK_start_thread);
   select_thread_in_use=1;
   mysql_mutex_unlock(&LOCK_start_thread);
@@ -5831,7 +5831,9 @@ int mysqld_main(int argc, char **argv)
   orig_argv= argv;
   my_defaults_mark_files= TRUE;
   load_defaults_or_exit(MYSQL_CONFIG_NAME, load_default_groups, &argc, &argv);
+#ifdef EMBEDDED_LIBRARY
   defaults_argc= argc;
+#endif
   defaults_argv= argv;
   remaining_argc= argc;
   remaining_argv= argv;

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -332,7 +332,6 @@ static int dtype_sql_name(unsigned mtype, unsigned prtype, unsigned len,
     return snprintf(name, name_sz, "%s%s%s", Main, Unsigned, Not_null);
 }
 
-static bool innodb_table_stats_not_found;
 static bool innodb_index_stats_not_found;
 static bool innodb_table_stats_not_found_reported;
 static bool innodb_index_stats_not_found_reported;
@@ -363,7 +362,6 @@ dict_table_schema_check(
 			if (innodb_table_stats_not_found_reported) {
 				return DB_STATS_DO_NOT_EXIST;
 			}
-			innodb_table_stats_not_found = true;
 			innodb_table_stats_not_found_reported = true;
 		} else {
 			ut_ad(req_schema == &index_stats_schema);

--- a/storage/maria/ma_checkpoint.c
+++ b/storage/maria/ma_checkpoint.c
@@ -53,9 +53,6 @@ static PAGECACHE_FILE *dfiles, /**< data files to flush in background */
   *dfiles_end; /**< list of data files ends here */
 static PAGECACHE_FILE *kfiles, /**< index files to flush in background */
   *kfiles_end; /**< list of index files ends here */
-/* those two statistics below could serve in SHOW GLOBAL STATUS */
-static uint checkpoints_total= 0, /**< all checkpoint requests made */
-  checkpoints_ok_total= 0; /**< all checkpoints which succeeded */
 
 struct st_filter_param
 {
@@ -314,8 +311,6 @@ end:
     my_free(record_pieces[i].str);
   mysql_mutex_lock(&LOCK_checkpoint);
   checkpoint_in_progress= CHECKPOINT_NONE;
-  checkpoints_total++;
-  checkpoints_ok_total+= !error;
   mysql_mutex_unlock(&LOCK_checkpoint);
   DBUG_RETURN(error);
 }


### PR DESCRIPTION
Let us remove a number of unused variables to suppress `-Wunused-but-set-global` and other warnings.

`test_thread()`: Instead of incrementing a global counter in a race condition prone fashion, invoke `MY_RELAX_CPU()` in order to spend some time.