### PR TITLE
MDEV-40454: aria_pack UBSAN 'shift exponent 64' in flush_bits()

### DIFF
--- a/storage/maria/aria_pack.c
+++ b/storage/maria/aria_pack.c
@@ -3032,16 +3032,19 @@ static void flush_bits(void)
   ulonglong bit_buffer;
 
   bits= file_buffer.bits & ~7;
-  bit_buffer= file_buffer.bitbucket >> bits;
-  bits= BITS_SAVED - bits;
-  while (bits > 0)
+  if (bits != BITS_SAVED)
   {
-    bits-= 8;
-    *file_buffer.pos++= (uchar) (bit_buffer >> bits);
+    bit_buffer= file_buffer.bitbucket >> bits;
+    bits= BITS_SAVED - bits;
+    while (bits > 0)
+    {
+      bits-= 8;
+      *file_buffer.pos++= (uchar) (bit_buffer >> bits);
+    }
+    if (file_buffer.pos >= file_buffer.end)
+      flush_buffer(~ (ulong) 0);
+    file_buffer.bits= BITS_SAVED;
   }
-  if (file_buffer.pos >= file_buffer.end)
-    flush_buffer(~ (ulong) 0);
-  file_buffer.bits= BITS_SAVED;
   file_buffer.bitbucket= 0;
 }
 


### PR DESCRIPTION
MDEV-40454: UBSAN `shift exponent 64 is too large for 64-bit type 'ulonglong'` in `aria_pack`

## Problem

The UBSAN buildbot reports on 10.11:

```
/home/buildbot/src/storage/maria/aria_pack.c:3035:37: runtime error: shift exponent 64 is too large for 64-bit type 'ulonglong' (aka 'unsigned long long')
    #0 flush_bits  storage/maria/aria_pack.c:3035
    #1 write_huff_tree  storage/maria/aria_pack.c:2435
    #2 compress  storage/maria/aria_pack.c:738
    #3 main  storage/maria/aria_pack.c:274
```

## Root cause

`flush_bits()` does:

```c
bits= file_buffer.bits & ~7;
bit_buffer= file_buffer.bitbucket >> bits;   // shift exponent 64
```

`file_buffer.bits` starts at `BITS_SAVED` (=64) and counts down as bits are
written. `flush_bits()` is called at the end of every Huffman-tree block in
`write_huff_tree()`, even when that block wrote nothing (its `tree_buff` was
empty / already flushed by the previous block). In that case
`file_buffer.bits & ~7 == BITS_SAVED`, and `bitbucket >> 64` is undefined
behavior.

On x86 the shift count is masked to `& 63`, so the garbage is silently
folded into the compressed output; under UBSAN with `halt_on_error` (as on
buildbot) `aria_pack` aborts. `maria.aria_pack_mdev14183` is the existing
test that trips it.

## Fix

Return early when there are no whole bytes to flush (`bits == BITS_SAVED`).
`flush_bits()` is a no-op in that case, so the change is behavior-preserving
and simply removes the undefined shift.

## Verification (11.4 debug + UBSAN)

- Reproduced with `-DWITH_UBSAN=ON`:
  `UBSAN_OPTIONS=halt_on_error=1 aria_pack -t t` aborts with the runtime error.
- With the fix: clean run, exit 0, packed data round-trips, `CHECK TABLE` OK.
- `mariadb-test-run --suite=maria aria_pack_mdev14183` passes; full `maria`
  suite is 60/60 green.

The same `flush_bits()` exists unchanged in 10.6/10.11/11.4, so the fix
applies to all maintained branches (merge-up from 10.6 if that's your flow).

@vuvova could you take a look?
