### PR TITLE
MDEV-39169: Replace deprecated network functions in `resolveip` (testfix 2)

### DIFF
--- a/mysql-test/include/check_ipv4_mapped.inc
+++ b/mysql-test/include/check_ipv4_mapped.inc
@@ -1,5 +1,0 @@
-# Check if IPv6 IPv4 mapped is available.
-#
-# The real check is done in the suite.pm
-# (it has to be done *before* mariadbd is started)
-#

--- a/mysql-test/main/resolveip.result
+++ b/mysql-test/main/resolveip.result
@@ -2,66 +2,34 @@
 # MDEV-39169: resolveip IPv6 support
 #
 #
-# IPv4 special addresses (deterministic, no DNS needed)
+# Special addresses
 #
 Broadcast
 Null-IP-Addr
-#
-# IPv4 reverse lookup
-#
-Host name of 127.0.0.1 is HOSTNAME
-#
-# IPv4 reverse lookup (silent mode)
-#
-HOSTNAME
-#
-# IPv6 special address (deterministic, no DNS needed)
-#
 Null-IP-Addr
-#
-# IPv6 unspecified address (full form)
-#
 Null-IP-Addr
-#
-# IPv6 reverse lookup
-#
-Host name of ::1 is HOSTNAME
-#
-# IPv6 reverse lookup (silent mode)
-#
-HOSTNAME
-#
-# IPv6 IPv4-mapped address
-#
-Host name of ::ffff:127.0.0.1 is HOSTNAME
-#
-# IPv6 full form address
-#
-Host name of 0000:0000:0000:0000:0000:0000:0000:0001 is HOSTNAME
-#
-# Multiple addresses in one call
-#
 Broadcast
 Null-IP-Addr
 #
-# Mixed IPv4 and IPv6 addresses
+# Several addresses in one call, mixed address families
 #
 Broadcast
 Null-IP-Addr
+Broadcast
+Null-IP-Addr
 #
-# Mixed IP address and hostname
+# Address without a host name is reverse-resolved, not treated as a
+# host name ("hostname" in the error, not "hostid")
 #
-REPLACED
-REPLACED
+resolveip: Unable to find hostname for '192.0.2.1'
+resolveip: Unable to find hostname for '::ffff:192.0.2.1'
 #
-# Invalid hostname
+# Unresolvable host name (.invalid never resolves, RFC 6761)
 #
 resolveip: Unable to find hostid for 'nonexistent.invalid': NAME_RESOLUTION_ERROR
 #
-# Invalid address mixed with valid address
+# Unresolvable host name after a valid address
 #
 Broadcast
 resolveip: Unable to find hostid for 'nonexistent.invalid': NAME_RESOLUTION_ERROR
-#
-# End of 13.0 tests
-#
+# End of 13.2 tests

--- a/mysql-test/main/resolveip.test
+++ b/mysql-test/main/resolveip.test
@@ -1,89 +1,57 @@
 --source include/not_windows.inc
---source include/check_ipv6.inc
---source include/check_ipv4_mapped.inc
 
-# Reverse DNS tests (getnameinfo with NI_NAMEREQD) require:
-#   - /etc/hosts entries for 127.0.0.1 and ::1 (or working DNS PTR records)
-#   - "hosts: files ..." in /etc/nsswitch.conf (or equivalent resolver config)
-#   - glibc nss_files backend mapping ::ffff:127.0.0.1 to the 127.0.0.1 entry
-#   - - musl libc (Alpine) may behave differently from glibc for mapped addresses
-# If reverse lookups fail, check: getent hosts 127.0.0.1 ::1 ::ffff:127.0.0.1
+# Deterministic cases only, so this file never skips.  Lookups that depend on
+# the resolver are in resolveip_lookup.test.
+# No pipes to sed here: a pipe hides resolveip's exit status, which mysqltest
+# checks (no --error means "must exit 0", --error 2 also fails on exit 0).
 
 --echo #
 --echo # MDEV-39169: resolveip IPv6 support
 --echo #
 
 --echo #
