### PR TITLE
MDEV-21879 GROUP_CONCAT(DISTINCT ORDER BY) is wrong when Unique spills

### DIFF
--- a/mysql-test/main/func_gconcat.result
+++ b/mysql-test/main/func_gconcat.result
@@ -863,7 +863,7 @@ group_concat(distinct a, c)
 00,01,10,11,31
 select group_concat(distinct a, c order by a) from t1;
 group_concat(distinct a, c order by a)
-00,01,11,10,31
+01,00,11,10,31
 select group_concat(distinct a, c) from t1;
 group_concat(distinct a, c)
 00,01,10,11,31

--- a/mysql-test/main/gconcat_cut_note.result
+++ b/mysql-test/main/gconcat_cut_note.result
@@ -1,0 +1,105 @@
+CREATE TABLE t1 (grp INT, t TEXT);
+INSERT INTO t1 SELECT seq, REPEAT(CHAR(64 + seq), 200) FROM seq_1_to_3;
+SET SESSION group_concat_max_len= 100;
+#
+# One row per group, so the result of each group is exactly the cut
+# value. Every answer is short by what was cut off its only row,
+# so every group warns.
+#
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+grp	len
+1	100
+2	100
+3	100
+Warnings:
+Warning	1260	Row 1 was cut by group_concat()
+Warning	1260	Row 2 was cut by group_concat()
+Warning	1260	Row 3 was cut by group_concat()
+#
+# Two aggregates in one statement, each warning for each of its
+# groups. The brackets JSON_ARRAYAGG() puts around the value push
+# its result past the limit, so it is cut a second time.
+#
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS gc_len,
+LENGTH(JSON_ARRAYAGG(t ORDER BY t)) AS ja_len FROM t1 GROUP BY grp;
+grp	gc_len	ja_len
+1	100	102
+2	100	102
+3	100	102
+Warnings:
+Warning	1260	Row 1 was cut by group_concat()
+Warning	1260	Row 1 was cut by json_arrayagg()
+Warning	1260	Row 2 was cut by group_concat()
+Warning	1260	Row 2 was cut by json_arrayagg()
+Warning	1260	Row 3 was cut by group_concat()
+Warning	1260	Row 3 was cut by json_arrayagg()
+#
+# The same statement run again reports for itself.
+#
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+grp	len
+1	100
+2	100
+3	100
+Warnings:
+Warning	1260	Row 1 was cut by group_concat()
+Warning	1260	Row 2 was cut by group_concat()
+Warning	1260	Row 3 was cut by group_concat()
+#
+# All three rows in one group, so the result is cut on top of the
+# values. Both are the same loss to the user and both are already
+# a warning, so it is given once.
+#
+SELECT LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1;
+len
+100
+Warnings:
+Warning	1260	Row 2 was cut by group_concat()
+#
+# Nothing is cut, so nothing is said.
+#
+SET SESSION group_concat_max_len= DEFAULT;
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+grp	len
+1	200
+2	200
+3	200
+DROP TABLE t1;
+#
+# Which of the two is given depends on the row, not on the group.
+# One group holds a short value and a long one, and a LIMIT decides
+# which of them the answer is built from.
+#
+CREATE TABLE t2 (t TEXT);
+INSERT INTO t2 VALUES ('aa'), (REPEAT('z', 200)), ('bb');
+SET SESSION group_concat_max_len= 100;
+#
+# The answer is built from the two short rows. The long value was
+# cut on its way in, but it is not in the answer, which is the same
+# answer a larger limit would have given: a note.
+#
+SELECT GROUP_CONCAT(t ORDER BY t LIMIT 2) AS gc FROM t2;
+gc
+aa,bb
+Warnings:
+Note	4266	Some values were cut while processing group_concat(). Increase group_concat_max_len if you want to avoid the cut
+#
+# The same data, and the offset moves the answer onto the row that
+# was cut. The answer is now short by what was cut: a warning.
+#
+SELECT LENGTH(GROUP_CONCAT(t ORDER BY t LIMIT 1 OFFSET 2)) AS gc_len FROM t2;
+gc_len
+100
+Warnings:
+Warning	1260	Row 3 was cut by group_concat()
+#
+# DISTINCT without ORDER BY builds the answer from the duplicate
+# filter instead of the sort tree, and is judged the same way.
+#
+SELECT LENGTH(GROUP_CONCAT(DISTINCT t LIMIT 1 OFFSET 2)) AS gc_len FROM t2;
+gc_len
+100
+Warnings:
+Warning	1260	Row 3 was cut by group_concat()
+SET SESSION group_concat_max_len= DEFAULT;
+DROP TABLE t2;

--- a/mysql-test/main/gconcat_cut_note.test
+++ b/mysql-test/main/gconcat_cut_note.test
@@ -1,0 +1,81 @@
+#
+# A TEXT value longer than group_concat_max_len is cut on its way into
+# blob_storage, while the group is being built. Whether that changed the
+# answer depends on whether the row carrying it reaches the answer at
+# all. If it does, the answer is short by what was cut and that is a
+# warning. If it does not, the answer may be exactly what it would have
+# been without the limit, and all that can honestly be said is a note.
+# One note is enough for the statement.
+#
+--source include/have_sequence.inc
+
+CREATE TABLE t1 (grp INT, t TEXT);
+INSERT INTO t1 SELECT seq, REPEAT(CHAR(64 + seq), 200) FROM seq_1_to_3;
+
+SET SESSION group_concat_max_len= 100;
+
+--echo #
+--echo # One row per group, so the result of each group is exactly the cut
+--echo # value. Every answer is short by what was cut off its only row,
+--echo # so every group warns.
+--echo #
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+
+--echo #
+--echo # Two aggregates in one statement, each warning for each of its
+--echo # groups. The brackets JSON_ARRAYAGG() puts around the value push
+--echo # its result past the limit, so it is cut a second time.
+--echo #
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS gc_len,
+       LENGTH(JSON_ARRAYAGG(t ORDER BY t)) AS ja_len FROM t1 GROUP BY grp;
+
+--echo #
+--echo # The same statement run again reports for itself.
+--echo #
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+
+--echo #
+--echo # All three rows in one group, so the result is cut on top of the
+--echo # values. Both are the same loss to the user and both are already
+--echo # a warning, so it is given once.
+--echo #
+SELECT LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1;
+
+--echo #
+--echo # Nothing is cut, so nothing is said.
+--echo #
+SET SESSION group_concat_max_len= DEFAULT;
+SELECT grp, LENGTH(GROUP_CONCAT(t ORDER BY t)) AS len FROM t1 GROUP BY grp;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Which of the two is given depends on the row, not on the group.
+--echo # One group holds a short value and a long one, and a LIMIT decides
+--echo # which of them the answer is built from.
+--echo #
+CREATE TABLE t2 (t TEXT);
+INSERT INTO t2 VALUES ('aa'), (REPEAT('z', 200)), ('bb');
+SET SESSION group_concat_max_len= 100;
+
+--echo #
+--echo # The answer is built from the two short rows. The long value was
+--echo # cut on its way in, but it is not in the answer, which is the same
+--echo # answer a larger limit would have given: a note.
+--echo #
+SELECT GROUP_CONCAT(t ORDER BY t LIMIT 2) AS gc FROM t2;
+
+--echo #
+--echo # The same data, and the offset moves the answer onto the row that
+--echo # was cut. The answer is now short by what was cut: a warning.
+--echo #
+SELECT LENGTH(GROUP_CONCAT(t ORDER BY t LIMIT 1 OFFSET 2)) AS gc_len FROM t2;
+
+--echo #
+--echo # DISTINCT without ORDER BY builds the answer from the duplicate
+--echo # filter instead of the sort tree, and is judged the same way.
+--echo #
+SELECT LENGTH(GROUP_CONCAT(DISTINCT t LIMIT 1 OFFSET 2)) AS gc_len FROM t2;
+
+SET SESSION group_concat_max_len= DEFAULT;
+DROP TABLE t2;

