### PR TITLE
MDEV_38952 Improve galera_sequences family of tests

### DIFF
--- a/mysql-test/suite/galera/r/galera_sequences_recovery.result
+++ b/mysql-test/suite/galera/r/galera_sequences_recovery.result
@@ -31,6 +31,8 @@ SELECT LASTVAL(s);
 LASTVAL(s)
 12
 SET GLOBAL innodb_log_checkpoint_now=1;
+connection node_1_ctrl;
+# Wait for the next_not_cached_value = 21 FROM s (1_ctrl)
 connection node_1;
 INSERT INTO t1(f2) values (1);
 INSERT INTO t1(f2) values (1);

--- a/mysql-test/suite/galera/t/galera_sequences_recovery.test
+++ b/mysql-test/suite/galera/t/galera_sequences_recovery.test
@@ -57,6 +57,16 @@ SELECT NEXTVAL(s);
 SELECT LASTVAL(s);
 SET GLOBAL innodb_log_checkpoint_now=1;
 
+# Node 1 has an open transaction and wsrep_sync_wait is not effective
+# inside a transaction. Wait here until node 1 has applied the sequence
+# update replicated by NEXTVAL above, otherwise node 1 may still consume
+# its own cached value before the update arrives.
+--connection node_1_ctrl
+--echo # Wait for the next_not_cached_value = 21 FROM s (1_ctrl)
+--let $wait_condition = SELECT next_not_cached_value = 21 FROM s
+--let $wait_condition_on_error_output = SELECT next_not_cached_value FROM s
+--source include/wait_condition_with_debug.inc
+
 --connection node_1
 # Update the sequence value further
 INSERT INTO t1(f2) values (1);


### PR DESCRIPTION
This commit fixes a sporadic failure with the test case 1, where recorded result depends on node 1 applying node 2's replicated sequence update before it resumes its already-open transaction:

- Node 2 SELECT NEXTVAL(s) writes reserved_until=21 and replicates it.
- On node 1 that lands in Rows_log_event::update_sequence() Since 21 > next_free_value (9), adjust_values(21) discards node 1's  still-cached value 9.

  Nothing enforced that ordering: node 1's INSERTs run inside BEGIN, and sync wait does not happen mid-transaction.

The fix is to use selarate session, node_1_ctrl, to wait until node 1 has applied the update, before node 1 resumes its transaction