### PR TITLE
MDEV-40553: unprintable gis ranges in trace and context

### DIFF
--- a/mysql-test/include/opt_context_list_tables_ddls.inc
+++ b/mysql-test/include/opt_context_list_tables_ddls.inc
@@ -12,10 +12,14 @@ set @opt_context=
          context,
          '(?<=set @opt_context=\')([\n\r].*)*(?=\'\;#opt_context_ends)')
          from information_schema.optimizer_context);
+# The DDLs run up to the first REPLACE INTO, or, when there are none, up to
+# the block that carries the context: "set @opt_ctx_sql_mode=..." followed
+# by "set @opt_context='...". Stop at "set @opt_ctx" so that neither of
+# those two statements is reported as a DDL.
 set @ddls=
     (select REGEXP_SUBSTR(
          context,
-         '(CREATE TABLE.*)([\n\r].*)*(?=(REPLACE INTO|set @opt_context))')
+         '(CREATE TABLE.*)([\n\r].*)*(?=(REPLACE INTO|set @opt_ctx))')
          from information_schema.optimizer_context);
 set @fn= (select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.name')));
 select name from json_table(@fn, '$[*]' columns(name text path '$')) as jt;

--- a/mysql-test/main/opt_context_replay_basic.result
+++ b/mysql-test/main/opt_context_replay_basic.result
@@ -669,5 +669,107 @@ SELECT a, b, v FROM t1;
 a	b	v
 1	10	101
 drop table t1;
+#
+# MDEV-40553: unprintable gis ranges in trace and context
+#
+CREATE TABLE t1 (
+id INT,
+g GEOMETRY NOT NULL,
+KEY k_prefix (g(6))
+) ENGINE=MyISAM;
+INSERT INTO t1 SELECT seq, POINT(seq, seq) FROM seq_1_to_5;
+INSERT INTO t1 VALUES (6, LINESTRING(POINT(1,1), POINT(2,2)));
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+db1.t1	analyze	status	Engine-independent statistics collected
+db1.t1	analyze	status	OK
+set optimizer_record_context=1;
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_prefix	k_prefix	8	NULL	6	Using where
+select context into dumpfile "../../tmp/dump1.sql"
+from information_schema.optimizer_context;
+set optimizer_record_context=0;
+drop table t1;
+set optimizer_replay_context='opt_context';
+# The ranges must match the recorded ones, so no warning is produced
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_prefix	k_prefix	8	NULL	6	Using where
+set optimizer_replay_context='';
+drop table t1;
+# The same, replayed from the context read straight out of
+# INFORMATION_SCHEMA.OPTIMIZER_CONTEXT rather than from the script.
+# The literal in the script must read back as the JSON itself, so
+# both ways of getting at it produce the same ranges.
+CREATE TABLE t1 (
+id INT,
+g GEOMETRY NOT NULL,
+KEY k_prefix (g(6))
+) ENGINE=MyISAM;
+INSERT INTO t1 SELECT seq, POINT(seq, seq) FROM seq_1_to_5;
+INSERT INTO t1 VALUES (6, LINESTRING(POINT(1,1), POINT(2,2)));
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+db1.t1	analyze	status	Engine-independent statistics collected
+db1.t1	analyze	status	OK
+set optimizer_record_context=1;
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_prefix	k_prefix	8	NULL	6	Using where
+set @opt_context=
+(select REGEXP_SUBSTR(
+context,
+'(?<=set @opt_context=\')([\n\r].*)*(?=\';#opt_context_ends)')
+from information_schema.optimizer_context);
+set optimizer_record_context=0;
+set optimizer_replay_context='opt_context';
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_prefix	k_prefix	8	NULL	6	Using where
+set optimizer_replay_context='';
+drop table t1;
+#
+# A key value may hold a single quote (0x27). It must not end the
+# string literal that carries the context in the recorded script.
+#
+create table t1 (a varbinary(10), key a_idx(a)) engine=myisam;
+insert into t1 values
+(0x2700),(0x2701),(0x2702),(0x2703),(0x2704),(0x2705),(0x2706),(0x2707);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+db1.t1	analyze	status	Engine-independent statistics collected
+db1.t1	analyze	status	OK
+set optimizer_record_context=1;
+explain select * from t1 where a=0x2700 or a=0x2701 or a=0x2702 or a=0x2703;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	a_idx	a_idx	13	NULL	4	Using where; Using index
+set @opt_context=
+(select REGEXP_SUBSTR(
+context,
+'(?<=set @opt_context=\')([\n\r].*)*(?=\';#opt_context_ends)')
+from information_schema.optimizer_context);
+set optimizer_record_context=0;
+# The quote is recorded as its JSON escape:
+select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.ranges')) as ranges_in_ctx;
+ranges_in_ctx
+[
+    [
+        "(\u0027\\x00) <= (a) <= (\u0027\\x00)",
+        "(\u0027\\x01) <= (a) <= (\u0027\\x01)",
+        "(\u0027\\x02) <= (a) <= (\u0027\\x02)",
+        "(\u0027\\x03) <= (a) <= (\u0027\\x03)"
+    ]
+]
+set optimizer_replay_context='opt_context';
+explain select * from t1 where a=0x2700 or a=0x2701 or a=0x2702 or a=0x2703;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	a_idx	a_idx	13	NULL	4	Using where; Using index
+set optimizer_replay_context='';
+drop table t1;
 # End of 13.1 tests
 drop database db1;

--- a/mysql-test/main/opt_context_replay_basic.test
+++ b/mysql-test/main/opt_context_replay_basic.test
@@ -489,6 +489,93 @@ set optimizer_replay_context='';
 SELECT a, b, v FROM t1;
 drop table t1;
 
+--echo #
+--echo # MDEV-40553: unprintable gis ranges in trace and context
+--echo #
+CREATE TABLE t1 (
+  id INT,
+  g GEOMETRY NOT NULL,
+  KEY k_prefix (g(6))
+) ENGINE=MyISAM;
+INSERT INTO t1 SELECT seq, POINT(seq, seq) FROM seq_1_to_5;
+INSERT INTO t1 VALUES (6, LINESTRING(POINT(1,1), POINT(2,2)));
+analyze table t1;
+
+set optimizer_record_context=1;
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+select context into dumpfile "../../tmp/dump1.sql"
+from information_schema.optimizer_context;
+set optimizer_record_context=0;
+drop table t1;
+--disable_query_log
+--disable_result_log
+--source "$MYSQLTEST_VARDIR/tmp/dump1.sql"
+--enable_query_log
+--enable_result_log
+
+set optimizer_replay_context='opt_context';
+
+--echo # The ranges must match the recorded ones, so no warning is produced
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+
+set optimizer_replay_context='';
+--remove_file "$MYSQLTEST_VARDIR/tmp/dump1.sql"
+drop table t1;
+
+--echo # The same, replayed from the context read straight out of
+--echo # INFORMATION_SCHEMA.OPTIMIZER_CONTEXT rather than from the script.
+--echo # The literal in the script must read back as the JSON itself, so
+--echo # both ways of getting at it produce the same ranges.
+CREATE TABLE t1 (
+  id INT,
+  g GEOMETRY NOT NULL,
+  KEY k_prefix (g(6))
+) ENGINE=MyISAM;
+INSERT INTO t1 SELECT seq, POINT(seq, seq) FROM seq_1_to_5;
+INSERT INTO t1 VALUES (6, LINESTRING(POINT(1,1), POINT(2,2)));
+analyze table t1;
+
+set optimizer_record_context=1;
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+set @opt_context=
+    (select REGEXP_SUBSTR(
+         context,
+         '(?<=set @opt_context=\')([\n\r].*)*(?=\';#opt_context_ends)')
+         from information_schema.optimizer_context);
+set optimizer_record_context=0;
+set optimizer_replay_context='opt_context';
+EXPLAIN SELECT id FROM t1 FORCE INDEX(k_prefix)
+WHERE g < POINT(1,1) OR g > LINESTRING(POINT(9,9), POINT(8,8));
+set optimizer_replay_context='';
+drop table t1;
+
+--echo #
+--echo # A key value may hold a single quote (0x27). It must not end the
+--echo # string literal that carries the context in the recorded script.
+--echo #
+create table t1 (a varbinary(10), key a_idx(a)) engine=myisam;
+insert into t1 values
+  (0x2700),(0x2701),(0x2702),(0x2703),(0x2704),(0x2705),(0x2706),(0x2707);
+analyze table t1;
+
+set optimizer_record_context=1;
+explain select * from t1 where a=0x2700 or a=0x2701 or a=0x2702 or a=0x2703;
+set @opt_context=
+    (select REGEXP_SUBSTR(
+         context,
+         '(?<=set @opt_context=\')([\n\r].*)*(?=\';#opt_context_ends)')
+         from information_schema.optimizer_context);
+set optimizer_record_context=0;
+--echo # The quote is recorded as its JSON escape:
+select JSON_DETAILED(JSON_EXTRACT(@opt_context, '$**.ranges')) as ranges_in_ctx;
+set optimizer_replay_context='opt_context';
+explain select * from t1 where a=0x2700 or a=0x2701 or a=0x2702 or a=0x2703;
+set optimizer_replay_context='';
+drop table t1;
+
 --echo # End of 13.1 tests
 
 drop database db1;

--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -243,6 +243,7 @@ REPLACE INTO mysql.column_stats VALUES ('db1', 't1', 'b', '0', '4', 0.0000, 4.00
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'PRIMARY', 1, 1.0000);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 drop table t1;
 #
@@ -289,6 +290,7 @@ REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 1, 2.0000);
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 2, 1.0000);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 drop table t1;
 #
