### PR TITLE
MDEV-40122: `+DEFAULT` is not a valid value for master_heartbeat_period

### DIFF
--- a/mysql-test/main/change_master_default.result
+++ b/mysql-test/main/change_master_default.result
@@ -258,6 +258,11 @@ master_ssl_crlpath
 using_gtid	Slave_Pos
 master_retry_count	100000
 slave_heartbeat_period	60.000
+#
+# MDEV-40122: `+DEFAULT` is not a valid value for master_heartbeat_period
+#
+CHANGE MASTER TO master_heartbeat_period= +DEFAULT;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'DEFAULT' at line 1
 # Clean-up
 DROP PROCEDURE show_defaultable_fields;
 RESET SLAVE 'unset' ALL;

--- a/mysql-test/main/change_master_default.test
+++ b/mysql-test/main/change_master_default.test
@@ -138,6 +138,15 @@ FROM information_schema.slave_status ORDER BY connection_name;
 --query_vertical CALL show_defaultable_fields()
 
 
+--echo #
+--echo # MDEV-40122: `+DEFAULT` is not a valid value for master_heartbeat_period
+--echo #
+
+# The `+` prefix may only precede a numeric literal, not `DEFAULT`
+--error ER_PARSE_ERROR
+CHANGE MASTER TO master_heartbeat_period= +DEFAULT;
+
+
 --echo # Clean-up
 
 DROP PROCEDURE show_defaultable_fields;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -2423,14 +2423,14 @@ master_def:
             { mi->master_ssl_crlpath= path; };
           }
 
-        | MASTER_HEARTBEAT_PERIOD_SYM '=' opt_plus num_or_default
+        | MASTER_HEARTBEAT_PERIOD_SYM '=' num_or_default
           {
-            if ($4)
+            if ($3)
             {
               uint32_t milliseconds;
               bool overprecise;
               auto decimal_buf= my_decimal(),
-                  *decimal= $4->val_decimal(&decimal_buf);
+                  *decimal= $3->val_decimal(&decimal_buf);
               DBUG_ASSERT(decimal);
               if (Master_info_file::Heartbeat_period_value::from_decimal(
                 milliseconds, *decimal, overprecise
@@ -2490,7 +2490,7 @@ master_use_gtid_enum:
         | DEFAULT         { $$= enum_master_use_gtid::DEFAULT; }
         ;
 num_or_default:
-          NUM_literal { DBUG_ASSERT($$); }
+          opt_plus NUM_literal { DBUG_ASSERT($2); $$= $2; }
         | DEFAULT { $$= nullptr; }
         ;
 


### PR DESCRIPTION
## Summary

`CHANGE MASTER TO master_heartbeat_period= +DEFAULT;` was accepted as valid syntax (equivalent to `= DEFAULT`). It now produces a syntax error again.

This is a mismerge of MDEV-38454 into MDEV-28302:
- MDEV-28302 changed the rule to `MASTER_HEARTBEAT_PERIOD_SYM '=' num_or_default`, adding `DEFAULT` support.
- MDEV-38454 added `opt_plus` (to allow values like `+60`) on top of it, resulting in `opt_plus num_or_default`, which also accepts `+DEFAULT`.

## Fix

Move `opt_plus` into `num_or_default`'s definition in `sql/sql_yacc.yy`, so the `+` prefix may only precede a numeric literal:

- `num_or_default := opt_plus NUM_literal | DEFAULT`

`master_heartbeat_period= +45` and `= DEFAULT` still work; `+DEFAULT` is rejected with `ER_PARSE_ERROR`.

Note: 11.4 and 11.8 use `opt_plus NUM_literal` (no `DEFAULT` at all), so they are not affected; the bug only exists on the 12.x line.

## Test

Extended `mysql-test/main/change_master_default.test` (the MDEV-28302 test) with a regression case for `+DEFAULT`. The `+`-with-a-number and `DEFAULT` cases are already covered by MDEV-38454's `rpl_heartbeat_basic` and earlier in this file respectively. Verified with:

```
./mariadb-test-run.pl --suite=main change_master_default ps_change_master
```

Both tests pass (the generated parser is rebuilt from `sql_yacc.yy` at build time).

Jira: https://jira.mariadb.org/browse/MDEV-40122

This contribution is licensed under the 3-clause BSD license.
