### PR TITLE
MDEV-36677 rsync sst fails with different innodb_log_group_home_dir a…

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_mdev_36677.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_mdev_36677.result
@@ -1,0 +1,91 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+CREATE TABLE t1 (id int not null primary key,f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1,'node1_committed_at_start');
+INSERT INTO t1 VALUES (2,'node1_committed_at_start');
+INSERT INTO t1 VALUES (3,'node1_committed_at_start');
+INSERT INTO t1 VALUES (4,'node1_committed_at_start');
+INSERT INTO t1 VALUES (5,'node1_committed_at_start');
+COMMIT;
+connection node_2;
+connection node_3;
+connection node_2;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (6,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (7,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (8,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (9,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (10,'node2_committed_when_node3_down');
+COMMIT;
+connection node_3;
+# restart: --wsrep_sst_donor=node2
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_10 FROM t1;
+EXPECT_10
+10
+SELECT * from t1;
+id	f1
+1	node1_committed_at_start
+2	node1_committed_at_start
+3	node1_committed_at_start
+4	node1_committed_at_start
+5	node1_committed_at_start
+6	node2_committed_when_node3_down
+7	node2_committed_when_node3_down
+8	node2_committed_when_node3_down
+9	node2_committed_when_node3_down
+10	node2_committed_when_node3_down
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+connection node_2;
+connection node_3;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (11,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (12,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (13,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (14,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (15,'node2_committed_when_node2_down');
+COMMIT;
+connection node_2;
+# restart: --wsrep_sst_donor=node3
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_15 FROM t1;
+EXPECT_15
+15
+SELECT * from t1;
+id	f1
+1	node1_committed_at_start
+2	node1_committed_at_start
+3	node1_committed_at_start
+4	node1_committed_at_start
+5	node1_committed_at_start
+6	node2_committed_when_node3_down
+7	node2_committed_when_node3_down
+8	node2_committed_when_node3_down
+9	node2_committed_when_node3_down
+10	node2_committed_when_node3_down
+11	node2_committed_when_node2_down
+12	node2_committed_when_node2_down
+13	node2_committed_when_node2_down
+14	node2_committed_when_node2_down
+15	node2_committed_when_node2_down
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (10, 15)) AS a1;
+COUNT(*) = 0
+0
+connection node_1;
+DROP TABLE t1;
+COMMIT;

--- a/mysql-test/suite/galera_3nodes/t/galera_mdev_36677.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_mdev_36677.cnf
@@ -1,0 +1,16 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=rsync
+
+[mysqld.1]
+wsrep_provider_options='pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
+
+[mysqld.2]
+wsrep_provider_options='pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
+innodb_log_group_home_dir=@ENV.MYSQL_TMP_DIR/mysqld.2/mdev_36677_log_dir
+aria_log_dir_path=@ENV.MYSQL_TMP_DIR/mysqld.2/mdev_36677_aria_log_dir
+
+[mysqld.3]
+wsrep_provider_options='pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
+

--- a/mysql-test/suite/galera_3nodes/t/galera_mdev_36677.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_mdev_36677.test
@@ -1,0 +1,126 @@
+#
+# MDEV-36677
+#
+# This test checks the rsync SST works also when InnoDB log files
+# reside in a dedicated directory other than the data directory.
+
+# The test comprises of two parts: in Part A the SST donor has InnoDB
+# log files outside the data dictionary and in Part B the SST joiner
+# has log files outside the data dictionary.
+#  
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/big_test.inc
+
+# Set up a 3-node cluster where node_2 has log files outside data dictionary
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--connection node_1
+--source include/wait_condition.inc
+--connection node_2
+--source include/wait_condition.inc
+--connection node_3
+--source include/wait_condition.inc
+
+--connection node_1
+CREATE TABLE t1 (id int not null primary key,f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1,'node1_committed_at_start');
+INSERT INTO t1 VALUES (2,'node1_committed_at_start');
+INSERT INTO t1 VALUES (3,'node1_committed_at_start');
+INSERT INTO t1 VALUES (4,'node1_committed_at_start');
+INSERT INTO t1 VALUES (5,'node1_committed_at_start');
+COMMIT;
+
+
+--connection node_2
+--source include/galera_wait_ready.inc
+
+let $MYSQLD2_DATADIR= `SELECT @@datadir`;
+let $MYSQLD2_INNODB_LOGDIR=  `SELECT @@innodb_log_group_home_dir`;
+let $MYSQLD2_ARIA_LOGDIR=  `SELECT @@aria_log_dir_path`;
+
+# Part A: SST from node_2 to node_3
+--connection node_3
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/grastate.dat
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.3/data
+
+--connection node_2
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (6,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (7,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (8,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (9,'node2_committed_when_node3_down');
+INSERT INTO t1 VALUES (10,'node2_committed_when_node3_down');
+COMMIT;
+
+--connection node_3
+--let $restart_parameters = --wsrep_sst_donor=node2
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+
+--let $wait_condition = SELECT COUNT(*)=10 FROM t1
+--source include/wait_condition.inc
+
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_10 FROM t1;
+SELECT * from t1;
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+
+# Part B: SST from node_3 to node_2
+--connection node_2
+--source include/shutdown_mysqld.inc
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.2/data
+--remove_files_wildcard  $MYSQL_TMP_DIR/mysqld.2/mdev_36677_log_dir
+--remove_files_wildcard  $MYSQL_TMP_DIR/mysqld.2/mdev_36677_aria_log_dir
+
+--connection node_3
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (11,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (12,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (13,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (14,'node2_committed_when_node2_down');
+INSERT INTO t1 VALUES (15,'node2_committed_when_node2_down');
+COMMIT;
+
+--connection node_2
+--let $restart_parameters = --wsrep_sst_donor=node3
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+
+--let $wait_condition = SELECT COUNT(*)=15 FROM t1
+--source include/wait_condition.inc
+
+# check that InnoDB log file was not copied to a data directory, but to a dedicated directory
+--exec if [ -f $MYSQLD2_DATADIR/ib_logfile0 ]; then false; fi
+--exec if [ ! -f $MYSQLD2_INNODB_LOGDIR/ib_logfile0 ]; then false; fi
+# check that Aria log file was not copied to a data directory, but to a dedicated directory
+--exec if [ -f $MYSQLD2_DATADIR/aria_log.00000001 ]; then false; fi
+--exec if [ ! -f $MYSQLD2_ARIA_LOGDIR/aria_log.00000001 ]; then false; fi
+
+SET AUTOCOMMIT=ON;
+SET SESSION wsrep_sync_wait=15;
+SELECT COUNT(*) AS EXPECT_15 FROM t1;
+SELECT * from t1;
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (10, 15)) AS a1;
+
+# cleanup
+--connection node_1
+--source ../galera/include/auto_increment_offset_restore.inc
+
+DROP TABLE t1;
+COMMIT;

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -324,6 +324,8 @@ RC=0
 
 if [ "$WSREP_SST_OPT_ROLE" = 'donor' ]; then
 
+    create_dirs
+
     if [ -n "$STUNNEL" ]; then
         cat << EOF > "$STUNNEL_CONF"
 key = $SSTKEY


### PR DESCRIPTION
…nd datadir

Backported the fix done by Pekka Lampio for mariaDB 11.4 in PR https://github.com/mariadb-corporation/codership-mariadb-server/pull/543

The PR has a fix for wsrep_sst_rsync script and new mtr test: galera_3nodes.galera_mdev_36677" to check that the rsync SST method of Galera works correctly also when the joiner node store InnoDB log files in a dedicated directory separate from the data dictionary

Note: merging this PR to 11.4 may not be fully functional as there are other changes in the rsync SST script. Take a look at the original 11.4 PR when merging.