### PR TITLE
MDEV-32401 expression cache lead to crash if table of wrong type created and the cache switched off

### DIFF
--- a/mysql-test/main/subselect_cache.result
+++ b/mysql-test/main/subselect_cache.result
@@ -3812,6 +3812,78 @@ pk	b
 29	3
 drop view v1;
 drop table t1,t2,t3,t4;
+#
+# MDEV-32401
+#
+CREATE TABLE t0 (c TEXT);
+INSERT INTO t0 VALUES (71), (-79);
+SELECT t1.d FROM (SELECT c AS d FROM t0) AS t1 JOIN t0 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+d
+71
+-79
+71
+-79
+EXPLAIN EXTENDED SELECT t1.d FROM (SELECT c AS d FROM t0) AS t1 JOIN t0 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using join buffer (flat, BNL join)
+3	DEPENDENT SUBQUERY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using temporary; Using filesort
+4	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+Warnings:
+Note	1276	Field or reference 'd' of SELECT #4 was resolved in SELECT #1
+Note	1981	Aggregate function 'bit_or()' of SELECT #4 belongs to SELECT #3
+Note	1276	Field or reference 'd' of SELECT #3 was resolved in SELECT #1
+Note	1003	/* select#1 */ select `test`.`t0`.`c` AS `d` from `test`.`t0` join `test`.`t0` where <expr_cache><`test`.`t0`.`c`>((/* select#3 */ select ord(<expr_cache><`test`.`t0`.`c`,bit_or(`test`.`t0`.`c`),bit_or(`test`.`t0`.`c`)>((/* select#4 */ select bit_or(`test`.`t0`.`c`)))) from `test`.`t0` group by `test`.`t0`.`c`))
+SELECT t1.d FROM (SELECT CAST(c as int) AS d FROM t0) AS t1 JOIN t0 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+d
+71
+-79
+71
+-79
+EXPLAIN EXTENDED SELECT t1.d FROM (SELECT CAST(c as int) AS d FROM t0) AS t1 JOIN t0 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+1	PRIMARY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using join buffer (flat, BNL join)
+3	DEPENDENT SUBQUERY	t0	ALL	NULL	NULL	NULL	NULL	2	100.00	Using temporary; Using filesort
+4	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+Warnings:
+Note	1276	Field or reference 'd' of SELECT #4 was resolved in SELECT #1
+Note	1981	Aggregate function 'bit_or()' of SELECT #4 belongs to SELECT #3
+Note	1276	Field or reference 'd' of SELECT #3 was resolved in SELECT #1
+Note	1003	/* select#1 */ select cast(`test`.`t0`.`c` as signed) AS `d` from `test`.`t0` join `test`.`t0` where <expr_cache><cast(`test`.`t0`.`c` as signed)>((/* select#3 */ select ord(<expr_cache><cast(`test`.`t0`.`c` as signed),bit_or(cast(`test`.`t0`.`c` as signed)),bit_or(cast(`test`.`t0`.`c` as signed))>((/* select#4 */ select bit_or(cast(`test`.`t0`.`c` as signed))))) from `test`.`t0` group by cast(`test`.`t0`.`c` as signed)))
+CREATE TABLE t1 (c INT);
+INSERT INTO t1 VALUES (71), (-79);
+SELECT t2.d FROM (SELECT c AS d FROM t1) AS t2 JOIN t1 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t1 GROUP BY d
+);
+d
+71
+-79
+71
+-79
+EXPLAIN EXTENDED SELECT t2.d FROM (SELECT c AS d FROM t1) AS t2 JOIN t1 ON (
+SELECT ORD((SELECT BIT_OR(d))) FROM t1 GROUP BY d
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using join buffer (flat, BNL join)
+3	DEPENDENT SUBQUERY	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using temporary; Using filesort
+4	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+Warnings:
+Note	1276	Field or reference 'd' of SELECT #4 was resolved in SELECT #1
+Note	1981	Aggregate function 'bit_or()' of SELECT #4 belongs to SELECT #3
+Note	1276	Field or reference 'd' of SELECT #3 was resolved in SELECT #1
+Note	1003	/* select#1 */ select `test`.`t1`.`c` AS `d` from `test`.`t1` join `test`.`t1` where <expr_cache><`test`.`t1`.`c`>((/* select#3 */ select ord(<expr_cache><`test`.`t1`.`c`,bit_or(`test`.`t1`.`c`),bit_or(`test`.`t1`.`c`)>((/* select#4 */ select bit_or(`test`.`t1`.`c`)))) from `test`.`t1` group by `test`.`t1`.`c`))
+DROP TABLE t0, t1;
+#
+# End of 10.5 tests
+#
 SET optimizer_switch=@save_optimizer_switch;
-# restore default
-set @@optimizer_switch= default;

--- a/mysql-test/main/subselect_cache.test
+++ b/mysql-test/main/subselect_cache.test
@@ -1737,7 +1737,37 @@ SELECT * FROM t4 WHERE b NOT IN ( SELECT * FROM v1 );
 drop view v1;
 drop table t1,t2,t3,t4;
 
-SET optimizer_switch=@save_optimizer_switch;
+--echo #
+--echo # MDEV-32401
+--echo #
 
---echo # restore default
-set @@optimizer_switch= default;
+CREATE TABLE t0 (c TEXT);
+INSERT INTO t0 VALUES (71), (-79);
+SELECT t1.d FROM (SELECT c AS d FROM t0) AS t1 JOIN t0 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+EXPLAIN EXTENDED SELECT t1.d FROM (SELECT c AS d FROM t0) AS t1 JOIN t0 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+SELECT t1.d FROM (SELECT CAST(c as int) AS d FROM t0) AS t1 JOIN t0 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+EXPLAIN EXTENDED SELECT t1.d FROM (SELECT CAST(c as int) AS d FROM t0) AS t1 JOIN t0 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t0 GROUP BY d
+);
+CREATE TABLE t1 (c INT);
+INSERT INTO t1 VALUES (71), (-79);
+SELECT t2.d FROM (SELECT c AS d FROM t1) AS t2 JOIN t1 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t1 GROUP BY d
+);
+EXPLAIN EXTENDED SELECT t2.d FROM (SELECT c AS d FROM t1) AS t2 JOIN t1 ON (
+  SELECT ORD((SELECT BIT_OR(d))) FROM t1 GROUP BY d
+);
+
+DROP TABLE t0, t1;
+
+--echo #
+--echo # End of 10.5 tests
+--echo #
+
+SET optimizer_switch=@save_optimizer_switch;

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -5232,8 +5232,6 @@ bool subselect_hash_sj_engine::init(List<Item> *tmp_columns, uint subquery_id)
   if (!(name.str= (char*) thd->memdup(buf, name.length + 1)))
     DBUG_RETURN(TRUE);
 