--- a/mysql-test/main/gconcat_distinct_rewalk.result
+++ b/mysql-test/main/gconcat_distinct_rewalk.result
@@ -1,0 +1,123 @@
+#
+# A plain aggregate, asked once and then asked twice. A HAVING
+# clause on the alias is the shortest statement that asks twice.
+#
+CREATE TABLE t1 (g INT, a VARCHAR(10));
+INSERT INTO t1 VALUES (1,'a'),(1,'b'),(1,'c'),(1,'d'),(2,'e'),(2,'f');
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1;
+v
+
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+HAVING v LIKE '%';
+v
+
+#
+# Two conditions ask for it a third time.
+#
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+HAVING v LIKE '%' AND v NOT LIKE 'zz%';
+v
+
+#
+# DISTINCT reaches the walk by the other route.
+#
+SELECT GROUP_CONCAT(DISTINCT a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+HAVING v LIKE '%';
+v
+
+#
+# One group spends the offset exactly and the other does not, so
+# both answers show up in the same statement.
+#
+SELECT g, GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1
+GROUP BY g HAVING v LIKE '%' ORDER BY g;
+g	v
+1	
+2	
+#
+# An offset that stops inside the group is not affected, the walk
+# having written a row, and neither is a group with no LIMIT.
+#
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 1) AS v FROM t1 WHERE g = 1
+HAVING v LIKE '%';
+v
+b,c
+SELECT GROUP_CONCAT(a ORDER BY a) AS v FROM t1 WHERE g = 1
+HAVING v LIKE '%';
+v
+a,b,c,d
+DROP TABLE t1;
+#
+# The same replay against a duplicate filter that has spilled to
+# disk, where the second walk is not merely wrong but unsupported.
+#
+CREATE TABLE t2 (g INT, a VARCHAR(100));
+INSERT INTO t2 SELECT seq MOD 4, LPAD(seq, 6, '0') FROM seq_1_to_2000;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t2;
+rows_in_table	distinct_values
+2000	2000
+SELECT g, COUNT(*) AS rows_in_group FROM t2 GROUP BY g ORDER BY g;
+g	rows_in_group
+0	500
+1	500
+2	500
+3	500
+SET @@tmp_memory_table_size=0;
+#
+# What an offset does while it stops inside the group: the same
+# query at two offsets returns two different windows of the same
+# ordered values, and each group returns values of its own.
+#
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 3) AS gc
+FROM t2 GROUP BY g ORDER BY g;
+g	gc
+0	000004,000008,000012
+1	000001,000005,000009
+2	000002,000006,000010
+3	000003,000007,000011
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 3 OFFSET 2) AS gc
+FROM t2 GROUP BY g ORDER BY g;
+g	gc
+0	000012,000016,000020
+1	000009,000013,000017
+2	000010,000014,000018
+3	000011,000015,000019
+#
+# An offset past the end of every group. Each group holds 500
+# values, so there is nothing left to return, and the HAVING asks
+# each group for its answer a second time.
+#
+SELECT g, GROUP_CONCAT(DISTINCT a LIMIT 5 OFFSET 1000) AS gc
+FROM t2 GROUP BY g HAVING gc <> 'x';
+g	gc
+0	
+1	
+2	
+3	
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5 OFFSET 1000) AS gc
+FROM t2 GROUP BY g HAVING gc <> 'x';
+g	gc
+0	
+1	
+2	
+3	
+#
+# An offset that skips only part of the group is not affected, and
+# the answer must not depend on whether the filter spilled.
+#
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 2 OFFSET 3) AS gc
+FROM t2 GROUP BY g HAVING gc <> 'x' ORDER BY g;
+g	gc
+0	000016,000020
+1	000013,000017
+2	000014,000018
+3	000015,000019
+SET @@tmp_memory_table_size=DEFAULT;
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 2 OFFSET 3) AS gc
+FROM t2 GROUP BY g HAVING gc <> 'x' ORDER BY g;
+g	gc
+0	000016,000020
+1	000013,000017
+2	000014,000018
+3	000015,000019
+DROP TABLE t2;

--- a/mysql-test/main/gconcat_distinct_rewalk.test
+++ b/mysql-test/main/gconcat_distinct_rewalk.test
@@ -1,0 +1,92 @@
+#
+# Nothing says how many times a statement asks for the result of a group,
+# and the answer must not depend on it. When an OFFSET skips every row of
+# the group, the walk writes nothing, and the aggregate must still record
+# that it has run. Otherwise the next caller walks again with the offset
+# already spent, which replays the group into a buffer that was handed
+# over once already, and, once the duplicate filter has spilled to disk,
+# walks a Unique that can only be walked once.
+#
+--source include/have_sequence.inc
+
+--echo #
+--echo # A plain aggregate, asked once and then asked twice. A HAVING
+--echo # clause on the alias is the shortest statement that asks twice.
+--echo #
+CREATE TABLE t1 (g INT, a VARCHAR(10));
+INSERT INTO t1 VALUES (1,'a'),(1,'b'),(1,'c'),(1,'d'),(2,'e'),(2,'f');
+
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1;
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+  HAVING v LIKE '%';
+
+--echo #
+--echo # Two conditions ask for it a third time.
+--echo #
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+  HAVING v LIKE '%' AND v NOT LIKE 'zz%';
+
+--echo #
+--echo # DISTINCT reaches the walk by the other route.
+--echo #
+SELECT GROUP_CONCAT(DISTINCT a LIMIT 2 OFFSET 4) AS v FROM t1 WHERE g = 1
+  HAVING v LIKE '%';
+
+--echo #
+--echo # One group spends the offset exactly and the other does not, so
+--echo # both answers show up in the same statement.
+--echo #
+SELECT g, GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 4) AS v FROM t1
+  GROUP BY g HAVING v LIKE '%' ORDER BY g;
+
+--echo #
+--echo # An offset that stops inside the group is not affected, the walk
+--echo # having written a row, and neither is a group with no LIMIT.
+--echo #
+SELECT GROUP_CONCAT(a ORDER BY a LIMIT 2 OFFSET 1) AS v FROM t1 WHERE g = 1
+  HAVING v LIKE '%';
+SELECT GROUP_CONCAT(a ORDER BY a) AS v FROM t1 WHERE g = 1
+  HAVING v LIKE '%';
+DROP TABLE t1;
+
+--echo #
+--echo # The same replay against a duplicate filter that has spilled to
+--echo # disk, where the second walk is not merely wrong but unsupported.
+--echo #
+CREATE TABLE t2 (g INT, a VARCHAR(100));
+INSERT INTO t2 SELECT seq MOD 4, LPAD(seq, 6, '0') FROM seq_1_to_2000;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t2;
+SELECT g, COUNT(*) AS rows_in_group FROM t2 GROUP BY g ORDER BY g;
+
+SET @@tmp_memory_table_size=0;
+
+--echo #
+--echo # What an offset does while it stops inside the group: the same
+--echo # query at two offsets returns two different windows of the same
+--echo # ordered values, and each group returns values of its own.
+--echo #
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 3) AS gc
+  FROM t2 GROUP BY g ORDER BY g;
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 3 OFFSET 2) AS gc
+  FROM t2 GROUP BY g ORDER BY g;
+
+--echo #
+--echo # An offset past the end of every group. Each group holds 500
+--echo # values, so there is nothing left to return, and the HAVING asks
+--echo # each group for its answer a second time.
+--echo #
+SELECT g, GROUP_CONCAT(DISTINCT a LIMIT 5 OFFSET 1000) AS gc
+  FROM t2 GROUP BY g HAVING gc <> 'x';
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5 OFFSET 1000) AS gc
+  FROM t2 GROUP BY g HAVING gc <> 'x';
+
+--echo #
+--echo # An offset that skips only part of the group is not affected, and
+--echo # the answer must not depend on whether the filter spilled.
+--echo #
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 2 OFFSET 3) AS gc
+  FROM t2 GROUP BY g HAVING gc <> 'x' ORDER BY g;
+SET @@tmp_memory_table_size=DEFAULT;
+SELECT g, GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 2 OFFSET 3) AS gc
+  FROM t2 GROUP BY g HAVING gc <> 'x' ORDER BY g;
+DROP TABLE t2;

