### PR TITLE
MDEV-35516 sp_lex_keeper use after free

### DIFF
--- a/sql/sp_instr.h
+++ b/sql/sp_instr.h
@@ -274,7 +274,7 @@ public:
     lex->sp_lex_in_use= true;
   }
 
-  ~sp_lex_keeper()
+  void destroy()
   {
     if (m_lex_resp)
     {
@@ -286,6 +286,8 @@ public:
       delete m_lex;
     }
   }
+  ~sp_lex_keeper()
+  { destroy(); }
 
   /**
     Prepare execution of instruction using LEX, if requested check whenever
@@ -410,15 +412,15 @@ public:
     {
       /*
         Free items owned by an instance of sp_lex_instr and call m_lex_keeper's
-        destructor explicitly to avoid referencing a deallocated memory
-        owned by the memory root m_mem_root_for_reparsing that else would take
-        place in case their implicit invocations (in that case, m_lex_keeper's
-        destructor and the method free_items() called by ~sp_instr are invoked
-        after the memory owned by the memory root m_mem_root_for_reparsing
-        be freed, that would result in abnormal server termination)
+        destroy explicitly to release memory it uses. m_lex_keeper memory is on
+        a different mem_root so its destructor examines one basic member and then
+        the object is freed.
+        m_lex_keeper's destructor and the method free_items() called by ~sp_instr
+        are invoked after the memory owned by the memory root m_mem_root_for_reparsing
+        be freed, that would result in abnormal server termination.
       */
       free_items();
-      m_lex_keeper.~sp_lex_keeper();
+      m_lex_keeper.destroy();
 
       /*
         Ignore the OOM error explicitly since we are inside destructor


### PR DESCRIPTION
MSAN reported that there is a use after destruction. This is obvious in ~sp_lex_instr where the explict destructor is called, followed by the implict call to an already freed memory.

Change ~sp_lex_keeper() to a destroy() method
freeing the contents of object. Make the destructor call destroy(). There is a flag set so no duplicate freeing occurs.

With this in place, ~sp_lex_instr() can call destroy, and leave the implict cleanup of the object to the ~sp_lex_keeper destructor.