### PR TITLE
MDEV-40803 Recursive CTE loses a row when its increment table converts

### DIFF
--- a/mysql-test/main/cte_recursive.result
+++ b/mysql-test/main/cte_recursive.result
@@ -6162,4 +6162,230 @@ UNION
 SELECT  1 > ( WITH cte AS ( SELECT 1 FROM x )  SELECT 1 FROM cte ) )
 SELECT 1 FROM x;
 ERROR HY000: Restrictions imposed on recursive definitions are violated for table 'x'
+#
+# Recursive CTE loses a row when the increment table is converted
+# into an on-disk temporary table
+#
+CREATE TABLE t1 (n INT, pad CHAR(255) CHARACTER SET utf8mb4);
+INSERT INTO t1 SELECT seq, REPEAT('x',255) FROM seq_1_to_64;
+SET @save_tmp_memory_table_size= @@tmp_memory_table_size;
+SET @save_max_heap_table_size= @@max_heap_table_size;
+# Each query below is run twice. The first run leaves the increment
+# table in memory, the second forces it to be converted to an on-disk
+# table while it is being filled. Both runs must return the same rows.
+#
+# The increment table overflows while the anchor part fills it
+#
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+FLUSH STATUS;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, pad FROM t1
+UNION ALL
+SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+# 0 = no temporary table was converted
+SELECT VARIABLE_VALUE > 0 AS converted FROM information_schema.SESSION_STATUS
+WHERE VARIABLE_NAME = 'Created_tmp_disk_tables';
+converted
+0
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+FLUSH STATUS;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, pad FROM t1
+UNION ALL
+SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+# 1 = a temporary table was converted
+SELECT VARIABLE_VALUE > 0 AS converted FROM information_schema.SESSION_STATUS
+WHERE VARIABLE_NAME = 'Created_tmp_disk_tables';
+converted
+1
+#
+# The increment table overflows during a recursive step
+#
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, pad FROM t1 WHERE n = 1
+UNION ALL
+SELECT r.lvl+1, t1.pad FROM r, t1 WHERE r.lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads
+1	1	1
+2	64	64
+3	4096	4096
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, pad FROM t1 WHERE n = 1
+UNION ALL
+SELECT r.lvl+1, t1.pad FROM r, t1 WHERE r.lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads
+1	1	1
+2	64	64
+3	4096	4096
+#
+# The same, for a CTE that eliminates duplicates
+#
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, pad FROM t1
+UNION
+SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, pad FROM t1
+UNION
+SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+#
+# The same, when the result table's key does not fit an on-disk table
+# and is replaced by a unique constraint. The result table's record
+# then carries a trailing hash field that the increment table's record
+# does not have, so the two records are of different length.
+#
+CREATE TABLE t2 (n INT,
+p1 CHAR(200) CHARACTER SET utf8mb4,
+p2 CHAR(200) CHARACTER SET utf8mb4,
+p3 CHAR(200) CHARACTER SET utf8mb4);
+INSERT INTO t2
+SELECT seq, REPEAT('a',200), REPEAT('b',200), REPEAT('c',200) FROM seq_1_to_64;
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, p1, p2, p3 FROM t2
+UNION
+SELECT lvl+1, n, p1, p2, p3 FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(p3) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, p1, p2, p3 FROM t2
+UNION
+SELECT lvl+1, n, p1, p2, p3 FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(p3) AS pads, SUM(n) AS sum_n
+FROM r GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+DROP TABLE t2;
+#
+# A prepared statement re-executed after its increment table was
+# converted on an earlier execution
+#
+PREPARE s FROM "
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, pad FROM t1
+     UNION ALL
+   SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM r GROUP BY lvl ORDER BY lvl";
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+EXECUTE s;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+EXECUTE s;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+EXECUTE s;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+DROP PREPARE s;
+#
+# Mutually recursive CTEs
+#
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+WITH RECURSIVE
+a AS (SELECT 1 AS lvl, n, pad FROM t1
+UNION ALL
+SELECT lvl+1, n, pad FROM b WHERE lvl < 4),
+b AS (SELECT lvl, n, pad FROM a)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM a GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+4	64	64	2080
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+WITH RECURSIVE
+a AS (SELECT 1 AS lvl, n, pad FROM t1
+UNION ALL
+SELECT lvl+1, n, pad FROM b WHERE lvl < 4),
+b AS (SELECT lvl, n, pad FROM a)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM a GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+4	64	64	2080
+#
+# INSERT ... SELECT, which takes a different warning-handling path
+# when the increment table is filled
+#
+CREATE TABLE t3 (lvl INT, n INT, pad CHAR(255) CHARACTER SET utf8mb4);
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+INSERT INTO t3
+WITH RECURSIVE r AS
+(SELECT 1 AS lvl, n, pad FROM t1
+UNION ALL
+SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, n, pad FROM r;
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+FROM t3 GROUP BY lvl ORDER BY lvl;
+lvl	cnt	pads	sum_n
+1	64	64	2080
+2	64	64	2080
+3	64	64	2080
+DROP TABLE t3;
+SET SESSION tmp_memory_table_size= @save_tmp_memory_table_size;
+SET SESSION max_heap_table_size= @save_max_heap_table_size;
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/main/cte_recursive.test
+++ b/mysql-test/main/cte_recursive.test
@@ -4251,4 +4251,179 @@ WITH RECURSIVE x AS (
     SELECT  1 > ( WITH cte AS ( SELECT 1 FROM x )  SELECT 1 FROM cte ) )
   SELECT 1 FROM x;
 
+--echo #
+--echo # Recursive CTE loses a row when the increment table is converted
+--echo # into an on-disk temporary table
+--echo #
+
+--source include/have_sequence.inc
+
+CREATE TABLE t1 (n INT, pad CHAR(255) CHARACTER SET utf8mb4);
+INSERT INTO t1 SELECT seq, REPEAT('x',255) FROM seq_1_to_64;
+
+SET @save_tmp_memory_table_size= @@tmp_memory_table_size;
+SET @save_max_heap_table_size= @@max_heap_table_size;
+
+--echo # Each query below is run twice. The first run leaves the increment
+--echo # table in memory, the second forces it to be converted to an on-disk
+--echo # table while it is being filled. Both runs must return the same rows.
+
+--echo #
+--echo # The increment table overflows while the anchor part fills it
+--echo #
+let $q=
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, pad FROM t1
+     UNION ALL
+   SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM r GROUP BY lvl ORDER BY lvl;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+FLUSH STATUS;
+eval $q;
+--echo # 0 = no temporary table was converted
+SELECT VARIABLE_VALUE > 0 AS converted FROM information_schema.SESSION_STATUS
+  WHERE VARIABLE_NAME = 'Created_tmp_disk_tables';
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+FLUSH STATUS;
+eval $q;
+--echo # 1 = a temporary table was converted
+SELECT VARIABLE_VALUE > 0 AS converted FROM information_schema.SESSION_STATUS
+  WHERE VARIABLE_NAME = 'Created_tmp_disk_tables';
+
+--echo #
+--echo # The increment table overflows during a recursive step
+--echo #
+let $q=
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, pad FROM t1 WHERE n = 1
+     UNION ALL
+   SELECT r.lvl+1, t1.pad FROM r, t1 WHERE r.lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads
+  FROM r GROUP BY lvl ORDER BY lvl;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+eval $q;
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+eval $q;
+
+--echo #
+--echo # The same, for a CTE that eliminates duplicates
+--echo #
+let $q=
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, pad FROM t1
+     UNION
+   SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM r GROUP BY lvl ORDER BY lvl;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+eval $q;
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+eval $q;
+
+--echo #
+--echo # The same, when the result table's key does not fit an on-disk table
+--echo # and is replaced by a unique constraint. The result table's record
+--echo # then carries a trailing hash field that the increment table's record
+--echo # does not have, so the two records are of different length.
+--echo #
+CREATE TABLE t2 (n INT,
+                 p1 CHAR(200) CHARACTER SET utf8mb4,
+                 p2 CHAR(200) CHARACTER SET utf8mb4,
+                 p3 CHAR(200) CHARACTER SET utf8mb4);
+INSERT INTO t2
+  SELECT seq, REPEAT('a',200), REPEAT('b',200), REPEAT('c',200) FROM seq_1_to_64;
+
+let $q=
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, p1, p2, p3 FROM t2
+     UNION
+   SELECT lvl+1, n, p1, p2, p3 FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(p3) AS pads, SUM(n) AS sum_n
+  FROM r GROUP BY lvl ORDER BY lvl;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+eval $q;
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+eval $q;
+
+DROP TABLE t2;
+
+--echo #
+--echo # A prepared statement re-executed after its increment table was
+--echo # converted on an earlier execution
+--echo #
+PREPARE s FROM "
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, pad FROM t1
+     UNION ALL
+   SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM r GROUP BY lvl ORDER BY lvl";
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+EXECUTE s;
+EXECUTE s;
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+EXECUTE s;
+DROP PREPARE s;
+
+--echo #
+--echo # Mutually recursive CTEs
+--echo #
+let $q=
+WITH RECURSIVE
+  a AS (SELECT 1 AS lvl, n, pad FROM t1
+          UNION ALL
+        SELECT lvl+1, n, pad FROM b WHERE lvl < 4),
+  b AS (SELECT lvl, n, pad FROM a)
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM a GROUP BY lvl ORDER BY lvl;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+eval $q;
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+eval $q;
+
+--echo #
+--echo # INSERT ... SELECT, which takes a different warning-handling path
+--echo # when the increment table is filled
+--echo #
+CREATE TABLE t3 (lvl INT, n INT, pad CHAR(255) CHARACTER SET utf8mb4);
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+INSERT INTO t3
+WITH RECURSIVE r AS
+  (SELECT 1 AS lvl, n, pad FROM t1
+     UNION ALL
+   SELECT lvl+1, n, pad FROM r WHERE lvl < 3)
+SELECT lvl, n, pad FROM r;
+SELECT lvl, COUNT(*) AS cnt, COUNT(pad) AS pads, SUM(n) AS sum_n
+  FROM t3 GROUP BY lvl ORDER BY lvl;
+DROP TABLE t3;
+
+SET SESSION tmp_memory_table_size= @save_tmp_memory_table_size;
+SET SESSION max_heap_table_size= @save_max_heap_table_size;
+DROP TABLE t1;
+
 --echo # End of 10.11 tests

--- a/mysql-test/main/union.result
+++ b/mysql-test/main/union.result
@@ -2783,3 +2783,40 @@ drop table t1;
 #
 # End of 10.3 tests
 #
+#
+# A result table that is converted to an on-disk table after its index
+# has been disabled
+#
+CREATE TABLE t1 (a INT);
+INSERT INTO t1 SELECT seq FROM seq_1_to_5000;
+SET @save_tmp_memory_table_size= @@tmp_memory_table_size;
+SET @save_max_heap_table_size= @@max_heap_table_size;
+# The index of the result table is dropped once the last distinct part
+# has been read, so the trailing UNION ALL part fills a table with no
+# index, and that table then outgrows the in-memory limit.
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+SELECT COUNT(*) AS cnt, COUNT(DISTINCT a) AS distinct_a FROM (
+SELECT a FROM t1 WHERE a <= 100
+UNION
+SELECT a FROM t1 WHERE a <= 100
+UNION ALL
+SELECT a FROM t1) d;
+cnt	distinct_a
+5100	5000
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+SELECT COUNT(*) AS cnt, COUNT(DISTINCT a) AS distinct_a FROM (
+SELECT a FROM t1 WHERE a <= 100
+UNION
+SELECT a FROM t1 WHERE a <= 100
+UNION ALL
+SELECT a FROM t1) d;
+cnt	distinct_a
+5100	5000
+SET SESSION tmp_memory_table_size= @save_tmp_memory_table_size;
+SET SESSION max_heap_table_size= @save_max_heap_table_size;
+DROP TABLE t1;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/union.test
+++ b/mysql-test/main/union.test
@@ -2026,3 +2026,43 @@ drop table t1;
 --echo #
 --echo # End of 10.3 tests
 --echo #
+
+--echo #
+--echo # A result table that is converted to an on-disk table after its index
+--echo # has been disabled
+--echo #
+
+--source include/have_sequence.inc
+
+CREATE TABLE t1 (a INT);
+INSERT INTO t1 SELECT seq FROM seq_1_to_5000;
+
+SET @save_tmp_memory_table_size= @@tmp_memory_table_size;
+SET @save_max_heap_table_size= @@max_heap_table_size;
+
+--echo # The index of the result table is dropped once the last distinct part
+--echo # has been read, so the trailing UNION ALL part fills a table with no
+--echo # index, and that table then outgrows the in-memory limit.
+let $q=
+SELECT COUNT(*) AS cnt, COUNT(DISTINCT a) AS distinct_a FROM (
+  SELECT a FROM t1 WHERE a <= 100
+    UNION
+  SELECT a FROM t1 WHERE a <= 100
+    UNION ALL
+  SELECT a FROM t1) d;
+
+SET SESSION tmp_memory_table_size= 16384;
+SET SESSION max_heap_table_size= 16384;
+eval $q;
+
+SET SESSION tmp_memory_table_size= 16777216;
+SET SESSION max_heap_table_size= 16777216;
+eval $q;
+
+SET SESSION tmp_memory_table_size= @save_tmp_memory_table_size;
+SET SESSION max_heap_table_size= @save_max_heap_table_size;
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -283,6 +283,16 @@ int select_union_recursive::send_data(List<Item> &values)
     if ((err= incr_table->file->ha_write_tmp_row(table->record[0])))
     {
       bool is_duplicate;
+      /*
+        create_internal_tmp_table_from_heap() appends the row that did not fit
+        from the record[0] of the table it converts, so the row has to be in
+        the increment table's own record buffer. Only reclength bytes of the
+        increment table are copied: if the union result table uses a unique
+        constraint its record has a trailing hash field, which is not part of
+        the increment table's record (see the assert above).
+      */
+      memcpy(incr_table->record[0], table->record[0],
+             incr_table->s->reclength);
       rc= create_internal_tmp_table_from_heap(thd, incr_table,
                                               tmp_table_param.start_recinfo, 
                                               &tmp_table_param.recinfo,


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-40803

A recursive CTE whose increment table outgrows the in-memory temporary table returns a wrong result. The row that overflows the increment table is replaced by an all-NULL record, so that row and every row the recursion would have derived from it are missing from the answer. No error and no warning is raised.

Targeted at 10.11, the lowest supported affected branch, as requested in review. `select_union_recursive::send_data()` is byte-identical on 10.11, 10.6 and `main`. 10.6 carries the same defect but is past EOL, and 10.5 has been end-of-life since 2025-04-28, so 10.11 is the lowest maintained branch that can take the fix.

## The defect

`select_union_recursive::send_data()` builds each new row in the record buffer of the **union result** table and writes it into the **increment** table. When that write overflows, it asks for the increment table to be converted:

```cpp
    if ((err= incr_table->file->ha_write_tmp_row(table->record[0])))
    {
      bool is_duplicate;
      rc= create_internal_tmp_table_from_heap(thd, incr_table, ...);
    }
```

`create_internal_tmp_table_from_heap()` copies every stored row into the new table and then appends the row that did not fit, taking it from the `record[0]` of the table it was given:

```cpp
  /* copy row that filled HEAP table */
  if (unlikely((write_err=new_table.file->ha_write_tmp_row(table->record[0]))))
```

There, `table` is the parameter, so this reads `incr_table->record[0]`. Nothing ever fills that buffer: `TABLE::insert_all_rows_into_tmp_table()` reads into the destination's `record[0]`, and the recursive scan reads the recursive result table. It still holds the empty record the table was opened with.

The increment table is created with no grouping and no distinct flag, so it carries no key and the substituted row is not rejected. On the next iteration that row's columns are NULL, the recursion predicate evaluates to NULL, and it produces no descendants.

## The fix

Copy the row into the increment table's own record buffer before asking for the conversion, so this caller satisfies the same precondition every other caller of `create_internal_tmp_table_from_heap()` already satisfies. All 13 other call sites were audited; each writes the pending row from the `record[0]` of the very table it converts, which is why the defect is confined to this one.

Only `incr_table->s->reclength` bytes are copied. When the union result table uses a unique constraint, its record carries a trailing `MARIA_UNIQUE_HASH_LENGTH` hash field, appended after the real columns, that the increment table's record does not have. This is the case the `DBUG_ASSERT` above the call already describes, and it was observed live at a conversion with `incr_reclength=2409 result_reclength=2413`.

## Testing

Seven shapes in `main.cte_recursive`, each run twice, once with the increment table small enough to stay in memory and once forced to convert, with the two runs required to agree: overflow during the anchor, overflow during a recursive step, `UNION` distinct, `UNION` distinct with a key too long for an on-disk table, a prepared statement re-executed across a conversion, mutually recursive CTEs, and `INSERT ... SELECT`.

Every shape was verified to fail before the fix and pass after it, with the `.result` file unchanged between the two runs. Backing the fix out of the build gives, for example:

```
 lvl	cnt	pads	sum_n
 1	64	64	2080
-2	64	64	2080
-3	64	64	2080
+2	63	63	2051
+3	63	63	2051
```

and, on the shape that measures the lost descendants, `4096` becomes `4032`.

Two properties are needed to expose the defect, and neither is obvious:

1. `tmp_memory_table_size=0` cannot be used to force the conversion. It makes `Create_tmp_table::choose_engine()` build the table on disk from the start, so the conversion never happens. This is why the existing tests in `cte_recursive.test` that set it never caught this.
2. The lost row has to be at a level of the recursion that still has descendants. The in-memory table is only checked for fullness at block boundaries, so a row width that pushes the conversion into the last level hides the defect entirely.

The test pins the character set of its table, so the record width, and with it the point at which the increment table stops fitting in memory, does not depend on the server default; each query also asserts whether a conversion happened, so a later change to the size limits cannot silently leave a shape uncovered.

`main.cte_recursive` and `main.union` re-recorded purely additively, no existing result changed. Full `main` and `heap` suites pass, 1259/1259, with the one `Check of testcase failed` attributable to a slave that `main.mysqldump-nl` leaves connecting on the same worker, not to this change.

## The second commit

`Cover converting a result table whose index has been disabled` is independent of the fix and can be dropped without affecting it. It adds the only reachable branch of `create_internal_tmp_table_from_heap()` that no test in the `main` suite took, measured over every test that manipulates the temporary table size limits.

The branch previously also carried `Drop the view left behind by cte_update_delete.test`. That commit is not here, because `cte_update_delete.test` does not exist on 10.11 -- it arrives on `main` with MDEV-37220. It will be sent separately against `main`.
