### PR TITLE
fix: MDEV-40610 sql injection in DEFAULT value expression fix

### DIFF
--- a/storage/duckdb/build.sh
+++ b/storage/duckdb/build.sh
@@ -11,7 +11,7 @@ BUILD_PATH=$(realpath "$MDB_SOURCE_PATH"/../DuckdbBuildOf_$(basename "$MDB_SOURC
 CPUS=$(getconf _NPROCESSORS_ONLN)
 BUILD_TYPE_OPTIONS=("Debug" "RelWithDebInfo")
 BUILD_TYPE="${BUILD_TYPE:-}"
-DISTRO_OPTIONS=("ubuntu:22.04" "ubuntu:24.04" "debian:12" "rockylinux:8" "rockylinux:9")
+DISTRO_OPTIONS=("ubuntu:22.04" "ubuntu:24.04" "debian:12" "debian:13" "rockylinux:8" "rockylinux:9")
 DEFAULT_MDB_DATADIR="/var/lib/mysql"
 USER="mysql"
 GROUP="mysql"
@@ -30,6 +30,7 @@ usage() {
     echo "  -D          Install build prerequisites (requires root/sudo)"
     echo "  -u          Build unit tests"
     echo "  -a          Enable ASAN/UBSAN (WITH_ASAN, WITH_ASAN_SCOPE, WITH_UBSAN)"
+    echo "  -m          Enable MSAN (WITH_MSAN)"
     echo "  -R          Use gcc-toolset-\${GCC_VERSION} on Rocky 8"
     echo "  -h          Show this help"
     exit 0
@@ -43,9 +44,10 @@ INSTALL_DEPS=false
 GCC_TOOLSET=false
 UNIT_TESTS=false
 WITH_ASAN=false
+WITH_MSAN=false
 OS=""
 
-while getopts "t:d:j:cpSnDRuah" opt; do
+while getopts "t:d:j:cpSnDRuamh" opt; do
     case $opt in
         t) BUILD_TYPE="$OPTARG" ;;
         d) OS="$OPTARG" ;;
@@ -58,6 +60,7 @@ while getopts "t:d:j:cpSnDRuah" opt; do
         R) GCC_TOOLSET=true ;;
         u) UNIT_TESTS=true ;;
         a) WITH_ASAN=true ;;
+        m) WITH_MSAN=true ;;
         h) usage ;;
         *) usage ;;
     esac
@@ -110,6 +113,7 @@ info "Build dir:  ${_CLR_YELLOW}$BUILD_PATH"
 info "Build type: ${_CLR_YELLOW}$BUILD_TYPE"
 info "Jobs:       ${_CLR_YELLOW}$CPUS"
 info "ASAN/UBSAN: ${_CLR_YELLOW}$WITH_ASAN"
+info "MSAN:       ${_CLR_YELLOW}$WITH_MSAN"
 info "Unit tests: ${_CLR_YELLOW}$UNIT_TESTS"
 if [[ $BUILD_PACKAGES = true ]]; then
     info "Packages:   ${_CLR_YELLOW}$PKG_FORMAT ($OS)"
@@ -234,6 +238,13 @@ construct_cmake_flags() {
         )
     fi
 
+    if [[ $WITH_MSAN = true ]]; then
+        MDB_CMAKE_FLAGS+=(
+            -DWITH_MSAN=ON
+            -DWITH_UNIT_TESTS=OFF
+        )
+    fi
+
     if [[ $BUILD_PACKAGES = true ]]; then
         if [[ "$PKG_FORMAT" == "rpm" ]]; then
             local os_version=${OS//[^0-9]/}
@@ -244,6 +255,7 @@ construct_cmake_flags() {
             local codename=""
             case "$OS" in
                 debian:12*)   codename="bookworm" ;;
+                debian:13*)   codename="trixie" ;;
                 ubuntu:22.04) codename="jammy" ;;
                 ubuntu:24.04) codename="noble" ;;
                 *)            fail "Unknown DEB codename for $OS" ;;
