### PR TITLE
`mariadb-binlog --verify-binlog-checksum --force-read` fixes

### DIFF
--- a/mysql-test/suite/binlog/r/unknown_log_event.result
+++ b/mysql-test/suite/binlog/r/unknown_log_event.result
@@ -4,3 +4,5 @@ DROP TABLE t;
 FLUSH BINARY LOGS;
 #mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=#binlog_start --stop-position=#binlog_stop #binlog_file 2>&1
 FOUND 1 /CRC32 0x[[:xdigit:]]{8}.*\n# [Uu]nknown [Ee]vent/ in unknown_log_event.sql
+#mariadb_binlog --debug=d,simulate_checksum_test_failure --stop-position=5 #binlog_file 2>&1
+FOUND 1 /CRC32 0x[[:xdigit:]]{8}.*\n# [Uu]nknown [Ee]vent/ in unknown_log_event.sql

--- a/mysql-test/suite/binlog/r/unknown_log_event.result
+++ b/mysql-test/suite/binlog/r/unknown_log_event.result
@@ -1,0 +1,6 @@
+CREATE TABLE t (a INT);
+INSERT INTO t VALUES (0);
+DROP TABLE t;
+FLUSH BINARY LOGS;
+#mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=#binlog_start --stop-position=#binlog_stop #binlog_file 2>&1
+FOUND 1 /CRC32 0x[[:xdigit:]]{8}.*\n# [Uu]nknown [Ee]vent/ in unknown_log_event.sql

--- a/mysql-test/suite/binlog/t/unknown_log_event.test
+++ b/mysql-test/suite/binlog/t/unknown_log_event.test
@@ -1,0 +1,29 @@
+# MDEV-40674: Test `mariadb-binlog --force`'s Unknown event output
+#
+# Also: MDEV-40542
+# MSAN use-of-uninitialized-value on Unknown_log_event::read_checksum_alg
+
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc # Testing with Table Map event
+
+# Setup
+CREATE TABLE t (a INT);
+--let $binlog_file= query_get_value(SHOW BINLOG STATUS, File, 1)
+--let $binlog_start= query_get_value(SHOW BINLOG STATUS, Position, 1)
+
+# Generate an invalid Table Map event followed by an otherwise-valid Rows Event
+INSERT INTO t VALUES (0);
+
+--let $binlog_stop= query_get_value(SHOW BINLOG STATUS, Position, 1)
+DROP TABLE t;
+FLUSH BINARY LOGS;
+
+
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/unknown_log_event.sql
+--let SEARCH_PATTERN= CRC32 0x[[:xdigit:]]{8}.*\\n# [Uu]nknown [Ee]vent
+--let $mariadb_binlog= $MYSQL_BINLOG --result-file=$SEARCH_FILE --verify-binlog-checksum --force-read
+--let $binlog_file= `SELECT CONCAT(@@datadir, '/$binlog_file')`
+
+--echo #mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=#binlog_start --stop-position=#binlog_stop #binlog_file 2>&1
+--exec $mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=$binlog_start --stop-position=$binlog_stop $binlog_file 2>&1
+--source include/search_pattern_in_file.inc

--- a/mysql-test/suite/binlog/t/unknown_log_event.test
+++ b/mysql-test/suite/binlog/t/unknown_log_event.test
@@ -27,3 +27,11 @@ FLUSH BINARY LOGS;
 --echo #mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=#binlog_start --stop-position=#binlog_stop #binlog_file 2>&1
 --exec $mariadb_binlog --debug=d,corrupt_table_map_colcnt_read --start-position=$binlog_start --stop-position=$binlog_stop $binlog_file 2>&1
 --source include/search_pattern_in_file.inc
