### PR TITLE
MDEV-40486 [fixup] Clamp max_length at MAX_FIELD_VARCHARLENGTH in Ite…

### DIFF
--- a/mysql-test/main/vector2.result
+++ b/mysql-test/main/vector2.result
@@ -160,7 +160,7 @@ drop table t;
 # MDEV-35141 Server crashes in Field_vector::report_wrong_value upon statistic collection
 #
 create table t1 (v vector(64) not null);
-insert into t1 select vec_fromtext(cast(concat('[',group_concat(1),']') as char(130))) from seq_1_to_64;
+insert into t1 select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
 analyze table t1 persistent for all;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	Engine-independent statistics collected
@@ -571,11 +571,11 @@ set sql_mode=@old_sql_mode;
 ## Original testcase
 CREATE TABLE t (a TEXT) AS SELECT '[1]' AS a;
 CREATE TABLE tt AS SELECT VEC_FROMTEXT(a) AS f FROM t;
-ERROR 42000: Column length too big for column 'f' (max = 16383); use BLOB or TEXT instead
+ERROR 22007: Incorrect vector value: '\x00\x00\x80?' for column `test`.`tt`.`f` at row 1
 DROP TABLE t;
 CREATE TABLE t (a LONGBLOB) AS SELECT '[1]' AS a;
 CREATE TABLE tt AS SELECT VEC_FROMTEXT(a) AS f FROM t;
-ERROR 42000: Column length too big for column 'f' (max = 16383); use BLOB or TEXT instead
+ERROR 22007: Incorrect vector value: '\x00\x00\x80?' for column `test`.`tt`.`f` at row 1
 DROP TABLE t;
 ## Another case, which would have failed with ERROR 1292
 ## without the fix
@@ -592,7 +592,15 @@ SELECT VEC_FROMTEXT(concat('[1', repeat(',1', 16382), ']')) AS f;
 DROP TABLE tt;
 CREATE TABLE tt AS
 SELECT VEC_FROMTEXT(concat('[1', repeat(',1', 16383), ']')) AS f;
-ERROR 42000: Column length too big for column 'f' (max = 16383); use BLOB or TEXT instead
+ERROR 22007: Truncated incorrect vector value: '[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,...'
+CREATE TABLE t1 (v VECTOR(2));
+INSERT INTO t1 VALUES (VEC_FROMTEXT(CONCAT('[1.', REPEAT('0',70000), ',2]')));
+DROP TABLE t1;
+SELECT VEC_FROMTEXT('😀😀😀');
+VEC_FROMTEXT('😀😀😀')
+NULL
+Warnings:
+Warning	4038	Syntax error in JSON text in argument 1 to function 'VEC_FromText' at position 1
 ## "Zero-dimensional" argument, no change in behaviour after fix
 SELECT VEC_FROMTEXT('[]') as f;
 f