---echo # IPv4 special addresses (deterministic, no DNS needed)
+--echo # Special addresses
 --echo #
 --exec $MYSQL_RESOLVEIP 255.255.255.255
 --exec $MYSQL_RESOLVEIP 0.0.0.0
-
---echo #
---echo # IPv4 reverse lookup
---echo #
---exec $MYSQL_RESOLVEIP 127.0.0.1 2>&1 | sed 's/Host name of 127\.0\.0\.1 is .*/Host name of 127.0.0.1 is HOSTNAME/'
-
---echo #
---echo # IPv4 reverse lookup (silent mode)
---echo #
---exec $MYSQL_RESOLVEIP -s 127.0.0.1 2>&1 | sed 's/.*/HOSTNAME/'
-
---echo #
---echo # IPv6 special address (deterministic, no DNS needed)
---echo #
 --exec $MYSQL_RESOLVEIP ::
-
---echo #
---echo # IPv6 unspecified address (full form)
---echo #
 --exec $MYSQL_RESOLVEIP 0000:0000:0000:0000:0000:0000:0000:0000
+--exec $MYSQL_RESOLVEIP -s 255.255.255.255
+--exec $MYSQL_RESOLVEIP -s ::
 
 --echo #
---echo # IPv6 reverse lookup
---echo #
---exec $MYSQL_RESOLVEIP ::1 2>&1 | sed 's/Host name of ::1 is .*/Host name of ::1 is HOSTNAME/'
-
---echo #
---echo # IPv6 reverse lookup (silent mode)
---echo #
---exec $MYSQL_RESOLVEIP -s ::1 2>&1 | sed 's/.*/HOSTNAME/'
-
---echo #
---echo # IPv6 IPv4-mapped address
---echo #
---exec $MYSQL_RESOLVEIP ::ffff:127.0.0.1 2>&1 | sed 's/Host name of ::ffff:127\.0\.0\.1 is .*/Host name of ::ffff:127.0.0.1 is HOSTNAME/'
-
---echo #
---echo # IPv6 full form address
---echo #
---exec $MYSQL_RESOLVEIP 0000:0000:0000:0000:0000:0000:0000:0001 2>&1 | sed 's/Host name of 0000:0000:0000:0000:0000:0000:0000:0001 is .*/Host name of 0000:0000:0000:0000:0000:0000:0000:0001 is HOSTNAME/'
-
---echo #
---echo # Multiple addresses in one call
+--echo # Several addresses in one call, mixed address families
 --echo #
 --exec $MYSQL_RESOLVEIP 255.255.255.255 0.0.0.0
-
---echo #
---echo # Mixed IPv4 and IPv6 addresses
---echo #
 --exec $MYSQL_RESOLVEIP 255.255.255.255 ::
 
 --echo #
---echo # Mixed IP address and hostname
+--echo # Address without a host name is reverse-resolved, not treated as a
+--echo # host name ("hostname" in the error, not "hostid")
 --echo #
---exec $MYSQL_RESOLVEIP -s 127.0.0.1 localhost | sed 's/.*/REPLACED/'
+# 192.0.2.1 is TEST-NET-1 (RFC 5737): resolvable nowhere, on any OS.
+--replace_result $MYSQL_RESOLVEIP resolveip
+--error 2
+--exec $MYSQL_RESOLVEIP 192.0.2.1 2>&1
+--replace_result $MYSQL_RESOLVEIP resolveip
+--error 2
+--exec $MYSQL_RESOLVEIP ::ffff:192.0.2.1 2>&1
 
 --echo #
---echo # Invalid hostname
+--echo # Unresolvable host name (.invalid never resolves, RFC 6761)
 --echo #
---exec $MYSQL_RESOLVEIP nonexistent.invalid 2>&1 | sed "s|.*Unable to find hostid for 'nonexistent.invalid': .*|resolveip: Unable to find hostid for 'nonexistent.invalid': NAME_RESOLUTION_ERROR|"
+# Only the resolver's wording after ':' differs between systems.
+--replace_regex /(hostid for 'nonexistent.invalid': )[^\n]*/\1NAME_RESOLUTION_ERROR/
+--replace_result $MYSQL_RESOLVEIP resolveip
+--error 2
+--exec $MYSQL_RESOLVEIP nonexistent.invalid 2>&1
 
 --echo #
