### PR TITLE
MDEV-40749 period.create test leaks/faults in asan

### DIFF
--- a/mysql-test/suite/period/r/create.result
+++ b/mysql-test/suite/period/r/create.result
@@ -132,9 +132,9 @@ drop table t2;
 select "yes" from information_schema.tables where engine="innodb" limit 1;
 yes
 yes
-select plugin_status from information_schema.all_plugins where plugin_name = "innodb";
-plugin_status
-DISABLED
+select SUPPORT from information_schema.engines where ENGINE='InnoDB';
+SUPPORT
+NO
 select * from information_schema.periods;
 TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PERIOD	START_COLUMN_NAME	END_COLUMN_NAME
 select * from information_schema.key_period_usage;

--- a/mysql-test/suite/period/t/create.test
+++ b/mysql-test/suite/period/t/create.test
@@ -113,7 +113,7 @@ drop table t2;
 --echo # Make sure innodb id disabled, but there's at least one innodb table
 --disable_warnings
 select "yes" from information_schema.tables where engine="innodb" limit 1;
-select plugin_status from information_schema.all_plugins where plugin_name = "innodb";
+select SUPPORT from information_schema.engines where ENGINE='InnoDB';
 select * from information_schema.periods;
 select * from information_schema.key_period_usage;
 --enable_warnings


### PR DESCRIPTION
Selecting from the information_schema.plugins causes the loading of all plugins. Because rockdb leaks, and duckdb triggers an address sanitizer warning on shutdown avoid this table.

Use the information_schema.ENGINES to validate that InnoDB is disabled per the original request in the review of MDEV-32205.