--- a/mysql-test/main/gconcat_distinct_spill.result
+++ b/mysql-test/main/gconcat_distinct_spill.result
@@ -1,0 +1,107 @@
+#
+# Each block records the answer computed with memory to spare, then
+# recomputes it with the duplicate filter starved, and compares.
+#
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, a VARCHAR(100) NOT NULL);
+INSERT INTO t1 (a) SELECT LPAD(seq, 4, '0') FROM seq_1_to_50;
+INSERT INTO t1 (a) SELECT a FROM t1 ORDER BY pk;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t1;
+rows_in_table	distinct_values
+100	50
+SELECT GROUP_CONCAT(DISTINCT a) INTO @gc FROM t1;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc_order FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a) INTO @ja FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) INTO @ja_order FROM t1;
+SET @@tmp_memory_table_size=0;
+SELECT GROUP_CONCAT(DISTINCT a) = @gc AS gc_unchanged FROM t1;
+gc_unchanged
+1
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) = @gc_order AS gc_order_unchanged FROM t1;
+gc_order_unchanged
+1
+SELECT JSON_ARRAYAGG(DISTINCT a) = @ja AS ja_unchanged FROM t1;
+ja_unchanged
+1
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) = @ja_order AS ja_order_unchanged FROM t1;
+ja_order_unchanged
+1
+SET @@tmp_memory_table_size=DEFAULT;
+DROP TABLE t1;
+#
+# Values wide enough that the filter flushes on nearly every row.
+# Here the ORDER BY case used to return a single value out of 30.
+#
+CREATE TABLE t2 (a VARCHAR(2000)) AS
+SELECT CONCAT(seq, REPEAT('.', 1990)) AS a FROM seq_1_to_30;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t2;
+rows_in_table	distinct_values
+30	30
+SELECT GROUP_CONCAT(DISTINCT a) INTO @gc FROM t2;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc_order FROM t2;
+SET @@tmp_memory_table_size=1000, @@max_heap_table_size=1000;
+Warnings:
+Warning	1292	Truncated incorrect tmp_memory_table_size value: '1000'
+Warning	1292	Truncated incorrect max_heap_table_size value: '1000'
+SELECT GROUP_CONCAT(DISTINCT a) = @gc AS gc_unchanged FROM t2;
+gc_unchanged
+1
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) = @gc_order AS gc_order_unchanged FROM t2;
+gc_order_unchanged
+1
+SET @@tmp_memory_table_size=DEFAULT, @@max_heap_table_size=DEFAULT;
+DROP TABLE t2;
+#
+# ORDER BY does not order the rows that tie on the ordering
+# expression. Which of them comes first is not specified, but it
+# must not depend on the memory available or on the order the rows
+# are read in.
+#
+CREATE TABLE t3 (a BIT(2), b VARCHAR(10), c BIT);
+INSERT INTO t3 VALUES (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
+(1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS at_default FROM t3;
+at_default
+01,00,11,10,31
+SET @@tmp_memory_table_size=0;
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS at_zero FROM t3;
+at_zero
+01,00,11,10,31
+SET @@tmp_memory_table_size=DEFAULT;
+DELETE FROM t3;
+INSERT INTO t3 VALUES (0, 'c', 0), (0, 'b', 1), (1, 'a', 0), (3, 'd', 1),
+(1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS reversed_scan_order FROM t3;
+reversed_scan_order
+01,00,11,10,31
+DROP TABLE t3;
+#
+# The sort tree can overflow too. Starving it makes repack_tree()
+# cut rows out of the group, which is expected, but the rows that
+# do come back must still be deduplicated and still be in order.
+#
+CREATE TABLE t4 (pk INT AUTO_INCREMENT PRIMARY KEY, a VARCHAR(20));
+INSERT INTO t4 (a) SELECT LPAD(seq, 6, '0') FROM seq_1_to_200;
+INSERT INTO t4 (a) SELECT a FROM t4 ORDER BY pk;
+SET @@tmp_memory_table_size=0, @@group_concat_max_len=4000;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc FROM t4;
+Warnings:
+Warning	1260	Row # was cut by group_concat()
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) INTO @ja FROM t4;
+Warnings:
+Warning	1260	Row # was cut by json_arrayagg()
+SET @@tmp_memory_table_size=DEFAULT, @@group_concat_max_len=DEFAULT;
+SELECT COUNT(*) = COUNT(DISTINCT val) AS gc_no_duplicates,
+GROUP_CONCAT(val ORDER BY val) = @gc AS gc_ascending
+FROM (SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(@gc, ',', seq), ',', -1) AS val
+FROM seq_1_to_500
+WHERE seq <= 1 + LENGTH(@gc) - LENGTH(REPLACE(@gc, ',', ''))) split;
+gc_no_duplicates	gc_ascending
+1	1
+SELECT JSON_VALID(@ja) AS ja_valid,
+COUNT(*) = COUNT(DISTINCT val) AS ja_no_duplicates,
+JSON_ARRAYAGG(val ORDER BY val) = @ja AS ja_ascending
+FROM (SELECT JSON_UNQUOTE(JSON_EXTRACT(@ja, CONCAT('$[', seq - 1, ']'))) AS val
+FROM seq_1_to_500 WHERE seq <= JSON_LENGTH(@ja)) split;
+ja_valid	ja_no_duplicates	ja_ascending
+1	1	1
+DROP TABLE t4;

--- a/mysql-test/main/gconcat_distinct_spill.result
+++ b/mysql-test/main/gconcat_distinct_spill.result
@@ -105,3 +105,28 @@ FROM seq_1_to_500 WHERE seq <= JSON_LENGTH(@ja)) split;
 ja_valid	ja_no_duplicates	ja_ascending
 1	1	1
 DROP TABLE t4;
+#
+# Running out of LIMIT stops the walk of the duplicate filter early,
+# but nothing is lost by it. It must not be reported as a cut value.
+#
+CREATE TABLE t5 (a VARCHAR(100));
+INSERT INTO t5 SELECT LPAD(seq MOD 200, 100, '0') FROM seq_1_to_600;
+SELECT COUNT(DISTINCT a) AS distinct_values FROM t5;
+distinct_values
+200
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a LIMIT 5)) AS gc_len FROM t5;
+gc_len
+504
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5)) AS gc_order_len FROM t5;
+gc_order_len
+504
+SET @@tmp_memory_table_size=0;
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a LIMIT 5)) AS gc_len_spilled FROM t5;
+gc_len_spilled
+504
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5)) AS gc_order_len_spilled
+FROM t5;
+gc_order_len_spilled
+504
+SET @@tmp_memory_table_size=DEFAULT;
+DROP TABLE t5;

--- a/mysql-test/main/gconcat_distinct_spill.test
+++ b/mysql-test/main/gconcat_distinct_spill.test
@@ -1,0 +1,97 @@
+#
+# GROUP_CONCAT(DISTINCT ...) and JSON_ARRAYAGG(DISTINCT ...) filter
+# duplicates with a Unique object, which flushes to disk when it runs out
+# of memory. The answer must not depend on whether that flush happened.
+#
+--source include/have_sequence.inc
+
+--echo #
+--echo # Each block records the answer computed with memory to spare, then
+--echo # recomputes it with the duplicate filter starved, and compares.
+--echo #
+
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, a VARCHAR(100) NOT NULL);
+INSERT INTO t1 (a) SELECT LPAD(seq, 4, '0') FROM seq_1_to_50;
+INSERT INTO t1 (a) SELECT a FROM t1 ORDER BY pk;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t1;
+
+SELECT GROUP_CONCAT(DISTINCT a) INTO @gc FROM t1;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc_order FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a) INTO @ja FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) INTO @ja_order FROM t1;
+
+SET @@tmp_memory_table_size=0;
+SELECT GROUP_CONCAT(DISTINCT a) = @gc AS gc_unchanged FROM t1;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) = @gc_order AS gc_order_unchanged FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a) = @ja AS ja_unchanged FROM t1;
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) = @ja_order AS ja_order_unchanged FROM t1;
+SET @@tmp_memory_table_size=DEFAULT;
+DROP TABLE t1;
+
+--echo #
+--echo # Values wide enough that the filter flushes on nearly every row.
+--echo # Here the ORDER BY case used to return a single value out of 30.
+--echo #
+CREATE TABLE t2 (a VARCHAR(2000)) AS
+  SELECT CONCAT(seq, REPEAT('.', 1990)) AS a FROM seq_1_to_30;
+SELECT COUNT(*) AS rows_in_table, COUNT(DISTINCT a) AS distinct_values FROM t2;
+
+SELECT GROUP_CONCAT(DISTINCT a) INTO @gc FROM t2;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc_order FROM t2;
+
+SET @@tmp_memory_table_size=1000, @@max_heap_table_size=1000;
+SELECT GROUP_CONCAT(DISTINCT a) = @gc AS gc_unchanged FROM t2;
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) = @gc_order AS gc_order_unchanged FROM t2;
+SET @@tmp_memory_table_size=DEFAULT, @@max_heap_table_size=DEFAULT;
+DROP TABLE t2;
+
+--echo #
+--echo # ORDER BY does not order the rows that tie on the ordering
+--echo # expression. Which of them comes first is not specified, but it
+--echo # must not depend on the memory available or on the order the rows
+--echo # are read in.
+--echo #
+CREATE TABLE t3 (a BIT(2), b VARCHAR(10), c BIT);
+INSERT INTO t3 VALUES (1, 'a', 0), (0, 'b', 1), (0, 'c', 0), (3, 'd', 1),
+(1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS at_default FROM t3;
+SET @@tmp_memory_table_size=0;
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS at_zero FROM t3;
+SET @@tmp_memory_table_size=DEFAULT;
+
+DELETE FROM t3;
+INSERT INTO t3 VALUES (0, 'c', 0), (0, 'b', 1), (1, 'a', 0), (3, 'd', 1),
+(1, 'e', 1), (3, 'f', 1), (0, 'g', 1);
+SELECT GROUP_CONCAT(DISTINCT a, c ORDER BY a) AS reversed_scan_order FROM t3;
+DROP TABLE t3;
+
+--echo #
+--echo # The sort tree can overflow too. Starving it makes repack_tree()
+--echo # cut rows out of the group, which is expected, but the rows that
+--echo # do come back must still be deduplicated and still be in order.
+--echo #
+CREATE TABLE t4 (pk INT AUTO_INCREMENT PRIMARY KEY, a VARCHAR(20));
+INSERT INTO t4 (a) SELECT LPAD(seq, 6, '0') FROM seq_1_to_200;
+INSERT INTO t4 (a) SELECT a FROM t4 ORDER BY pk;
+
+SET @@tmp_memory_table_size=0, @@group_concat_max_len=4000;
+# Which row the tree overflows on depends on the size of a TREE_ELEMENT,
+# so the number in the warning differs between 32-bit and 64-bit builds.
+--replace_regex /Row [0-9]+ was cut/Row # was cut/
+SELECT GROUP_CONCAT(DISTINCT a ORDER BY a) INTO @gc FROM t4;
+--replace_regex /Row [0-9]+ was cut/Row # was cut/
+SELECT JSON_ARRAYAGG(DISTINCT a ORDER BY a) INTO @ja FROM t4;
+SET @@tmp_memory_table_size=DEFAULT, @@group_concat_max_len=DEFAULT;
+
+SELECT COUNT(*) = COUNT(DISTINCT val) AS gc_no_duplicates,
+       GROUP_CONCAT(val ORDER BY val) = @gc AS gc_ascending
+FROM (SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(@gc, ',', seq), ',', -1) AS val
+      FROM seq_1_to_500
+      WHERE seq <= 1 + LENGTH(@gc) - LENGTH(REPLACE(@gc, ',', ''))) split;
+
+SELECT JSON_VALID(@ja) AS ja_valid,
+       COUNT(*) = COUNT(DISTINCT val) AS ja_no_duplicates,
+       JSON_ARRAYAGG(val ORDER BY val) = @ja AS ja_ascending
+FROM (SELECT JSON_UNQUOTE(JSON_EXTRACT(@ja, CONCAT('$[', seq - 1, ']'))) AS val
+      FROM seq_1_to_500 WHERE seq <= JSON_LENGTH(@ja)) split;
+DROP TABLE t4;

