### PR TITLE
MDEV-40801 ppc64le ro_after_init isn't pagesize aligned

### DIFF
--- a/sql/mysqld_ro.lds
+++ b/sql/mysqld_ro.lds
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2026, MariaDB plc.
+   Copyright (c) 2026, MariaDB plc, MariaDB Foundation
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -21,11 +21,11 @@
 */
 SECTIONS
 {
-  ro_after_init ALIGN(CONSTANT(COMMONPAGESIZE)) :
+  ro_after_init ALIGN(CONSTANT(MAXPAGESIZE)) :
   {
     ro_after_init_start = .;
     *(ro_after_init)
-    . = ALIGN(CONSTANT(COMMONPAGESIZE));
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     ro_after_init_end = .;
   }
 } INSERT AFTER .data;


### PR DESCRIPTION
Align ro_after_init using MAXPAGESIZE instead of COMMONPAGESIZE.

COMMONPAGESIZE may be smaller than the actual page size supported by the target ABI. This can leave ro_after_init sharing an OS page with adjacent sections, causing mprotect() to change permissions on data outside ro_after_init.

Use MAXPAGESIZE so the section boundaries are aligned to the maximum page size required by the target linker/ABI.

This is particularly important on architectures such as ppc64le and aarch64, where the runtime page size can differ from COMMONPAGESIZE.

Before:
  .data          0x...1b80000
  ro_after_init  0x...1c70000
  .bss           0x...1c72000

After:
  ro_after_init starts and ends on MAXPAGESIZE boundaries, ensuring
  mprotect() only affects pages belonging to ro_after_init.