### PR TITLE
MDEV-40080: innodb_log_archive=ON corruption

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1933,7 +1933,7 @@ inline lsn_t log_t::write_checkpoint(lsn_t checkpoint, lsn_t end_lsn) noexcept
             resize_target= (offset + 4095) & ~off_t{4095};
             sql_print_warning("InnoDB: Adjusting innodb_log_file_size="
                               LSN_PF "k", resize_target >> 10);
-            ut_a(os_file_set_size(get_archive_path().c_str(), resize_log.m_file,
+            ut_a(os_file_set_size(get_archive_path().c_str(), log.m_file,
                                   resize_target, false));
           }
         }

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1538,14 +1538,16 @@ void log_t::archived_mmap_switch_prepare(bool late, bool ex) noexcept
       (l & (WRITE_BACKOFF - 1));
     waits++;
     ut_ad(archive);
-    ut_ad(!resize_buf);
     ut_ad(!resize_in_progress());
     ut_ad(resize_target >= 4U << 20);
     ut_ad(is_latest());
     ut_ad(log.is_opened());
-    ut_ad(!!checkpoint_buf == resize_log.is_opened());
+    ut_ad((checkpoint_buf || resize_buf) == resize_log.is_opened());
 
-    if (UNIV_LIKELY_NULL(checkpoint_buf))
+    if (resize_buf)
+      /* archive_create(..., false) had recently succeeded in another thread */
+      ut_ad(!checkpoint_buf);
+    else if (UNIV_LIKELY_NULL(checkpoint_buf))
       /* Both archived_mmap_switch_prepare() and
       archived_mmap_switch_complete() were invoked by another thread,
       but write_checkpoint() did not clean up yet. */


### PR DESCRIPTION
`log_t::write_checkpoint()`: Extend the the correct file.

`log_t::archived_mmap_switch_prepare()`: Tolerate a near-concurrent `buf_flush_archive_create()` from the `buf_flush_page_cleaner()` thread.

This fixes up #4817. I tested both changes with the [test case](https://jira.mariadb.org/browse/MDEV-40080?focusedCommentId=336569&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-336569) in [MDEV-40080](https://jira.mariadb.org/browse/MDEV-40080). The first one is for the `WITH_INNODB_PMEM=OFF` code path (`pwrite` based log writes), and the second one is for the memory-mapped log writes.