--- a/mysql-test/main/gconcat_distinct_spill.test
+++ b/mysql-test/main/gconcat_distinct_spill.test
@@ -95,3 +95,21 @@ SELECT JSON_VALID(@ja) AS ja_valid,
 FROM (SELECT JSON_UNQUOTE(JSON_EXTRACT(@ja, CONCAT('$[', seq - 1, ']'))) AS val
       FROM seq_1_to_500 WHERE seq <= JSON_LENGTH(@ja)) split;
 DROP TABLE t4;
+
+--echo #
+--echo # Running out of LIMIT stops the walk of the duplicate filter early,
+--echo # but nothing is lost by it. It must not be reported as a cut value.
+--echo #
+CREATE TABLE t5 (a VARCHAR(100));
+INSERT INTO t5 SELECT LPAD(seq MOD 200, 100, '0') FROM seq_1_to_600;
+SELECT COUNT(DISTINCT a) AS distinct_values FROM t5;
+
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a LIMIT 5)) AS gc_len FROM t5;
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5)) AS gc_order_len FROM t5;
+
+SET @@tmp_memory_table_size=0;
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a LIMIT 5)) AS gc_len_spilled FROM t5;
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a ORDER BY a LIMIT 5)) AS gc_order_len_spilled
+FROM t5;
+SET @@tmp_memory_table_size=DEFAULT;
+DROP TABLE t5;

--- a/mysql-test/main/gconcat_distinct_walk_fail.result
+++ b/mysql-test/main/gconcat_distinct_walk_fail.result
@@ -1,0 +1,62 @@
+CREATE TABLE t1 (a VARCHAR(100));
+INSERT INTO t1 SELECT LPAD(seq MOD 200, 100, '0') FROM seq_1_to_600;
+#
+# Starve the duplicate filter so that it spills and the walk has to
+# merge, then make the merging walk fail.
+#
+SET @@tmp_memory_table_size=0;
+SET SESSION debug_dbug='+d,unique_walk_merge_fail';
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+gc_len
+0
+Warnings:
+Warning	4265	Result was cut by group_concat() because of tmp_memory_table_size limit
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+ja_len
+0
+Warnings:
+Warning	4265	Result was cut by json_arrayagg() because of tmp_memory_table_size limit
+SET SESSION debug_dbug=DEFAULT;
+SET @@tmp_memory_table_size=DEFAULT;
+#
+# The duplicate filter gets the smaller of the two memory limits, so
+# the warning names whichever of them is the one holding it down.
+#
+SET @@max_heap_table_size=16384;
+SET SESSION debug_dbug='+d,unique_walk_merge_fail';
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+gc_len
+0
+Warnings:
+Warning	4265	Result was cut by group_concat() because of max_heap_table_size limit
+SET SESSION debug_dbug=DEFAULT;
+SET @@max_heap_table_size=DEFAULT;
+#
+# A walk that failed for a reason it reported itself, an out of
+# memory one for instance, needs no warning of its own: the user has
+# already been told, and the statement is failing anyway.
+#
+SET @@tmp_memory_table_size=0;
+SET SESSION debug_dbug='+d,unique_walk_merge_error';
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+ERROR HY000: Out of memory.
+SHOW COUNT(*) WARNINGS;
+@@session.warning_count
+1
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+ERROR HY000: Out of memory.
+SHOW COUNT(*) WARNINGS;
+@@session.warning_count
+1
+SET SESSION debug_dbug=DEFAULT;
+SET @@tmp_memory_table_size=DEFAULT;
+#
+# Without the injected failure the same queries are complete and quiet.
+#
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+gc_len
+20199
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+ja_len
+200
+DROP TABLE t1;

--- a/mysql-test/main/gconcat_distinct_walk_fail.test
+++ b/mysql-test/main/gconcat_distinct_walk_fail.test
@@ -1,0 +1,56 @@
+#
+# GROUP_CONCAT(DISTINCT ...) builds its result by walking the Unique that
+# filtered the duplicates. That walk merges back what the Unique spilled to
+# disk, so it can fail on its own, without the callback that appends the
+# rows getting a chance to say anything. The result is then short and the
+# user has to be told about it.
+#
+--source include/have_debug.inc
+--source include/have_sequence.inc
+
+CREATE TABLE t1 (a VARCHAR(100));
+INSERT INTO t1 SELECT LPAD(seq MOD 200, 100, '0') FROM seq_1_to_600;
+
+--echo #
+--echo # Starve the duplicate filter so that it spills and the walk has to
+--echo # merge, then make the merging walk fail.
+--echo #
+SET @@tmp_memory_table_size=0;
+SET SESSION debug_dbug='+d,unique_walk_merge_fail';
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+SET SESSION debug_dbug=DEFAULT;
+SET @@tmp_memory_table_size=DEFAULT;
+
+--echo #
+--echo # The duplicate filter gets the smaller of the two memory limits, so
+--echo # the warning names whichever of them is the one holding it down.
+--echo #
+SET @@max_heap_table_size=16384;
+SET SESSION debug_dbug='+d,unique_walk_merge_fail';
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+SET SESSION debug_dbug=DEFAULT;
+SET @@max_heap_table_size=DEFAULT;
+
+--echo #
+--echo # A walk that failed for a reason it reported itself, an out of
+--echo # memory one for instance, needs no warning of its own: the user has
+--echo # already been told, and the statement is failing anyway.
+--echo #
+SET @@tmp_memory_table_size=0;
+SET SESSION debug_dbug='+d,unique_walk_merge_error';
+--error ER_OUT_OF_RESOURCES
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+SHOW COUNT(*) WARNINGS;
+--error ER_OUT_OF_RESOURCES
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+SHOW COUNT(*) WARNINGS;
+SET SESSION debug_dbug=DEFAULT;
+SET @@tmp_memory_table_size=DEFAULT;
+
+--echo #
+--echo # Without the injected failure the same queries are complete and quiet.
+--echo #
+SELECT LENGTH(GROUP_CONCAT(DISTINCT a)) AS gc_len FROM t1;
+SELECT JSON_LENGTH(JSON_ARRAYAGG(DISTINCT a)) AS ja_len FROM t1;
+DROP TABLE t1;

--- a/mysql-test/main/gconcat_warn.result
+++ b/mysql-test/main/gconcat_warn.result
@@ -80,13 +80,18 @@ INSERT INTO t2 SELECT seq FROM seq_1_to_1000;
 #    The exact result depends on sizeof(TREE_ELEMENT) and the
 #    reclength, so only check that the result came out short.
 #
+#    The row the warning names is how many rows the budget held,
+#    so it depends on the same two things and is masked as well.
+#    It is 88 where a pointer is eight bytes and 127 where it is
+#    four.
+#
 SET SESSION group_concat_max_len= 1024;
 SET SESSION tmp_table_size= 0;
 SELECT LENGTH(GROUP_CONCAT(a ORDER BY a)) < 1024 AS cut_by_memory FROM t2;
 cut_by_memory
 1
 Warnings:
