### PR TITLE
MDEV-40621 InnoDB: Failing assertion: doc_id == src_node->last_doc_id

### DIFF
--- a/mysql-test/suite/innodb_fts/r/fulltext.result
+++ b/mysql-test/suite/innodb_fts/r/fulltext.result
@@ -846,3 +846,18 @@ DROP TABLE t1, t2;
 #
 # End of 10.11 tests
 #
+#
+# MDEV-40621 InnoDB: Failing assertion: doc_id == src_node->last_doc_id
+#
+CREATE TABLE t1 (f1 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+f2 MEDIUMTEXT,
+FULLTEXT KEY ftidx (f2)) ENGINE=InnoDB;
+INSERT INTO t1 (f2) SELECT REPEAT('megaword ', 30) FROM seq_1_to_260;
+DELETE FROM t1 WHERE f1 = 1;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+SET GLOBAL innodb_optimize_fulltext_only = OFF;
+DROP TABLE t1;
+# End of 13.1 tests

--- a/mysql-test/suite/innodb_fts/t/fulltext.test
+++ b/mysql-test/suite/innodb_fts/t/fulltext.test
@@ -3,6 +3,7 @@
 #
 
 --source include/have_innodb.inc
+--source include/have_sequence.inc
 
 CREATE TABLE t1 (a VARCHAR(200), b TEXT, FULLTEXT (a,b)) ENGINE = InnoDB;
 INSERT INTO t1 VALUES('MySQL has now support', 'for full-text search'),
@@ -855,3 +856,17 @@ DROP TABLE t1, t2;
 --echo # End of 10.11 tests
 --echo #
 
+--echo #
+--echo # MDEV-40621 InnoDB: Failing assertion: doc_id == src_node->last_doc_id
+--echo #
+CREATE TABLE t1 (f1 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                 f2 MEDIUMTEXT,
+                 FULLTEXT KEY ftidx (f2)) ENGINE=InnoDB;
+INSERT INTO t1 (f2) SELECT REPEAT('megaword ', 30) FROM seq_1_to_260;
+DELETE FROM t1 WHERE f1 = 1;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+OPTIMIZE TABLE t1;
+SET GLOBAL innodb_optimize_fulltext_only = OFF;
+DROP TABLE t1;
+
+--echo # End of 13.1 tests

--- a/storage/innobase/fts/fts0exec.cc
+++ b/storage/innobase/fts/fts0exec.cc
@@ -761,9 +761,6 @@ dberr_t AuxRecordReader::default_word_processor(
   const byte* doc_count_data= rec_get_nth_field(rec, offsets, 5, &doc_count_len);
   uint32_t doc_count= mach_read_from_4(doc_count_data);
 
-  ulint ilist_len;
-  const byte* ilist_data= rec_get_nth_field(rec, offsets, 6, &ilist_len);
-
   fts_word_t *word;
   bool is_word_init= false;
 
@@ -800,16 +797,29 @@ dberr_t AuxRecordReader::default_word_processor(
   node->ilist_size_alloc= node->ilist_size= 0;
   node->ilist= nullptr;
 
+  ulint ilist_len;
+  const byte* ilist_data;
+  mem_heap_t* ext_heap= nullptr;
+  if (rec_offs_nth_extern(offsets, 6))
+  {
+    ext_heap= mem_heap_create(FTS_ILIST_MAX_SIZE);
+    ilist_data= btr_rec_copy_externally_stored_field(
+      rec, offsets, index->table->space->zip_size(), 6, &ilist_len,
+      ext_heap);
+  }
+  else
+    ilist_data= rec_get_nth_field(rec, offsets, 6, &ilist_len);
+
   if (ilist_data && ilist_len != UNIV_SQL_NULL && ilist_len > 0)
   {
     node->ilist_size_alloc= node->ilist_size= ilist_len;
-    if (ilist_len)
-    {
-      node->ilist= static_cast<byte*>(ut_malloc_nokey(ilist_len));
-      memcpy(node->ilist, ilist_data, ilist_len);
-    }
-    if (ilist_len == 0) return DB_SUCCESS_LOCKED_REC;
+    node->ilist=
+      static_cast<byte*>(memcpy(ut_malloc_nokey(ilist_len), ilist_data,
+                                ilist_len));
   }
+
+  if (ext_heap)
+    mem_heap_free(ext_heap);
 
   if (this->total_memory)
   {


### PR DESCRIPTION
AuxRecordReader::default_word_processor(): InnoDB fails to consider the ilist data can be stored externally while decoding the auxiliary table record.