### PR TITLE
MDEV-33411 OPTIMIZE TABLE for graph indexes

### DIFF
--- a/mysql-test/main/vector_bulk.combinations
+++ b/mysql-test/main/vector_bulk.combinations
@@ -1,0 +1,9 @@
+[innodb]
+innodb
+default-storage-engine=innodb
+
+[myisam]
+default-storage-engine=myisam
+
+[aria]
+default-storage-engine=aria

--- a/mysql-test/main/vector_bulk.result
+++ b/mysql-test/main/vector_bulk.result
@@ -42,3 +42,52 @@ id	d
 999	0
 drop table t1;
 set global mhnsw_max_cache_size= @old_cache_size;
+#
+# 3. Test OPTIMIZE TABLE uses bulk insert and rebuilds vector index
+#
+# 3.1 Normal OPTIMIZE TABLE with bulk insert
+create table t1 (id int auto_increment primary key, v vector(3) not null);
+insert into t1 (v) values (x'000000000000000000000000'),
+(x'0000803f0000000000000000'),
+(x'000000000000803f00000000'),
+(x'00000000000000000000803f');
+alter table t1 add vector index (v);
+delete from t1 where id in (1, 3);
+optimize table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+# Test search query after OPTIMIZE TABLE
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d;
+id	d
+2	0
+4	1.41421
+drop table t1;
+# 3.2 OPTIMIZE TABLE with small cache size triggers bulk insert fallback warning
+set @old_cache_size= @@global.mhnsw_max_cache_size;
+set global mhnsw_max_cache_size= 1048576;
+set max_recursive_iterations= 300;
+create table t1 (id int auto_increment primary key, v vector(3000) not null);
+insert into t1 (v)
+with recursive cte as (
+select 1 as n
+union all
+select n + 1 from cte where n < 100
+)
+select repeat(x'00', 12000) from cte;
+insert into t1 (id, v) values (999, concat(repeat(x'00', 11996), x'0000803f'));
+set global mhnsw_max_cache_size= 104857600;
+alter table t1 add vector index (v) m=16;
+set global mhnsw_max_cache_size= 1048576;
+optimize table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+show warnings;
+Level	Code	Message
+# Test search using the index after OPTIMIZE TABLE
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 11996), x'0000803f')) d from t1 order by d limit 1;
+id	d
+999	0
+drop table t1;
+set global mhnsw_max_cache_size= @old_cache_size;

--- a/mysql-test/main/vector_bulk.result
+++ b/mysql-test/main/vector_bulk.result
@@ -1,0 +1,47 @@
+#
+# Test memory budget fallback during MHNSW bulk insert
+#
+# 1. Normal bulk insert works when memory budget is large enough
+create table t1 (id int auto_increment primary key, v vector(3) not null);
+insert into t1 (v) values (x'000000000000000000000000'),
+(x'0000803f0000000000000000'),
+(x'000000000000803f00000000'),
+(x'00000000000000000000803f');
+alter table t1 add vector index (v);
+show warnings;
+Level	Code	Message
+# Test search using the successfully bulk-built index
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 3;
+id	d
+2	0
+1	1
+3	1.41421
+drop table t1;
+# 2. Bulk insert falls back to normal insert when mhnsw_max_cache_size is small
+set @old_cache_size= @@global.mhnsw_max_cache_size;
+set global mhnsw_max_cache_size= 1048576;
+set max_recursive_iterations= 300;
+create table t1 (id int auto_increment primary key, v vector(1000) not null);
+insert into t1 (v)
+with recursive cte as (
+select 1 as n
+union all
+select n + 1 from cte where n < 250
+)
+select repeat(x'00', 4000) from cte;
+insert into t1 (v) values (concat(repeat(x'00', 3996), x'0000803f'));
+# Adding index with small cache size should trigger fallback and show a warning
+alter table t1 add vector index (v) m=200;
+Warnings:
+Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (1335571) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
+show warnings;
+Level	Code	Message
+Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (1335571) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
+# Test search using the fallback-built index to ensure it is healthy and correct
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 3996), x'0000803f')) d from t1 order by d limit 3;
+id	d
+251	0
+250	1
+142	1
+drop table t1;
+set global mhnsw_max_cache_size= @old_cache_size;

--- a/mysql-test/main/vector_bulk.result
+++ b/mysql-test/main/vector_bulk.result
@@ -11,37 +11,34 @@ alter table t1 add vector index (v);
 show warnings;
 Level	Code	Message
 # Test search using the successfully bulk-built index
-select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 3;
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 2;
 id	d
 2	0
 1	1
-3	1.41421
 drop table t1;
 # 2. Bulk insert falls back to normal insert when mhnsw_max_cache_size is small
 set @old_cache_size= @@global.mhnsw_max_cache_size;
 set global mhnsw_max_cache_size= 1048576;
 set max_recursive_iterations= 300;
-create table t1 (id int auto_increment primary key, v vector(1000) not null);
+create table t1 (id int auto_increment primary key, v vector(3000) not null);
 insert into t1 (v)
 with recursive cte as (
 select 1 as n
 union all
-select n + 1 from cte where n < 250
+select n + 1 from cte where n < 115
 )
-select repeat(x'00', 4000) from cte;
-insert into t1 (v) values (concat(repeat(x'00', 3996), x'0000803f'));
+select repeat(x'00', 12000) from cte;
+insert into t1 (id, v) values (999, concat(repeat(x'00', 11996), x'0000803f'));
 # Adding index with small cache size should trigger fallback and show a warning
 alter table t1 add vector index (v) m=200;
 Warnings:
-Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (1335571) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
+Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (estimated_mem) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
 show warnings;
 Level	Code	Message
-Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (1335571) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
+Note	1105	MHNSW: Bulk insert disabled because estimated memory usage (estimated_mem) exceeds mhnsw_max_cache_size (1048576). Falling back to normal insert.
 # Test search using the fallback-built index to ensure it is healthy and correct
-select id, vec_distance_euclidean(v, concat(repeat(x'00', 3996), x'0000803f')) d from t1 order by d limit 3;
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 11996), x'0000803f')) d from t1 order by d limit 1;
 id	d
-251	0
-250	1
-142	1
+999	0
 drop table t1;
 set global mhnsw_max_cache_size= @old_cache_size;

--- a/mysql-test/main/vector_bulk.test
+++ b/mysql-test/main/vector_bulk.test
@@ -49,3 +49,67 @@ select id, vec_distance_euclidean(v, concat(repeat(x'00', 11996), x'0000803f')) 
 
 drop table t1;
 set global mhnsw_max_cache_size= @old_cache_size;
+
+--echo #
+--echo # 3. Test OPTIMIZE TABLE uses bulk insert and rebuilds vector index
+--echo #
+
+--echo # 3.1 Normal OPTIMIZE TABLE with bulk insert
+create table t1 (id int auto_increment primary key, v vector(3) not null);
+insert into t1 (v) values (x'000000000000000000000000'),
+                          (x'0000803f0000000000000000'),
+                          (x'000000000000803f00000000'),
+                          (x'00000000000000000000803f');
+alter table t1 add vector index (v);
+
+# Delete rows to create deleted nodes in the index
+delete from t1 where id in (1, 3);
+
+optimize table t1;
+
+--echo # Test search query after OPTIMIZE TABLE
+--replace_regex /(\.\d{5})\d+/\1/
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d;
+
+drop table t1;
+
+--echo # 3.2 OPTIMIZE TABLE with small cache size triggers bulk insert fallback warning
+set @old_cache_size= @@global.mhnsw_max_cache_size;
+set global mhnsw_max_cache_size= 1048576;
+set max_recursive_iterations= 300;
+
+create table t1 (id int auto_increment primary key, v vector(3000) not null);
+
+# Insert 100 rows of 3000-dimensional vectors.
+# Total size with M=16: 101 * ~12.3 KB = ~1.24 MB, exceeding 1MB.
+insert into t1 (v)
+with recursive cte as (
+  select 1 as n
+  union all
+  select n + 1 from cte where n < 100
+)
+select repeat(x'00', 12000) from cte;
+
+insert into t1 (id, v) values (999, concat(repeat(x'00', 11996), x'0000803f'));
+
+# Temporarily increase cache size to allow initial index creation via bulk insert
+set global mhnsw_max_cache_size= 104857600;
+alter table t1 add vector index (v) m=16;
+
+# Lower cache size back to trigger fallback during OPTIMIZE TABLE
+set global mhnsw_max_cache_size= 1048576;
+
+--replace_regex /usage \(\d+\)/usage (estimated_mem)/
+optimize table t1;
+--replace_regex /usage \(\d+\)/usage (estimated_mem)/
+show warnings;
+
+--echo # Test search using the index after OPTIMIZE TABLE
+--replace_regex /(\.\d{5})\d+/\1/
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 11996), x'0000803f')) d from t1 order by d limit 1;
+
+drop table t1;
+set global mhnsw_max_cache_size= @old_cache_size;
+
+
+

--- a/mysql-test/main/vector_bulk.test
+++ b/mysql-test/main/vector_bulk.test
@@ -13,7 +13,7 @@ show warnings;
 
 --echo # Test search using the successfully bulk-built index
 --replace_regex /(\.\d{5})\d+/\1/
-select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 3;
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 2;
 
 drop table t1;
 
@@ -22,28 +22,30 @@ set @old_cache_size= @@global.mhnsw_max_cache_size;
 set global mhnsw_max_cache_size= 1048576;
 set max_recursive_iterations= 300;
 
-create table t1 (id int auto_increment primary key, v vector(1000) not null);
+create table t1 (id int auto_increment primary key, v vector(3000) not null);
 