-Warning	1260	Row 88 was cut by group_concat()
+Warning	1260	Row # was cut by group_concat()
 SHOW COUNT(*) WARNINGS;
 @@session.warning_count
 1

--- a/mysql-test/main/gconcat_warn.test
+++ b/mysql-test/main/gconcat_warn.test
@@ -78,8 +78,14 @@ INSERT INTO t2 SELECT seq FROM seq_1_to_1000;
 --echo #    The exact result depends on sizeof(TREE_ELEMENT) and the
 --echo #    reclength, so only check that the result came out short.
 --echo #
+--echo #    The row the warning names is how many rows the budget held,
+--echo #    so it depends on the same two things and is masked as well.
+--echo #    It is 88 where a pointer is eight bytes and 127 where it is
+--echo #    four.
+--echo #
 SET SESSION group_concat_max_len= 1024;
 SET SESSION tmp_table_size= 0;
+--replace_regex /Row [0-9]+ was cut/Row # was cut/
 SELECT LENGTH(GROUP_CONCAT(a ORDER BY a)) < 1024 AS cut_by_memory FROM t2;
 SHOW COUNT(*) WARNINGS;
 

--- a/mysql-test/suite/heap/count_distinct_blob_convert.result
+++ b/mysql-test/suite/heap/count_distinct_blob_convert.result
@@ -21,7 +21,7 @@ set @save_tmp_memory_table_size=@@tmp_memory_table_size;
 set @save_max_heap_table_size=@@max_heap_table_size;
 set @small_heap=65536;
 #
-# Setup: 1000 distinct values, each present twice, with the two copies
+# Setup: 4000 distinct values, each present twice, with the two copies
 # adjacent.
 #
 # A write that is rejected as a duplicate returns the record it had
@@ -45,6 +45,21 @@ set @small_heap=65536;
 # pending row is covered on its own, without depending on any of this,
 # in count_distinct_blob_convert_debug.
 #
+# The number of rows is what makes the table overflow, so it has to be
+# far enough past the point where it does that a build with smaller
+# records still reaches it. A record holding a blob carries a pointer
+# to the value, and that pointer is four bytes rather than eight where
+# a pointer is four bytes wide, so a count only just above the limit
+# on one build sits below it on another. The count here is several
+# times what is needed on the wider build.
+#
+# Only the count is chosen that way. The value widths and the limit
+# are left where they were measured, because they are what puts the
+# overflow on a record slot rather than on a blob value, and moving
+# either of them can leave the conversion covered while the duplicate
+# it has to handle is gone. Rows added past the overflow do not move
+# it: it happens once the table is full, whatever follows.
+#
 CREATE TABLE t1 (id INT PRIMARY KEY, v TEXT, w TEXT, s VARCHAR(64))
 ENGINE=MyISAM;
 INSERT INTO t1
@@ -52,10 +67,10 @@ SELECT seq,
 LPAD((seq+1) DIV 2, 6, 'x'),
 LPAD((seq+1) DIV 2, 10, 'y'),
 LPAD((seq+1) DIV 2, 6, 'z')
-FROM seq_1_to_2000;
+FROM seq_1_to_8000;
 SELECT COUNT(*) AS rows_stored FROM t1;
 rows_stored
-2000
+8000
 #
 # ================================================================
 # Run 1: the temporary table overflows and is converted
@@ -67,7 +82,7 @@ set @@max_heap_table_size=@small_heap;
 FLUSH STATUS;
 SELECT COUNT(DISTINCT v) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -77,7 +92,7 @@ ON
 FLUSH STATUS;
 SELECT COUNT(DISTINCT w) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -87,7 +102,7 @@ ON
 FLUSH STATUS;
 SELECT COUNT(DISTINCT v, w) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -97,7 +112,7 @@ ON
 FLUSH STATUS;
 SELECT COUNT(DISTINCT v, s) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -107,7 +122,7 @@ ON
 FLUSH STATUS;
 SELECT COUNT(DISTINCT s) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -125,8 +140,8 @@ FLUSH STATUS;
 SELECT id MOD 2 AS g, COUNT(DISTINCT v) AS distinct_values
 FROM t1 GROUP BY g ORDER BY g;
 g	distinct_values
-0	1000
-1	1000
+0	4000
+1	4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';
@@ -142,24 +157,24 @@ set @@max_heap_table_size=1024*1024*512;
 FLUSH STATUS;
 SELECT COUNT(DISTINCT v) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT COUNT(DISTINCT w) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT COUNT(DISTINCT v, w) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT COUNT(DISTINCT v, s) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT COUNT(DISTINCT s) AS distinct_values FROM t1;
 distinct_values
-1000
+4000
 SELECT id MOD 2 AS g, COUNT(DISTINCT v) AS distinct_values
 FROM t1 GROUP BY g ORDER BY g;
 g	distinct_values
-0	1000
-1	1000
+0	4000
+1	4000
 SELECT IF(VARIABLE_VALUE > 0, 'ON', 'OFF') AS CONVERTED
 FROM INFORMATION_SCHEMA.SESSION_STATUS
 WHERE VARIABLE_NAME = 'CREATED_TMP_DISK_TABLES';

--- a/mysql-test/suite/heap/count_distinct_blob_convert.test
+++ b/mysql-test/suite/heap/count_distinct_blob_convert.test
@@ -25,7 +25,7 @@ set @save_max_heap_table_size=@@max_heap_table_size;
 set @small_heap=65536;
 
 --echo #
---echo # Setup: 1000 distinct values, each present twice, with the two copies
+--echo # Setup: 4000 distinct values, each present twice, with the two copies
 --echo # adjacent.
 --echo #
 --echo # A write that is rejected as a duplicate returns the record it had
@@ -49,6 +49,21 @@ set @small_heap=65536;
 --echo # pending row is covered on its own, without depending on any of this,
 --echo # in count_distinct_blob_convert_debug.
 --echo #
+--echo # The number of rows is what makes the table overflow, so it has to be
+--echo # far enough past the point where it does that a build with smaller
+--echo # records still reaches it. A record holding a blob carries a pointer
+--echo # to the value, and that pointer is four bytes rather than eight where
+--echo # a pointer is four bytes wide, so a count only just above the limit
+--echo # on one build sits below it on another. The count here is several
+--echo # times what is needed on the wider build.
+--echo #
+--echo # Only the count is chosen that way. The value widths and the limit
+--echo # are left where they were measured, because they are what puts the
+--echo # overflow on a record slot rather than on a blob value, and moving
+--echo # either of them can leave the conversion covered while the duplicate
+--echo # it has to handle is gone. Rows added past the overflow do not move
+--echo # it: it happens once the table is full, whatever follows.
+--echo #
 
 CREATE TABLE t1 (id INT PRIMARY KEY, v TEXT, w TEXT, s VARCHAR(64))
 ENGINE=MyISAM;
@@ -57,7 +72,7 @@ SELECT seq,
        LPAD((seq+1) DIV 2, 6, 'x'),
        LPAD((seq+1) DIV 2, 10, 'y'),
        LPAD((seq+1) DIV 2, 6, 'z')
-FROM seq_1_to_2000;
+FROM seq_1_to_8000;
 
 SELECT COUNT(*) AS rows_stored FROM t1;
 

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -8977,20 +8977,22 @@ int Field_blob::handle_group_concat(const char *from, size_t length,
 
   size_t new_length= length;
   size_t copy_length= table->in_use->variables.group_concat_max_len;
+  bool cut= false;
   if (new_length > copy_length)
   {
     new_length= Well_formed_prefix(cs, from, copy_length, new_length).length();
+    cut= true;
     table->blob_storage->set_truncated_value(true);
   }
 
   char *tmp;
   if (with_zero_prefix)
   {
-    tmp= table->blob_storage->store_with_zero_prefix(from, new_length);
+    tmp= table->blob_storage->store_with_zero_prefix(from, new_length, cut);
     new_length++;                               // Count the extra 0
   }
   else
-    tmp= table->blob_storage->store(from, new_length);
+    tmp= table->blob_storage->store(from, new_length, cut);
 
   if (!tmp)
     goto oom_error;

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -3900,13 +3900,11 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
   uint max_length= table->in_use->gconcat_max_len();
   String tmp((char *)table->record[1], table->s->reclength,
              default_charset_info);
-  String tmp2;
   uchar *key= (uchar *) key_arg;
   String *result= &item->result;
   Item **arg= item->args, **arg_end= item->args + item->arg_count_field;
   uint old_length= result->length();
 
-  ulonglong *offset_limit= &item->copy_offset_limit;
   ulonglong *row_limit = &item->copy_row_limit;
   if (item->limit_clause && !(*row_limit))
   {
@@ -3914,15 +3912,14 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
     item->walk_stopped= true;
     return 1;
   }
-
-  tmp.length(0);
-
-  if (item->limit_clause && (*offset_limit))
+  if (item->copy_offset_limit)
   {
+    item->copy_offset_limit--;
     item->row_count++;
-    (*offset_limit)--;
     return 0;
   }
+
+  tmp.length(0);
 
   if (!item->result_finalized)
     item->result_finalized= true;
@@ -4187,6 +4184,10 @@ Item *Item_func_group_concat::copy_or_same(THD* thd)
 }
 
 
