### PR TITLE
MDEV-40728 Recovery wrongly fails if FILE_CREATE is followed by FILE_RENAME

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -940,6 +940,18 @@ processed:
         d++;
         continue;
       }
+      else
+      {
+        recv_spaces_t::iterator it{recv_spaces.find(d->first)};
+        if (UNIV_UNLIKELY(it == recv_spaces.end()))
+          ut_ad("inconsistent data structures" == 0);
+        else if (it->second.create_lsn)
+          /*
+            Because a FILE_CREATE record exists, the entire file must
+            be recoverable via log records.
+          */
+          goto next_item;
+      }
       const page_id_t page_id{d->first, 0};
       const byte *page= recv_sys.dblwr.find_page(page_id, max_lsn);
       if (!page)
@@ -1325,19 +1337,14 @@ static void fil_name_process(const char *name, ulint len, uint32_t space_id,
 	ut_ad(p.first->first == space_id);
 
 	file_name_t&	f = p.first->second;
-
+	ut_ad(!f.space || f.space->id == space_id);
 	auto d = deferred_spaces.find(space_id);
-	if (d) {
-		if (deleted) {
-			d->deleted = true;
-			goto got_deleted;
-		}
-		goto reload;
-	}
 
 	if (deleted) {
-got_deleted:
 		/* Got FILE_DELETE */
+		if (d) {
+			d->deleted = true;
+		}
 		if (!p.second && f.status != file_name_t::DELETED) {
 			f.status = file_name_t::DELETED;
 			if (f.space != NULL) {
@@ -1347,10 +1354,9 @@ got_deleted:
 		}
 
 		ut_ad(f.space == NULL);
-		goto reset_create;
-	} else if (p.second // the first FILE_MODIFY or FILE_RENAME
+		f.create_lsn = 0;
+	} else if (d || p.second /* the first FILE_MODIFY or FILE_RENAME */
 		   || f.name != fname.name) {
-reload:
 		if (f.name.size() == 0) {
 			/* Augment the recv_spaces.emplace_hint() for the
 			FILE_MODIFY record that had been added by
@@ -1364,7 +1370,8 @@ reload:
 		the space_id. If not, ignore the file after displaying
 		a note. Abort if there are multiple files with the
 		same space_id. */
-		switch (fil_ibd_load(space_id, fname.name.c_str(), space)) {
+		switch (fil_load_status s
+			= fil_ibd_load(space_id, fname.name.c_str(), space)) {
 		case FIL_LOAD_OK:
 			ut_ad(space != NULL);
 
@@ -1399,25 +1406,28 @@ same_space:
 			break;
 
 		case FIL_LOAD_ID_CHANGED:
-			ut_ad(space == NULL);
-			break;
-
 		case FIL_LOAD_NOT_FOUND:
 			/* No matching tablespace was found; maybe it
 			was renamed, and we will find a subsequent
 			FILE_* record. */
 			ut_ad(space == NULL);
 
-			if (srv_operation == SRV_OPERATION_RESTORE && d
-			    && ftype == FILE_RENAME) {
+			if (f.create_lsn) {
+				if (d && ftype == FILE_RENAME) {
 rename:
-				d->file_name = fname.name;
-				f.name = fname.name;
+					d->file_name = fname.name;
+					f.name = fname.name;
+				}
 				break;
 			}
 
-			if (f.create_lsn) {
-				return;
+			if (ftype == FILE_CREATE) {
+				f.create_lsn = lsn;
+				break;
+			}
+
+			if (s == FIL_LOAD_ID_CHANGED) {
+				break;
 			}
 
 			if (srv_force_recovery
@@ -1437,11 +1447,10 @@ rename:
 					int(fname.name.size()),
 					fname.name.data(), space_id);
 			}
-			return;
+			break;
 
 		case FIL_LOAD_DEFER:
-			if (d && ftype == FILE_RENAME
-			    && srv_operation == SRV_OPERATION_RESTORE) {
+			if (d && ftype == FILE_RENAME && f.create_lsn) {
 				goto rename;
 			}
 			/* Skip the deferred spaces
@@ -1473,8 +1482,6 @@ rename:
 					  " due to innodb_force_recovery",
 					  int(len), name, space_id);
 		}
-reset_create:
-		f.create_lsn = 0;
 	} else if (ftype == FILE_CREATE && !f.space) {
 		f.create_lsn = lsn;
 	}
@@ -2796,6 +2803,12 @@ static recv_sys_t::parse_mtr_result
 log_parse_file(const page_id_t id, bool if_exists,
                const byte b, const byte *l, uint32_t rlen)
 {
+  if (recv_sys.scanned_lsn > recv_sys.lsn)
+    /*
+      We must already have parsed this record, in the skip_the_rest:
+      loop in recv_scan_log() before starting multi-batch recovery.
+    */
+    return recv_sys_t::OK;
   if (UNIV_LIKELY(rlen));
   else if (!id.raw() && b == FILE_CHECKPOINT + 2)
     /* FILE_CHECKPOINT followed by any number of NUL bytes could be


### PR DESCRIPTION
`fil_name_process()`: Simplify the logic. If no matching tablespace is found but `file_name_t::create_lsn` had been set in response to parsing a `FILE_CREATE` record, try to apply `FILE_RENAME` to `deferred_spaces`.

`deferred_spaces.deferred_dblwr()`: Skip newly created tablespaces to avoid a bogus invocation of `fil_space_free()`.

This is a variant of #5530 that does not depend on #4405.