-# Insert 250 rows of 1000-dimensional vectors.
-# Total size: 250 * ~5271 bytes/row (with M=200) = ~1.31 MB, exceeding 1MB.
+# Insert 115 rows of 3000-dimensional vectors.
+# Total size: 115 * ~9288 bytes/row (with M=200) = ~1.06 MB, exceeding 1MB.
 insert into t1 (v)
 with recursive cte as (
   select 1 as n
   union all
-  select n + 1 from cte where n < 250
+  select n + 1 from cte where n < 115
 )
-select repeat(x'00', 4000) from cte;
+select repeat(x'00', 12000) from cte;
 
-# Insert a unique search target vector before alter table to verify it is copied correctly
-insert into t1 (v) values (concat(repeat(x'00', 3996), x'0000803f'));
+# Insert a unique search target vector with fixed ID 999 to guarantee deterministic results across all engines
+insert into t1 (id, v) values (999, concat(repeat(x'00', 11996), x'0000803f'));
 
 --echo # Adding index with small cache size should trigger fallback and show a warning
+--replace_regex /usage \(\d+\)/usage (estimated_mem)/
 alter table t1 add vector index (v) m=200;
+--replace_regex /usage \(\d+\)/usage (estimated_mem)/
 show warnings;
 
 --echo # Test search using the fallback-built index to ensure it is healthy and correct
 --replace_regex /(\.\d{5})\d+/\1/
-select id, vec_distance_euclidean(v, concat(repeat(x'00', 3996), x'0000803f')) d from t1 order by d limit 3;
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 11996), x'0000803f')) d from t1 order by d limit 1;
 
 drop table t1;
 set global mhnsw_max_cache_size= @old_cache_size;

--- a/mysql-test/main/vector_bulk.test
+++ b/mysql-test/main/vector_bulk.test
@@ -1,0 +1,49 @@
+--echo #
+--echo # Test memory budget fallback during MHNSW bulk insert
+--echo #
+
+--echo # 1. Normal bulk insert works when memory budget is large enough
+create table t1 (id int auto_increment primary key, v vector(3) not null);
+insert into t1 (v) values (x'000000000000000000000000'),
+                          (x'0000803f0000000000000000'),
+                          (x'000000000000803f00000000'),
+                          (x'00000000000000000000803f');
+alter table t1 add vector index (v);
+show warnings;
+
+--echo # Test search using the successfully bulk-built index
+--replace_regex /(\.\d{5})\d+/\1/
+select id, vec_distance_euclidean(v, x'0000803f0000000000000000') d from t1 order by d limit 3;
+
+drop table t1;
+
+--echo # 2. Bulk insert falls back to normal insert when mhnsw_max_cache_size is small
+set @old_cache_size= @@global.mhnsw_max_cache_size;
+set global mhnsw_max_cache_size= 1048576;
+set max_recursive_iterations= 300;
+
+create table t1 (id int auto_increment primary key, v vector(1000) not null);
+
+# Insert 250 rows of 1000-dimensional vectors.
+# Total size: 250 * ~5271 bytes/row (with M=200) = ~1.31 MB, exceeding 1MB.
+insert into t1 (v)
+with recursive cte as (
+  select 1 as n
+  union all
+  select n + 1 from cte where n < 250
+)
+select repeat(x'00', 4000) from cte;
+
+# Insert a unique search target vector before alter table to verify it is copied correctly
+insert into t1 (v) values (concat(repeat(x'00', 3996), x'0000803f'));
+
+--echo # Adding index with small cache size should trigger fallback and show a warning
+alter table t1 add vector index (v) m=200;
+show warnings;
+
+--echo # Test search using the fallback-built index to ensure it is healthy and correct
+--replace_regex /(\.\d{5})\d+/\1/
+select id, vec_distance_euclidean(v, concat(repeat(x'00', 3996), x'0000803f')) d from t1 order by d limit 3;
+
+drop table t1;
+set global mhnsw_max_cache_size= @old_cache_size;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -5881,7 +5881,12 @@ handler::ha_optimize(THD* thd, HA_CHECK_OPT* check_opt)
   mark_trx_read_write();
 
   // in-engine optimize can modify rowids, which will break hlindexes
-  return table->s->hlindexes() ? HA_ADMIN_TRY_ALTER : optimize(thd, check_opt);
+  if (table->s->hlindexes())
+  {
+    thd->optimize_mhnsw= true;
+    return HA_ADMIN_TRY_ALTER;
+  }
+  return optimize(thd, check_opt);
 }
 
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -10215,10 +10215,17 @@ int TABLE::hlindex_read_end()
 
 int TABLE::hlindexes_bulk_insert_begin(ha_rows rows)
 {
-    if (hlindex && hlindex->in_use)
+    if (s->hlindexes())
     {
-        hlindex->bulk_insert_active= true;
-        return mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
+        if (!hlindex || !hlindex->in_use)
+            if (int err= open_hlindexes_for_write())
+                return err;
+                
+        if (hlindex && hlindex->in_use)
+        {
+            hlindex->bulk_insert_active= true;
+            return mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
+        }
     }
     return 0;
 }

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -10145,11 +10145,15 @@ int TABLE::unlock_hlindexes()
 
 int TABLE::hlindexes_on_insert()
 {
-  DBUG_ASSERT(s->hlindexes() == (hlindex != NULL));
-  if (hlindex && hlindex->in_use)
-    if (int err= mhnsw_insert(this, key_info + s->keys))
-      return err;
-  return 0;
+    DBUG_ASSERT(s->hlindexes() == (hlindex != NULL));
+    if (hlindex && hlindex->in_use)
+    {
+        if (hlindex->bulk_insert_active)
+            return mhnsw_bulk_insert_row(this, key_info + s->keys);
+        else
+            return mhnsw_insert(this, key_info + s->keys);
+    }
+    return 0;
 }
 
 int TABLE::hlindexes_on_update()
@@ -10207,4 +10211,24 @@ int TABLE::hlindex_read_next()
 int TABLE::hlindex_read_end()
 {
   return mhnsw_read_end(this);
+}
+
+int TABLE::hlindexes_bulk_insert_begin(ha_rows rows)
+{
+    if (hlindex && hlindex->in_use)
+    {
+        hlindex->bulk_insert_active= true;
+        return mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
+    }
+    return 0;
+}
+
+int TABLE::hlindexes_bulk_insert_end()
+{
+    if (hlindex && hlindex->in_use)
+    {
+        hlindex->bulk_insert_active= false;
+        return mhnsw_bulk_insert_end(this, key_info + s->keys);
+    }
+    return 0;
 }

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -10223,13 +10223,14 @@ int TABLE::hlindexes_bulk_insert_begin(ha_rows rows)
                 
         if (hlindex && hlindex->in_use)
         {
-            hlindex->bulk_insert_active= true;
             int err= mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
             if (err)
             {
                 hlindex->bulk_insert_active= false;
                 return err;
             }
+            if (hlindex->context)
+                hlindex->bulk_insert_active= true;
         }
     }
     return 0;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -10224,7 +10224,12 @@ int TABLE::hlindexes_bulk_insert_begin(ha_rows rows)
         if (hlindex && hlindex->in_use)
         {
             hlindex->bulk_insert_active= true;
-            return mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
+            int err= mhnsw_bulk_insert_begin(this, key_info + s->keys, rows);
+            if (err)
+            {
+                hlindex->bulk_insert_active= false;
+                return err;
+            }
         }
     }
     return 0;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -829,6 +829,7 @@ THD::THD(my_thread_id id, bool is_wsrep_applier)
 
   mdl_context.init(this);
   is_setting_returning= false;
+  optimize_mhnsw= false;
   mdl_backup_lock= 0;
 
   /*

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3192,6 +3192,7 @@ private:
 
 public:
   bool is_setting_returning;
+  bool optimize_mhnsw; // Set during OPTIMIZE TABLE for graph indexes
   MDL_context mdl_context;
 
   /* Used to execute base64 coded binlog events in MySQL server */

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -13009,11 +13009,16 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
   }
 
   bulk_insert_started= 0;
-  if (hlindex_bulk_started && to->hlindexes_bulk_insert_end() && error <= 0)
+  if (hlindex_bulk_started)
   {
+    int err= to->hlindexes_bulk_insert_end();
+    thd->optimize_mhnsw= false;
+    if (err && error <= 0)
+    {
       if (!thd->is_error())
-          to->file->print_error(my_errno, MYF(0));
+        to->file->print_error(my_errno, MYF(0));
       error= 1;
+    }
   }
   hlindex_bulk_started=0;
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12663,16 +12663,19 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
 
   from->file->info(HA_STATUS_VARIABLE);
   to->file->extra(HA_EXTRA_PREPARE_FOR_ALTER_TABLE);
+
   if (!to->s->long_unique_table)
   {
-      to->file->ha_start_bulk_insert(from->file->stats.records,
-              ignore ? 0 : HA_CREATE_UNIQUE_INDEX_BY_SORT);
-      bulk_insert_started= 1;
-
       if (to->s->hlindexes())
       {
           if (to->hlindexes_bulk_insert_begin(from->file->stats.records) == 0)
               hlindex_bulk_started= 1;
+      }
+      if (!to->s->hlindexes() || hlindex_bulk_started)
+      {
+          to->file->ha_start_bulk_insert(from->file->stats.records,
+                  ignore ? 0 : HA_CREATE_UNIQUE_INDEX_BY_SORT);
+          bulk_insert_started= 1;
       }
   }
   mysql_stage_set_work_estimated(thd->m_stage_progress_psi, from->file->stats.records);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12616,6 +12616,7 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
   bool make_unversioned= from->versioned() && !to->versioned();
   bool keep_versioned= from->versioned() && to->versioned();
   bool bulk_insert_started= 0;