---echo # Invalid address mixed with valid address
+--echo # Unresolvable host name after a valid address
 --echo #
---exec $MYSQL_RESOLVEIP 255.255.255.255 nonexistent.invalid 2>&1 | sed "s|.*Unable to find hostid for 'nonexistent.invalid': .*|resolveip: Unable to find hostid for 'nonexistent.invalid': NAME_RESOLUTION_ERROR|"
+--replace_regex /(hostid for 'nonexistent.invalid': )[^\n]*/\1NAME_RESOLUTION_ERROR/
+--replace_result $MYSQL_RESOLVEIP resolveip
+--error 2
+--exec $MYSQL_RESOLVEIP 255.255.255.255 nonexistent.invalid 2>&1
 
---echo #
---echo # End of 13.0 tests
---echo #
+--echo # End of 13.2 tests

--- a/mysql-test/main/resolveip_lookup.result
+++ b/mysql-test/main/resolveip_lookup.result
@@ -1,0 +1,25 @@
+#
+# MDEV-39169: resolveip reverse lookups
+#
+#
+# IPv4
+#
+Host name of 127.0.0.1 is HOSTNAME
+HOSTNAME
+#
+# IPv6, short and long form
+#
+Host name of ::1 is HOSTNAME
+HOSTNAME
+Host name of 0000:0000:0000:0000:0000:0000:0000:0001 is HOSTNAME
+#
+# IPv4-mapped IPv6
+#
+Host name of ::ffff:127.0.0.1 is HOSTNAME
+HOSTNAME
+#
+# An address and a host name in one call
+#
+HOSTNAME
+LOOPBACK_ADDR
+# End of 13.2 tests

--- a/mysql-test/main/resolveip_lookup.test
+++ b/mysql-test/main/resolveip_lookup.test
@@ -1,0 +1,76 @@
+--source include/not_windows.inc
+
+# Reverse lookups of the loopback addresses.  The names come from /etc/hosts
+# and differ per system (::1 is "localhost" on macOS but "ip6-localhost" on
+# Debian), and whether ::ffff:127.0.0.1 has a name at all depends on the libc
+# (glibc and musl map it to 127.0.0.1; macOS does not).  So probe first, with
+# the same call resolveip makes - getnameinfo(NI_NAMEREQD) - and skip unless
+# every address resolves.  The probe returns the actual names, so the tests
+# below require them exactly instead of accepting any output.
+
+perl;
+  use Socket;
+  my %name;
+  # eval{}: Socket before Perl 5.14 lacks getnameinfo(); then nothing
+  # resolves and the test skips.
+  eval {
+    for my $addr ('127.0.0.1', '::1', '::ffff:127.0.0.1') {
+      my $sa= $addr =~ /:/
+        ? Socket::pack_sockaddr_in6(0, Socket::inet_pton(Socket::AF_INET6, $addr))
+        : Socket::pack_sockaddr_in(0, Socket::inet_pton(Socket::AF_INET, $addr));
+      my ($err, $host)= Socket::getnameinfo($sa, Socket::NI_NAMEREQD());
+      $name{$addr}= $host unless $err;
+    }
+  };
+  open F, '>', "$ENV{MYSQL_TMP_DIR}/rdns.inc" or die $!;
+  print F "let \$rdns_ok= ", (keys %name == 3 ? 1 : 0), ";\n";
+  print F "let \$name_v4= $name{'127.0.0.1'};\n" .
+          "let \$name_v6= $name{'::1'};\n" .
+          "let \$name_mapped= $name{'::ffff:127.0.0.1'};\n" if keys %name == 3;
+  close F;
+EOF
+--source $MYSQL_TMP_DIR/rdns.inc
+--remove_file $MYSQL_TMP_DIR/rdns.inc
+if (!$rdns_ok) {
+  --skip getnameinfo() cannot resolve the loopback addresses on this system
+}
+
+--echo #
+--echo # MDEV-39169: resolveip reverse lookups
+--echo #
+
+--echo #
+--echo # IPv4
+--echo #
+--replace_result $name_v4 HOSTNAME
+--exec $MYSQL_RESOLVEIP 127.0.0.1
+--replace_result $name_v4 HOSTNAME
+--exec $MYSQL_RESOLVEIP -s 127.0.0.1
+
+--echo #
+--echo # IPv6, short and long form
+--echo #
+--replace_result $name_v6 HOSTNAME
+--exec $MYSQL_RESOLVEIP ::1
+--replace_result $name_v6 HOSTNAME
+--exec $MYSQL_RESOLVEIP -s ::1
+--replace_result $name_v6 HOSTNAME
+--exec $MYSQL_RESOLVEIP 0000:0000:0000:0000:0000:0000:0000:0001
+
+--echo #
+--echo # IPv4-mapped IPv6
+--echo #
+--replace_result $name_mapped HOSTNAME
+--exec $MYSQL_RESOLVEIP ::ffff:127.0.0.1
+--replace_result $name_mapped HOSTNAME
+--exec $MYSQL_RESOLVEIP -s ::ffff:127.0.0.1
+
+--echo #
+--echo # An address and a host name in one call
+--echo #
+# localhost may map to either loopback address, hence the regex.
+--replace_regex /^(127\.0\.0\.1|::1)$/LOOPBACK_ADDR/
+--replace_result $name_v4 HOSTNAME
+--exec $MYSQL_RESOLVEIP -s 127.0.0.1 localhost
+
+--echo # End of 13.2 tests