+/*
+  Clear is called for the first element in a new group
+*/
+
 void Item_func_group_concat::clear()
 {
   result.length(0);
@@ -4197,8 +4198,10 @@ void Item_func_group_concat::clear()
   value_cut_in_result= FALSE;
   walk_failed= FALSE;
   result_finalized= false;
+  copy_offset_limit= 0;
   if (offset_limit)
     copy_offset_limit= offset_limit->val_int();
+  /* copy_row_limit does not have to be zeroed if row_limit is not set */
   if (row_limit)
     copy_row_limit= row_limit->val_int();
   if (tree)
@@ -4788,9 +4791,12 @@ String* Item_func_group_concat::val_str(String* str)
         walk_failed= TRUE;
     }
     else if (row_limit && copy_row_limit == (ulonglong)row_limit->val_int())
+    {
+      /* No rows copied; Empty result */
       return &result;
+    }
     else
-      DBUG_ASSERT(false); // Can't happen
+      DBUG_ASSERT(false); // Can't happen. If it happens, no wrong result
     /*
       dump_leaf_key() sets this when it writes a row, but a group can end
       without one: an OFFSET can eat every row, and a walk that failed

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -3851,6 +3851,25 @@ static void report_cut_result_error(THD *thd, const char *fname)
 }
 
 
+/*
+  Tell the user that a value was cut to group_concat_max_len on its way
+  into blob_storage.
+
+  This is only a note. Whether the answer would have been different with
+  a bigger limit is not known here: the result may well have been cut at
+  the same place anyway, in which case nothing was lost that the user
+  could have seen.
+*/
+
+static void report_cut_value_note(THD *thd, const char *fname)
+{
+  push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+                      ER_CUT_VALUES_WHILE_PROCESSING,
+                      ER_THD(thd, ER_CUT_VALUES_WHILE_PROCESSING),
+                      fname, "group_concat_max_len");
+}
+
+
 void Item_func_group_concat::cut_max_length(String *result,
         uint old_length, uint max_length) const
 {
@@ -3931,8 +3950,22 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
         uint offset= (field->offset(field->table->record[0]) -
                       table->s->null_bytes);
         DBUG_ASSERT(offset < table->s->reclength);
+        const uchar *rec= key + offset + item->get_null_bytes();
         res= item->get_str_from_field(*arg, field, &tmp, key,
                                       offset + item->get_null_bytes());
+        /*
+          This row is going into the answer. If the value it carries was
+          cut on its way into blob_storage then the answer is short by
+          what was cut, which val_str() reports as a warning. A value cut
+          for a row that never gets here may have changed nothing.
+        */
+        if (table->blob_storage && (field->flags & BLOB_FLAG))
+        {
+          /* A NULL blob was never stored, so there is no mark to read. */
+          const uchar *val= ((Field_blob*) field)->get_ptr(rec);
+          if (val && Blob_mem_storage::was_cut((const char*) val))
+            item->value_cut_in_result= true;
+        }
       }
       else
         res= item->get_str_from_item(*arg, &tmp);
@@ -3986,8 +4019,9 @@ Item_func_group_concat(THD *thd, Name_resolution_context *context_arg,
    arg_count_field(select_list->elements),
    row_count(0),
    distinct(distinct_arg),
-   warning_for_row(FALSE), result_cut(FALSE), walk_stopped(FALSE),
-   walk_failed(FALSE), always_null(FALSE),
+   warning_for_row(FALSE), result_cut(FALSE), cut_note_given(FALSE),
+   value_cut_in_result(FALSE), walk_stopped(FALSE), walk_failed(FALSE),
+   always_null(FALSE),
    force_copy_fields(0), row_limit(NULL),
    offset_limit(NULL), limit_clause(limit_clause),
    copy_offset_limit(0), copy_row_limit(0), original(0)
@@ -4055,6 +4089,8 @@ Item_func_group_concat::Item_func_group_concat(THD *thd,
   distinct(item->distinct),
   warning_for_row(item->warning_for_row),
   result_cut(item->result_cut),
+  cut_note_given(item->cut_note_given),
+  value_cut_in_result(item->value_cut_in_result),
   walk_stopped(item->walk_stopped),
   walk_failed(item->walk_failed),
   always_null(item->always_null),
@@ -4127,6 +4163,7 @@ void Item_func_group_concat::cleanup()
     row_count= 0;
     DBUG_ASSERT(tree == 0);
   }
+  cut_note_given= false;
   /*
     As the ORDER structures pointed to by the elements of the
     'order' array may be modified in find_order_in_list() called
@@ -4157,6 +4194,7 @@ void Item_func_group_concat::clear()
   null_value= TRUE;
   warning_for_row= FALSE;
   result_cut= FALSE;
+  value_cut_in_result= FALSE;
   walk_failed= FALSE;
   result_finalized= false;
   if (offset_limit)
@@ -4755,19 +4793,44 @@ String* Item_func_group_concat::val_str(String* str)
       DBUG_ASSERT(false); // Can't happen
   }
 
-  if (result_cut ||
-      (table && table->blob_storage &&
-       table->blob_storage->is_truncated_value()))
+  /*
+    The answer came out short: it was cut at gconcat_max_len(), the sort
+    tree could not keep every row it was given, or a row that reached the
+    answer carried a value that was cut on its way into blob_storage.
+    Values the user asked for are missing, so this is a warning.
+  */
+  if (result_cut || value_cut_in_result)
   {
     warning_for_row= true;
     report_cut_value_error(current_thd, row_count, func_name());
+    /*
+      A cut value that reached the answer has now been reported as the
+      warning it is, so it must not be reported again as a note.
+    */
+    if (value_cut_in_result && table && table->blob_storage)
+      table->blob_storage->set_truncated_value(false);
     /*
       Clear the marks so that we give only one warning per group, even
       if val_str() is called more than once for this group.
     */
     result_cut= false;
-    if (table && table->blob_storage)
-      table->blob_storage->set_truncated_value(false);
+    value_cut_in_result= false;
+  }
+
+  /*
+    A value was cut on its way into blob_storage, but no row carrying one
+    reached the answer, so the answer may well be what it would have been
+    without the limit: one note per statement.
+  */
+  if (table && table->blob_storage &&
+      table->blob_storage->is_truncated_value())
+  {
+    if (!cut_note_given)
+    {
+      cut_note_given= true;
+      report_cut_value_note(current_thd, func_name());
+    }
+    table->blob_storage->set_truncated_value(false);
   }
 
   /*

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -3828,6 +3828,29 @@ static void report_cut_value_error(THD *thd, uint row_count, const char *fname)
 }
 
 
+/*
+  Tell the user that the walk of the duplicate filter could not deliver
+  the whole group.
+
+  The cut value warning would carry a row number here, and that number
+  means nothing in this case: nothing had been written when the walk
+  failed, and how much was lost is not known. Name the limit that held
+  the walk down instead. Unique is given thd->ram_limitation() to work
+  in, which is the smaller of the two variables below.
+*/
+
+static void report_cut_result_error(THD *thd, const char *fname)
+{
+  const char *limit= (thd->variables.tmp_memory_table_size <=
+                      thd->variables.max_heap_table_size ?
+                      "tmp_memory_table_size" : "max_heap_table_size");
+  push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                      ER_RESULT_CUT_BY_LIMIT,
+                      ER_THD(thd, ER_RESULT_CUT_BY_LIMIT),
+                      fname, limit);
+}
+
+
 void Item_func_group_concat::cut_max_length(String *result,
         uint old_length, uint max_length) const
 {
@@ -3869,6 +3892,7 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
   if (item->limit_clause && !(*row_limit))
   {
     item->result_finalized= true;
+    item->walk_stopped= true;
     return 1;
   }
 
@@ -3932,6 +3956,7 @@ int dump_leaf_key(void* key_arg, element_count count __attribute__((unused)),
       that the user gets one warning even if several things were cut.
     */
     item->result_cut= true;
+    item->walk_stopped= true;
     return 1;
   }
   return 0;
@@ -3961,7 +3986,8 @@ Item_func_group_concat(THD *thd, Name_resolution_context *context_arg,
    arg_count_field(select_list->elements),
    row_count(0),
    distinct(distinct_arg),
-   warning_for_row(FALSE), result_cut(FALSE), always_null(FALSE),
+   warning_for_row(FALSE), result_cut(FALSE), walk_stopped(FALSE),
+   walk_failed(FALSE), always_null(FALSE),
    force_copy_fields(0), row_limit(NULL),
    offset_limit(NULL), limit_clause(limit_clause),
    copy_offset_limit(0), copy_row_limit(0), original(0)
@@ -4029,6 +4055,8 @@ Item_func_group_concat::Item_func_group_concat(THD *thd,
   distinct(item->distinct),
   warning_for_row(item->warning_for_row),
   result_cut(item->result_cut),
+  walk_stopped(item->walk_stopped),
+  walk_failed(item->walk_failed),
   always_null(item->always_null),
   force_copy_fields(item->force_copy_fields),
   row_limit(item->row_limit), offset_limit(item->offset_limit),
@@ -4129,6 +4157,7 @@ void Item_func_group_concat::clear()
   null_value= TRUE;
   warning_for_row= FALSE;
   result_cut= FALSE;
+  walk_failed= FALSE;
   result_finalized= false;
   if (offset_limit)
     copy_offset_limit= offset_limit->val_int();
@@ -4698,7 +4727,28 @@ String* Item_func_group_concat::val_str(String* str)
       }
     }
     else if (distinct)                          // distinct (and no order by)
-      unique_filter->walk(table, &dump_leaf_key, this);
+    {
+      /*
+        walk() returns non-zero both when dump_leaf_key() stopped it and
+        when the walk itself failed. dump_leaf_key() reports what it did:
+        it sets result_cut when it cut the result, and it stops without
+        losing anything when the LIMIT is used up.
+
+        A walk that failed mostly reports itself: the merge buffer is
+        allocated with MY_WME and the spill file is opened with MY_WME,
+        so running out of memory or failing to read raises an error. Only
+        the guard at the top of merge_walk(), which refuses a merge
+        buffer too small to hold one key per chunk, returns quietly. Ask
+        for the warning in that case alone. Where an error was raised the
+        user has already been told and the statement is failing, so a
+        warning about the length of a result nobody will see would only
+        be noise.
+      */
+      walk_stopped= FALSE;
+      if (unique_filter->walk(table, &dump_leaf_key, this) && !walk_stopped &&
+          !current_thd->is_error())
+        walk_failed= TRUE;
+    }
     else if (row_limit && copy_row_limit == (ulonglong)row_limit->val_int())
       return &result;
     else
@@ -4718,6 +4768,19 @@ String* Item_func_group_concat::val_str(String* str)
     result_cut= false;
     if (table && table->blob_storage)
       table->blob_storage->set_truncated_value(false);
+  }
+
+  /*
+    The walk of the duplicate filter failed, so the group was never
+    delivered. This is a different loss from a result cut to the length
+    the user asked for, and it is undone by a different variable.
+  */
+  if (walk_failed)
+  {
+    warning_for_row= true;
+    report_cut_result_error(current_thd, func_name());
+    /* One warning per group, however often val_str() is called for it */
+    walk_failed= false;
   }
 
   return &result;

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -4791,6 +4791,15 @@ String* Item_func_group_concat::val_str(String* str)
       return &result;
     else
       DBUG_ASSERT(false); // Can't happen
