### PR TITLE
Fix galera SST-abort tests to allow exit code 0 on some platforms

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_mariabackup_missing_ssl.test
+++ b/mysql-test/suite/galera/t/galera_sst_mariabackup_missing_ssl.test
@@ -34,8 +34,9 @@ call mtr.add_suppression("WSREP: Will never receive state. Need to abort.");
 --remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
 
 --echo # Start node_2 with SSL cert/key simulated as missing
-# Abort exit code varies by platform.
---error 1,134
+# Joiner mariadbd exits when SST is aborted; the exit code varies by
+# platform (clean 0 on some systems, signalled 134 / 1 on others).
+--error 0,1,134
 --exec MTR_SST_SIMULATE_NO_SSL_CERT=1 $MYSQLD_LAST_CMD
 --echo # node_2 failed to start, as expected
 

--- a/mysql-test/suite/galera/t/galera_sst_rsync_missing_stunnel.test
+++ b/mysql-test/suite/galera/t/galera_sst_rsync_missing_stunnel.test
@@ -31,8 +31,9 @@ call mtr.add_suppression("WSREP: Will never receive state. Need to abort.");
 --remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
 
 --echo # Start node_2 with stunnel simulated as missing
-# Abort exit code
---error 1,134
+# Joiner mariadbd exits when SST is aborted; the exit code varies by
+# platform (clean 0 on some systems, signalled 134 / 1 on others).
+--error 0,1,134
 --exec MTR_SST_SIMULATE_NO_STUNNEL=1 $MYSQLD_LAST_CMD
 --echo # node_2 failed to start, as expected
 


### PR DESCRIPTION
Issue: galera_sst_mariabackup_missing_ssl and galera_sst_rsync_missing_stunnel only accepted exit codes 1,134 when the joiner mariadbd aborts SST, causing intermittent failures (e.g. on FreeBSD) where the process exits cleanly with 0.

Solution: accept exit code 0 as well, matching the precedent already established in galera_sst_cn_injection.test / galera_sst_mariabackup_encrypt_with_key_server.test.