--- a/mysql-test/suite.pm
+++ b/mysql-test/suite.pm
@@ -65,18 +65,6 @@ sub skip_combinations {
   }
   $skip{'include/check_ipv6.inc'} = 'No IPv6' unless ipv6_ok();
 
-  sub ipv4_mapped_ok() {
-    use Socket;
-    return 0 unless socket my $sock, PF_INET6, SOCK_STREAM, getprotobyname('tcp');
-    $!="";
-    # eval{}, if there's no Socket::sockaddr_in6 at all, old Perl installation <5.14
-    eval { bind $sock, sockaddr_in6($::baseport, Socket::inet_pton(Socket::AF_INET6,
-                                    '::ffff:127.0.0.1')) };
-    return $@ eq "" && $! eq ""
-  }
-  $skip{'include/check_ipv4_mapped.inc'} = 'No IPv6 -> IPv4 mapped address'
-    unless ipv4_mapped_ok();
-
   # SSL is complicated
   my $ssl_lib= $::mysqld_variables{'version-ssl-library'};
   my $openssl_ver= $ssl_lib =~ /OpenSSL (\S+)/ ? $1 : "";


### PR DESCRIPTION
fixes `resolveip` test failures after [MDEV-39169](https://jira.mariadb.org/browse/MDEV-39169) 

### Problem:
The test piped `resolveip` through `sed` patterns that rewrote its failure message into the expected success line, and the pipe also discarded the exit status - the test could not fail.  Removing the masking exposes the real issue: reverse lookup results are OS dependent. The name of `::1` differs per system, and `::ffff:127.0.0.1` has a name on glibc and musl (which map it to `127.0.0.1`) but none on macOS.
The suite.pm check bound a socket to the address, which asks the kernel, not the resolver: it fails under net.ipv6.bindv6only=1 where the lookup works and succeeds on macOS where it doesn't.

### Fix:
Split the test in two:
- main/resolveip.test: deterministic cases, never skips.  Lookup failures are pinned with addresses that resolve nowhere (`192.0.2.1`, nonexistent.invalid), checking the exit status and that IPv4-mapped literals take the reverse-lookup path on every OS.

- main/resolveip_lookup.test: the reverse lookups.  A perl probe resolves the three loopback addresses with the same call resolveip makes, getnameinfo(NI_NAMEREQD), skips unless all have names, and returns the names so the test requires them exactly.

Output is normalized with replace_result/replace_regex instead of pipes, keeping the exit status checked.