### PR TITLE
[demo] Do not call lock_rec_convert_impl_to_expl if a table S-lock is…

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -6628,6 +6628,7 @@ lock_clust_rec_read_check_and_lock(
 
 	trx_t *trx = thr_get_trx(thr);
 	if (lock_table_has(trx, index->table, LOCK_X)
+      || lock_table_has(trx, index->table, LOCK_S)
 	    || heap_no == PAGE_HEAP_NO_SUPREMUM) {
 	} else if (lock_rec_convert_impl_to_expl<true>(trx, *block, rec, index,
 						       offsets) == trx


### PR DESCRIPTION
… held

In lock_clust_rec_read_check_and_lock there's a test on lock_table_has(trx, index->table, LOCK_X) which if fails would result in a call to lock_rec_convert_impl_to_expl<true>, which 1. has a comment "If an implicit x-lock exists on a record, convert it to an explicit one." that does not apply if a table S-lock is held and 2. does a few things such as looking up the trx_id of the record and find the trx in a global hash trx_sys. In this patch we do the same check for a table S-lock. This could potentially improve the performance of LOCK IN SHARE MODE (TODO: check)