-  result_sink->get_tmp_table_param()->materialized_subquery= true;
-
   if (item->substype() == Item_subselect::IN_SUBS &&
       (item->get_IN_subquery()->is_jtbm_merged))
   {

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4508,7 +4508,6 @@ void TMP_TABLE_PARAM::init()
   table_charset= 0;
   precomputed_group_by= 0;
   bit_fields_as_long= 0;
-  materialized_subquery= 0;
   force_not_null_cols= 0;
   skip_create_table= 0;
   tmp_name= "temptable";                        // Name of temp table on disk

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -6538,8 +6538,6 @@ public:
   bool  using_outer_summary_function;
   CHARSET_INFO *table_charset;
   bool schema_table;
-  /* TRUE if the temp table is created for subquery materialization. */
-  bool materialized_subquery;
   /* TRUE if all columns of the table are guaranteed to be non-nullable */
   bool force_not_null_cols;
   /*
@@ -6567,7 +6565,7 @@ public:
     :copy_field(0), group_parts(0),
      group_length(0), group_null_parts(0),
      using_outer_summary_function(0),
-     schema_table(0), materialized_subquery(0), force_not_null_cols(0),
+     schema_table(0), force_not_null_cols(0),
      precomputed_group_by(0), group_concat(0),
      force_copy_fields(0), bit_fields_as_long(0), skip_create_table(0)
   {

--- a/sql/sql_priv.h
+++ b/sql/sql_priv.h
@@ -123,6 +123,14 @@
 #define OPTION_BIG_SELECTS      (1ULL << 9)     // THD, user
 #define OPTION_LOG_OFF          (1ULL << 10)    // THD, user
 #define OPTION_QUOTE_SHOW_CREATE (1ULL << 11)   // THD, user
+/*
+  Include all colums in temporary table, i.e. do not ignore aggregate and
+  constants, i.e. the temporary table created for other purposes than
+  aggregation.
+
+  As a side effect it also require do not modify result_field of the
+  Items by which the temporary table created
+*/
 #define TMP_TABLE_ALL_COLUMNS   (1ULL << 12)    // SELECT, intern
 #define OPTION_WARNINGS         (1ULL << 13)    // THD, user
 #define OPTION_AUTO_IS_NULL     (1ULL << 14)    // THD, user, binlog

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -20312,8 +20312,11 @@ bool Create_tmp_table::add_fields(THD *thd,
           temp table to override the 'result_field' that was set for
           the internal temp table.
         */
-        if (!agg_item->result_field || !param->materialized_subquery)
+        if (not_all_columns)
+        {
+          DBUG_ASSERT(!agg_item->result_field);
           agg_item->result_field= new_field;
+        }
       }
       tmp_from_field++;
 


### PR DESCRIPTION
1) take into account TMP_TABLE_ALL_COLUMNS when
   we are modifying agg_item->result_field
2) remove unused now "bool materialized_subquery;"

(cherry picked from commit 3d0ea3d2bc89e924a7ef212305d865083d0b6595)