@@ -352,6 +354,7 @@ REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 1, 2.0000);
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 2, 1.0000);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 truncate table t1;
 analyze table t1;
@@ -383,6 +386,7 @@ REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 1, NULL);
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 2, NULL);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 set optimizer_record_context=OFF;
 drop table t1;
@@ -442,6 +446,7 @@ REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 1, 2.0000);
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 2, 1.0000);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 truncate table t1;
 analyze table t1;
@@ -473,6 +478,7 @@ REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 1, NULL);
 
 REPLACE INTO mysql.index_stats VALUES ('db1', 't1', 'idx_ab', 2, NULL);
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 drop table t1;
 #
@@ -507,6 +513,7 @@ select @const_table_inserts;
 @const_table_inserts
 REPLACE INTO db1.t0(a, b) VALUES (1, 'aaa\'bbb');
 
+set @opt_ctx_sql_mode=@@sql_mode, sql_mode='NO_BACKSLASH_ESCAPES';
 
 drop table t1;
 drop table t0;
@@ -646,4 +653,215 @@ index_name	ranges	num_rows	max_index_blocks	max_row_blocks
 a	["(10) <= (a) <= (10)"]	49	1	11
 # == End of optimizer context
 drop table t1;
+#
+# MDEV-40553: unprintable gis ranges in trace and context
+#
+create table t1 (
+id int,
+g1 geometry not null,
+g2 geometry,
+key k_prefix (g1(5)),
+key k_full (g1(200)),
+key k_null (g2(200))
+) engine=myisam;
+insert into t1 select seq, point(seq, seq), point(seq, seq) from seq_1_to_5;
+insert into t1 values (6, point(6,6), NULL);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+# The index holds the whole value.
+# It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_full) where g1=point(2,2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ref	k_full	k_full	202	const	1	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t1	6	NULL	NULL
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+k_full	["(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"]	1	1	1
+# == End of optimizer context
+# multiple ranges
+explain 
+select id from t1 force index (k_full)
+where g1=point(3,3) or g1=linestring(point(1,1), point(2,2));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_full	k_full	202	NULL	2	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t1	6	NULL	NULL
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+k_full	[
+                "(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"
+            ]	2	2	1
+# == End of optimizer context
+# NULL values and multiple ranges
+explain 
+select id from t1 force index (k_null)
+where g2=point(3,3) or g2 is null or g2=linestring(point(1,1), point(2,2));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_null	k_null	203	NULL	3	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t1	6	NULL	NULL
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+k_null	[
+                "(NULL) <= (g2) <= (NULL)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@) <= (g2) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g2) <= (\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"
+            ]	3	3	1
+# == End of optimizer context
+# The index holds only a prefix of the value.
+# It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_prefix) where g1=point(2,2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ref	k_prefix	k_prefix	7	const	6	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t1	6	NULL	NULL
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+k_prefix	["(\\x00\\x00\\x00\\x00\\x01) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01)"]	6	1	1
+# == End of optimizer context
+drop table t1;
+#
+# A SPATIAL index stores the MBR of the value. It is printed as the
+# WKT of the MBR together with the spatial relation the range uses.
+#
+create table t2 (
+id int,
+g geometry not null,
+spatial key (g)
+) engine=myisam;
+insert into t2 select seq, point(seq, seq) from seq_1_to_20;
+insert into t2 values
+(21, geomfromtext('LINESTRING(0 0, 5 8)')),
+(22, geomfromtext('POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
+analyze table t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+# mbrcontains(value, column)
+explain
+select id from t2 where mbrcontains(geomfromtext('POLYGON((0 0,0 3,3 3,3 0,0 0))'), g);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRWITHIN (POLYGON((0 0,3 0,3 3,0 3,0 0)))"]	4	1	1
+# == End of optimizer context
+# mbrwithin(column, value)
+explain
+select id from t2 where mbrwithin(g, geomfromtext('LINESTRING(1 1, 9 12)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	9	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRWITHIN (POLYGON((1 1,9 1,9 12,1 12,1 1)))"]	9	1	1
+# == End of optimizer context
+# The other spatial relations
+explain
+select id from t2 where mbrcontains(g, geomfromtext('POINT(2 2)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	3	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRCONTAINS (POLYGON((2 2,2 2,2 2,2 2,2 2)))"]	3	1	1
+# == End of optimizer context
+explain
+select id from t2 where mbrequals(g, geomfromtext('POINT(7 7)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	1	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBREQUALS (POLYGON((7 7,7 7,7 7,7 7,7 7)))"]	1	1	1
+# == End of optimizer context
+explain
+select id from t2 where mbrintersects(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"]	4	1	1
+# == End of optimizer context
+# mbrtouches/mbroverlaps all use the mbrintersects relation
+explain
+select id from t2 where mbrtouches(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"]	4	1	1
+# == End of optimizer context
+explain
+select id from t2 where mbroverlaps(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"]	4	1	1
+# == End of optimizer context
+explain
+select id from t2 where mbrdisjoint(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	ALL	g	NULL	NULL	NULL	22	Using where
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
+test.t2	22	g	["22"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+g	["(g) MBRDISJOINT (POLYGON((0 0,2 0,2 2,0 2,0 0)))"]	2147483647	0	0
+Warnings:
+Warning	1264	Out of range value for column 'num_rows' at row 1
+# == End of optimizer context
+drop table t2;
 # End of 13.1 tests

--- a/mysql-test/main/opt_context_store_stats.test
+++ b/mysql-test/main/opt_context_store_stats.test
@@ -470,4 +470,101 @@ select * from t1 partition (p1) where a=10;
 
 drop table t1;
 
+--echo #
+--echo # MDEV-40553: unprintable gis ranges in trace and context
+--echo #
+create table t1 (
+  id int,
+  g1 geometry not null,
+  g2 geometry,
+  key k_prefix (g1(5)),
+  key k_full (g1(200)),
+  key k_null (g2(200))
+) engine=myisam;
+
+insert into t1 select seq, point(seq, seq), point(seq, seq) from seq_1_to_5;
+insert into t1 values (6, point(6,6), NULL);
+analyze table t1;
+
+--echo # The index holds the whole value.
+--echo # It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_full) where g1=point(2,2);
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # multiple ranges
+explain 
+select id from t1 force index (k_full)
+where g1=point(3,3) or g1=linestring(point(1,1), point(2,2));
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # NULL values and multiple ranges
+explain 
+select id from t1 force index (k_null)
+where g2=point(3,3) or g2 is null or g2=linestring(point(1,1), point(2,2));
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # The index holds only a prefix of the value.
+--echo # It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_prefix) where g1=point(2,2);
+--source include/opt_context_list_tables_and_ranges.inc
+
+drop table t1;
+
+--echo #
+--echo # A SPATIAL index stores the MBR of the value. It is printed as the
+--echo # WKT of the MBR together with the spatial relation the range uses.
+--echo #
+
+create table t2 (
+  id int,
+  g geometry not null,
+  spatial key (g)
+) engine=myisam;
+
+insert into t2 select seq, point(seq, seq) from seq_1_to_20;
+insert into t2 values
+  (21, geomfromtext('LINESTRING(0 0, 5 8)')),
+  (22, geomfromtext('POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
+analyze table t2;
+
+--echo # mbrcontains(value, column)
+explain
+select id from t2 where mbrcontains(geomfromtext('POLYGON((0 0,0 3,3 3,3 0,0 0))'), g);
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # mbrwithin(column, value)
+explain
+select id from t2 where mbrwithin(g, geomfromtext('LINESTRING(1 1, 9 12)'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # The other spatial relations
+explain
+select id from t2 where mbrcontains(g, geomfromtext('POINT(2 2)'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+explain
+select id from t2 where mbrequals(g, geomfromtext('POINT(7 7)'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+explain
+select id from t2 where mbrintersects(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+--echo # mbrtouches/mbroverlaps all use the mbrintersects relation
+explain
+select id from t2 where mbrtouches(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+explain
+select id from t2 where mbroverlaps(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+explain
+select id from t2 where mbrdisjoint(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+--source include/opt_context_list_tables_and_ranges.inc
+
+drop table t2;
+
 --echo # End of 13.1 tests

--- a/mysql-test/main/opt_trace.result
+++ b/mysql-test/main/opt_trace.result
@@ -13845,6 +13845,306 @@ select json_valid(@trace);
 json_valid(@trace)
 1
 drop table t1;
+#
+# MDEV-40553: unprintable gis ranges in trace and context
+#
+create table t1 (
+id int,
+g1 geometry not null,
+g2 geometry,
+key k_prefix (g1(5)),
+key k_full (g1(200)),
+key k_null (g2(200))
+) engine=myisam;
+insert into t1 select seq, point(seq, seq), point(seq, seq) from seq_1_to_5;
+insert into t1 values (6, point(6,6), NULL);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+# The index holds the whole value.
+# It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_full) where g1=point(2,2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ref	k_full	k_full	202	const	1	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "k_full",
+            "ranges": 
+            ["(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 1,
+            "cost": 0.002574553,
+            "chosen": true
+        }
+    ]
+]
+# multiple ranges
+explain 
+select id from t1 force index (k_full)
+where g1=point(3,3) or g1=linestring(point(1,1), point(2,2));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_full	k_full	202	NULL	2	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "k_full",
+            "ranges": 
+            [
+                "(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"
+            ],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 2,
+            "cost": 0.004394164,
+            "chosen": true
+        }
+    ]
+]
+# NULL values and multiple ranges
+explain 
+select id from t1 force index (k_null)
+where g2=point(3,3) or g2 is null or g2=linestring(point(1,1), point(2,2));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k_null	k_null	203	NULL	3	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "k_null",
+            "ranges": 
+            [
+                "(NULL) <= (g2) <= (NULL)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@) <= (g2) <= (\\x00\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@)",
+                "(\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@) <= (g2) <= (\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@)"
+            ],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 3,
+            "cost": 0.006213775,
+            "chosen": true
+        }
+    ]
+]
+# The index holds only a prefix of the value.
+# It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_prefix) where g1=point(2,2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ref	k_prefix	k_prefix	7	const	6	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "k_prefix",
+            "ranges": 
+            ["(\\x00\\x00\\x00\\x00\\x01) <= (g1) <= (\\x00\\x00\\x00\\x00\\x01)"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 6,
+            "cost": 0.008743898,
+            "chosen": true
+        }
+    ]
+]
+drop table t1;
+#
+# A SPATIAL index stores the MBR of the value. It is printed as the
+# WKT of the MBR together with the spatial relation the range uses.
+#
+create table t2 (
+id int,
+g geometry not null,
+spatial key (g)
+) engine=myisam;
+insert into t2 select seq, point(seq, seq) from seq_1_to_20;
+insert into t2 values
+(21, geomfromtext('LINESTRING(0 0, 5 8)')),
+(22, geomfromtext('POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
+analyze table t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	Engine-independent statistics collected
+test.t2	analyze	status	OK
+# mbrcontains(value, column)
+explain
+select id from t2 where mbrcontains(geomfromtext('POLYGON((0 0,0 3,3 3,3 0,0 0))'), g);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRWITHIN (POLYGON((0 0,3 0,3 3,0 3,0 0)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 4,
+            "cost": 0.00627616,
+            "chosen": true
+        }
+    ]
+]
+# mbrwithin(column, value)
+explain
+select id from t2 where mbrwithin(g, geomfromtext('LINESTRING(1 1, 9 12)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	9	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRWITHIN (POLYGON((1 1,9 1,9 12,1 12,1 1)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 9,
+            "cost": 0.012445505,
+            "chosen": true
+        }
+    ]
+]
+# The other spatial relations
+explain
+select id from t2 where mbrcontains(g, geomfromtext('POINT(2 2)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	3	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRCONTAINS (POLYGON((2 2,2 2,2 2,2 2,2 2)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 3,
+            "cost": 0.005042291,
+            "chosen": true
+        }
+    ]
+]
+explain
+select id from t2 where mbrequals(g, geomfromtext('POINT(7 7)'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	1	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBREQUALS (POLYGON((7 7,7 7,7 7,7 7,7 7)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 1,
+            "cost": 0.002574553,
+            "chosen": true
+        }
+    ]
+]
+explain
+select id from t2 where mbrintersects(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 4,
+            "cost": 0.00627616,
+            "chosen": true
+        }
+    ]
+]
+# mbrtouches/mbroverlaps all use the mbrintersects relation
+explain
+select id from t2 where mbrtouches(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 4,
+            "cost": 0.00627616,
+            "chosen": true
+        }
+    ]
+]
+explain
+select id from t2 where mbroverlaps(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	g	g	34	NULL	4	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g",
+            "ranges": 
+            ["(g) MBRINTERSECTS (POLYGON((0 0,2 0,2 2,0 2,0 0)))"],
+            "rowid_ordered": false,
+            "using_mrr": false,
+            "index_only": false,
+            "rows": 4,
+            "cost": 0.00627616,
+            "chosen": true
+        }
+    ]
+]
+explain
+select id from t2 where mbrdisjoint(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	ALL	g	NULL	NULL	NULL	22	Using where
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+rsa
+[
+    [
+        {
+            "index": "g"
+        }
+    ]
+]
+drop table t2;
+# End of 13.1 tests
 set  @@optimizer_switch= @save_optimizer_switch;
 set  @@use_stat_tables= @save_use_stat_tables;
 set  @@histogram_size= @save_histogram_size;

--- a/mysql-test/main/opt_trace.test
+++ b/mysql-test/main/opt_trace.test
@@ -1364,6 +1364,105 @@ select json_valid(@trace);
 
 drop table t1;
 
+--echo #
+--echo # MDEV-40553: unprintable gis ranges in trace and context
+--echo #
+create table t1 (
+  id int,
+  g1 geometry not null,
+  g2 geometry,
+  key k_prefix (g1(5)),
+  key k_full (g1(200)),
+  key k_null (g2(200))
+) engine=myisam;
+
+insert into t1 select seq, point(seq, seq), point(seq, seq) from seq_1_to_5;
+insert into t1 values (6, point(6,6), NULL);
+analyze table t1;
+
+--echo # The index holds the whole value.
+--echo # It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_full) where g1=point(2,2);
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # multiple ranges
+explain 
+select id from t1 force index (k_full)
+where g1=point(3,3) or g1=linestring(point(1,1), point(2,2));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # NULL values and multiple ranges
+explain 
+select id from t1 force index (k_null)
+where g2=point(3,3) or g2 is null or g2=linestring(point(1,1), point(2,2));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # The index holds only a prefix of the value.
+--echo # It is printed as a binary string, like any other BLOB prefix.
+explain
+select id from t1 force index (k_prefix) where g1=point(2,2);
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+drop table t1;
+
+--echo #
+--echo # A SPATIAL index stores the MBR of the value. It is printed as the
+--echo # WKT of the MBR together with the spatial relation the range uses.
+--echo #
+
+create table t2 (
+  id int,
+  g geometry not null,
+  spatial key (g)
+) engine=myisam;
+
+insert into t2 select seq, point(seq, seq) from seq_1_to_20;
+insert into t2 values
+  (21, geomfromtext('LINESTRING(0 0, 5 8)')),
+  (22, geomfromtext('POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
+analyze table t2;
+
+--echo # mbrcontains(value, column)
+explain
+select id from t2 where mbrcontains(geomfromtext('POLYGON((0 0,0 3,3 3,3 0,0 0))'), g);
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # mbrwithin(column, value)
+explain
+select id from t2 where mbrwithin(g, geomfromtext('LINESTRING(1 1, 9 12)'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # The other spatial relations
+explain
+select id from t2 where mbrcontains(g, geomfromtext('POINT(2 2)'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+explain
+select id from t2 where mbrequals(g, geomfromtext('POINT(7 7)'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+explain
+select id from t2 where mbrintersects(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+--echo # mbrtouches/mbroverlaps all use the mbrintersects relation
+explain
+select id from t2 where mbrtouches(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+explain
+select id from t2 where mbroverlaps(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+explain
+select id from t2 where mbrdisjoint(g, geomfromtext('POLYGON((0 0,0 2,2 2,2 0,0 0))'));
+select json_detailed(json_extract(trace, '$**.range_scan_alternatives')) as rsa from information_schema.optimizer_trace;
+
+drop table t2;
+
+--echo # End of 13.1 tests
+
 set  @@optimizer_switch= @save_optimizer_switch;
 set  @@use_stat_tables= @save_use_stat_tables;
 set  @@histogram_size= @save_histogram_size;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -11833,11 +11833,14 @@ void Field_blob::print_key_value(String *out, uint32 length)
     key                value of the key
     length             Length of field in bytes,
                        excluding NULL flag and length bytes
+    image_type         Form in which the value is stored in the key:
+                       itRAW for regular indexes, itMBR for SPATIAL indexes
 */
 
 
 void
-Field::print_key_part_value(String *out, const uchar* key, uint32 length)
+Field::print_key_part_value(String *out, const uchar* key, uint32 length,
+                            imagetype image_type)
 {
   StringBuffer<128> tmp(system_charset_info);
   uint null_byte= 0;

--- a/sql/field.h
+++ b/sql/field.h
@@ -1759,7 +1759,8 @@ public:
   bool set_warning(Sql_condition::enum_warning_level, unsigned int code,
                    int cuted_increment, ulong current_row=0) const;
   virtual void print_key_value(String *out, uint32 length);
-  void print_key_part_value(String *out, const uchar *key, uint32 length);
+  virtual void print_key_part_value(String *out, const uchar *key, uint32 length,
+                                    imagetype image_type);
   void print_key_value_binary(String *out, const uchar* key, uint32 length);
   void raise_note_cannot_use_key_part(THD *thd, uint keynr, uint part,
                                       const LEX_CSTRING &op,

--- a/sql/my_json_writer.cc
+++ b/sql/my_json_writer.cc
@@ -525,9 +525,13 @@ void Single_line_formatting_helper::disable_and_flush()
     }
     else
     {
-      //if (nr == 1)
-      //  owner->start_array();
-      owner->add_str(str, len);
+      /*
+        The buffer holds the values as they were passed to
+        Json_writer::add_escaped_str(), that is, already escaped. Print them
+        as-is, the way flush_on_one_line() does. Passing them through
+        Json_writer::add_str() here would escape them a second time.
+      */
+      owner->add_escaped_str(str, len);
     }
     
     nr++;

--- a/sql/opt_context_store_replay.cc
+++ b/sql/opt_context_store_replay.cc
@@ -633,26 +633,38 @@ static bool store_db_ddl(THD *thd, HASH *db_name_hash, String &script,
 
 /*
   @brief
-    Append the @arg json to sql_script, by escaping only backslash,
-    and single quote
+    Append @arg json to sql_script as the body of a single-quoted string
+    literal.
+
+  @detail
+    The literal is written with NO_BACKSLASH_ESCAPES in effect (the caller
+    switches sql_mode around it), so a backslash inside it stands for itself
+    and needs no escaping.
+
+    This is what keeps the text of the literal identical to the JSON it
+    carries. The context is read back in two ways: by running the script,
+    which lets the SQL parser produce the JSON, and by picking the literal
+    out of INFORMATION_SCHEMA.OPTIMIZER_CONTEXT with a regexp, which does
+    not. Escaping backslashes here would leave those two forms one escaping
+    level apart, and a context extracted the second way would no longer
+    match the ranges the optimizer prints - see
+    Optimizer_context_replay::infuse_multi_range_read_info_const().
+
+    A single quote is then the only character that could still end the
+    literal. Write it as its JSON escape \u0027 instead of doubling it, so
+    that no SQL-level escaping is left at all. In JSON a quote can only
+    occur inside a string, where \u0027 denotes the very same character.
 */
-static void escape_json_for_sql_literal(const String& json, String *sql_script)
+static void append_json_as_sql_literal(const String& json, String *sql_script)
 {
   const char *str= json.ptr();
   const char *end= str + json.length();
   for (; str < end; str++)
   {
-    switch (*str)
-    {
-    case '\\':
-      sql_script->append(STRING_WITH_LEN("\\\\"));
-      break;
-    case '\'':
-      sql_script->append(STRING_WITH_LEN("\\'"));
-      break;
-    default:
+    if (*str == '\'')
+      sql_script->append(STRING_WITH_LEN("\\u0027"));
+    else
       sql_script->append(*str);
-    }
   }
 }
 
@@ -925,13 +937,23 @@ bool Optimizer_context_recorder::dump_sql_script(THD* thd, String &sql_script)
   sql_script.append(sys_vars_script);
   sql_script.append(qry_ctx_script);
 
+  /*
+    Store the context so that the literal below reads back as the JSON
+    itself, both when this script is run and when the literal is picked out
+    of INFORMATION_SCHEMA.OPTIMIZER_CONTEXT directly. That needs the
+    backslashes in the JSON to be taken literally, so turn off backslash
+    escapes for this one statement, and put sql_mode back right after.
+  */
+  sql_script.append(STRING_WITH_LEN(
+      "set @opt_ctx_sql_mode=@@sql_mode, "
+      "sql_mode='NO_BACKSLASH_ESCAPES';\n"));
+
   sql_script.append(STRING_WITH_LEN("set @opt_context=\'\n"));
 
-  // require extra escaping of the opt_ctx so as to counter the
-  // unescaping done by sql parse
-  escape_json_for_sql_literal(*ctx_writer.output.get_string(), &sql_script);
+  append_json_as_sql_literal(*ctx_writer.output.get_string(), &sql_script);
 
-  sql_script.append(STRING_WITH_LEN("\n\';#opt_context_ends\n\n"));
+  sql_script.append(STRING_WITH_LEN("\n\';#opt_context_ends\n"));
+  sql_script.append(STRING_WITH_LEN("set sql_mode=@opt_ctx_sql_mode;\n\n"));
   sql_script.append(
       STRING_WITH_LEN("SET optimizer_replay_context=\'opt_context\'"));
   sql_script.append(STRING_WITH_LEN(";\n\n"));
@@ -1130,8 +1152,12 @@ void Optimizer_context_recorder::record_records_in_range(
   rec_in_range_ctx->keynr= keynr;
   String min_key;
   String max_key;
-  print_key_value(&min_key, key_part, min_range->key, min_range->length);
-  print_key_value(&max_key, key_part, max_range->key, max_range->length);
+  Field::imagetype image_type=
+      Field::image_type(tbl->key_info[keynr].algorithm);
+  print_key_value(&min_key, key_part, min_range->key, min_range->length,
+                  image_type);
+  print_key_value(&max_key, key_part, max_range->key, max_range->length,
+                  image_type);
 
   if (!(rec_in_range_ctx->min_key= strdup_root(mem_root, &min_key)))
     return; // OOM
@@ -1748,6 +1774,7 @@ bool Optimizer_context_replay::infuse_multi_range_read_info_const(
   const char *idx_name= keyinfo->name.str;
   const KEY_PART_INFO *key_part= keyinfo->key_part;
   uint n_key_parts= table->actual_n_key_parts(keyinfo);
+  Field::imagetype image_type= Field::image_type(keyinfo->algorithm);
   KEY_MULTI_RANGE multi_range;
   range_seq_t seq_it;
   List<Multi_range_read_const_call_record> mrr_const_calls;
@@ -1760,7 +1787,7 @@ bool Optimizer_context_replay::infuse_multi_range_read_info_const(
   while (!seq_if->next(seq_it, &multi_range))
   {
     StringBuffer<128> range_info(system_charset_info);
-    print_range(&range_info, key_part, &multi_range, n_key_parts);
+    print_range(&range_info, key_part, &multi_range, n_key_parts, image_type);
     char *r1= range_info.c_ptr_safe();
     text_ranges.push_back(strdup_root(thd->mem_root, &range_info));
     act_ranges.append(r1, strlen(r1));
@@ -1965,8 +1992,12 @@ bool Optimizer_context_replay::infuse_records_in_range(
   String min_key;
   String max_key;
   String tbl_name;
-  print_key_value(&min_key, key_part, min_range->key, min_range->length);
-  print_key_value(&max_key, key_part, max_range->key, max_range->length);
+  Field::imagetype image_type=
+      Field::image_type(tbl->key_info[keynr].algorithm);
+  print_key_value(&min_key, key_part, min_range->key, min_range->length,
+                  image_type);
+  print_key_value(&max_key, key_part, max_range->key, max_range->length,
+                  image_type);
   append_base_table_name(tbl, &tbl_name);
 
   if (table_context_for_replay *tbl_ctx=

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -12376,7 +12376,7 @@ public:
     range_info.length(0);
     if (seq_if.next(seq_it, &range))
       return true; // No more ranges
-    print_range(&range_info, cur_key_part, &range, n_key_parts);
+    print_range(&range_info, cur_key_part, &range, n_key_parts, image_type);
     return false;
   }
   const String& get_interval_str() override { return range_info; }
@@ -12386,6 +12386,7 @@ public:
   {
     KEY *keyinfo= param->table->key_info + param->real_keynr[idx];
     n_key_parts= param->table->actual_n_key_parts(keyinfo);
+    image_type= Field::image_type(keyinfo->algorithm);
     seq.keyno= idx;
     seq.key_parts= param->key[idx];
     seq.real_keyno= param->real_keynr[idx];
@@ -12406,6 +12407,8 @@ private:
   StringBuffer<128> range_info;
   uint n_key_parts;
   const KEY_PART_INFO *cur_key_part;
+  /* Form in which this index stores the column values, see print_range() */
+  Field::imagetype image_type;
 };
 
 
@@ -17595,34 +17598,99 @@ static void print_max_range_operator(String *out, const ha_rkey_function flag)
     out->append(STRING_WITH_LEN(" ? "));
 }
 
+/*
+  @brief Print the spatial relation used by a range over a SPATIAL index
+
+  @detail
+    The relation is printed the way it reads with the indexed column on the
+    left side, that is, the range
+      (g) mbrwithin (POLYGON(...))
+    reads rows whose MBR is within the MBR of the printed value.
+    Note that mbrtouches/mbrcrosses/mbroverlaps all use the same
+    HA_READ_MBR_INTERSECT relation, so they are all printed as mbrintersects.
+*/
+
+static void print_mbr_range_operator(String *out, const ha_rkey_function flag)
+{
+  switch (flag)
+  {
+  case HA_READ_MBR_CONTAIN:
+    out->append(STRING_WITH_LEN(" MBRWITHIN "));
+    break;
+  case HA_READ_MBR_WITHIN:
+    out->append(STRING_WITH_LEN(" MBRCONTAINS "));
+    break;
+  case HA_READ_MBR_INTERSECT:
+    out->append(STRING_WITH_LEN(" MBRINTERSECTS "));
+    break;
+  case HA_READ_MBR_DISJOINT:
+    out->append(STRING_WITH_LEN(" MBRDISJOINT "));
+    break;
+  case HA_READ_MBR_EQUAL:
+    out->append(STRING_WITH_LEN(" MBREQUALS "));
+    break;
+  default:
+    out->append(STRING_WITH_LEN(" ? "));
+    break;
+  }
+}
+
+/*
+  @brief Print one range of an index
+
+  @param[out] out          String the range is appended to
+  @param[in]  key_part     Index components description
+  @param[in]  range        The range to print
+  @param[in]  n_key_parts  Number of keyparts in the index
+  @param[in]  image_type   Form in which the index stores the column values,
+                           that is, Field::image_type() of the index's
+                           algorithm: itMBR for SPATIAL (RTREE) indexes,
+                           itRAW for all others.
+
+  @detail
+    Note that image_type is a property of the index, not of the range: an
+    RTREE index stores an MBR whether or not this particular range carries
+    GEOM_FLAG. Deciding it from range->range_flag instead would make the key
+    of a non-GEOM range over an RTREE index be read as a BLOB prefix.
+*/
+
 void print_range(String *out, const KEY_PART_INFO *key_part,
-                 KEY_MULTI_RANGE *range, uint n_key_parts)
+                 KEY_MULTI_RANGE *range, uint n_key_parts,
+                 Field::imagetype image_type)
 {
   Check_level_instant_set check_field(current_thd, CHECK_FIELD_IGNORE);
   uint flag= range->range_flag;
   String key_name;
   key_name.set_charset(system_charset_info);
-  key_part_map keypart_map= range->start_key.keypart_map |
-                            range->end_key.keypart_map;
 
   if (flag & GEOM_FLAG)
   {
     /*
-      The flags of GEOM ranges do not work the same way as for other
-      range types, so printing "col < some_geom" doesn't make sense.
-      Just print the column name, not operator.
+      The flags of GEOM ranges do not work the same way as for other range
+      types: there is no min/max bound, the range is the set of rows whose
+      MBR has the given spatial relation with the MBR of the value.
+      Print it as "col mbr_relation value".
+
+      Only start_key is filled in for a GEOM range, see
+      sel_arg_range_seq_next(), so end_key must not be looked at here.
     */
-    print_keyparts_name(out, key_part, n_key_parts, keypart_map);
-    out->append(STRING_WITH_LEN(" "));
+    /* GEOM ranges are only produced for SPATIAL indexes */
+    DBUG_ASSERT(image_type == Field::itMBR);
+    print_keyparts_name(out, key_part, n_key_parts,
+                        range->start_key.keypart_map);
+    print_mbr_range_operator(out, range->start_key.flag);
     print_key_value(out, key_part, range->start_key.key,
-                    range->start_key.length);
+                    range->start_key.length, image_type);
     return;
   }
+
+  key_part_map keypart_map= range->start_key.keypart_map |
+                            range->end_key.keypart_map;
 
   if (range->start_key.length)
   {
     print_key_value(out, key_part, range->start_key.key,
-                    range->start_key.length);
+                    range->start_key.length, image_type);
     print_min_range_operator(out, range->start_key.flag);
   }
 
@@ -17631,8 +17699,8 @@ void print_range(String *out, const KEY_PART_INFO *key_part,
   if (range->end_key.length)
   {
     print_max_range_operator(out, range->end_key.flag);
-    print_key_value(out, key_part, range->end_key.key,
-                    range->end_key.length);
+    print_key_value(out, key_part, range->end_key.key, range->end_key.length,
+                    image_type);
   }
 }
 
@@ -17656,7 +17724,8 @@ void print_range_for_non_indexed_field(String *out, Field *field,
 
   if (range->start_key.length)
   {
-    field->print_key_part_value(out, range->start_key.key, field->key_length());
+    field->print_key_part_value(out, range->start_key.key, field->key_length(),
+                                Field::itRAW);
     print_min_range_operator(out, range->start_key.flag);
   }
 
@@ -17665,7 +17734,8 @@ void print_range_for_non_indexed_field(String *out, Field *field,
   if (range->end_key.length)
   {
     print_max_range_operator(out, range->end_key.flag);
-    field->print_key_part_value(out, range->end_key.key, field->key_length());
+    field->print_key_part_value(out, range->end_key.key, field->key_length(),
+                                Field::itRAW);
   }
   dbug_tmp_restore_column_maps(&table->read_set, &table->write_set, old_sets);
 }
@@ -17703,10 +17773,13 @@ static void trace_ranges(Json_writer_array *range_trace, PARAM *param,
   @param[in]  key_part     Index components description
   @param[in]  key          Key tuple
   @param[in]  used_length  length of the key tuple
+  @param[in]  image_type   Form in which the key stores the column values:
+                           itRAW for regular indexes, itMBR for SPATIAL ones
 */
 
 void print_key_value(String *out, const KEY_PART_INFO *key_part,
-                     const uchar *key, uint used_length)
+                     const uchar *key, uint used_length,
+                     Field::imagetype image_type)
 {
   out->append(STRING_WITH_LEN("("));
   Field *field= key_part->field;
@@ -17722,7 +17795,7 @@ void print_key_value(String *out, const KEY_PART_INFO *key_part,
     field= key_part->field;
     store_length= key_part->store_length;
 
-    field->print_key_part_value(out, key, key_part->length);
+    field->print_key_part_value(out, key, key_part->length, image_type);
 
     if (key + store_length < key_end)
       out->append(STRING_WITH_LEN(","));

--- a/sql/opt_range.h
+++ b/sql/opt_range.h
@@ -2041,10 +2041,12 @@ bool calculate_cond_selectivity_for_table(THD *thd, TABLE *table, Item **cond);
 bool eq_ranges_exceeds_limit(RANGE_SEQ_IF *seq, void *seq_init_param,
                              uint limit);
 void print_range(String *out, const KEY_PART_INFO *key_part,
-                 KEY_MULTI_RANGE *range, uint n_key_parts);
+                 KEY_MULTI_RANGE *range, uint n_key_parts,
+                 Field::imagetype image_type);
 
 void print_key_value(String *out, const KEY_PART_INFO *key_part,
-                     const uchar *key, uint used_length);
+                     const uchar *key, uint used_length,
+                     Field::imagetype image_type);
 
 #ifdef WITH_PARTITION_STORAGE_ENGINE
 bool prune_partitions(THD *thd, TABLE *table, Item *pprune_cond);

--- a/sql/sql_type_geom.cc
+++ b/sql/sql_type_geom.cc
@@ -1001,6 +1001,79 @@ uint Field_geom::get_key_image(uchar *buff,uint length, const uchar *ptr_arg,
   return Field_blob::get_key_image_itRAW(ptr_arg, buff, length);
 }
 
+/*
+  @brief
+    Print the value of a key part over a GEOMETRY column.
+
+  @detail
+    SPATIAL indexes do not store the column value. They store its MBR
+    (Minimum Bounding Rectangle) instead, as four doubles:
+      xmin, xmax, ymin, ymax
+    Print the MBR as a WKT POLYGON, the same way ST_Envelope() would
+    return it.
+    For the other index types the key holds the value (or its prefix),
+    which is printed by Field_blob::print_key_value().
+*/
+
+void Field_geom::print_key_part_value(String *out, const uchar *key,
+                                      uint32 length, imagetype image_type)
+{
+  if (image_type != itMBR)
+  {
+    Field_blob::print_key_part_value(out, key, length, image_type);
+    return;
+  }
+
+  if (real_maybe_null())
+  {
+    /*
+      SPATIAL keys do not support NULL, but be graceful here as this is
+      only used for printing.
+    */
+    if (*key)
+    {
+      out->append(NULL_clex_str);
+      return;
+    }
+    key++;                                      // Skip the null byte
+  }
+
+  if (length < SIZEOF_STORED_DOUBLE * 4)
+  {
+    /*
+      The key part is too short to hold a full MBR (four doubles). This should
+      not happen for a SPATIAL index, but be graceful and print whatever bytes
+      are there as a binary string instead of reading past the key.
+    */
+    DBUG_ASSERT(0);
+    print_key_value_binary(out, key, length);
+    return;
+  }
+
+  double xmin, xmax, ymin, ymax;
+  float8get(xmin, key);
+  float8get(xmax, key + SIZEOF_STORED_DOUBLE);
+  float8get(ymin, key + SIZEOF_STORED_DOUBLE * 2);
+  float8get(ymax, key + SIZEOF_STORED_DOUBLE * 3);
+
+  if (out->reserve(MY_GCVT_MAX_FIELD_WIDTH * 10 + 32))
+    return;                                     // Out of memory
+
+  out->qs_append(STRING_WITH_LEN("POLYGON(("));
+  const double points[5][2]= {{xmin, ymin}, {xmax, ymin}, {xmax, ymax},
+                              {xmin, ymax}, {xmin, ymin}};
+  for (uint i= 0; i < array_elements(points); i++)
+  {
+    if (i)
+      out->qs_append(',');
+    out->qs_append(points[i][0]);
+    out->qs_append(' ');
+    out->qs_append(points[i][1]);
+  }
+  out->qs_append(STRING_WITH_LEN("))"));
+}
+
+
 Binlog_type_info Field_geom::binlog_type_info() const
 {
   DBUG_ASSERT(Field_geom::type() == binlog_type());

--- a/sql/sql_type_geom.h
+++ b/sql/sql_type_geom.h
@@ -463,10 +463,8 @@ public:
   bool load_data_set_null(THD *thd) override;
   bool load_data_set_no_data(THD *thd, bool fixed_format) override;
 
-  void print_key_value(String *out, uint32 length) override
-  {
-    out->append(STRING_WITH_LEN("unprintable_geometry_value"));
-  }
+  void print_key_part_value(String *out, const uchar *key, uint32 length,
+                            imagetype image_type) override;
   Binlog_type_info binlog_type_info() const override;
 };
 


### PR DESCRIPTION
When ranges were specified in a query for GIS types, the recorded trace
and context couldn't print the range information. Instead, it only
showed unprintable_geometry_value.

This PR extends the geometric field type Field_geom to print key value
in binary form (same as what is done for Blobs today), along with the
comparison operator, when recorded in the range.
For spatial indexes, the operators like MBRWITHIN, MBRCONTAINS, etc...
are stored appropriately, and for normal indexes, operators like
<, <=, >, >=, etc... are recorded appropriately.

Implementation Details: -
  Add an argument imagetype to Field::print_key_part_value(), to determine
  if an index key part value is to be printed in WKT or binary format.
  For Geometric type, imagetype is set to itMBR. When printing ranges,
  the MBR operators are printed as well, as implemented in
  print_mbr_range_operator().