+    /*
+      dump_leaf_key() sets this when it writes a row, but a group can end
+      without one: an OFFSET can eat every row, and a walk that failed
+      hands over nothing. val_str() can be called again for the same
+      group, and unique_filter must not be walked twice - Unique::walk()
+      leaves the object undefined and the second walk asserts in
+      merge_walk().
+    */
+    result_finalized= true;
   }
 
   /*

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -4319,6 +4319,60 @@ bool Item_func_group_concat::repack_tree(THD *thd)
 }
 
 
+/*
+  Insert one row into the ORDER BY tree, repacking it first if it has
+  grown past the memory we are allowed to use.
+
+  'key' is a temporary table record in the format produced by
+  get_record_pointer(). table->field[0] of that record holds the length
+  the row adds to the result, which is what repack_tree() adds up to
+  decide where to cut.
+
+  @return FALSE  row inserted
+  @return TRUE   out of memory
+*/
+
+bool Item_func_group_concat::insert_to_order_tree(uchar *key)
+{
+  DBUG_ASSERT(tree);
+  THD *thd= table->in_use;
+  /*
+    Repack when GCONCAT_TREE_REPACK_PARTS of the memory we may use is
+    gone. The rest is needed for the new tree that repack_tree()
+    allocates while the old one is still around.
+  */
+  if (tree->allocated >
+      max_tree_size / GCONCAT_TREE_PARTS * GCONCAT_TREE_REPACK_PARTS &&
+      tree->elements_in_tree > 1)
+    if (repack_tree(thd))
+      return TRUE;
+  /* check if there was enough memory to insert the row */
+  return !tree_insert(tree, key, 0, tree->custom_arg);
+}
+
+
+/*
+  Insert one deduplicated row into the ORDER BY tree.
+
+  Callback for Unique::walk(). The walk merges what unique_filter spilled
+  to disk back with what it still holds in memory, so it is the first
+  point at which the whole set of distinct rows is known. Every row it
+  visits belongs in the result.
+
+  @return 0  row inserted
+  @return 1  out of memory, which stops the walk
+*/
+
+int Item_func_group_concat::dump_leaf_key_to_tree(void *key_arg,
+                                                  element_count count
+                                                  __attribute__((unused)),
+                                                  void *item_arg)
+{
+  Item_func_group_concat *item= (Item_func_group_concat *) item_arg;
+  return item->insert_to_order_tree((uchar *) key_arg);
+}
+
+
 bool Item_func_group_concat::add(bool exclude_nulls)
 {
   if (always_null && exclude_nulls)
@@ -4360,7 +4414,15 @@ bool Item_func_group_concat::add(bool exclude_nulls)
   null_value= FALSE;
   bool row_eligible= TRUE;
 
-  if (distinct) 
+  /*
+    Store how much this row adds to the result in the record itself. With
+    DISTINCT the row does not reach the ORDER BY tree until val_str(), and
+    the record kept by unique_filter is all that is left of it by then.
+  */
+  if (tree)
+    table->field[0]->store(row_str_len, FALSE);
+
+  if (distinct)
   {
     /* Filter out duplicate rows. */
     uint count= unique_filter->elements_in_tree();
@@ -4368,25 +4430,17 @@ bool Item_func_group_concat::add(bool exclude_nulls)
     if (count == unique_filter->elements_in_tree())
       row_eligible= FALSE;
   }
-
-  TREE_ELEMENT *el= 0;                          // Only for safety
-  if (row_eligible && tree)
+  else
   {
-    THD *thd= table->in_use;
-    table->field[0]->store(row_str_len, FALSE);
     /*
-      Repack when GCONCAT_TREE_REPACK_PARTS of the memory we may use is
-      gone. The rest is needed for the new tree that repack_tree()
-      allocates while the old one is still around.
+      row_eligible only reflects the part of unique_filter that is
+      currently in memory, so as soon as unique_filter starts flushing
+      to disk it stops telling us whether a row is a
+      duplicate. val_str() fills the tree instead, from the
+      unique_filter walk that merges everything back together.
     */
-    if (tree->allocated >
-        max_tree_size / GCONCAT_TREE_PARTS * GCONCAT_TREE_REPACK_PARTS &&
-        tree->elements_in_tree > 1)
-      if (repack_tree(thd))
-        return 1;
-    el= tree_insert(tree, get_record_pointer(), 0, tree->custom_arg);
-    /* check if there was enough memory to insert the row */
-    if (!el)
+    if (row_eligible && tree &&
+        insert_to_order_tree(get_record_pointer()))
       return 1;
   }
 
@@ -4618,9 +4672,32 @@ String* Item_func_group_concat::val_str(String* str)
 
   if (!result_finalized) // Result yet to be written.
   {
-    if (tree != NULL) // order by
-      tree_walk(tree, &dump_leaf_key, this, left_root_right);
-    else if (distinct) // distinct (and no order by).
+    if (tree)                                   // Order by
+    {
+      if (distinct)                             // distinct and order by
+      {
+        /*
+          Sort the distinct rows now. add() could not do it, as a row is
+          only known not to be a duplicate once unique_filter has merged
+          everything it flushed to disk, which the walk below does.
+        */
+        if (unique_filter->walk(table, &dump_leaf_key_to_tree, this))
+        {
+          /*
+            Out of memory; mysys has reported it. The tree holds only part
+            of the group, so tell the user that the result was cut instead
+            of returning a short one silently.
+          */
+          result_cut= TRUE;
+        }
+        tree_walk(tree, &dump_leaf_key, this, left_root_right);
+      }
+      else                                      // Order by, no distinct
+      {
+        tree_walk(tree, &dump_leaf_key, this, left_root_right);
+      }
+    }
+    else if (distinct)                          // distinct (and no order by)
       unique_filter->walk(table, &dump_leaf_key, this);
     else if (row_limit && copy_row_limit == (ulonglong)row_limit->val_int())
       return &result;

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2199,6 +2199,9 @@ public:
   qsort_cmp2 get_comparator_function_for_order_by();
   uchar* get_record_pointer();
   uint get_null_bytes();
+  bool insert_to_order_tree(uchar *key);
+  static int dump_leaf_key_to_tree(void *key_arg, element_count count,
+                                   void *item_arg);
 
 protected:
   Item *shallow_copy(THD *thd) const override

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2094,6 +2094,20 @@ class Item_func_group_concat : public Item_sum_str
   */
   bool result_cut;
   /*
+    Set once the note about values cut on their way into blob_storage has
+    been given for this aggregate. One note per statement is enough,
+    however many groups had a value cut. cleanup() clears it, so a
+    statement that is run again gets its own note.
+  */
+  bool cut_note_given;
+  /*
+    Set by dump_leaf_key() when a row it appends carries a value that was
+    cut on its way into blob_storage. The answer is then short by what
+    was cut, which is a warning rather than the note a cut value that
+    never reached the answer gets.
+  */
+  bool value_cut_in_result;
+  /*
     Set by dump_leaf_key() when it is the one that stops a walk, so that
     val_str() can tell that apart from the walk itself having failed.
   */

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2093,6 +2093,16 @@ class Item_func_group_concat : public Item_sum_str
     cut value warning for it.
   */
   bool result_cut;
+  /*
+    Set by dump_leaf_key() when it is the one that stops a walk, so that
+    val_str() can tell that apart from the walk itself having failed.
+  */
+  bool walk_stopped;
+  /*
+    Set when the walk of the duplicate filter failed and said nothing
+    about it. val_str() reports the group it never delivered.
+  */
+  bool walk_failed;
   bool always_null;
   bool force_copy_fields;
   /** True if entire result of GROUP_CONCAT has been written to output buffer. */

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12408,3 +12408,5 @@ ER_WARN_QB_NAME_PATH_NOT_SUPPORTED_INSIDE_VIEW
         eng "Hint %s is ignored. QB_NAME hints with path are not supported inside view definitions."
 ER_RESULT_CUT_BY_LIMIT
         eng "Result was cut by %s) because of %s limit"
+ER_CUT_VALUES_WHILE_PROCESSING
+        eng "Some values were cut while processing %s). Increase %s if you want to avoid the cut"

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12406,3 +12406,5 @@ ER_WARN_QB_NAME_PATH_VIEW_NOT_FOUND
         eng "Hint %s is ignored. `%s` required at element #%u of the path is not found in the target query block."
 ER_WARN_QB_NAME_PATH_NOT_SUPPORTED_INSIDE_VIEW
         eng "Hint %s is ignored. QB_NAME hints with path are not supported inside view definitions."
+ER_RESULT_CUT_BY_LIMIT
+        eng "Result was cut by %s) because of %s limit"

--- a/sql/table.h
+++ b/sql/table.h
@@ -1315,34 +1315,56 @@ public:
     free_root(&storage, MYF(MY_MARK_BLOCKS_FREE));
     truncated_value= false;
   }
+  /*
+    Every value is stored behind one byte that records whether the value
+    was cut on its way in. The byte is not part of the value and the
+    returned pointer is what the record holds, so a reader that has the
+    record can ask was_cut() about a value without knowing which row it
+    came from.
+  */
+  char *store_with_cut_mark(const char *from, size_t length, bool cut,
+                            size_t prefix)
+  {
+    char *res= (char*) alloc_root(&storage, length + prefix + 1);
+    if (res)
+    {
+      *res++= (char) cut;
+      if (prefix)
+        res[0]= 0;
+      memcpy(res + prefix, from, length);
+    }
+    return res;
+  }
   /**
      Function creates duplicate of 'from'
      string in 'storage' MEM_ROOT.
 
      @param from           string to copy
      @param length         string length
+     @param cut            'from' was cut to fit the limit
 
      @retval Pointer to the copied string.
      @retval 0 if an error occurred.
   */
-  char *store(const char *from, size_t length)
+  char *store(const char *from, size_t length, bool cut)
   {
-    return (char*) memdup_root(&storage, from, length);
+    return store_with_cut_mark(from, length, cut, 0);
   }
   /*
     Store string with a 0 prefix. This is used for storing
     Field_blob_compressed fields in a not compressed format.
   */
-  char *store_with_zero_prefix(const char *from, size_t length)
+  char *store_with_zero_prefix(const char *from, size_t length, bool cut)
   {
-    char *res= (char*) alloc_root(&storage, length+1);
-    if (res)
-    {
-      res[0]= 0;
-      memcpy(res+1, from, length);
-    }
-    return res;
+    return store_with_cut_mark(from, length, cut, 1);
   }
+  /*
+    Whether the value at 'ptr' was cut on its way in. 'ptr' must be a
+    pointer this storage handed out, which is the case for every blob in
+    a table that has a Blob_mem_storage: Field_blob::store() sends all of
+    them through Field_blob::handle_group_concat().
+  */
+  static bool was_cut(const char *ptr) { return ptr[-1] != 0; }
   void set_truncated_value(bool is_truncated_value)
   {
     truncated_value= is_truncated_value;

--- a/sql/uniques.cc
+++ b/sql/uniques.cc
@@ -671,6 +671,11 @@ bool Unique::walk(TABLE *table, tree_walk_action action, void *walk_action_arg)
   if (elements == 0)                       /* the whole tree is in memory */
     return tree_walk(&tree, action, walk_action_arg, left_root_right);
 
+  DBUG_EXECUTE_IF("unique_walk_merge_fail", return 1;);
+  /* A failure that reported itself, as an out of memory one would */
+  DBUG_EXECUTE_IF("unique_walk_merge_error",
+                  { my_error(ER_OUT_OF_RESOURCES, MYF(0)); return 1; });
+
   sort.return_rows= elements+tree.elements_in_tree;
   /* flush current tree to the file to have some memory for merge buffer */
   if (flush())


### PR DESCRIPTION
`GROUP_CONCAT(DISTINCT x ORDER BY y)` and `JSON_ARRAYAGG(DISTINCT x ORDER BY y)`
return a wrong answer once the duplicate filter runs out of memory.

## The defect

`Item_func_group_concat::add()` decides whether a row is a duplicate by checking
whether `Unique::elements_in_tree()` grew after `unique_add()`. `Unique` flushes
its whole in-memory tree to disk when it runs out of memory, and
`elements_in_tree()` only counts what is still in memory, so after the first
flush that test says nothing about the rows already spilled.

**MDEV-11563** made this harmless for `GROUP_CONCAT(DISTINCT x)` by building the
result in `val_str()` from `unique_filter->walk()`, which merges the spilled
parts back in. It left the `ORDER BY` case alone, where the result comes from the
sort tree that `add()` fills gated by the broken test.

Both directions of the failure are reachable, depending on how often the filter
flushes relative to the insert:

1. **Duplicates reach the result** - 100 rows holding 50 distinct values give all
   100 values back.
2. **Rows are lost** - 30 distinct rows of 2000 bytes give one value back.

## The fix

`add()` no longer fills the sort tree when `DISTINCT` is used. `val_str()` walks
the merged `unique_filter` into the sort tree and then walks the sort tree, so the
rows are sorted after duplicate filtering is complete instead of during it.

`Unique::walk()` merges everything it flushed, so the sort tree can be handed more
rows than fit in memory. `insert_to_order_tree()` repacks it on the same memory
budget `add()` used, and a walk that runs out of memory sets `result_cut` so the
user gets a cut value warning rather than a silently short result.

This targets `bb-blob-main-monty` rather than `main` because it relies on
`37077ccef15` "Limit the memory used by GROUP_CONCAT() with ORDER BY". Without
that commit's `tree->allocated` bound and its `st.oom` correction to
`repack_tree()`, pouring a spilled `Unique` into the sort tree trades a wrong
answer for an out-of-memory error.

## Behaviour change

`ORDER BY` does not order rows that tie on the ordering expression, and which of
them comes first changes here. It used to follow the order the rows were read in;
it now follows the order the duplicate filter keeps them in. Unlike the old order,
the new one depends on neither the memory available nor the physical row order.
`main.func_gconcat` records one such tie and is re-recorded accordingly.

## Testing

New `main.gconcat_distinct_spill` covers three things, and each assertion was
confirmed to fail before the fix and pass after, with the test unchanged between
the two runs:

- the answer with the filter starved must equal the answer with memory to spare,
  for `GROUP_CONCAT` and `JSON_ARRAYAGG`, with and without `ORDER BY`
- with the sort tree also starved so `repack_tree()` cuts the group, whatever
  comes back must still be deduplicated, still ordered, and still valid JSON
- the tie order must not depend on the memory available or on the physical row
  order

Full `main`+`heap` suite: **1436/1436 pass**.