+  bool hlindex_bulk_started= 0;
   Field *to_row_start= NULL, *to_row_end= NULL, *from_row_end= NULL;
   MYSQL_TIME query_start;
   DBUG_ENTER("copy_data_between_tables");
@@ -12662,11 +12663,17 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
 
   from->file->info(HA_STATUS_VARIABLE);
   to->file->extra(HA_EXTRA_PREPARE_FOR_ALTER_TABLE);
-  if (!to->s->long_unique_table && !to->s->hlindexes())
+  if (!to->s->long_unique_table)
   {
-    to->file->ha_start_bulk_insert(from->file->stats.records,
-                                   ignore ? 0 : HA_CREATE_UNIQUE_INDEX_BY_SORT);
-    bulk_insert_started= 1;
+      to->file->ha_start_bulk_insert(from->file->stats.records,
+              ignore ? 0 : HA_CREATE_UNIQUE_INDEX_BY_SORT);
+      bulk_insert_started= 1;
+
+      if (to->s->hlindexes())
+      {
+          to->hlindexes_bulk_insert_begin(from->file->stats.records);
+          hlindex_bulk_started= 1;
+      }
   }
   mysql_stage_set_work_estimated(thd->m_stage_progress_psi, from->file->stats.records);
   List_iterator<Create_field> it(alter_info->create_list);
@@ -12999,6 +13006,14 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
   }
 
   bulk_insert_started= 0;
+  if (hlindex_bulk_started && to->hlindexes_bulk_insert_end() && error <= 0)
+  {
+      if (!thd->is_error())
+          to->file->print_error(my_errno, MYF(0));
+      error= 1;
+  }
+  hlindex_bulk_started=0;
+
   if (error <= 0 && !to->s->hlindexes())
   {
     Abort_on_warning_instant_set save_abort_on_warning(thd, false);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12671,8 +12671,8 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
 
       if (to->s->hlindexes())
       {
-          to->hlindexes_bulk_insert_begin(from->file->stats.records);
-          hlindex_bulk_started= 1;
+          if (to->hlindexes_bulk_insert_begin(from->file->stats.records) == 0)
+              hlindex_bulk_started= 1;
       }
   }
   mysql_stage_set_work_estimated(thd->m_stage_progress_psi, from->file->stats.records);

--- a/sql/table.h
+++ b/sql/table.h
@@ -1632,6 +1632,7 @@ public:
   */
   bool alias_name_used;              /* true if table_name is alias */
   bool get_fields_in_item_tree;      /* Signal to fix_field */
+  bool bulk_insert_active;           /* mhnsw bulk_insert_started flag */
 private:
   bool m_needs_reopen;
   bool created;    /* For tmp tables. TRUE <=> tmp table was actually created.*/

--- a/sql/table.h
+++ b/sql/table.h
@@ -1876,6 +1876,8 @@ public:
   int hlindexes_on_update();
   int hlindexes_on_delete(const uchar *buf);
   int hlindexes_on_delete_all(bool truncate);
+  int hlindexes_bulk_insert_begin(ha_rows rows);
+  int hlindexes_bulk_insert_end();
   int unlock_hlindexes();
 
   void prepare_triggers_for_insert_stmt_or_event();

--- a/sql/table.h
+++ b/sql/table.h
@@ -1632,7 +1632,7 @@ public:
   */
   bool alias_name_used;              /* true if table_name is alias */
   bool get_fields_in_item_tree;      /* Signal to fix_field */
-  bool bulk_insert_active;           /* mhnsw bulk_insert_started flag */
+  bool bulk_insert_active=false;           /* mhnsw bulk_insert_started flag */
 private:
   bool m_needs_reopen;
   bool created;    /* For tmp tables. TRUE <=> tmp table was actually created.*/

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -33,6 +33,7 @@ static constexpr float NEAREST = -1.0f;
 // Algorithm parameters
 static constexpr float leniency= 1.1f;
 static constexpr uint ef_construction= 10;
+static constexpr uint refine_ef= 20;
 static constexpr uint max_ef= 10000;
 static constexpr size_t subdist_part= 192;
 static constexpr float subdist_margin= 1.05f;
@@ -1173,7 +1174,8 @@ class VisitedSet
 static int select_neighbors(MHNSW_param *p, FVectorNode *target,
                             const Neighborhood &candidates,
                             FVectorNode *extra_candidate,
-                            size_t max_neighbor_connections)
+                            size_t max_neighbor_connections,
+                            bool keep_discarded= true)
 {
   Queue<Visited> pq; // working queue
 
@@ -1215,7 +1217,10 @@ static int select_neighbors(MHNSW_param *p, FVectorNode *target,
       discarded[discarded_num++]= vec;
   }
 
-  for (size_t i= 0; i < discarded_num && temp_num < max_neighbor_connections; i++)
+  size_t target_min_connections= keep_discarded ? max_neighbor_connections
+                                                : std::min(max_neighbor_connections,
+                                                           (size_t)p->ctx->M);
+  for (size_t i= 0; i < discarded_num && temp_num < target_min_connections; i++)
     temp_links[temp_num++]= discarded[i]->node;
 
   // Publish the new neighbors atomically
@@ -1662,6 +1667,128 @@ static void *bulk_build_thread(void *param)
   return nullptr;
 }
 
