### PR TITLE
MDEV-34482 main.events_processlist test fix

### DIFF
--- a/mysql-test/main/events_processlist.test
+++ b/mysql-test/main/events_processlist.test
@@ -23,7 +23,8 @@ CREATE EVENT e
 
 # Wait until the event worker appears in PROCESSLIST for the current user
 let $wait_condition= SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
-                     WHERE INFO LIKE '%SLEEP(10000)%' AND ID <> CONNECTION_ID();
+                     WHERE INFO LIKE '%SLEEP(10000)%' AND ID <> CONNECTION_ID()
+                       AND STATE='User sleep';
 --source include/wait_condition.inc
 
 # Check that show processlist works


### PR DESCRIPTION
As the test result is dependent of SHOW PROCESSLIST output, adjust the wait condition to ensure the state is in sleeping rather than "init" or another state.

example failure from https://buildbot.mariadb.org/#/builders/1262/builds/1075/steps/16/logs/stdio
```
CURRENT_TEST: main.events_processlist
--- /home/buildbot/src/mysql-test/main/events_processlist.result	2026-08-12 14:05:37.000000000 +0000
+++ /home/buildbot/src/mysql-test/main/events_processlist.reject	2026-08-12 14:44:54.345040191 +0000
@@ -13,7 +13,7 @@
 show processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 #	u	localhost	test	Query	0	starting	show processlist	0.000
-#	u	localhost	test	Connect	0	User sleep	SELECT SLEEP(10000)	0.000
+#	u	localhost	test	Connect	0	init	SELECT SLEEP(10000)	0.000
 KILL QUERY id;
 disconnect c1;
 connection default;
```