### PR TITLE
rocksdb: don't abort early in submodule update

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -19,10 +19,6 @@ MACRO(SKIP_ROCKSDB_PLUGIN msg)
   RETURN()
 ENDMACRO()
 
-IF (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/CMakeLists.txt")
-  SKIP_ROCKSDB_PLUGIN("Missing CMakeLists.txt in rocksdb directory. Try \"git submodule update\".")
-ENDIF()
-
 CHECK_LIBRARY_EXISTS(rt timer_delete "" HAVE_TIMER_DELETE)
 IF (HAVE_TIMER_DELETE)
   ADD_DEFINITIONS(-DHAVE_TIMER_DELETE)


### PR DESCRIPTION
Fix for 1fb075512a7aeab8646a163cbb6f265c49f4c075 to allow the ADD_SUBMODULE to perform updates.