### PR TITLE
MDEV-40584 ST_CROSSES always returns 0 for different-dimension geometries

### DIFF
--- a/mysql-test/main/gis-precise.result
+++ b/mysql-test/main/gis-precise.result
@@ -881,6 +881,66 @@ SELECT ST_CROSSES( ST_GEOMFROMTEXT('POLYGON ((59 18,67 18,67 13,59 13,59 18)) ')
 a
 NULL
 #
+# MDEV-40584 ST_CROSSES always returns 0 for geometries of different dimensions
+#
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(1 3, 2 2, 3 2)'),
+ST_GeomFromText('LINESTRING(0 3, 1 1, 2 2, 2 0)')) a;
+a
+1
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(1 1, 1 3, 2 3)'),
+ST_GeomFromText('POLYGON((0 0, 0 3, 2 0, 0 0))')) a;
+a
+1
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 1, 3 2, 4 1)'),
+ST_GeomFromText('POLYGON((1 0, 1 2, 2 3, 2 1, 1 0))')) a;
+a
+1
+# line x line, crossing (dims 1,1) -> 1
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 2)'),
+ST_GeomFromText('LINESTRING(0 2, 2 0)')) a;
+a
+1
+# line x line, not crossing (dims 1,1) -> 0
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 0)'),
+ST_GeomFromText('LINESTRING(0 1, 2 1)')) a;
+a
+0
+# point x line, disjoint (dims 0,1) -> 0
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(10 10)'),
+ST_GeomFromText('LINESTRING(0 0, 1 1)')) a;
+a
+0
+# point x polygon, disjoint (dims 0,2) -> 0
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(100 100)'),
+ST_GeomFromText('POLYGON((0 0, 0 3, 2 0, 0 0))')) a;
+a
+0
+# line x point (g2 is a point) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 1 1)'),
+ST_GeomFromText('POINT(5 5)')) a;
+a
+NULL
+# line x multipoint (g2 is a multipoint) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 5 5)'),
+ST_GeomFromText('MULTIPOINT(1 1, 2 2)')) a;
+a
+NULL
+# multipolygon x line (g1 is a multipolygon) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOLYGON(((0 0, 0 3, 3 3, 3 0, 0 0)))'),
+ST_GeomFromText('LINESTRING(1 1, 2 2)')) a;
+a
+NULL
+# polygon x line, reversed order of a valid crossing case -> NULL
+SELECT ST_Crosses(ST_GeomFromText('POLYGON((1 0, 1 2, 2 3, 2 1, 1 0))'),
+ST_GeomFromText('LINESTRING(0 1, 3 2, 4 1)')) a;
+a
+NULL
+# line x same line, equal (not lower-dim intersection) -> 0
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 2)'),
+ST_GeomFromText('LINESTRING(0 0, 2 2)')) a;
+a
+0
+#
 # MDEV-31267 Server crash or assertion failure in get_n_sincos with nested ST_BUFFER.
 #
 set @geom=ST_BUFFER(ST_BUFFER(ST_POLYGONFROMTEXT('POLYGON((0 0, 5 5, 6 6, 0 0))'),1),2);

--- a/mysql-test/main/gis-precise.test
+++ b/mysql-test/main/gis-precise.test
@@ -495,6 +495,45 @@ SELECT ST_CROSSES( ST_GEOMFROMTEXT('POLYGON ((59 18,67 18,67 13,59 13,59 18)) ')
 SELECT ST_CROSSES( ST_GEOMFROMTEXT('POLYGON ((59 18,67 18,67 13,59 13,59 18)) '), st_geomfromtext('point(1 1)') ) a;
 
 --echo #
+--echo # MDEV-40584 ST_CROSSES always returns 0 for geometries of different dimensions
+--echo #
+
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(1 3, 2 2, 3 2)'),
+                  ST_GeomFromText('LINESTRING(0 3, 1 1, 2 2, 2 0)')) a;
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(1 1, 1 3, 2 3)'),
+                  ST_GeomFromText('POLYGON((0 0, 0 3, 2 0, 0 0))')) a;
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 1, 3 2, 4 1)'),
+                  ST_GeomFromText('POLYGON((1 0, 1 2, 2 3, 2 1, 1 0))')) a;
+
+--echo # line x line, crossing (dims 1,1) -> 1
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 2)'),
+                  ST_GeomFromText('LINESTRING(0 2, 2 0)')) a;
+--echo # line x line, not crossing (dims 1,1) -> 0
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 0)'),
+                  ST_GeomFromText('LINESTRING(0 1, 2 1)')) a;
+--echo # point x line, disjoint (dims 0,1) -> 0
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(10 10)'),
+                  ST_GeomFromText('LINESTRING(0 0, 1 1)')) a;
+--echo # point x polygon, disjoint (dims 0,2) -> 0
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOINT(100 100)'),
+                  ST_GeomFromText('POLYGON((0 0, 0 3, 2 0, 0 0))')) a;
+--echo # line x point (g2 is a point) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 1 1)'),
+                  ST_GeomFromText('POINT(5 5)')) a;
+--echo # line x multipoint (g2 is a multipoint) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 5 5)'),
+                  ST_GeomFromText('MULTIPOINT(1 1, 2 2)')) a;
+--echo # multipolygon x line (g1 is a multipolygon) -> NULL
+SELECT ST_Crosses(ST_GeomFromText('MULTIPOLYGON(((0 0, 0 3, 3 3, 3 0, 0 0)))'),
+                  ST_GeomFromText('LINESTRING(1 1, 2 2)')) a;
+--echo # polygon x line, reversed order of a valid crossing case -> NULL
+SELECT ST_Crosses(ST_GeomFromText('POLYGON((1 0, 1 2, 2 3, 2 1, 1 0))'),
+                  ST_GeomFromText('LINESTRING(0 1, 3 2, 4 1)')) a;
+--echo # line x same line, equal (not lower-dim intersection) -> 0
+SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 2)'),
+                  ST_GeomFromText('LINESTRING(0 0, 2 2)')) a;
+
+--echo #
 --echo # MDEV-31267 Server crash or assertion failure in get_n_sincos with nested ST_BUFFER.
 --echo #
 

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1509,7 +1509,9 @@ bool Item_func_spatial_precise_rel::val_bool()
         null_value= true;
         goto exit;
       }
-      /* fall through */
+      handle_sp_crosses_func_case(func, trn, g1, g2,
+                                  shape_a, shape_b, null_value);
+      break;
     case SP_OVERLAPS_FUNC:
     {
       // Both geometries must have the same number of dimensions.


### PR DESCRIPTION
MDEV-36058 added a dimension-equality check ("Both geometries must
have the same number of dimensions") for SP_OVERLAPS_FUNC, but a
stray fall-through from SP_CROSSES_FUNC into that same case made
CROSSES share it too. CROSSES is defined precisely for geometries
of different dimensions, so any such pair now hit
"if (g1_dim != g2_dim) DBUG_RETURN(0)" and always returned 0.

Give SP_CROSSES_FUNC its own case again, calling
handle_sp_crosses_func_case() directly without the dimension check.
SP_OVERLAPS_FUNC keeps the check.
