### PR TITLE
MDEV-38633 | Row events in statement based binlog: optimization possible?

### DIFF
--- a/mysql-test/main/tmp_table_binlog.result
+++ b/mysql-test/main/tmp_table_binlog.result
@@ -29,3 +29,98 @@ INSERT INTO t2 (c) VALUES ('b');
 INSERT INTO t2 (c) VALUES ('b');
 ERROR 23000: Duplicate entry 'b' for key 'PRIMARY'
 drop table t1,t2;
+#
+# Start of 12.3 tests
+#
+#
+# MDEV-38633 Row events in statement based binlog: optimization possible?
+#
+CREATE TABLE t1 (c INT);
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY);
+INSERT INTO tt VALUES (1),(2);
+UPDATE tt SET c=2;
+ERROR 23000: Duplicate entry '2' for key 'PRIMARY'
+INSERT INTO t1 SELECT * FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 SELECT * FROM tt
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt;
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY);
+INSERT INTO tt VALUES (1),(2);
+CREATE TEMPORARY TABLE tt2 (c INT);
+INSERT INTO tt2 VALUES (1);
+UPDATE tt, tt2 SET tt.c=2;
+ERROR 23000: Duplicate entry '2' for key 'PRIMARY'
+INSERT INTO t1 SELECT * FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 SELECT * FROM tt
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt, tt2;
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1),(2);
+UPDATE tt SET c=2;
+ERROR 23000: Duplicate entry '2' for key 'PRIMARY'
+INSERT INTO t1 SELECT * FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 SELECT * FROM tt
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt;
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1),(2);
+CREATE TEMPORARY TABLE tt2 (c INT) ENGINE=InnoDB;
+INSERT INTO tt2 VALUES (1);
+UPDATE tt, tt2 SET tt.c=2;
+ERROR 23000: Duplicate entry '2' for key 'PRIMARY'
+INSERT INTO t1 SELECT * FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 SELECT * FROM tt
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt, tt2;
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY, d INT);
+INSERT INTO tt VALUES (1,1),(2,2);
+SET @@session.binlog_format=MIXED;
+UPDATE tt SET d=LENGTH(UUID());
+SELECT * FROM tt ORDER BY c;
+c	d
+1	36
+2	36
+INSERT INTO t1 SELECT c FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Annotate_rows	#	#	INSERT INTO t1 SELECT c FROM tt
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt;
+SET @@session.binlog_format=STATEMENT;
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY, d INT) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1,1),(2,2);
+SET @@session.binlog_format=MIXED;
+UPDATE tt SET d=LENGTH(UUID());
+SELECT * FROM tt ORDER BY c;
+c	d
+1	36
+2	36
+INSERT INTO t1 SELECT c FROM tt;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Annotate_rows	#	#	INSERT INTO t1 SELECT c FROM tt
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+DROP TABLE tt;
+SET @@session.binlog_format=STATEMENT;
+DROP TABLE t1;
+#
+# End of 12.3 tests
+#

--- a/mysql-test/main/tmp_table_binlog.test
+++ b/mysql-test/main/tmp_table_binlog.test
@@ -31,3 +31,82 @@ INSERT INTO t2 (c) VALUES ('b');
 --error ER_DUP_ENTRY
 INSERT INTO t2 (c) VALUES ('b');
 drop table t1,t2;
+
+--echo #
+--echo # Start of 12.3 tests
+--echo #
+
+--echo #
+--echo # MDEV-38633 Row events in statement based binlog: optimization possible?
+--echo #
+
+CREATE TABLE t1 (c INT);
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY);
+INSERT INTO tt VALUES (1),(2);
+--error ER_DUP_ENTRY
+UPDATE tt SET c=2;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT * FROM tt;
+--source include/show_binlog_events.inc
+DROP TABLE tt;
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY);
+INSERT INTO tt VALUES (1),(2);
+CREATE TEMPORARY TABLE tt2 (c INT);
+INSERT INTO tt2 VALUES (1);
+--error ER_DUP_ENTRY
+UPDATE tt, tt2 SET tt.c=2;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT * FROM tt;
+--source include/show_binlog_events.inc
+
+DROP TABLE tt, tt2;
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1),(2);
+--error ER_DUP_ENTRY
+UPDATE tt SET c=2;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT * FROM tt;
+--source include/show_binlog_events.inc
+DROP TABLE tt;
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1),(2);
+CREATE TEMPORARY TABLE tt2 (c INT) ENGINE=InnoDB;
+INSERT INTO tt2 VALUES (1);
+--error ER_DUP_ENTRY
+UPDATE tt, tt2 SET tt.c=2;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT * FROM tt;
+--source include/show_binlog_events.inc
+DROP TABLE tt, tt2;
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY, d INT);
+INSERT INTO tt VALUES (1,1),(2,2);
+SET @@session.binlog_format=MIXED;
+UPDATE tt SET d=LENGTH(UUID());
+SELECT * FROM tt ORDER BY c;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT c FROM tt;
+--source include/show_binlog_events.inc
+DROP TABLE tt;
+SET @@session.binlog_format=STATEMENT;
+
+CREATE TEMPORARY TABLE tt (c INT PRIMARY KEY, d INT) ENGINE=InnoDB;
+INSERT INTO tt VALUES (1,1),(2,2);
+SET @@session.binlog_format=MIXED;
+UPDATE tt SET d=LENGTH(UUID());
+SELECT * FROM tt ORDER BY c;
+--let $binlog_start= query_get_value(SHOW MASTER STATUS, Position, 1)
+INSERT INTO t1 SELECT c FROM tt;
+--source include/show_binlog_events.inc
+DROP TABLE tt;
+SET @@session.binlog_format=STATEMENT;
+
+DROP TABLE t1;
+
+--echo #
+--echo # End of 12.3 tests
+--echo #

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -1088,7 +1088,12 @@ cleanup:
     }
   }
   if (!binlogged)
