### PR TITLE
MDEV-40667 Infinite loop on SET GLOBAL innodb_log_archive=ON

### DIFF
--- a/mysql-test/suite/mariabackup/huge_lsn,strict_crc32.rdiff
+++ b/mysql-test/suite/mariabackup/huge_lsn,strict_crc32.rdiff
@@ -1,6 +1,6 @@
---- suite/mariabackup/huge_lsn.result
-+++ suite/mariabackup/huge_lsn.reject
-@@ -1,8 +1,8 @@
+--- huge_lsn.result
++++ huge_lsn,strict_crc32.result
+@@ -1,11 +1,10 @@
  #
  # MDEV-13416 mariabackup fails with EFAULT "Bad Address"
  #
@@ -10,4 +10,7 @@
 +FOUND 1 /redo log: [0-9.]*[KMGT]iB; LSN=17596481010687\b/ in mysqld.1.err
  CREATE TABLE t(i INT) ENGINE=INNODB ENCRYPTED=YES;
  INSERT INTO t VALUES(1);
+-SET GLOBAL innodb_log_archive=ON, innodb_log_archive=OFF;
  # xtrabackup backup
+ SET GLOBAL innodb_flush_log_at_trx_commit=1;
+ INSERT INTO t VALUES(2);

--- a/mysql-test/suite/mariabackup/huge_lsn.result
+++ b/mysql-test/suite/mariabackup/huge_lsn.result
@@ -5,6 +5,7 @@
 FOUND 1 /InnoDB: log sequence number 17596481011216/ in mysqld.1.err
 CREATE TABLE t(i INT) ENGINE=INNODB ENCRYPTED=YES;
 INSERT INTO t VALUES(1);
+SET GLOBAL innodb_log_archive=ON, innodb_log_archive=OFF;
 # xtrabackup backup
 SET GLOBAL innodb_flush_log_at_trx_commit=1;
 INSERT INTO t VALUES(2);

--- a/mysql-test/suite/mariabackup/huge_lsn.test
+++ b/mysql-test/suite/mariabackup/huge_lsn.test
@@ -76,6 +76,10 @@ let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 CREATE TABLE t(i INT) ENGINE=INNODB ENCRYPTED=YES;
 INSERT INTO t VALUES(1);
 
+if (!$MTR_COMBINATION_STRICT_CRC32) {
+SET GLOBAL innodb_log_archive=ON, innodb_log_archive=OFF;
+}
+
 echo # xtrabackup backup;
 let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 --disable_result_log

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1942,7 +1942,6 @@ inline lsn_t log_t::write_checkpoint(lsn_t checkpoint, lsn_t end_lsn) noexcept
         archive_header_was_reset= first_lsn + capacity();
         ut_ad(current_lsn >= first_lsn);
         ut_ad(current_lsn < archive_header_was_reset);
-        circular_recovery_from_sequence_bit_0= false;
         next_checkpoint_no= uint16_t(4 * is_encrypted());
 
         if (is_encrypted())
@@ -1951,8 +1950,18 @@ inline lsn_t log_t::write_checkpoint(lsn_t checkpoint, lsn_t end_lsn) noexcept
 #ifdef HAVE_PMEM
         c= checkpoint_buf;
 #endif
+
+        goto all_sequence_bit_1;
       }
     }
+    else
+    all_sequence_bit_1:
+      /*
+        All log records starting with this checkpoint in the
+        innodb_log_archive=ON format will have been
+        written with the sequence bit 1.
+      */
+      circular_recovery_from_sequence_bit_0= false;
 
     ut_ad(end_lsn >= first_lsn);
     offset= next_checkpoint_no * 8;
@@ -2213,6 +2222,7 @@ static lsn_t log_checkpoint_low(lsn_t oldest_lsn, lsn_t end_lsn) noexcept
   if (oldest_lsn == log_sys.last_checkpoint_lsn ||
       (oldest_lsn == end_lsn &&
        !log_sys.resize_in_progress() &&
+       (!log_sys.archive || !log_sys.circular_recovery_from_0()) &&
        oldest_lsn == log_sys.last_checkpoint_lsn +
        log_sys.is_encrypted() * 8 + SIZE_OF_FILE_CHECKPOINT))
     if (oldest_lsn != log_sys.get_first_lsn())