+
+# Test checksum failure
+#
+# Only test the first event since the rest of the binlog is unreadable
+# without a valid Format Description, which is typically the first event.
+--echo #mariadb_binlog --debug=d,simulate_checksum_test_failure --stop-position=5 #binlog_file 2>&1
+--exec $mariadb_binlog --debug=d,simulate_checksum_test_failure --stop-position=5 $binlog_file 2>&1
+--source include/search_pattern_in_file.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1110,21 +1110,19 @@ Log_event* Log_event::read_log_event(const uchar *buf, uint event_len,
   if (crc_check && event_checksum_test(const_cast<uchar*>(buf), event_len, alg))
   {
 #ifdef MYSQL_CLIENT
-    *error= "Event crc check failed! Most likely there is event corruption.";
     if (force_opt)
     {
       event_len-= BINLOG_CHECKSUM_LEN;
       ev= new Unknown_log_event(buf, fdle);
       goto exit;
     }
-    else
-      DBUG_RETURN(NULL);
+    *error= "Event crc check failed! Most likely there is event corruption.";
 #else
     *error= ER_THD_OR_DEFAULT(current_thd, ER_BINLOG_READ_EVENT_CHECKSUM_FAILURE);
     if (print_errors)
       sql_print_error("%s", *error);
-    DBUG_RETURN(NULL);
 #endif
+    DBUG_RETURN(NULL);
   }
 
   if (event_type > fdle->number_of_event_types &&

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1113,8 +1113,9 @@ Log_event* Log_event::read_log_event(const uchar *buf, uint event_len,
     *error= "Event crc check failed! Most likely there is event corruption.";
     if (force_opt)
     {
+      event_len-= BINLOG_CHECKSUM_LEN;
       ev= new Unknown_log_event(buf, fdle);
-      DBUG_RETURN(ev);
+      goto exit;
     }
     else
       DBUG_RETURN(NULL);
@@ -1330,16 +1331,6 @@ Log_event* Log_event::read_log_event(const uchar *buf, uint event_len,
   }
 exit:
 
-  if (ev)
-  {
-    ev->checksum_alg= alg;
-#ifdef MYSQL_CLIENT
-    if (ev->checksum_alg != BINLOG_CHECKSUM_ALG_OFF &&
-        ev->checksum_alg != BINLOG_CHECKSUM_ALG_UNDEF)
-      ev->crc= uint4korr(buf + (event_len));
-#endif
-  }
-
   DBUG_PRINT("read_event", ("%s(type_code: %u; event_len: %u)",
                             ev ? ev->get_type_str() : "<unknown>",
                             (uchar)buf[EVENT_TYPE_OFFSET],
@@ -1372,6 +1363,16 @@ exit:
     if (!*error)
       *error= "Found invalid event in binary log";
     DBUG_RETURN(0);
+#endif
+  }
+
+  if (ev)
+  {
+    ev->checksum_alg= alg;
+#ifdef MYSQL_CLIENT
+    if (ev->checksum_alg != BINLOG_CHECKSUM_ALG_OFF &&
+        ev->checksum_alg != BINLOG_CHECKSUM_ALG_UNDEF)
+      ev->crc= uint4korr(buf + (event_len));
 #endif
   }
   DBUG_RETURN(ev);  


### PR DESCRIPTION
## MDEV-40674 Include the checksum for non-corrupted Unknown events
* Resolves [MDEV-40674](https://jira.mariadb.org/browse/MDEV-40674)
  * Fixes [MDEV-40542](https://jira.mariadb.org/browse/MDEV-40542) on 11.4
    * Merge conflict resolution: included in #5465

This commit reörders code so the checksum is populated after `mariadb-binlog --force` generates `Unknown_log_event` substitutes.
Previously, `mariadb-binlog --force` inconsistently omitted those checksums from the output even if the checksum is presumably usable.

After merging to 11.4 (MDEV-31273), this commit will also fix «MDEV-40542 MSAN use-of-uninitialized-value on Unknown_log_event::read_checksum_alg», which was exposed by MDEV-31273’s removal of the base `Log_event::checksum_alg` field.

## MDEV-40544 Assertion fail / Memory leak in mariadb-binlog --force-read
(needed this to test MDEV-40674’s checksum failure case)
* Fixes [MDEV-40544](https://jira.mariadb.org/browse/MDEV-40544)

A checksum error in `mariadb-binlog --verify-binlog-checksum --force-read` previously resulted in both an error message and an Unknown event substitute, the latter of which failed an assertion in debug builds or became forgotten (memory leak) in non-debug (release) builds.

Since `mariadb-binlog --force-read` outputs “Unknown event”s rather than errors in other invalid event cases, this commit removes the error status from this situation to match.