### PR TITLE
MDEV-40827: prefetch MHNSW neighbours during search

### DIFF
--- a/include/my_cpu.h
+++ b/include/my_cpu.h
@@ -110,6 +110,25 @@ static inline void MY_RELAX_CPU(void)
 }
 
 
+/*
+  Hint the CPU to start loading a cache line for reading.
+
+  Like YieldProcessor() above, PreFetchCacheLine() is architecture-independent:
+  winnt.h picks the instruction per target, unlike _mm_prefetch().
+  clang-cl defines __clang__ but not __GNUC__, so it must take the first branch.
+*/
+static inline void my_prefetch(const void *addr)
+{
+#if defined(__GNUC__) || defined(__clang__)
+  __builtin_prefetch(addr, 0, 3);
+#elif defined(_WIN32)
+  PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, addr);
+#else
+  (void) addr;
+#endif
+}
+
+
 #ifdef HAVE_PAUSE_INSTRUCTION
 # ifdef __cplusplus
 extern "C" {

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -22,6 +22,7 @@
 #include "vector_mhnsw.h"
 #include <scope.h>
 #include <my_atomic_wrapper.h>
+#include <my_cpu.h>                            // my_prefetch()
 #include "bloom_filters.h"
 
 // distance can be a little bit < 0 because of fast math
@@ -1347,7 +1348,6 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
       if (res == 0xff)
         continue;
 
-#if defined(__GNUC__)
       // A node and its vector share one allocation. Prefetch unseen nodes before
       // computing distances so later loads can overlap with work on earlier ones.
       for (size_t i= 0; i < 8; i++)
@@ -1355,11 +1355,11 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
         FVectorNode *link= links[i];
         if (!(res & (1 << i)) && link)
         {
-          __builtin_prefetch(link, 0, 3);
-          __builtin_prefetch(reinterpret_cast<const char*>(link) + 64, 0, 3);
+          my_prefetch(link);
+          my_prefetch(reinterpret_cast<const char*>(link)
+                      + CPU_LEVEL1_DCACHE_LINESIZE);
         }
       }
-#endif
 
       for (size_t i= 0; i < 8; i++)
       {

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1347,6 +1347,20 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
       if (res == 0xff)
         continue;
 
+#if defined(__GNUC__)
+      // A node and its vector share one allocation. Prefetch unseen nodes before
+      // computing distances so later loads can overlap with work on earlier ones.
+      for (size_t i= 0; i < 8; i++)
+      {
+        FVectorNode *link= links[i];
+        if (!(res & (1 << i)) && link)
+        {
+          __builtin_prefetch(link, 0, 3);
+          __builtin_prefetch(reinterpret_cast<const char*>(link) + 64, 0, 3);
+        }
+      }
+#endif
+
       for (size_t i= 0; i < 8; i++)
       {
         if (res & (1 << i))


### PR DESCRIPTION
## Summary

Prefetch unseen MHNSW neighbour allocations before their distance evaluations.  

## Correctness

- Clean debug and release builds; the non-GNU `#else` path also compiles.
- `--do-test=vector` and `main.mysqld--help` pass in both.
- Exact brute-force recall is identical with and without the patch in every cell below.

## Performance

Counterbalanced AB/BA, warm cache, both binaries querying the same persisted graph (200k x 1024, cosine, M=6); 200 queries, 30 paired observations per cell.
AMD EPYC 7713, RelWithDebInfo, 8-CPU cgroup quota on a shared host.

| `ef_search` | upstream | prefetch | paired median spe
|---:|---:|---:|---:|
| 40 | 1364.2 | 1518.2 | +10.1% (+8.0%, +14.4%) |
| 160 | 795.2 | 913.8 | +13.8% (+11.8%, +20.0%) |

The gain grows with `ef_search`: larger `ef` expands more nodes, so more neighbour groups are scanned and more memory latency is available to hide.