@@ -625,9 +633,10 @@ t2	CREATE TABLE `t2` (
 DROP TABLE t1, t2;
 CREATE TABLE t3 (f VECTOR(0));
 ERROR 42000: Incorrect column specifier for column 'f'
-## Fails because concat('[',group_concat(1),']') is mediumblob
 create view v1 as select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
-ERROR 42000: Column length too big for column 'vec_fromtext(concat('[',group_concat(1),']'))' (max = 16383); use BLOB or TEXT instead
+DROP view v1;
+create table t1 as select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
+ERROR 22007: Incorrect vector value: '\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00\x80?\x00\x00...' for column `test`.`t1`.`vec_fromtext(concat('[',group_concat(1),']'))` at row 65
 ## NULLs
 select vec_fromtext(NULL);
 vec_fromtext(NULL)

--- a/mysql-test/main/vector2.result
+++ b/mysql-test/main/vector2.result
@@ -703,4 +703,16 @@ ERROR 22007: Incorrect vector value: '' for column `test`.`t1`.`vec_fromtext(?)`
 execute p1 using '';
 ERROR HY000: Unexpected end of JSON text in argument 1 to function 'VEC_FromText'
 deallocate prepare p1;
+#
+# MDEV-40751 CREATE ... SELECT VEC_FROMTEXT(...) may create VECTOR columns that reject every value
+#
+CREATE TABLE t1 (a CHAR(4));
+create table t2 select vec_fromtext(a) from t1;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `vec_fromtext(a)` vector(1) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
+insert into t2 values (vec_fromtext('[1]'));
+DROP TABLE t1, t2;
 # End of 11.8 tests

--- a/mysql-test/main/vector2.test
+++ b/mysql-test/main/vector2.test
@@ -560,4 +560,14 @@ execute p1 using '[]';
 execute p1 using '';
 deallocate prepare p1;
 
+--echo #
+--echo # MDEV-40751 CREATE ... SELECT VEC_FROMTEXT(...) may create VECTOR columns that reject every value
+--echo #
+
+CREATE TABLE t1 (a CHAR(4));
+create table t2 select vec_fromtext(a) from t1;
+show create table t2;
+insert into t2 values (vec_fromtext('[1]'));
+DROP TABLE t1, t2;
+
 --echo # End of 11.8 tests

--- a/mysql-test/main/vector2.test
+++ b/mysql-test/main/vector2.test
@@ -125,7 +125,7 @@ drop table t;
 --echo # MDEV-35141 Server crashes in Field_vector::report_wrong_value upon statistic collection
 --echo #
 create table t1 (v vector(64) not null);
-insert into t1 select vec_fromtext(cast(concat('[',group_concat(1),']') as char(130))) from seq_1_to_64;
+insert into t1 select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
 analyze table t1 persistent for all;
 drop table t1;
 
@@ -453,12 +453,12 @@ set sql_mode=@old_sql_mode;
 
 --echo ## Original testcase
 CREATE TABLE t (a TEXT) AS SELECT '[1]' AS a;
---error ER_TOO_BIG_FIELDLENGTH
+--error ER_TRUNCATED_WRONG_VALUE
 CREATE TABLE tt AS SELECT VEC_FROMTEXT(a) AS f FROM t;
 DROP TABLE t;
 
 CREATE TABLE t (a LONGBLOB) AS SELECT '[1]' AS a;
---error ER_TOO_BIG_FIELDLENGTH
+--error ER_TRUNCATED_WRONG_VALUE
 CREATE TABLE tt AS SELECT VEC_FROMTEXT(a) AS f FROM t;
 DROP TABLE t;
 
@@ -478,9 +478,15 @@ CREATE TABLE tt AS
   SELECT VEC_FROMTEXT(concat('[1', repeat(',1', 16382), ']')) AS f;
 DROP TABLE tt;
 
---error ER_TOO_BIG_FIELDLENGTH
+--error ER_TRUNCATED_WRONG_VALUE
 CREATE TABLE tt AS
   SELECT VEC_FROMTEXT(concat('[1', repeat(',1', 16383), ']')) AS f;
+
+CREATE TABLE t1 (v VECTOR(2));
+INSERT INTO t1 VALUES (VEC_FROMTEXT(CONCAT('[1.', REPEAT('0',70000), ',2]')));
+DROP TABLE t1;
+
+SELECT VEC_FROMTEXT('😀😀😀');
 
 --echo ## "Zero-dimensional" argument, no change in behaviour after fix
 SELECT VEC_FROMTEXT('[]') as f;
@@ -503,9 +509,11 @@ DROP TABLE t1, t2;
 --error ER_WRONG_FIELD_SPEC
 CREATE TABLE t3 (f VECTOR(0));
 
---echo ## Fails because concat('[',group_concat(1),']') is mediumblob
---error ER_TOO_BIG_FIELDLENGTH
 create view v1 as select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
+DROP view v1;
+
+--error ER_TRUNCATED_WRONG_VALUE
+create table t1 as select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;
 
 --echo ## NULLs
 select vec_fromtext(NULL);

--- a/sql/item_vectorfunc.cc
+++ b/sql/item_vectorfunc.cc
@@ -181,22 +181,19 @@ Item_func_vec_fromtext::Item_func_vec_fromtext(THD *thd, Item *a)
 
 bool Item_func_vec_fromtext::fix_length_and_dec(THD *thd)
 {
-  uint32 maxlen= args[0]->max_char_length();
+  ulonglong maxlen= args[0]->max_char_length();
   decimals= 0;
   /* Worst case scenario, for a valid input we have a string of the form:
      [1,2,3,4,5,...] single digit numbers.
      This means we can have (maxlen - 1) / 2 floats.
-     Each float takes 4 bytes, so we do (maxlen - 1) * 2. Clamp at 4
-     (so that result is at least VECTOR(1)) and UINT_MAX32 - 1 (to
-     avoid overflow) */
-  if (maxlen <= 2)
-    maxlen= 4;
-  else if (maxlen > INT_MAX32)
-    maxlen= UINT_MAX32 - 1;
-  else
+     Each float takes 4 bytes, so we do (maxlen - 1) * 2. */
+  if (maxlen > 0)
     maxlen= (maxlen - 1) * 2;
-  fix_length_and_charset(maxlen, &my_charset_bin);
-  set_if_smaller(max_length, MAX_FIELD_VARCHARLENGTH);
+  set_if_smaller(maxlen, MAX_FIELD_VARCHARLENGTH);
+  /* VECTOR(0) is not allowed */
+  set_if_bigger(maxlen, 4);
+  /* Field_vector length must be a whole number of floats */
+  fix_length_and_charset((uint32) (maxlen & ~3ULL), &my_charset_bin);
   set_maybe_null();
   return false;
 }

--- a/sql/item_vectorfunc.cc
+++ b/sql/item_vectorfunc.cc
@@ -196,12 +196,7 @@ bool Item_func_vec_fromtext::fix_length_and_dec(THD *thd)
   else
     maxlen= (maxlen - 1) * 2;
   fix_length_and_charset(maxlen, &my_charset_bin);
-  if (max_length > MAX_FIELD_VARCHARLENGTH)
-  {
-    my_error(ER_TOO_BIG_FIELDLENGTH, MYF(0), name.str,
-             static_cast<ulong>(MAX_FIELD_VARCHARLENGTH / sizeof(float)));
-    return true;
-  }
+  set_if_smaller(max_length, MAX_FIELD_VARCHARLENGTH);
   set_maybe_null();
   return false;
 }
@@ -264,7 +259,8 @@ String *Item_func_vec_fromtext::val_str(String *buf)
   if (!end_ok)
     goto error_format;
 
-  if (Type_handler_vector::is_valid(buf->ptr(), buf->length()))
+  if (buf->length() <= MAX_FIELD_VARCHARLENGTH &&
+      Type_handler_vector::is_valid(buf->ptr(), buf->length()))
     return buf;
 
   null_value= true;


### PR DESCRIPTION
…m_func_vec_fromtext::fix_length_and_dec

This allows

create table t1 (v vector(64) not null);
insert into t1 select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;

which was banned in the previous fix
bb0ac437015dec04fbee226745a8eb2bb4825917, though this also introduces the inconsistency(?) where

create table t1 as select vec_fromtext(concat('[',group_concat(1),']')) from seq_1_to_64;

still fails ER_TRUNCATED_WRONG_VALUE

see updated tests

Pre-approved by: Oleksandr Byelkin <sanja@mariadb.com>