### PR TITLE
MDEV-40791 SET GLOBAL innodb_log_archive=OFF triggers full flush

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -812,33 +812,49 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
     if (archive)
     {
       const lsn_t limit{wait_lsn - (wait_lsn - first_lsn) % capacity()};
-      /* We are in innodb_log_archive=OFF. If the file has wrapped
-      around between the checkpoint and the current position, we must
-      wait for a log checkpoint not before the desired first_lsn of
-      our innodb_log_archive=ON log file, because that format does not
-      allow any wrap-around. */
+      ut_ad(get_sequence_bit(limit) == get_sequence_bit(wait_lsn));
       if (checkpoint < limit)
+        /*
+          The circular ib_logfile0 is currently wrapped around between
+          the checkpoint and the current position. Wait for a checkpoint,
+          because innodb_log_archive=ON does not allow any wrap-around.
+        */
         goto retry_after_checkpoint;
-      circular_recovery_from_sequence_bit_0= limit != wait_lsn;
+      ut_ad(get_sequence_bit(checkpoint) == get_sequence_bit(wait_lsn));
       wait_lsn= limit;
+      /*
+        The innodb_log_archive=ON recovery ignores the sequence bit,
+        so this transition is clear.
+
+        However, a future set_archive(false) must ensure that recovery
+        will not observe any get_sequence_bit() == 0 residue from the
+        previous time this log file was in innodb_log_archive=OFF
+        format.
+
+        The following assignment controls the condition in the "else if"
+        below, in a subsequent invocation of set_archive(false).
+      */
+      circular_recovery_from_sequence_bit_0= !get_sequence_bit(wait_lsn);
     }
-    else if (circular_recovery_from_sequence_bit_0)
+    else if (circular_recovery_from_sequence_bit_0 || checkpoint < first_lsn)
     {
-      /* When switching innodb_log_archive back and forth, it could be
-      the case that some records since the latest checkpoint were
-      written with get_sequence_bit() == 0. Let us wait for another
-      checkpoint. This guarantees that if the server crashes between
-      the completion of set_archive(false) and the next
-      write_checkpoint(), recovery will only encounter
-      get_sequence_bit() == 1, consistent with our first_lsn. */
-      goto retry_after_checkpoint;
-    }
-    else if (checkpoint < first_lsn)
-    {
-      /* write_checkpoint() switched files, but the latest FILE_CHECKPOINT
-      record points to a previous log file. In the innodb_log_archive=OFF
-      format the checkpoint must be within the only log file. */
-      wait_lsn= first_lsn;
+      /*
+        Some records after the latest checkpoint may have been written
+        with get_sequence_bit() == 0 in innodb_log_archive=OFF
+        mode. Since then we may have switched to innodb_log_archive=ON
+        without advancing the checkpoint (see the above "if" body),
+        and now back to innodb_log_archive=OFF again.
+
+        Wait for write_checkpoint() to ensure that recovery will only
+        find get_sequence_bit() == 1, consistent with our first_lsn.
+
+        Alternatively, before we can switch to innodb_log_archive=OFF,
+        we must ensure that the checkpoint resides within the last file.
+
+        Progress is guaranteed by setting a checkpoint target right
+        after the latest written FILE_CHECKPOINT record.
+      */
+      wait_lsn= end_lsn;
       goto retry_after_checkpoint;
     }
 
@@ -880,14 +896,14 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
     {
       std::swap(old_name, new_name);
       std::string spare{get_archive_path(first_lsn + capacity())};
-      if (!get_sequence_bit(last_checkpoint_lsn))
+      if (!get_sequence_bit(checkpoint))
         /*
           In the innodb_log_archive=ON format, mtr_t::finish_writer()
           always writes the sequence bit as 1. Ensure that the
           innodb_log_archive=OFF recovery will expect this value.
         */
         first_lsn-= capacity();
-      ut_ad(get_sequence_bit(last_checkpoint_lsn));
+      ut_ad(get_sequence_bit(checkpoint));
       ut_ad(get_sequence_bit(get_lsn()));
       header_rewrite(false);
       IF_WIN(DeleteFile(spare.c_str()), unlink(spare.c_str()));
@@ -942,7 +958,7 @@ void log_t::set_archive(my_bool archive, THD *thd) noexcept
     {
       ut_ad(wait_lsn == get_lsn());
       /* apply similar logic as log_close() */
-      const lsn_t checkpoint_age{wait_lsn - log_sys.last_checkpoint_lsn};
+      const lsn_t checkpoint_age{wait_lsn - checkpoint};
       if (checkpoint_age < max_modified_age_async)
         wait_lsn= 0;
       else

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -5565,12 +5565,22 @@ inline void log_t::set_recovered() noexcept
   ut_ad(!resize_log.is_opened());
   ut_ad(!resize_buf);
   ut_ad(!resize_flush_buf);
-  /* If innodb_log_archive=ON, we always write the sequence bit as 0.
-  A subsequent log_t::set_archive(archive=false, ...) must wait for
-  a checkpoint, to guarantee that recovery with innodb_log_archive=OFF
-  will observe all sequence bits as 1. */
-  circular_recovery_from_sequence_bit_0= archive ||
-    !get_sequence_bit(last_checkpoint_lsn);
+  ut_ad(!archive || !recv_sys.log_archive.empty());
+  /*
+    Remember if a subsequent set_archive(false) must wait for a
+    checkpoint, to guarantee that recovery with innodb_log_archive=OFF
+    will observe all sequence bits as 1.
+
+    While innodb_log_archive=ON always writes the sequence bit as 1,
+    some earlier records may have been written in the
+    innodb_log_archive=OFF format as 0 at the time set_archive(true)
+    rewrote the header. It is only possible that the server had been
+    killed between SET GLOBAL innodb_log_archive=ON and a checkpoint
+    if we recovered from a single log file.
+  */
+  circular_recovery_from_sequence_bit_0= archive
+    ? recv_sys.log_archive.size() < 2
+    : !get_sequence_bit(last_checkpoint_lsn);
   ut_ad(write_size >= 512);
   ut_ad(ut_is_2pow(write_size));
 


### PR DESCRIPTION
`log_t::set_archive()`: When a checkpoint needs to be forced, set a minimum target that guarantees progress, instead of flushing the entire buffer pool. Remove some duplicated reads of `last_checkpoint_lsn`.

When switching `innodb_log_archive` from `OFF` to `ON`, accurately remember whether any log records may have been written with `get_sequence_bit() == 0`, to ensure that a checkpoint will be waited for on a subsequent switch from `ON` to `OFF`.

`log_t::set_recovered()`: If `innodb_log_archive=ON`, only make a future `set_archive(false)` trigger a checkpoint if we may have recovered a server that was killed between `set_archive(true)` and `write_checkpoint()`.