@@ -279,8 +291,13 @@ install_deps() {
     local DEB_DEPS="build-essential git cmake ninja-build bison flex \
         libncurses-dev libreadline-dev libssl-dev zlib1g-dev libbz2-dev \
         libzstd-dev libcurl4-openssl-dev libaio-dev libxml2-dev libpcre2-dev \
-        libxcrypt-dev liblzma-dev libpam0g-dev libperl-dev python3 python3-dev \
+        liblz4-dev liblzma-dev liblzo2-dev libsnappy-dev libpam0g-dev libperl-dev python3 python3-dev \
         ccache devscripts equivs debhelper libdistro-info-perl"
+
+    # libxcrypt-dev is not available on Debian 13 (Trixie)
+    if [[ "$OS" != debian:13* ]]; then
+        DEB_DEPS="$DEB_DEPS libxcrypt-dev"
+    fi
 
     local command=""
     case "$OS" in

--- a/storage/duckdb/convertor/ddl_convertor.cc
+++ b/storage/duckdb/convertor/ddl_convertor.cc
@@ -288,7 +288,21 @@ static std::string get_field_default_for_duckdb(Field *field,
     String str(buf, sizeof(buf), system_charset_info);
     String *val= field->val_str(&str);
     if (val && val->length() > 0)
-      default_value= "'" + std::string(val->ptr(), val->length()) + "'";
+    {
+      /*
+        Escape the literal by doubling any embedded single quote so a crafted
+        DEFAULT string cannot terminate the generated DuckDB literal and inject
+        further DuckDB statements (MDEV-40610). escape_quotes_for_mysql() is
+        charset aware and performs exactly this doubling.
+      */
+      std::string escaped(2 * val->length(), '\0');
+      my_bool overflow;
+      size_t escaped_len= escape_quotes_for_mysql(val->charset(), &escaped[0],
+                                                  0, val->ptr(), val->length(),
+                                                  &overflow);
+      escaped.resize(escaped_len);
+      default_value= "'" + escaped + "'";
+    }
     else
       default_value= "NULL";
   }

--- a/storage/duckdb/mysql-test/duckdb/r/duckdb_default_value_injection.result
+++ b/storage/duckdb/mysql-test/duckdb/r/duckdb_default_value_injection.result
@@ -1,0 +1,25 @@
+#
+# MDEV-40610: an unescaped column DEFAULT string must not inject DuckDB SQL
+#
+# get_field_default_for_duckdb() wrapped a string DEFAULT in single quotes
+# without doubling an embedded quote, so a crafted default closed the
+# generated DuckDB literal and the rest was parsed as DuckDB SQL. The gate
+# below fails while the injection works and passes once literals are escaped.
+SET NAMES utf8mb4;
+# The crafted DEFAULT closes the generated literal and appends a DuckDB COPY
+# that would write a file in the data directory. With the literal escaped the
+# payload is stored as data and no statement is injected.
+CREATE TABLE t (id INT PRIMARY KEY, c VARCHAR(200) DEFAULT 'a'');COPY(SELECT 2)TO ''zz_def.csv'';--') ENGINE=DuckDB CHARSET=utf8mb4|
+# No injected COPY ran: zz_def.csv must not exist anywhere under the vardir.
+# The default round-trips through MariaDB as plain data.
+INSERT INTO t (id) VALUES (1);
+SELECT c FROM t WHERE id = 1;
+c
+a');COPY(SELECT 2)TO 'zz_def.csv';--
+# A legitimate quote in a DEFAULT is stored and returned verbatim.
+ALTER TABLE t ADD COLUMN d VARCHAR(20) DEFAULT 'a''b';
+INSERT INTO t (id) VALUES (2);
+SELECT d FROM t WHERE id = 2;
+d
+a'b
+DROP TABLE t;

--- a/storage/duckdb/mysql-test/duckdb/t/alter_default_debug.test
+++ b/storage/duckdb/mysql-test/duckdb/t/alter_default_debug.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE t(id INT PRIMARY KEY, a INT, b INT, c INT) ENGINE = DuckDB;
 INSERT INTO t VALUES(1, 1, 1, 1);

--- a/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_column.test
+++ b/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_column.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo ####################
 --echo # TEST FOR INSTANT #
 --echo ####################

--- a/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_column_copy.test
+++ b/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_column_copy.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #################
 --echo # TEST FOR COPY #
 --echo #################

--- a/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_index.test
+++ b/storage/duckdb/mysql-test/duckdb/t/alter_duckdb_index.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo ####################
 --echo # TEST FOR INSTANT #
 --echo ####################

--- a/storage/duckdb/mysql-test/duckdb/t/alter_engine_duckdb.test
+++ b/storage/duckdb/mysql-test/duckdb/t/alter_engine_duckdb.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 SET GLOBAL duckdb_copy_ddl_in_batch=ON;
 --source ../include/alter_engine_duckdb.inc
 

--- a/storage/duckdb/mysql-test/duckdb/t/batch_disconnect.test
+++ b/storage/duckdb/mysql-test/duckdb/t/batch_disconnect.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --disable_query_log
 SET @saved_duckdb_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;

--- a/storage/duckdb/mysql-test/duckdb/t/batch_rollback.test
+++ b/storage/duckdb/mysql-test/duckdb/t/batch_rollback.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --disable_query_log
 SET @saved_duckdb_dml_in_batch = @@GLOBAL.duckdb_dml_in_batch;

--- a/storage/duckdb/mysql-test/duckdb/t/bugfix_crash_after_commit_error.test
+++ b/storage/duckdb/mysql-test/duckdb/t/bugfix_crash_after_commit_error.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --skip TODO
 create table t1(id int primary key) engine = duckdb;

--- a/storage/duckdb/mysql-test/duckdb/t/bugfix_temp_and_system_database.test
+++ b/storage/duckdb/mysql-test/duckdb/t/bugfix_temp_and_system_database.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 # DuckDB has default databases named 'temp' and 'system', if we try to create
 # schema named 'temp' or 'system', we get an error.

--- a/storage/duckdb/mysql-test/duckdb/t/charset_and_collation.test
+++ b/storage/duckdb/mysql-test/duckdb/t/charset_and_collation.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 --echo #
 --echo # check collation config when execute
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/create_table_column.test
+++ b/storage/duckdb/mysql-test/duckdb/t/create_table_column.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 # file: duckdb_create_table.test
 #
 # Test case for creating tables with various MySQL field types in DuckDB.

--- a/storage/duckdb/mysql-test/duckdb/t/create_table_column_timestamp.test
+++ b/storage/duckdb/mysql-test/duckdb/t/create_table_column_timestamp.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --source include/have_debug.inc
 
 --disable_query_log

--- a/storage/duckdb/mysql-test/duckdb/t/create_table_constraint.test
+++ b/storage/duckdb/mysql-test/duckdb/t/create_table_constraint.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 --source include/have_debug.inc
 
 

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_join.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_join.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # Cross-engine join: DuckDB + InnoDB via _mdb_scan replacement scan
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow_dup.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow_dup.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo #
 --echo # Cross-engine RYOW: the same external table referenced more than once.

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow_limit.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_ryow_limit.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_union.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_union.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # Cross-engine UNION: DuckDB + InnoDB via select_handler unit pushdown
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/cross_engine_where.test
+++ b/storage/duckdb/mysql-test/duckdb/t/cross_engine_where.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/decimal_high_precision.test
+++ b/storage/duckdb/mysql-test/duckdb/t/decimal_high_precision.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/decimal_precision_all_possibilities.test
+++ b/storage/duckdb/mysql-test/duckdb/t/decimal_precision_all_possibilities.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 set global duckdb_dml_in_batch = OFF;
 --source ../include/decimal_precision_all_possibilities.inc
 

--- a/storage/duckdb/mysql-test/duckdb/t/dml_delete.test
+++ b/storage/duckdb/mysql-test/duckdb/t/dml_delete.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # DuckDB DELETE operations test
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/dml_update.test
+++ b/storage/duckdb/mysql-test/duckdb/t/dml_update.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # DuckDB UPDATE operations test
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/drop_database.test
+++ b/storage/duckdb/mysql-test/duckdb/t/drop_database.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # DuckDB DROP DATABASE operations test
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_add_backticks.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_add_backticks.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 SET GLOBAL duckdb_require_primary_key=OFF;
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_agg_func.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_agg_func.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE t_innodb (
 	id INT PRIMARY KEY,

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_allow_encryption.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_allow_encryption.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 
 --disable_warnings
 DROP DATABASE IF EXISTS encryption_test;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_alter_table_engine.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_alter_table_engine.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo #
 --echo # Test DDL: alter table engine = innodb from duckdb tables

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_appender_allocator_flush_threshold.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_appender_allocator_flush_threshold.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 SHOW GLOBAL VARIABLES LIKE "duckdb_appender_allocator_flush_threshold";
 SELECT run_in_duckdb("FROM duckdb_settings() WHERE name = 'allocator_flush_threshold'");

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_auto_increment.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_auto_increment.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --disable_query_log
 CREATE DATABASE IF NOT EXISTS db_autoinc CHARACTER SET utf8mb4;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_bit_string.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_bit_string.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE t1 (id INT PRIMARY KEY, col1 VARCHAR(100)) ENGINE=DuckDB;
 CREATE TABLE t2 (id INT PRIMARY KEY, col1 BLOB) ENGINE=DuckDB;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_collate.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_collate.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --disable_query_log
 --disable_warnings
 DROP TABLE IF EXISTS t1;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_cte.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_cte.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 CREATE DATABASE IF NOT EXISTS duckdb_cte;
 USE duckdb_cte;
 

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_db_table_strconvert.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_db_table_strconvert.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 # Test for escape characters in the table name or database name.
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_ddl_during_transaction.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_ddl_during_transaction.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo ###########################################################################
 --echo # Prepare

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_default_expr.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_default_expr.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --disable_query_log
 CREATE DATABASE IF NOT EXISTS db_default_expr CHARACTER SET utf8mb4;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_default_value_injection.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_default_value_injection.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo #
 --echo # MDEV-40610: an unescaped column DEFAULT string must not inject DuckDB SQL

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_default_value_injection.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_default_value_injection.test
@@ -1,0 +1,45 @@
+--source ../include/have_duckdb.inc
+
+--echo #
+--echo # MDEV-40610: an unescaped column DEFAULT string must not inject DuckDB SQL
+--echo #
+--echo # get_field_default_for_duckdb() wrapped a string DEFAULT in single quotes
+--echo # without doubling an embedded quote, so a crafted default closed the
+--echo # generated DuckDB literal and the rest was parsed as DuckDB SQL. The gate
+--echo # below fails while the injection works and passes once literals are escaped.
+
+--disable_query_log
+CREATE DATABASE IF NOT EXISTS injdb CHARACTER SET utf8mb4;
+USE injdb;
+--enable_query_log
+SET NAMES utf8mb4;
+
+--echo # The crafted DEFAULT closes the generated literal and appends a DuckDB COPY
+--echo # that would write a file in the data directory. With the literal escaped the
+--echo # payload is stored as data and no statement is injected.
+--delimiter |
+CREATE TABLE t (id INT PRIMARY KEY, c VARCHAR(200) DEFAULT 'a'');COPY(SELECT 2)TO ''zz_def.csv'';--') ENGINE=DuckDB CHARSET=utf8mb4|
+--delimiter ;
+
+--echo # No injected COPY ran: zz_def.csv must not exist anywhere under the vardir.
+perl;
+  use File::Find;
+  my $found= 0;
+  find(sub { $found= 1 if $_ eq 'zz_def.csv' }, $ENV{MYSQLTEST_VARDIR});
+  die "MDEV-40610: crafted DEFAULT injected a COPY (zz_def.csv written)\n" if $found;
+EOF
+
+--echo # The default round-trips through MariaDB as plain data.
+INSERT INTO t (id) VALUES (1);
+SELECT c FROM t WHERE id = 1;
+
+--echo # A legitimate quote in a DEFAULT is stored and returned verbatim.
+ALTER TABLE t ADD COLUMN d VARCHAR(20) DEFAULT 'a''b';
+INSERT INTO t (id) VALUES (2);
+SELECT d FROM t WHERE id = 2;
+
+DROP TABLE t;
+
+--disable_query_log
+DROP DATABASE injdb;
+--enable_query_log

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_fix_sql.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_fix_sql.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE fake_innodb_table (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO fake_innodb_table VALUES (0);

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_json.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_json.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE t1_innodb (id INT PRIMARY KEY, col1 JSON) ENGINE=InnoDB;
 CREATE TABLE t1_duckdb (id INT PRIMARY KEY, col1 JSON) ENGINE=DuckDB;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_kill.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_kill.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --source include/have_debug.inc
 --source include/have_debug_sync.inc

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_monitor.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_monitor.test
@@ -1,4 +1,7 @@
 --source ../include/have_duckdb.inc
+# MDEV-40449: MSan reports use-of-uninitialized-value in
+# duckdb::JemallocExtension::ThreadFlush (false positive from uninstrumented jemalloc).
+--source include/not_msan.inc
 
 #
 # DuckDB monitoring status variables test.

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_numeric_func.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_numeric_func.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 # 1. CONV(), CRC32(), MOD, DIV, TRUNCATE() is not support yet.
 # 2. The RAND() function in duckdb and mysql uses different random number generation algorithms, so it cannot support the seed argument.

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_refuse_xa.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_refuse_xa.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 CREATE TABLE t1 (c1 INT PRIMARY KEY, c2 VARCHAR(5)) ENGINE=duckdb;
 

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_require_primary_key.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_require_primary_key.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 
 

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_set_operation.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_set_operation.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 CREATE TABLE t1 (id INT PRIMARY KEY, col1 INT) ENGINE=DuckDB;
 INSERT INTO t1 VALUES (1, 1), (2, 1), (3, 2), (4, 2);
 CREATE TABLE t2 (id INT PRIMARY KEY, col1 INT) ENGINE=DuckDB;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_sql_mode.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_sql_mode.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo
 --echo 1. ONLY_FULL_GROUP_BY

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_sql_syntax.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_sql_syntax.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 # WITH ROLLUP
 CREATE TABLE t1 (id INT PRIMARY KEY, col1 INT, col2 INT);
 SELECT id, col1, col2 FROM t1 GROUP BY id, col1, col2 WITH ROLLUP;

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_string_func.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_string_func.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 # 1. In Duckdb, some string function does not support blob fields as input
 # 2. Regex-related functions are basically incompatible, and regex functions will be processed uniformly in the future.

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_time_func.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_time_func.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 # Compared with MySQL, duckdb's date functions generally have the following incompatibilities:
 # 1. Conversion between integer type and date/timestamp/time type

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_time_func_unsupported.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_time_func_unsupported.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 # Unsupported / incompatible date-time functions for DuckDB pushdown.
 # This is the companion of duckdb_time_func.test which keeps only the

--- a/storage/duckdb/mysql-test/duckdb/t/duckdb_uuid.test
+++ b/storage/duckdb/mysql-test/duckdb/t/duckdb_uuid.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/feature_duckdb_data_type.test
+++ b/storage/duckdb/mysql-test/duckdb/t/feature_duckdb_data_type.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 # Feature ORC data type test
 
 # Prepare

--- a/storage/duckdb/mysql-test/duckdb/t/ha_duckdb.test
+++ b/storage/duckdb/mysql-test/duckdb/t/ha_duckdb.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # Basic DuckDB handler test: DDL and DML operations
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/mdev_40379.test
+++ b/storage/duckdb/mysql-test/duckdb/t/mdev_40379.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 #
 # MDEV-40379: Assertion failure in CreateTableConvertor::translate
 # upon CREATE TEMPORARY TABLE with ENGINE=DuckDB

--- a/storage/duckdb/mysql-test/duckdb/t/pushdown_rewrite.test
+++ b/storage/duckdb/mysql-test/duckdb/t/pushdown_rewrite.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --disable_warnings
 DROP DATABASE IF EXISTS pushdown_rewrite;

--- a/storage/duckdb/mysql-test/duckdb/t/rename_duckdb_table.test
+++ b/storage/duckdb/mysql-test/duckdb/t/rename_duckdb_table.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 --echo #
 --echo # 1) Prepare

--- a/storage/duckdb/mysql-test/duckdb/t/run_in_duckdb_access.test
+++ b/storage/duckdb/mysql-test/duckdb/t/run_in_duckdb_access.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 
 SET @saved_allow_run_in_duckdb = @@GLOBAL.duckdb_allow_run_in_duckdb;
 # The suite enables duckdb_allow_run_in_duckdb globally (suite.opt), and MTR may

--- a/storage/duckdb/mysql-test/duckdb/t/space_reclaim.test
+++ b/storage/duckdb/mysql-test/duckdb/t/space_reclaim.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/streaming_select.test
+++ b/storage/duckdb/mysql-test/duckdb/t/streaming_select.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --source include/have_sequence.inc
 
 --disable_warnings

--- a/storage/duckdb/mysql-test/duckdb/t/supported_copy_ddl.test
+++ b/storage/duckdb/mysql-test/duckdb/t/supported_copy_ddl.test
@@ -1,4 +1,5 @@
 --source ../include/have_duckdb.inc
+--source include/not_msan.inc
 # Test for DDL which are supported by DuckDB using COPY algorithm
 --echo #
 --echo # RENAME TABLE WITH DIFFERENT DATABASES

--- a/storage/duckdb/mysql-test/duckdb/t/system_timezone.test
+++ b/storage/duckdb/mysql-test/duckdb/t/system_timezone.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --source ../include/have_mysqld_safe.inc
 
 # 1) Set valiables to be used in parameters of mysqld_safe.

--- a/storage/duckdb/mysql-test/duckdb/t/transaction.test
+++ b/storage/duckdb/mysql-test/duckdb/t/transaction.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # DuckDB transaction tests
 --echo #

--- a/storage/duckdb/mysql-test/duckdb/t/truncate_and_maintenance_duckdb_table.test
+++ b/storage/duckdb/mysql-test/duckdb/t/truncate_and_maintenance_duckdb_table.test
@@ -1,3 +1,4 @@
+--source include/not_msan.inc
 --echo #
 --echo # 1) PREPARE
 --echo #


### PR DESCRIPTION
## Fix DEFAULT-expression SQL injection; add MSAN build support and gate MTR on it

### What
Two fixes for the DuckDB engine. MDEV-40610: a string column DEFAULT was
wrapped in single quotes without escaping embedded quotes, letting a crafted
default close the generated DuckDB literal and inject arbitrary DuckDB SQL.
MDEV-40386: adds an MSAN build mode and disables the MTR suite there because
MSAN builds are currently unstable.

### Key changes
- `convertor/ddl_convertor.cc`: escape string DEFAULT literals via charset-aware
  `escape_quotes_for_mysql()` (doubles embedded single quotes) in
  `get_field_default_for_duckdb()`.
- New MTR `duckdb_default_value_injection` test + result proving a crafted
  DEFAULT no longer injects a `COPY`, and a legit quote round-trips verbatim.
- `build.sh`: add `-m` (WITH_MSAN, unit tests off) and Debian 13 (trixie)
  packaging support, adjusting deps (drop libxcrypt on trixie).
- Add `--source include/not_msan.inc` to all duckdb MTR tests to skip under MSAN.

### How to test
`./run_mtr.sh duckdb_default_value_injection` (passes; injected `zz_def.csv` is
never written). Optionally `./build.sh -m -t Debug` to exercise the MSAN path.