### PR TITLE
MDEV-37224 Remove UBSAN limitation from MTR tests

### DIFF
--- a/mysql-test/include/not_ubsan.inc
+++ b/mysql-test/include/not_ubsan.inc
@@ -1,8 +1,0 @@
-# This file should only be used with test that finds bugs in ASan that can not
-# be overcome. In normal cases one should fix the bug server/test case or in
-# the worst case add a (temporary?) suppression in asan.supp or lsan.supp
-
-if (`select count(*) from information_schema.system_variables where variable_name='have_sanitizer' and global_value LIKE "%UBSAN"`)
-{
---skip Can't be run with UBSAN
-}

--- a/mysql-test/main/lotofstack.test
+++ b/mysql-test/main/lotofstack.test
@@ -5,11 +5,15 @@
 # making writing tests that depend on reaching
 # the depth hard.
 #
-source include/not_asan.inc;
 source include/not_embedded.inc;
-source include/not_ubsan.inc;
 # MSAN with debug exceeds the stack early.
 source include/not_msan_with_debug.inc;
+if (`select count(*) from information_schema.system_variables
+     where variable_name='have_sanitizer'
+     and global_value REGEXP '(A|UB)SAN'`)
+{
+--skip Can't be run in UBSAN/ASAN (stack size predictability)
+}
 
 #
 # Bug#10100 function (and stored procedure?) recursivity problem


### PR DESCRIPTION
Having a not_ubsan.inc as a test case exclusion mechanism is allowing developers to ignore UBSAN issues. As undefined behaviour detected at runtime or compile time isn't acceptable in the code base, remove the exclusion.

The lotofstack test, the only user of not_ubsan, is has this exclusion because the stack size under UBSAN lacks predictability.

Adjust its exclusion because of this criteria, and not its UBSAN status.