-    table->mark_as_not_binlogged();
+  {
+    if (!thd->transaction->stmt.modified_non_trans_table && !deleted)
+      thd->tmp_table_binlog_handled= 1;
+    else
+      table->mark_as_not_binlogged();
+  }
 
   DBUG_ASSERT(transactional_table || !deleted || thd->transaction->stmt.modified_non_trans_table);
   
@@ -1501,10 +1506,19 @@ void multi_delete::abort_result_set()
 
   ***************************************************************************/
 
-  /* the error was handled or nothing deleted and no side effects return */
-  if (error_handled ||
-      (!thd->transaction->stmt.modified_non_trans_table && !deleted))
+  /*
+    Nothing was deleted and there are no side effects: no temporary table
+    was changed, so they all stay up to date in the binary log.
+  */
+  if (!thd->transaction->stmt.modified_non_trans_table && !deleted)
+  {
+    thd->tmp_table_binlog_handled= 1;
     DBUG_VOID_RETURN;
+  }
+  /* The error was already handled */
+  if (error_handled)
+    goto end;
+
 
   /* Something already deleted so we have to invalidate cache */
   if (deleted)
@@ -1551,6 +1565,7 @@ void multi_delete::abort_result_set()
                                transactional_tables, FALSE, FALSE, errcode);
     }
   }
+end:
   /*
     Mark all temporay tables as not completely binlogged
     All future usage of these tables will enforce row level logging, which

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1305,7 +1305,12 @@ update_end:
     }
   }
   if (!binlogged)
-    table->mark_as_not_binlogged();
+  {
+    if (!thd->transaction->stmt.modified_non_trans_table && !updated)
+      thd->tmp_table_binlog_handled= 1;
+    else
+      table->mark_as_not_binlogged();
+  }
 
   DBUG_ASSERT(transactional_table || !updated || thd->transaction->stmt.modified_non_trans_table);
   free_underlaid_joins(thd, select_lex);
@@ -2564,9 +2569,17 @@ void multi_update::abort_result_set()
 {
   TABLE_LIST *cur_table;
 
-  /* the error was handled or nothing deleted and no side effects return */
-  if (unlikely(error_handled ||
-               (!thd->transaction->stmt.modified_non_trans_table && !updated)))
+  /*
+    Nothing was updated and there are no side effects: no temporary table
+    was changed, so they all stay up to date in the binary log.
+  */
+  if (unlikely(!thd->transaction->stmt.modified_non_trans_table && !updated))
+  {
+    thd->tmp_table_binlog_handled= 1;
+    return;
+  }
+  /* The error was already handled */
+  if (unlikely(error_handled))
     goto end;
 
   /****************************************************************************


### PR DESCRIPTION
fixes [MDEV-38633](https://jira.mariadb.org/browse/MDEV-38633)
### Problem:
Row events in statement based binlog: optimization possible?

### Cause:
A failing multi-table UPDATE or DELETE marked every target temporary table as not up to date in the binary log, even when nothing had been changed.
Any later statement reading such a table was then forced to use row logging.

### Fix:
Only mark the tables when something was actually changed—that is, when rows were updated/deleted or a non-transactional table was modified.
If nothing changed, set THD::tmp_table_binlog_handled so that mark_tmp_table_as_free_for_reuse() does not mark them either.
1- multi_update::abort_result_set(), Sql_cmd_update::update_single_table  resets the binlog state
2- Added the same logic for multi_delete::abort_result_set()  and Sql_cmd_delete::delete_from_single_table