@@ -2327,6 +2337,7 @@ ATTRIBUTE_COLD void buf_flush_wait(lsn_t lsn, bool checkpoint) noexcept
   lsn_t oldest_lsn;
   if (!checkpoint);
   else if (lsn == log_sys.get_lsn() &&
+           (!log_sys.archive || !log_sys.circular_recovery_from_0()) &&
            lsn == log_sys.last_checkpoint_lsn +
            SIZE_OF_FILE_CHECKPOINT + 8 * log_sys.is_encrypted());
   else if (buf_flush_sync_lsn < lsn)
@@ -2361,7 +2372,8 @@ ATTRIBUTE_COLD void buf_flush_wait(lsn_t lsn, bool checkpoint) noexcept
     {
       lsn= log_sys.get_lsn();
       if (lsn != log_sys.last_checkpoint_lsn +
-          SIZE_OF_FILE_CHECKPOINT + 8 * log_sys.is_encrypted())
+          SIZE_OF_FILE_CHECKPOINT + 8 * log_sys.is_encrypted() ||
+          (log_sys.archive && log_sys.circular_recovery_from_0()))
       {
         buf_flush_sync_lsn= lsn;
         log_sys.set_check_for_checkpoint(true);

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -572,6 +572,11 @@ public:
   lsn_t checkpoint_age_max() const noexcept
   { return max_checkpoint_age + archive * file_size; }
 
+  /** @return whether !archive log records may have been written with
+  get_sequence_bit()==0 */
+  bool circular_recovery_from_0() const noexcept
+  { ut_ad(latch_have_wr()); return circular_recovery_from_sequence_bit_0; }
+
   /** Make previous write_buf() durable and update flushed_to_disk_lsn. */
   bool flush(lsn_t lsn) noexcept;
 

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -799,7 +799,7 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
       if (wait_lsn)
       {
         mysql_mutex_lock(&buf_pool.flush_list_mutex);
-        buf_flush_wait(wait_lsn, false);
+        buf_flush_wait(wait_lsn, circular_recovery_from_sequence_bit_0);
         mysql_mutex_unlock(&buf_pool.flush_list_mutex);
       }
       latch.wr_unlock();
@@ -819,6 +819,7 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
       allow any wrap-around. */
       if (checkpoint < limit)
         goto retry_after_checkpoint;
+      circular_recovery_from_sequence_bit_0= limit != wait_lsn;
       wait_lsn= limit;
     }
     else if (circular_recovery_from_sequence_bit_0)
@@ -830,7 +831,6 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
       the completion of set_archive(false) and the next
       write_checkpoint(), recovery will only encounter
       get_sequence_bit() == 1, consistent with our first_lsn. */
-      circular_recovery_from_sequence_bit_0= false;
       goto retry_after_checkpoint;
     }
     else if (checkpoint < first_lsn)
@@ -879,8 +879,17 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
     if (!archive)
     {
       std::swap(old_name, new_name);
-      header_rewrite(archive);
       std::string spare{get_archive_path(first_lsn + capacity())};
+      if (!get_sequence_bit(last_checkpoint_lsn))
+        /*
+          In the innodb_log_archive=ON format, mtr_t::finish_writer()
+          always writes the sequence bit as 1. Ensure that the
+          innodb_log_archive=OFF recovery will expect this value.
+        */
+        first_lsn-= capacity();
+      ut_ad(get_sequence_bit(last_checkpoint_lsn));
+      ut_ad(get_sequence_bit(get_lsn()));
+      header_rewrite(false);
       IF_WIN(DeleteFile(spare.c_str()), unlink(spare.c_str()));
     }
 #if defined HAVE_PMEM && !defined _WIN32
@@ -925,7 +934,7 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
 
     if (archive)
     {
-      header_rewrite(archive);
+      header_rewrite(true);
       archive_set_size();
       wait_lsn= 0;
     }

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -811,14 +811,15 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
 
     if (archive)
     {
-      wait_lsn-= (wait_lsn - first_lsn) % capacity();
+      const lsn_t limit{wait_lsn - (wait_lsn - first_lsn) % capacity()};
       /* We are in innodb_log_archive=OFF. If the file has wrapped
       around between the checkpoint and the current position, we must
       wait for a log checkpoint not before the desired first_lsn of
       our innodb_log_archive=ON log file, because that format does not
       allow any wrap-around. */
-      if (checkpoint < wait_lsn)
+      if (checkpoint < limit)
         goto retry_after_checkpoint;
+      wait_lsn= limit;
     }
     else if (circular_recovery_from_sequence_bit_0)
     {


### PR DESCRIPTION
`log_t::set_archive()`: Always invoke `buf_flush_wait(wait_lsn, false)` on the latest sampled `get_lsn()`, so that if a checkpoint is possible, one will be executed.

This fixes up #4405.