### PR TITLE
Do not dump stats for read only engines' tables.

### DIFF
--- a/mysql-test/main/opt_context_store_ddls.result
+++ b/mysql-test/main/opt_context_store_ddls.result
@@ -543,16 +543,28 @@ SELECT SETVAL(db1.s1, 1);
 
 
 drop table s1;
-# no ddl should be captured here
+# ddls should be captured here
 explain select * from seq_1_to_10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	seq_1_to_10	index	NULL	PRIMARY	8	NULL	10	Using index
 # == Optimizer Context Tables
 name
-db1.seq_1_to_10
 # === Optimizer Context DDLs
 @ddls
 CREATE TABLE IF NOT EXISTS `seq_1_to_10` (
+  `seq` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`seq`)
+) ENGINE=SEQUENCE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+
+
+explain select * from seq_1_to_15_step_2 where seq = 5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	seq_1_to_15_step_2	const	PRIMARY	PRIMARY	8	const	1	Using index
+# == Optimizer Context Tables
+name
+# === Optimizer Context DDLs
+@ddls
+CREATE TABLE IF NOT EXISTS `seq_1_to_15_step_2` (
   `seq` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`seq`)
 ) ENGINE=SEQUENCE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;

--- a/mysql-test/main/opt_context_store_ddls.test
+++ b/mysql-test/main/opt_context_store_ddls.test
@@ -321,8 +321,10 @@ explain select * from s1;
 --source include/opt_context_list_tables_ddls.inc
 drop table s1;
 
---echo # no ddl should be captured here
+--echo # ddls should be captured here
 explain select * from seq_1_to_10;
+--source include/opt_context_list_tables_ddls.inc
+explain select * from seq_1_to_15_step_2 where seq = 5;
 --source include/opt_context_list_tables_ddls.inc
 
 --echo # End of 13.1 tests

--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -603,7 +603,16 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 # === Tables
 # Tables in the context
 table_name	file_stat_records	index_name	rec_per_key
-test.seq_1_to_10	10	PRIMARY	["0"]
+# === Range accesses
+index_name	ranges	num_rows	max_index_blocks	max_row_blocks
+# == End of optimizer context
+explain select * from seq_1_to_15_step_2 where seq = 5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	seq_1_to_15_step_2	const	PRIMARY	PRIMARY	8	const	1	Using index
+# == Optimizer Context
+# === Tables
+# Tables in the context
+table_name	file_stat_records	index_name	rec_per_key
 # === Range accesses
 index_name	ranges	num_rows	max_index_blocks	max_row_blocks
 # == End of optimizer context

--- a/mysql-test/main/opt_context_store_stats.test
+++ b/mysql-test/main/opt_context_store_stats.test
@@ -443,6 +443,9 @@ explain select * from seq_1_to_10;
 
 --source include/opt_context_list_tables_and_ranges.inc
 
+explain select * from seq_1_to_15_step_2 where seq = 5;
+--source include/opt_context_list_tables_and_ranges.inc
+
 --echo #
 --echo # partitioned table test
 --echo # context result should have stats for this table

--- a/sql/opt_context_store_replay.cc
+++ b/sql/opt_context_store_replay.cc
@@ -844,6 +844,16 @@ bool Optimizer_context_recorder::dump_sql_script(THD* thd, String &sql_script)
 
       continue;
     }
+    else if (tbl->table->s->db_type() &&
+             tbl->table->s->db_type()->discover_table)
+    {
+      /*
+        No need to collect stats, and record const rows for
+        sequence tables such as seq_1_to_10 or
+        other read only engines' (Archive, S3, PerfSchema) tables.
+      */
+      continue;
+    }
 
     /* No, it's a base table */
     Json_writer_object ctx_wrapper(&ctx_writer);


### PR DESCRIPTION
Stats for tables from engines such as Archive, S3, PerfSchema, and
Sequence shouldn't be recorded in the context. Similarly, const row
records should also not be stored in the context.

Added few tests for Sequence's engine tables like seq_1_to_5.