### PR TITLE
MDEV-40750 gcc-16.1.0 on ppc64 causes innodb to fail to compile

### DIFF
--- a/storage/innobase/sync/cache.cc
+++ b/storage/innobase/sync/cache.cc
@@ -99,6 +99,17 @@ static decltype(pmem_control::persist) pmem_persist_init()
   return (getauxval(AT_HWCAP) & HWCAP_DCPOP) ? pmem_cvap : pmem_cvac;
 }
 # elif defined __powerpc64__
+
+# if defined(__clang__)
+#   define HAVE_TARGET_POWER10 1
+__attribute__((target("arch=pwr10")))
+# elif defined(__GNUC__)
+    // GCC: Power10 support starts with GCC 10.
+#   if (__GNUC__ == 10 && __GNUC_MINOR__ >= 1)
+#       define HAVE_TARGET_POWER10 1
+__attribute__((target("cpu=power10")))
+#   endif
+# endif
 static void pmem_phwsync(const void* buf, size_t size)
 {
   for (uintptr_t u= uintptr_t(buf) & ~(CPU_LEVEL1_DCACHE_LINESIZE),
@@ -111,14 +122,14 @@ static void pmem_phwsync(const void* buf, size_t size)
 
     Let us hope that having a recent enough GCC is an adequate proxy
     for having a recent enough assembler. */
-#  if __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 12)
+#  ifdef HAVE_TARGET_POWER10
     __asm__ __volatile__("dcbstps 0,%0" :: "r"(u) : "memory");
 #  else
     __asm__ __volatile__(".long (0x7cc000AC | %0 << 11)" :: "r"(u) : "memory");
 #  endif
   }
 
-#  if __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 18)
+#  ifdef HAVE_TARGET_POWER10
   __asm__ __volatile__("phwsync" ::: "memory");
 #  else
   __asm__ __volatile__(".long 0x7c80040a" ::: "memory");


### PR DESCRIPTION
Assembler comes up with the error:
unrecognized opcode: `dcbstps'

dcbstps is a Power 10 instruction. The default target arch on most platforms is Power 8 or 9.

Added the target power10 to the function pmem_phwsync. The execution of this function is gated on the ISA 3.1 in pmem_persist_init so there's no chance of a SIGILL.

Before and after on sid container on ppc64le:
```
[100%] Building CXX object storage/innobase/CMakeFiles/innobase.dir/sync/cache.cc.o
/tmp/ccTRNneR.s: Assembler messages:
/tmp/ccTRNneR.s:53: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:71: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:82: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:93: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:110: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:120: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:130: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:140: Error: unrecognized opcode: `dcbstps'
/tmp/ccTRNneR.s:153: Error: unrecognized opcode: `phwsync'
gmake[3]: *** [storage/innobase/CMakeFiles/innobase.dir/build.make:1619: storage/innobase/CMakeFiles/innobase.dir/sync/cache.cc.o] Error 1
gmake[3]: *** Waiting for unfinished jobs....
gmake[2]: *** [CMakeFiles/Makefile2:7016: storage/innobase/CMakeFiles/innobase.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:7023: storage/innobase/CMakeFiles/innobase.dir/rule] Error 2
gmake: *** [Makefile:1499: innobase] Error 2
buildbot@5bb9477a0460:/build$ cmake --build . --target innobase --parallel 8
[  0%] Built target uca-dump
[  0%] Built target GenUnicodeDataSource
[ 38%] Built target mysys
[ 53%] Built target strings
[ 53%] Built target dbug
[ 53%] Built target comp_err
[ 53%] Built target GenError
[ 61%] Built target tpool
[ 61%] Building CXX object storage/innobase/CMakeFiles/innobase.dir/sync/cache.cc.o
[ 61%] Linking CXX static library libinnobase.a
[100%] Built target innobase
buildbot@5bb9477a0460:/build$ gcc --version  
gcc (Debian 16.1.0-3) 16.1.0
Copyright (C) 2026 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```