+
+/*
+  Each node gets a fresh search_layer + select_neighbors
+  using the full graph structure.
+*/
+static void *bulk_refine_thread(void *param)
+{
+  my_thread_init();
+  SCOPE_EXIT([]() { my_thread_end(); });
+
+  BulkBuildThreadArg *arg= (BulkBuildThreadArg*) param;
+  MHNSW_Bulk_context *bulk= arg->bulk;
+  MHNSW_Share *ctx= bulk->ctx;
+
+  MEM_ROOT thread_root;
+  init_alloc_root(PSI_INSTRUMENT_MEM, &thread_root, 256*1024, 0, MYF(0));
+  SCOPE_EXIT([&thread_root]() { free_root(&thread_root, MYF(0)); });
+  for (size_t i= arg->start_idx; i < arg->end_idx; i++)
+  {
+    FVectorNode *target= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
+    const uint8_t max_layer= ctx->start->max_layer;
+    uint8_t target_layer= target->max_layer;
+
+    MHNSW_param p(ctx, nullptr, max_layer, &thread_root);
+
+    const size_t candidates_cap= refine_ef;
+    Neighborhood candidates;
+    candidates.init((FVectorNode**)alloc_root(&thread_root,
+                     sizeof(FVectorNode*) * (candidates_cap + 8)),
+                    candidates_cap);
+    candidates.links[candidates.num++]= ctx->start;
+
+    for (; p.layer > target_layer; p.layer--)
+    {
+      if ((arg->error= search_layer(&p, target->vec, NEAREST, 1,
+                                    &candidates, false)))
+        return nullptr;
+    }
+
+    for (; p.layer >= 0; p.layer--)
+    {
+      uint max_neighbors= ctx->max_neighbors(p.layer);
+
+      /* Get the worst distance threshold from the last neighbor in links */
+      float d_worst= 0;
+      Neighborhood &cur_nb= target->neighbors[p.layer];
+      if (cur_nb.num < max_neighbors)
+      {
+        d_worst= FLT_MAX;
+      }
+      else
+      {
+        d_worst= cur_nb.links[cur_nb.num - 1]->distance_to(target->vec);
+      }
+
+      if ((arg->error= search_layer(&p, target->vec, NEAREST,
+                                    refine_ef, &candidates, true)))
+        return nullptr;
+
+      /* Check if any candidate is closer than the worst current neighbor */
+      bool found_better= false;
+      for (size_t j= 0; j < candidates.num; j++)
+      {
+        float d= candidates.links[j]->distance_to(target->vec);
+        if (d < d_worst)
+        {
+          found_better= true;
+          break;
+        }
+      }
+
+      if (found_better)
+      {
+        /*
+          Merge existing neighbors with search results
+        */
+        size_t merged_cap= candidates.num + cur_nb.num;
+
+        Neighborhood merged;
+        merged.init((FVectorNode **)alloc_root(&thread_root,
+                     sizeof(FVectorNode *) * (merged_cap + 8)),
+                    merged_cap);
+
+        auto add_unique= [&](FVectorNode *nb)
+        {
+          /* Avoid self-link */
+          if (nb == target)
+            return;
+
+          /* Avoid duplicates */
+          for (size_t k= 0; k < merged.num; ++k)
+          {
+            if (merged.links[k] == nb)
+              return;
+          }
+
+          merged.links[merged.num++]= nb;
+        };
+
+        /* Merge search results */
+        for (size_t j= 0; j < candidates.num; ++j)
+          add_unique(candidates.links[j]);
+
+        /* Merge existing neighbors */
+        for (size_t j= 0; j < cur_nb.num; ++j)
+          add_unique(cur_nb.links[j]);
+
+        if ((arg->error= select_neighbors(&p, target, merged, 0,
+                                          max_neighbors, false)))
+          return nullptr;
+
+        if ((arg->error= update_second_degree_neighbors(&p, target)))
+          return nullptr;
+      }
+    }
+
+    free_root(&thread_root, MYF(MY_MARK_BLOCKS_FREE));
+  }
+
+  return nullptr;
+}
+
 int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
 {
   TABLE *graph= table->hlindex;
@@ -1878,6 +2005,47 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
 
   if (final_err)
     return final_err;
+
+  /*
+    Refine neighborhoods using the complete graph and warm heuristics
+  */
+  if (table->in_use->optimize_mhnsw)
+  {
+    current_start= 1;
+    workers_spawned= 0;
+    chunk_size= total_nodes / workers;
+    remainder= total_nodes % workers;
+
+    for (size_t i= 0; i < workers; i++)
+    {
+      size_t count= chunk_size + (i == 0 ? remainder : 0);
+      args[i].bulk= bulk;
+      args[i].start_idx= current_start;
+      args[i].end_idx= current_start + count;
+      args[i].error= 0;
+      current_start += count;
+
+      int err= mysql_thread_create(0, &threads[i], nullptr,
+                                   bulk_refine_thread, &args[i]);
+      if (err)
+      {
+        for (size_t j= 0; j < workers_spawned; j++)
+          pthread_join(threads[j], nullptr);
+        return HA_ERR_OUT_OF_MEM;
+      }
+      workers_spawned++;
+    }
+
+    for (size_t i= 0; i < workers_spawned; i++)
+    {
+      pthread_join(threads[i], nullptr);
+      if (args[i].error && !final_err)
+        final_err= args[i].error;
+    }
+
+    if (final_err)
+      return final_err;
+  }
 
   graph->file->ha_start_bulk_insert(bulk->nodes.elements, 0);
   bool bulk_base_started= true;

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -485,7 +485,7 @@ public:
 class MHNSW_Share : public Sql_alloc
 {
   mysql_mutex_t cache_lock;     // for node_cache and stats
-  mysql_mutex_t node_lock[32];  // XXX how to choose what's the best value here?
+  mysql_mutex_t node_lock[127];  // XXX how to choose what's the best value here?
 
   void cache_internal(FVectorNode *node)
   {
@@ -544,6 +544,14 @@ public:
     uint ticket= hasher.m_nr1 % array_elements(node_lock);
     mysql_mutex_lock(node_lock + ticket);
     return ticket;
+  }
+
+  bool try_lock_node(FVectorNode *ptr, uint &ticket)
+  {
+    my_hasher_st hasher= my_hasher_mysql5x();
+    my_hash_sort_bin(&hasher, 0, (uchar*)&ptr, sizeof(ptr));
+    ticket= hasher.m_nr1 % array_elements(node_lock);
+    return mysql_mutex_trylock(node_lock + ticket) == 0;
   }
 
   void unlock_node(uint ticket)
@@ -1280,13 +1288,39 @@ static int update_second_degree_neighbors(MHNSW_param *p, FVectorNode *node)
 {
   const uint max_neighbors= p->ctx->max_neighbors(p->layer);
   const bool bulk= p->ctx->bulk_active;
+  const size_t num_neighbors= node->neighbors[p->layer].num;
 
-  for (size_t i= 0; i < node->neighbors[p->layer].num; i++)
+  if (num_neighbors == 0)
+    return 0;
+
+  FVectorNode **q= (FVectorNode**) my_safe_alloca(sizeof(FVectorNode*) * num_neighbors);
+
+  for (size_t i= 0; i < num_neighbors; i++)
+    q[i]= node->neighbors[p->layer].links[i];
+
+  size_t head= 0;
+  size_t tail= 0;
+  size_t q_len= num_neighbors;
+
+  while (q_len > 0)
   {
-    FVectorNode *neigh= node->neighbors[p->layer].links[i];
+    FVectorNode *neigh= q[head];
+    head= (head + 1) % num_neighbors;
+    q_len--;
+
     uint ticket= 0;
     if (bulk)
-      ticket= p->ctx->lock_node(neigh);
+    {
+      if (q_len == 0)
+        ticket= p->ctx->lock_node(neigh);
+      else if (!p->ctx->try_lock_node(neigh, ticket))
+      {
+        q[tail]= neigh;
+        tail= (tail + 1) % num_neighbors;
+        q_len++;
+        continue;
+      }
+    }
 
     Neighborhood &neighneighbors= neigh->neighbors[p->layer];
     int err= 0;
@@ -1301,8 +1335,13 @@ static int update_second_degree_neighbors(MHNSW_param *p, FVectorNode *node)
       err= neigh->save(p->graph);
 
     if (err)
+    {
+      my_safe_afree(q, sizeof(FVectorNode*) * num_neighbors);
       return err;
+    }
   }
+
+  my_safe_afree(q, sizeof(FVectorNode*) * num_neighbors);
   return 0;
 }
 
@@ -1791,7 +1830,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
   // XXX how many threads to use?
   uint N= std::thread::hardware_concurrency();
   size_t total_nodes= bulk->nodes.elements - 1;
-  size_t workers= std::min<size_t>(N, total_nodes);
+  size_t workers= N;
 
   pthread_t *threads= (pthread_t*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(pthread_t) * workers, MYF(MY_WME));
   BulkBuildThreadArg *args= (BulkBuildThreadArg*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(BulkBuildThreadArg) * workers, MYF(MY_WME));

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -25,6 +25,7 @@
 #include "bloom_filters.h"
 #include <thread>
 #include <atomic>
+#include <algorithm>
 
 // distance can be a little bit < 0 because of fast math
 static constexpr float NEAREST = -1.0f;
@@ -395,9 +396,11 @@ struct Neighborhood: public Sql_alloc
 {
   FVectorNode **links;
   size_t num;
+  Atomic_relaxed<size_t> num_bulk;
   FVectorNode **init(FVectorNode **ptr, size_t n)
   {
     num= 0;
+    num_bulk.store(0, std::memory_order_relaxed);
     links= ptr;
     n= MY_ALIGN(n, 8);
     bzero(ptr, n*sizeof(*ptr));
@@ -482,7 +485,7 @@ public:
 class MHNSW_Share : public Sql_alloc
 {
   mysql_mutex_t cache_lock;     // for node_cache and stats
-  mysql_mutex_t node_lock[32];
+  mysql_mutex_t node_lock[32];  // XXX how to choose what's the best value here?
 
   void cache_internal(FVectorNode *node)
   {
@@ -669,13 +672,7 @@ public:
     mysql_mutex_unlock(&cache_lock);
   }
 
-  void update_start_parallel(FVectorNode *node)
-  {
-    mysql_mutex_lock(&cache_lock);
-    if (!start || node->max_layer > start->max_layer)
-      start= node;
-    mysql_mutex_unlock(&cache_lock);
-  }
+
 };
 
 /*
@@ -1058,8 +1055,9 @@ void FVectorNode::push_neighbor(size_t layer, FVectorNode *other)
   DBUG_ASSERT(neighbors[layer].num < ctx->max_neighbors(layer));
   size_t cur_num= neighbors[layer].num;
   neighbors[layer].links[cur_num]= other;
-  std::atomic_thread_fence(std::memory_order_release);
   neighbors[layer].num= cur_num + 1;
+  if (ctx->bulk_active)
+    neighbors[layer].num_bulk.store(cur_num + 1, std::memory_order_release);
 }
 
 size_t FVectorNode::tref_len() const { return ctx->tref_len; }
@@ -1216,8 +1214,9 @@ static int select_neighbors(MHNSW_param *p, FVectorNode *target,
   for (size_t i= 0; i < temp_num; i++)
     neighbors.links[i]= temp_links[i];
 
-  std::atomic_thread_fence(std::memory_order_release);
   neighbors.num= temp_num;
+  if (p->ctx->bulk_active)
+    neighbors.num_bulk.store(temp_num, std::memory_order_release);
 
   my_safe_afree(temp_links, sizeof(FVectorNode*) * max_neighbor_connections);
   my_safe_afree(discarded, sizeof(Visited**)*max_neighbor_connections);
@@ -1375,8 +1374,11 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
     visited.flush();
 
     Neighborhood &neighbors= cur.node->neighbors[p->layer];
-    std::atomic_thread_fence(std::memory_order_acquire);
-    FVectorNode **links= neighbors.links, **end= links + neighbors.num;
+    FVectorNode **links= neighbors.links;
+    size_t cur_num= p->ctx->bulk_active
+                  ? neighbors.num_bulk.load(std::memory_order_acquire)
+                  : neighbors.num;
+    FVectorNode **end= links + cur_num;
     for (; links < end; links+= 8)
     {
       uint8_t res= visited.seen(links);
@@ -1541,8 +1543,9 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
 
 
 struct MHNSW_Bulk_context : public Sql_alloc {
-    MHNSW_Share *ctx;       
-    DYNAMIC_ARRAY nodes;    
+    MHNSW_Share *ctx;
+    DYNAMIC_ARRAY nodes;
+    uint start_node_idx;
     uint8_t current_max_layer;
 };
 
@@ -1565,6 +1568,12 @@ static void *bulk_build_thread(void *param)
   BulkBuildThreadArg *arg= (BulkBuildThreadArg*) param;
   MHNSW_Bulk_context *bulk= arg->bulk;
   MHNSW_Share *ctx= bulk->ctx;
+  // Sort this thread's chunk by descending layer
+  FVectorNode **chunk_start= dynamic_element(&bulk->nodes, arg->start_idx, FVectorNode**);
+  FVectorNode **chunk_end= dynamic_element(&bulk->nodes, arg->end_idx, FVectorNode**);
+  std::sort(chunk_start, chunk_end, [](const FVectorNode *a, const FVectorNode *b) {
+    return a->max_layer > b->max_layer;
+  });
 
   MEM_ROOT thread_root;
   init_alloc_root(PSI_INSTRUMENT_MEM, &thread_root, 256*1024, 0, MYF(0));
@@ -1607,10 +1616,6 @@ static void *bulk_build_thread(void *param)
         return nullptr;
     }
 
-    if (target_layer > max_layer)
-    {
-      ctx->update_start_parallel(target);
-    }
 
     free_root(&thread_root, MYF(MY_MARK_BLOCKS_FREE));
   }
@@ -1667,6 +1672,11 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
     ctx->release(table);
     return 0;
   }
+  if (rows < N * 100)
+  {
+    ctx->release(table);
+    return 0;
+  }
 
   MHNSW_Bulk_context *bulk= new (table->in_use->mem_root) MHNSW_Bulk_context();
   if (!bulk)
@@ -1688,6 +1698,7 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
   bulk->ctx->bulk_active= 1;
   DBUG_ASSERT(!bulk->ctx->start);
   bulk->current_max_layer= 0;
+  bulk->start_node_idx= 0;
   table->hlindex->context= bulk;
   return 0;
 }
@@ -1698,6 +1709,9 @@ int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo)
   MHNSW_Bulk_context *bulk= (MHNSW_Bulk_context*)graph->context;
   MHNSW_Share *ctx= bulk->ctx;
   MY_BITMAP *old_map= dbug_tmp_use_all_columns(table, &table->read_set);
+  SCOPE_EXIT([table, old_map]() {
+    dbug_tmp_restore_column_map(&table->read_set, old_map);
+  });
 
   DBUG_ASSERT(graph);
   DBUG_ASSERT(bulk);
@@ -1730,7 +1744,10 @@ int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo)
     target_layer= 0;
 
   if (target_layer > bulk->current_max_layer)
+  {
     bulk->current_max_layer= target_layer;
+    bulk->start_node_idx= bulk->nodes.elements;
+  }
 
   FVectorNode *node= new (ctx->alloc_node())
     FVectorNode(ctx, table->file->ref, target_layer, res->ptr());
@@ -1738,7 +1755,6 @@ int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo)
   if (insert_dynamic(&bulk->nodes, (uchar*)&node))
     return HA_ERR_OUT_OF_MEM;
 
-  dbug_tmp_restore_column_map(&table->read_set, old_map);
   return 0;
 }
 
@@ -1763,10 +1779,16 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
 
   if (bulk->nodes.elements == 0)
     return 0;
+     
+  // Swap the start node (highest layer) to index 0
+  if (bulk->start_node_idx != 0)
+  {
+    FVectorNode **arr= (FVectorNode**)bulk->nodes.buffer;
+    std::swap(arr[0], arr[bulk->start_node_idx]);
+  }
+  ctx->start= *dynamic_element(&bulk->nodes, 0, FVectorNode**);
 
-  FVectorNode *first_target= *(FVectorNode**)dynamic_element(&bulk->nodes, 0, FVectorNode**);
-  ctx->start= first_target;
-
+  // XXX how many threads to use?
   uint N= std::thread::hardware_concurrency();
   uint total_nodes= bulk->nodes.elements - 1;
   uint workers= std::min(N, total_nodes);
@@ -1802,7 +1824,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
     {
       for (uint j= 0; j < workers_spawned; j++)
         pthread_join(threads[j], nullptr);
-      return err;
+      return HA_ERR_OUT_OF_MEM;
     }
     workers_spawned++;
   }

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1545,7 +1545,7 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
 struct MHNSW_Bulk_context : public Sql_alloc {
     MHNSW_Share *ctx;
     DYNAMIC_ARRAY nodes;
-    uint start_node_idx;
+    size_t start_node_idx;
     uint8_t current_max_layer;
 };
 
@@ -1554,8 +1554,8 @@ struct MHNSW_Bulk_context : public Sql_alloc {
 struct BulkBuildThreadArg
 {
   MHNSW_Bulk_context *bulk;
-  uint start_idx;
-  uint end_idx;
+  size_t start_idx;
+  size_t end_idx;
   int error;
 };
 
@@ -1579,7 +1579,7 @@ static void *bulk_build_thread(void *param)
   init_alloc_root(PSI_INSTRUMENT_MEM, &thread_root, 256*1024, 0, MYF(0));
   SCOPE_EXIT([&thread_root]() { free_root(&thread_root, MYF(0)); });
 
-  for (uint i = arg->start_idx; i < arg->end_idx; i++)
+  for (size_t i = arg->start_idx; i < arg->end_idx; i++)
   {
     FVectorNode *target= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
     const uint8_t max_layer= ctx->start->max_layer;
@@ -1790,8 +1790,8 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
 
   // XXX how many threads to use?
   uint N= std::thread::hardware_concurrency();
-  uint total_nodes= bulk->nodes.elements - 1;
-  uint workers= std::min(N, total_nodes);
+  size_t total_nodes= bulk->nodes.elements - 1;
+  size_t workers= std::min<size_t>(N, total_nodes);
 
   pthread_t *threads= (pthread_t*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(pthread_t) * workers, MYF(MY_WME));
   BulkBuildThreadArg *args= (BulkBuildThreadArg*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(BulkBuildThreadArg) * workers, MYF(MY_WME));
@@ -1804,15 +1804,15 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
     return HA_ERR_OUT_OF_MEM;
   }
 
-  uint chunk_size = total_nodes / workers;
-  uint remainder = total_nodes % workers;
-  uint current_start = 1;
+  size_t chunk_size = total_nodes / workers;
+  size_t remainder = total_nodes % workers;
+  size_t current_start = 1;
 
-  uint workers_spawned= 0;
+  size_t workers_spawned= 0;
 
-  for (uint i= 0; i < workers; i++)
+  for (size_t i= 0; i < workers; i++)
   {
-    uint count = chunk_size + (i == 0 ? remainder : 0);
+    size_t count = chunk_size + (i == 0 ? remainder : 0);
     args[i].bulk= bulk;
     args[i].start_idx = current_start;
     args[i].end_idx = current_start + count;
@@ -1822,7 +1822,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
     int err= mysql_thread_create(0, &threads[i], nullptr, bulk_build_thread, &args[i]);
     if (err)
     {
-      for (uint j= 0; j < workers_spawned; j++)
+      for (size_t j= 0; j < workers_spawned; j++)
         pthread_join(threads[j], nullptr);
       return HA_ERR_OUT_OF_MEM;
     }
@@ -1830,7 +1830,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
   }
 
   int final_err= 0;
-  for (uint i= 0; i < workers_spawned; i++)
+  for (size_t i= 0; i < workers_spawned; i++)
   {
     pthread_join(threads[i], nullptr);
     if (args[i].error && !final_err)
@@ -1847,7 +1847,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
       graph->file->ha_end_bulk_insert();
   });
 
-  for (uint i= 0; i < bulk->nodes.elements; i++)
+  for (size_t i= 0; i < bulk->nodes.elements; i++)
   {
     FVectorNode *node= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
     if (int err= node->save(graph))
@@ -1863,7 +1863,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
   SCOPE_EXIT([graph](){ graph->file->ha_rnd_end(); });
 
   // fix neighbors grefs
-  for (uint i= 0; i < bulk->nodes.elements; i++)
+  for (size_t i= 0; i < bulk->nodes.elements; i++)
   {
     FVectorNode *node= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
     if (int err= node->save(graph))

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -510,7 +510,7 @@ public:
   const uint M;
   metric_type metric;
   bool use_subdist;
-  bool bulk_active;
+  bool bulk_active=false;
   MHNSW_Share(TABLE *t)
     : tref_len(t->file->ref_length), gref_len(t->hlindex->file->ref_length),
       M(static_cast<uint>(t->s->key_info[t->s->keys].option_struct->M)),
@@ -1527,9 +1527,8 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
 
   bulk->estimated_rows= rows;
   if (my_init_dynamic_array(PSI_INSTRUMENT_MEM, &bulk->nodes, sizeof(FVectorNode*),
-                            rows + rows * 0.1, rows, MYF(0)))
+                            rows + rows / 10, rows, MYF(0)))
   {
-    delete bulk;
     return HA_ERR_OUT_OF_MEM;
   }
 
@@ -1537,10 +1536,13 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
   if (err && err != HA_ERR_END_OF_FILE && err != HA_ERR_KEY_NOT_FOUND)
   {
     delete_dynamic(&bulk->nodes);
-    delete bulk;
     return err;
   }
 
+  if (bulk->ctx->vec_len == 0)
+    bulk->ctx->set_lengths(keyinfo->key_part->field->field_length);
+
+  DBUG_ASSERT(!bulk->ctx->start);
   bulk->ctx->bulk_active= 1;
   bulk->current_max_layer= 0;
   table->hlindex->context= bulk;
@@ -1599,8 +1601,11 @@ int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo)
 
 int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
 {
-  THD *thd= table->in_use;
   TABLE *graph= table->hlindex;
+  if (!graph->context)
+    return 0;
+
+  THD *thd= table->in_use;
   MHNSW_Bulk_context *bulk= (MHNSW_Bulk_context*)graph->context;
 
   DBUG_ASSERT(graph);
@@ -1668,6 +1673,11 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
   }
 
   graph->file->ha_start_bulk_insert(bulk->nodes.elements, 0);
+  bool bulk_base_started= true;
+  SCOPE_EXIT([graph, &bulk_base_started](){
+    if (bulk_base_started)
+      graph->file->ha_end_bulk_insert();
+  });
 
   for (uint i= 0; i < bulk->nodes.elements; i++)
   {
@@ -1676,6 +1686,7 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
       return err;
   }
 
+  bulk_base_started= false;
   if (int err= graph->file->ha_end_bulk_insert())
     return err;
 

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -23,6 +23,8 @@
 #include <scope.h>
 #include <my_atomic_wrapper.h>
 #include "bloom_filters.h"
+#include <thread>
+#include <atomic>
 
 // distance can be a little bit < 0 because of fast math
 static constexpr float NEAREST = -1.0f;
@@ -480,7 +482,7 @@ public:
 class MHNSW_Share : public Sql_alloc
 {
   mysql_mutex_t cache_lock;     // for node_cache and stats
-  mysql_mutex_t node_lock[8];
+  mysql_mutex_t node_lock[32];
 
   void cache_internal(FVectorNode *node)
   {
@@ -664,6 +666,14 @@ public:
     stats.diameter= std::max(stats.diameter, addend.diameter);
     stats.ef_power= std::max(stats.ef_power, addend.ef_power);
     stats.subdist.add(addend.subdist);
+    mysql_mutex_unlock(&cache_lock);
+  }
+
+  void update_start_parallel(FVectorNode *node)
+  {
+    mysql_mutex_lock(&cache_lock);
+    if (!start || node->max_layer > start->max_layer)
+      start= node;
     mysql_mutex_unlock(&cache_lock);
   }
 };
@@ -1046,7 +1056,10 @@ int FVectorNode::load_from_record(TABLE *graph)
 void FVectorNode::push_neighbor(size_t layer, FVectorNode *other)
 {
   DBUG_ASSERT(neighbors[layer].num < ctx->max_neighbors(layer));
-  neighbors[layer].links[neighbors[layer].num++]= other;
+  size_t cur_num= neighbors[layer].num;
+  neighbors[layer].links[cur_num]= other;
+  std::atomic_thread_fence(std::memory_order_release);
+  neighbors[layer].num= cur_num + 1;
 }
 
 size_t FVectorNode::tref_len() const { return ctx->tref_len; }
@@ -1070,8 +1083,10 @@ struct MHNSW_param
   Stats acc;
   dgt_mode mode;
   double max_est_size;
-  MHNSW_param(MHNSW_Share *ctx, TABLE *graph, int layer)
-    : ctx(ctx), graph(graph), layer(layer)
+  MEM_ROOT *mem_root;
+  MHNSW_param(MHNSW_Share *ctx, TABLE *graph, int layer, MEM_ROOT *mem_root_arg= nullptr)
+    : ctx(ctx), graph(graph), layer(layer),
+      mem_root(mem_root_arg ? mem_root_arg : (graph ? graph->in_use->mem_root : nullptr))
   {
     Stats stats;
     ctx->read_stats(&stats);
@@ -1159,7 +1174,7 @@ static int select_neighbors(MHNSW_param *p, FVectorNode *target,
   if (pq.init(max_ef, false, Visited::cmp))
     return my_errno= HA_ERR_OUT_OF_MEM;
 
-  MEM_ROOT * const root= p->graph->in_use->mem_root;
+  MEM_ROOT * const root= p->mem_root;
   auto discarded= (Visited**)my_safe_alloca(sizeof(Visited**)*max_neighbor_connections);
   size_t discarded_num= 0;
   Neighborhood &neighbors= target->neighbors[p->layer];
@@ -1173,29 +1188,38 @@ static int select_neighbors(MHNSW_param *p, FVectorNode *target,
   }
   if (extra_candidate)
     pq.push(new (root) Visited(extra_candidate, extra_candidate->distance_to(target->vec)));
-
   DBUG_ASSERT(pq.elements());
-  neighbors.num= 0;
 
-  while (pq.elements() && neighbors.num < max_neighbor_connections)
+  size_t temp_num = 0;
+  FVectorNode **temp_links = (FVectorNode**)my_safe_alloca(sizeof(FVectorNode*) * max_neighbor_connections);
+
+  while (pq.elements() && temp_num < max_neighbor_connections)
   {
     Visited *vec= pq.pop();
     FVectorNode * const node= vec->node;
     const float target_dista= std::max(32*FLT_EPSILON, vec->distance_to_target);
     bool discard= false;
-    for (size_t i=0; i < neighbors.num; i++)
-      if ((discard= node->distance_greater_than(neighbors.links[i]->vec,
+    for (size_t i=0; i < temp_num; i++)
+      if ((discard= node->distance_greater_than(temp_links[i]->vec,
                             target_dista, p->mode, &p->acc) < target_dista))
         break;
     if (!discard)
-      target->push_neighbor(p->layer, node);
-    else if (discarded_num + neighbors.num < max_neighbor_connections)
+      temp_links[temp_num++]= node;
+    else if (discarded_num + temp_num < max_neighbor_connections)
       discarded[discarded_num++]= vec;
   }
 
-  for (size_t i=0; i < discarded_num && neighbors.num < max_neighbor_connections; i++)
-    target->push_neighbor(p->layer, discarded[i]->node);
+  for (size_t i= 0; i < discarded_num && temp_num < max_neighbor_connections; i++)
+    temp_links[temp_num++]= discarded[i]->node;
 
+  // Publish the new neighbors atomically
+  for (size_t i= 0; i < temp_num; i++)
+    neighbors.links[i]= temp_links[i];
+
+  std::atomic_thread_fence(std::memory_order_release);
+  neighbors.num= temp_num;
+
+  my_safe_afree(temp_links, sizeof(FVectorNode*) * max_neighbor_connections);
   my_safe_afree(discarded, sizeof(Visited**)*max_neighbor_connections);
   return 0;
 }
@@ -1256,21 +1280,29 @@ int FVectorNode::save(TABLE *graph)
 static int update_second_degree_neighbors(MHNSW_param *p, FVectorNode *node)
 {
   const uint max_neighbors= p->ctx->max_neighbors(p->layer);
-  // it seems that one could update nodes in the gref order
-  // to avoid InnoDB deadlocks, but it produces no noticeable effect
-  for (size_t i=0; i < node->neighbors[p->layer].num; i++)
+  const bool bulk= p->ctx->bulk_active;
+
+  for (size_t i= 0; i < node->neighbors[p->layer].num; i++)
   {
     FVectorNode *neigh= node->neighbors[p->layer].links[i];
+    uint ticket= 0;
+    if (bulk)
+      ticket= p->ctx->lock_node(neigh);
+
     Neighborhood &neighneighbors= neigh->neighbors[p->layer];
+    int err= 0;
     if (neighneighbors.num < max_neighbors)
       neigh->push_neighbor(p->layer, node);
     else
-      if (int err= select_neighbors(p, neigh, neighneighbors, node,
-                                    max_neighbors))
-        return err;
-    if (!p->ctx->bulk_active)
-        if (int err= neigh->save(p->graph))
-            return err;
+      err= select_neighbors(p, neigh, neighneighbors, node, max_neighbors);
+
+    if (bulk)
+      p->ctx->unlock_node(ticket);
+    else if (!err)
+      err= neigh->save(p->graph);
+
+    if (err)
+      return err;
   }
   return 0;
 }
@@ -1293,7 +1325,7 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
 {
   DBUG_ASSERT(inout->num > 0);
 
-  MEM_ROOT * const root= p->graph->in_use->mem_root;
+  MEM_ROOT * const root= p->mem_root;
   Queue<Visited> candidates, best;
   bool skip_deleted;
   uint ef= result_size;
@@ -1343,6 +1375,7 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
     visited.flush();
 
     Neighborhood &neighbors= cur.node->neighbors[p->layer];
+    std::atomic_thread_fence(std::memory_order_acquire);
     FVectorNode **links= neighbors.links, **end= links + neighbors.num;
     for (; links < end; links+= 8)
     {
@@ -1513,6 +1546,78 @@ struct MHNSW_Bulk_context : public Sql_alloc {
     uint8_t current_max_layer;
 };
 
+
+
+struct BulkBuildThreadArg
+{
+  MHNSW_Bulk_context *bulk;
+  uint start_idx;
+  uint end_idx;
+  int error;
+};
+
+
+static void *bulk_build_thread(void *param)
+{
+  my_thread_init();
+  SCOPE_EXIT([]() { my_thread_end(); });
+
+  BulkBuildThreadArg *arg= (BulkBuildThreadArg*) param;
+  MHNSW_Bulk_context *bulk= arg->bulk;
+  MHNSW_Share *ctx= bulk->ctx;
+
+  MEM_ROOT thread_root;
+  init_alloc_root(PSI_INSTRUMENT_MEM, &thread_root, 256*1024, 0, MYF(0));
+  SCOPE_EXIT([&thread_root]() { free_root(&thread_root, MYF(0)); });
+
+  for (uint i = arg->start_idx; i < arg->end_idx; i++)
+  {
+    FVectorNode *target= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
+    const uint8_t max_layer= ctx->start->max_layer;
+    uint8_t target_layer= target->max_layer;
+
+    MHNSW_param p(ctx, nullptr, max_layer, &thread_root);
+    p.acc.graph_size= 1;
+
+    const size_t max_found= ctx->max_neighbors(0);
+    Neighborhood candidates;
+    candidates.init((FVectorNode**)alloc_root(&thread_root, sizeof(FVectorNode*) * (max_found + 8)), max_found);
+    candidates.links[candidates.num++]= ctx->start;
+
+    for (; p.layer > target_layer; p.layer--)
+    {
+      if ((arg->error= search_layer(&p, target->vec, NEAREST, 1, &candidates, false)))
+        return nullptr;
+    }
+
+    for (; p.layer >= 0; p.layer--)
+    {
+      uint max_neighbors= ctx->max_neighbors(p.layer);
+      if ((arg->error= search_layer(&p, target->vec, NEAREST, max_neighbors, &candidates, true)))
+        return nullptr;
+      if ((arg->error= select_neighbors(&p, target, candidates, 0, max_neighbors)))
+        return nullptr;
+    }
+
+    ctx->add_to_stats(p.acc);
+
+    for (p.layer= target_layer; p.layer >= 0; p.layer--)
+    {
+      if ((arg->error= update_second_degree_neighbors(&p, target)))
+        return nullptr;
+    }
+
+    if (target_layer > max_layer)
+    {
+      ctx->update_start_parallel(target);
+    }
+
+    free_root(&thread_root, MYF(MY_MARK_BLOCKS_FREE));
+  }
+
+  return nullptr;
+}
+
 int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
 {
   TABLE *graph= table->hlindex;
@@ -1547,6 +1652,18 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
                         "MHNSW: Bulk insert disabled because estimated memory usage (%llu) "
                         "exceeds mhnsw_max_cache_size (%llu). Falling back to normal insert.",
                         (ulonglong)estimated_mem, (ulonglong)mhnsw_max_cache_size);
+    ctx->release(table);
+    return 0;
+  }
+
+  uint N= std::thread::hardware_concurrency();
+  if (N <= 1)
+  {
+    push_warning_printf(table->in_use, Sql_condition::WARN_LEVEL_NOTE,
+                        ER_UNKNOWN_ERROR,
+                        "MHNSW: Bulk insert disabled because available thread count (%u) is <= 1. "
+                        "Falling back to normal insert.",
+                        N);
     ctx->release(table);
     return 0;
   }
@@ -1631,7 +1748,6 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
   if (!graph->context)
     return 0;
 
-  THD *thd= table->in_use;
   MHNSW_Bulk_context *bulk= (MHNSW_Bulk_context*)graph->context;
 
   DBUG_ASSERT(graph);
@@ -1645,58 +1761,62 @@ int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
     table->hlindex->context= nullptr;
   });
 
-  for (uint i= 0; i < bulk->nodes.elements; i++)
+  if (bulk->nodes.elements == 0)
+    return 0;
+
+  FVectorNode *first_target= *(FVectorNode**)dynamic_element(&bulk->nodes, 0, FVectorNode**);
+  ctx->start= first_target;
+
+  uint N= std::thread::hardware_concurrency();
+  uint total_nodes= bulk->nodes.elements - 1;
+  uint workers= std::min(N, total_nodes);
+
+  pthread_t *threads= (pthread_t*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(pthread_t) * workers, MYF(MY_WME));
+  BulkBuildThreadArg *args= (BulkBuildThreadArg*) my_malloc(PSI_INSTRUMENT_MEM, sizeof(BulkBuildThreadArg) * workers, MYF(MY_WME));
+  SCOPE_EXIT([threads, args]() {
+    my_free(threads);
+    my_free(args);
+  });
+  if (!threads || !args)
   {
-    FVectorNode *target= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
-
-    if (!ctx->start)
-    {
-      ctx->start= target;
-      continue;
-    }
-
-    MEM_ROOT_SAVEPOINT memroot_sv;
-    root_make_savepoint(thd->mem_root, &memroot_sv);
-    SCOPE_EXIT([memroot_sv](){ root_free_to_savepoint(&memroot_sv); });
-
-    const uint8_t max_layer= ctx->start->max_layer;
-    uint8_t target_layer= target->max_layer;
-
-    MHNSW_param p(ctx, graph, max_layer);
-    p.acc.graph_size= 1;
-
-    const size_t max_found= ctx->max_neighbors(0);
-    Neighborhood candidates;
-    candidates.init(thd->alloc<FVectorNode*>(max_found + 7), max_found);
-    candidates.links[candidates.num++]= ctx->start;
-
-    for (; p.layer > target_layer; p.layer--)
-    {
-      if (int err= search_layer(&p, target->vec, NEAREST, 1, &candidates, false))
-        return err;
-    }
-
-    for (; p.layer >= 0; p.layer--)
-    {
-      uint max_neighbors= ctx->max_neighbors(p.layer);
-      if (int err= search_layer(&p, target->vec, NEAREST, max_neighbors,
-                                &candidates, true))
-        return err;
-      if (int err= select_neighbors(&p, target, candidates, 0, max_neighbors))
-        return err;
-    }
-
-    ctx->add_to_stats(p.acc);
-
-    if (target_layer > max_layer)
-      ctx->start= target;
-
-    for (p.layer= target_layer; p.layer >= 0; p.layer--)
-    {
-      if (int err= update_second_degree_neighbors(&p, target))
-        return err;
-    }
+    return HA_ERR_OUT_OF_MEM;
   }
+
+  uint chunk_size = total_nodes / workers;
+  uint remainder = total_nodes % workers;
+  uint current_start = 1;
+
+  uint workers_spawned= 0;
+
+  for (uint i= 0; i < workers; i++)
+  {
+    uint count = chunk_size + (i == 0 ? remainder : 0);
+    args[i].bulk= bulk;
+    args[i].start_idx = current_start;
+    args[i].end_idx = current_start + count;
+    args[i].error= 0;
+    current_start += count;
+
+    int err= mysql_thread_create(0, &threads[i], nullptr, bulk_build_thread, &args[i]);
+    if (err)
+    {
+      for (uint j= 0; j < workers_spawned; j++)
+        pthread_join(threads[j], nullptr);
+      return err;
+    }
+    workers_spawned++;
+  }
+
+  int final_err= 0;
+  for (uint i= 0; i < workers_spawned; i++)
+  {
+    pthread_join(threads[i], nullptr);
+    if (args[i].error && !final_err)
+      final_err= args[i].error;
+  }
+
+  if (final_err)
+    return final_err;
 
   graph->file->ha_start_bulk_insert(bulk->nodes.elements, 0);
   bool bulk_base_started= true;

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1521,29 +1521,51 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
   DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
   DBUG_ASSERT(keyinfo->usable_key_parts == 1);
 
+  MHNSW_Share *ctx;
+  int err= MHNSW_Share::acquire(&ctx, table, true);
+  if (err && err != HA_ERR_END_OF_FILE && err != HA_ERR_KEY_NOT_FOUND)
+    return err;
+
+  if (ctx->vec_len == 0)
+    ctx->set_lengths(keyinfo->key_part->field->field_length);
+
+  size_t node_alloc_size= sizeof(FVectorNode) + ctx->gref_len + ctx->tref_len +
+                          FVector::alloc_size(ctx->vec_len);
+  size_t neighborhood_alloc_size= sizeof(Neighborhood) +
+                                  sizeof(FVectorNode*) * MY_ALIGN(ctx->M, 4) * 2;
+
+  ulonglong estimated_mem= rows * (sizeof(FVectorNode*) + node_alloc_size +
+                                   neighborhood_alloc_size);
+
+  if (estimated_mem > mhnsw_max_cache_size)
+  {
+    push_warning_printf(table->in_use, Sql_condition::WARN_LEVEL_NOTE,
+                        ER_UNKNOWN_ERROR,
+                        "MHNSW: Bulk insert disabled because estimated memory usage (%llu) "
+                        "exceeds mhnsw_max_cache_size (%llu). Falling back to normal insert.",
+                        (ulonglong)estimated_mem, (ulonglong)mhnsw_max_cache_size);
+    ctx->release(table);
+    return 1;
+  }
+
   MHNSW_Bulk_context *bulk= new (table->in_use->mem_root) MHNSW_Bulk_context();
   if (!bulk)
+  {
+    ctx->release(table);
     return HA_ERR_OUT_OF_MEM;
+  }
 
+  bulk->ctx= ctx;
   bulk->estimated_rows= rows;
   if (my_init_dynamic_array(PSI_INSTRUMENT_MEM, &bulk->nodes, sizeof(FVectorNode*),
                             rows + rows / 10, rows, MYF(0)))
   {
+    ctx->release(table);
     return HA_ERR_OUT_OF_MEM;
   }
 
-  int err= MHNSW_Share::acquire(&bulk->ctx, table, true);
-  if (err && err != HA_ERR_END_OF_FILE && err != HA_ERR_KEY_NOT_FOUND)
-  {
-    delete_dynamic(&bulk->nodes);
-    return err;
-  }
-
-  if (bulk->ctx->vec_len == 0)
-    bulk->ctx->set_lengths(keyinfo->key_part->field->field_length);
-
-  DBUG_ASSERT(!bulk->ctx->start);
   bulk->ctx->bulk_active= 1;
+  DBUG_ASSERT(!bulk->ctx->start);
   bulk->current_max_layer= 0;
   table->hlindex->context= bulk;
   return 0;

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -510,7 +510,7 @@ public:
   const uint M;
   metric_type metric;
   bool use_subdist;
-
+  bool bulk_active;
   MHNSW_Share(TABLE *t)
     : tref_len(t->file->ref_length), gref_len(t->hlindex->file->ref_length),
       M(static_cast<uint>(t->s->key_info[t->s->keys].option_struct->M)),
@@ -1012,6 +1012,8 @@ int FVectorNode::load_from_record(TABLE *graph)
   FVector *vec_ptr= FVector::align_ptr(tref() + tref_len());
   memcpy(vec_ptr->data(), v->ptr(), v->length());
   vec_ptr->postprocess(ctx->use_subdist, ctx->vec_len);
+  if (ctx->metric == COSINE)
+    vec_ptr->abs2= 0.5f;
 
   longlong layer= graph->field[FIELD_LAYER]->val_int();
   if (layer > 100) // 10e30 nodes at M=2, more at larger M's
@@ -1266,8 +1268,9 @@ static int update_second_degree_neighbors(MHNSW_param *p, FVectorNode *node)
       if (int err= select_neighbors(p, neigh, neighneighbors, node,
                                     max_neighbors))
         return err;
-    if (int err= neigh->save(p->graph))
-      return err;
+    if (!p->ctx->bulk_active)
+        if (int err= neigh->save(p->graph))
+            return err;
   }
   return 0;
 }
@@ -1503,6 +1506,193 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
   return 0;
 }
 
+
+struct MHNSW_Bulk_context : public Sql_alloc {
+    MHNSW_Share *ctx;       
+    DYNAMIC_ARRAY nodes;    
+    ha_rows estimated_rows; 
+    uint8_t current_max_layer;
+};
+
+int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
+{
+  TABLE *graph= table->hlindex;
+  DBUG_ASSERT(graph);
+  DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
+  DBUG_ASSERT(keyinfo->usable_key_parts == 1);
+
+  MHNSW_Bulk_context *bulk= new (table->in_use->mem_root) MHNSW_Bulk_context();
+  if (!bulk)
+    return HA_ERR_OUT_OF_MEM;
+
+  bulk->estimated_rows= rows;
+  if (my_init_dynamic_array(PSI_INSTRUMENT_MEM, &bulk->nodes, sizeof(FVectorNode*),
+                            rows + rows * 0.1, rows, MYF(0)))
+  {
+    delete bulk;
+    return HA_ERR_OUT_OF_MEM;
+  }
+
+  int err= MHNSW_Share::acquire(&bulk->ctx, table, true);
+  if (err && err != HA_ERR_END_OF_FILE && err != HA_ERR_KEY_NOT_FOUND)
+  {
+    delete_dynamic(&bulk->nodes);
+    delete bulk;
+    return err;
+  }
+
+  bulk->ctx->bulk_active= 1;
+  bulk->current_max_layer= 0;
+  table->hlindex->context= bulk;
+  return 0;
+}
+
+int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo)
+{
+  TABLE *graph= table->hlindex;
+  MHNSW_Bulk_context *bulk= (MHNSW_Bulk_context*)graph->context;
+  MHNSW_Share *ctx= bulk->ctx;
+  MY_BITMAP *old_map= dbug_tmp_use_all_columns(table, &table->read_set);
+
+  DBUG_ASSERT(graph);
+  DBUG_ASSERT(bulk);
+  DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
+  DBUG_ASSERT(keyinfo->usable_key_parts == 1);
+
+  Field *vec_field= keyinfo->key_part->field;
+  String buf, *res= vec_field->val_str(&buf);
+
+  DBUG_ASSERT(vec_field->binary());
+  DBUG_ASSERT(vec_field->cmp_type() == STRING_RESULT);
+  DBUG_ASSERT(res); // ER_INDEX_CANNOT_HAVE_NULL
+  DBUG_ASSERT(res->length() > 0 && res->length() % 4 == 0);
+  DBUG_ASSERT(table->file->ref_length <= graph->field[FIELD_TREF]->field_length);
+
+  table->file->position(table->record[0]);
+
+  if (ctx->byte_len == 0)
+    ctx->set_lengths(res->length());
+
+  if (ctx->byte_len != res->length())
+    return my_errno= HA_ERR_CRASHED;
+
+  const double NORMALIZATION_FACTOR= 1 / std::log(ctx->M);
+  double log= -std::log(my_rnd(&table->in_use->rand)) * NORMALIZATION_FACTOR;
+  uint8_t max_layer= bulk->current_max_layer;
+  uint8_t target_layer= std::min<uint8_t>(static_cast<uint8_t>(std::floor(log)), max_layer + 1);
+
+  if (bulk->nodes.elements == 0)
+    target_layer= 0;
+
+  if (target_layer > bulk->current_max_layer)
+    bulk->current_max_layer= target_layer;
+
+  FVectorNode *node= new (ctx->alloc_node())
+    FVectorNode(ctx, table->file->ref, target_layer, res->ptr());
+
+  if (insert_dynamic(&bulk->nodes, (uchar*)&node))
+    return HA_ERR_OUT_OF_MEM;
+
+  dbug_tmp_restore_column_map(&table->read_set, old_map);
+  return 0;
+}
+
+int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo)
+{
+  THD *thd= table->in_use;
+  TABLE *graph= table->hlindex;
+  MHNSW_Bulk_context *bulk= (MHNSW_Bulk_context*)graph->context;
+
+  DBUG_ASSERT(graph);
+  DBUG_ASSERT(bulk);
+
+  MHNSW_Share *ctx= bulk->ctx;
+  SCOPE_EXIT([ctx, bulk, table](){
+    delete_dynamic(&bulk->nodes);
+    ctx->bulk_active= 0;
+    ctx->release(table);
+    table->hlindex->context= nullptr;
+  });
+
+  for (uint i= 0; i < bulk->nodes.elements; i++)
+  {
+    FVectorNode *target= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
+
+    if (!ctx->start)
+    {
+      ctx->start= target;
+      continue;
+    }
+
+    MEM_ROOT_SAVEPOINT memroot_sv;
+    root_make_savepoint(thd->mem_root, &memroot_sv);
+    SCOPE_EXIT([memroot_sv](){ root_free_to_savepoint(&memroot_sv); });
+
+    const uint8_t max_layer= ctx->start->max_layer;
+    uint8_t target_layer= target->max_layer;
+
+    MHNSW_param p(ctx, graph, max_layer);
+    p.acc.graph_size= 1;
+
+    const size_t max_found= ctx->max_neighbors(0);
+    Neighborhood candidates;
+    candidates.init(thd->alloc<FVectorNode*>(max_found + 7), max_found);
+    candidates.links[candidates.num++]= ctx->start;
+
+    for (; p.layer > target_layer; p.layer--)
+    {
+      if (int err= search_layer(&p, target->vec, NEAREST, 1, &candidates, false))
+        return err;
+    }
+
+    for (; p.layer >= 0; p.layer--)
+    {
+      uint max_neighbors= ctx->max_neighbors(p.layer);
+      if (int err= search_layer(&p, target->vec, NEAREST, max_neighbors,
+                                &candidates, true))
+        return err;
+      if (int err= select_neighbors(&p, target, candidates, 0, max_neighbors))
+        return err;
+    }
+
+    ctx->add_to_stats(p.acc);
+
+    if (target_layer > max_layer)
+      ctx->start= target;
+
+    for (p.layer= target_layer; p.layer >= 0; p.layer--)
+    {
+      if (int err= update_second_degree_neighbors(&p, target))
+        return err;
+    }
+  }
+
+  graph->file->ha_start_bulk_insert(bulk->nodes.elements, 0);
+
+  for (uint i= 0; i < bulk->nodes.elements; i++)
+  {
+    FVectorNode *node= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
+    if (int err= node->save(graph))
+      return err;
+  }
+
+  if (int err= graph->file->ha_end_bulk_insert())
+    return err;
+
+  if (int err= graph->file->ha_rnd_init(0))
+    return err;
+  SCOPE_EXIT([graph](){ graph->file->ha_rnd_end(); });
+
+  // fix neighbors grefs
+  for (uint i= 0; i < bulk->nodes.elements; i++)
+  {
+    FVectorNode *node= *(FVectorNode**)dynamic_element(&bulk->nodes, i, FVectorNode**);
+    if (int err= node->save(graph))
+      return err;
+  }
+
+  return 0;
+}
 
 struct Search_context: public Sql_alloc
 {

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1510,7 +1510,6 @@ int mhnsw_insert(TABLE *table, KEY *keyinfo)
 struct MHNSW_Bulk_context : public Sql_alloc {
     MHNSW_Share *ctx;       
     DYNAMIC_ARRAY nodes;    
-    ha_rows estimated_rows; 
     uint8_t current_max_layer;
 };
 
@@ -1521,10 +1520,14 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
   DBUG_ASSERT(keyinfo->algorithm == HA_KEY_ALG_VECTOR);
   DBUG_ASSERT(keyinfo->usable_key_parts == 1);
 
-  MHNSW_Share *ctx;
+  MHNSW_Share *ctx= nullptr;
   int err= MHNSW_Share::acquire(&ctx, table, true);
   if (err && err != HA_ERR_END_OF_FILE && err != HA_ERR_KEY_NOT_FOUND)
+  {
+    if (ctx)
+      ctx->release(table);
     return err;
+  }
 
   if (ctx->vec_len == 0)
     ctx->set_lengths(keyinfo->key_part->field->field_length);
@@ -1545,7 +1548,7 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
                         "exceeds mhnsw_max_cache_size (%llu). Falling back to normal insert.",
                         (ulonglong)estimated_mem, (ulonglong)mhnsw_max_cache_size);
     ctx->release(table);
-    return 1;
+    return 0;
   }
 
   MHNSW_Bulk_context *bulk= new (table->in_use->mem_root) MHNSW_Bulk_context();
@@ -1556,7 +1559,8 @@ int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows)
   }
 
   bulk->ctx= ctx;
-  bulk->estimated_rows= rows;
+
+  /*we add a 10% margin to avoid reallocations when rows is approximate (InnoDB)*/
   if (my_init_dynamic_array(PSI_INSTRUMENT_MEM, &bulk->nodes, sizeof(FVectorNode*),
                             rows + rows / 10, rows, MYF(0)))
   {

--- a/sql/vector_mhnsw.h
+++ b/sql/vector_mhnsw.h
@@ -34,6 +34,9 @@ int mhnsw_invalidate(TABLE *table, const uchar *rec, KEY *keyinfo);
 int mhnsw_delete_all(TABLE *table, KEY *keyinfo, bool truncate);
 void mhnsw_free(TABLE_SHARE *share);
 Item_func_vec_distance::distance_kind mhnsw_uses_distance(const TABLE *table, KEY *keyinfo);
+int mhnsw_bulk_insert_begin(TABLE *table, KEY *keyinfo, ha_rows rows);
+int mhnsw_bulk_insert_end(TABLE *table, KEY *keyinfo);
+int mhnsw_bulk_insert_row(TABLE *table, KEY *keyinfo);
 
 extern ha_create_table_option mhnsw_index_options[];
 extern st_plugin_int *mhnsw_plugin;


### PR DESCRIPTION
MDEV-33411: OPTIMIZE TABLE for graph indexes

Re-evaluate vector node neighborhoods on the completed graph during OPTIMIZE TABLE