### PR TITLE
MDEV-36986 Support tracing arrays of primitive types

### DIFF
--- a/mysql-test/include/opt_context_schema.inc
+++ b/mysql-test/include/opt_context_schema.inc
@@ -46,7 +46,7 @@ let $opt_context_schema=
                 "rec_per_key": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "number"
                   }
                 }
               },
@@ -197,13 +197,14 @@ let $opt_context_schema=
                 "copy_cost"
               ]
             }
-          }
+          },
           "subquery_runs": {
             "type": "array",
             "uniqueItems": true,
             "minItems": 1,
             "items": {
               "type": "number"
+            }
           }
         },
         "required": [

--- a/mysql-test/main/join_outer_reorder.result
+++ b/mysql-test/main/join_outer_reorder.result
@@ -62,14 +62,14 @@ DEPS
             "row_may_be_null": true,
             "map_bit": 1,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t2",
             "row_may_be_null": true,
             "map_bit": 2,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         }
     ]
 ]
@@ -103,14 +103,14 @@ DEPS
             "row_may_be_null": true,
             "map_bit": 1,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t3",
             "row_may_be_null": true,
             "map_bit": 2,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         }
     ]
 ]
@@ -142,7 +142,7 @@ DEPS
             "row_may_be_null": true,
             "map_bit": 1,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t3",
@@ -150,8 +150,8 @@ DEPS
             "map_bit": 2,
             "depends_on_map_bits": 
             [
-                "0",
-                "1"
+                0,
+                1
             ]
         }
     ]
@@ -193,28 +193,28 @@ DEPS
             "row_may_be_null": true,
             "map_bit": 1,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t4_2",
             "row_may_be_null": true,
             "map_bit": 2,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t3",
             "row_may_be_null": true,
             "map_bit": 3,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         },
         {
             "table": "t4_3",
             "row_may_be_null": true,
             "map_bit": 4,
             "depends_on_map_bits": 
-            ["0"]
+            [0]
         }
     ]
 ]

--- a/mysql-test/main/opt_context_load_stats_basic.result
+++ b/mysql-test/main/opt_context_load_stats_basic.result
@@ -278,7 +278,7 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].name');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "name" element not present at offset 1583.
+Warning	4269	Failed to parse saved optimizer context: "name" element not present at offset 1575.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].ddl');
 select * from t1 where a > 10;
 a	b
@@ -289,12 +289,12 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].file_stat_record
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "file_stat_records" element not present at offset 1576.
+Warning	4269	Failed to parse saved optimizer context: "file_stat_records" element not present at offset 1568.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].indexes[0].index_name');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 211.
+Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 209.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].indexes[0].rec_per_key');
 select * from t1 where a > 10;
 a	b
@@ -304,37 +304,37 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 744.
+Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 736.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].ranges');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "ranges" element not present at offset 736.
+Warning	4269	Failed to parse saved optimizer context: "ranges" element not present at offset 728.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].num_rows');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "num_rows" element not present at offset 754.
+Warning	4269	Failed to parse saved optimizer context: "num_rows" element not present at offset 746.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].cost');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "cost" element not present at offset 538.
+Warning	4269	Failed to parse saved optimizer context: "cost" element not present at offset 530.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].max_index_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 747.
+Warning	4269	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 739.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].max_row_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 749.
+Warning	4269	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 741.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].multi_range_read_info_const_calls[0].call_number');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "call_number" element not present at offset 752.
+Warning	4269	Failed to parse saved optimizer context: "call_number" element not present at offset 744.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].indexes[0]');
 select * from t1 where a > 10;
 a	b
@@ -376,51 +376,51 @@ set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_r
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 621.
+Warning	4269	Failed to parse saved optimizer context: "index_name" element not present at offset 613.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].num_records');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "num_records" element not present at offset 629.
+Warning	4269	Failed to parse saved optimizer context: "num_records" element not present at offset 621.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].eq_ref');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "eq_ref" element not present at offset 634.
+Warning	4269	Failed to parse saved optimizer context: "eq_ref" element not present at offset 626.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].index_cost_io');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "index_cost_io" element not present at offset 627.
+Warning	4269	Failed to parse saved optimizer context: "index_cost_io" element not present at offset 619.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].index_cost_cpu');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "index_cost_cpu" element not present at offset 616.
+Warning	4269	Failed to parse saved optimizer context: "index_cost_cpu" element not present at offset 608.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].row_cost_io');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "row_cost_io" element not present at offset 629.
+Warning	4269	Failed to parse saved optimizer context: "row_cost_io" element not present at offset 621.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].row_cost_cpu');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "row_cost_cpu" element not present at offset 618.
+Warning	4269	Failed to parse saved optimizer context: "row_cost_cpu" element not present at offset 610.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].max_index_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 624.
+Warning	4269	Failed to parse saved optimizer context: "max_index_blocks" element not present at offset 616.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].max_row_blocks');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 626.
+Warning	4269	Failed to parse saved optimizer context: "max_row_blocks" element not present at offset 618.
 set @opt_context=json_remove(@saved_opt_context_1, '$.tables[0].cost_for_index_read_calls[0].copy_cost');
 select * from t1 where a > 10;
 a	b
 Warnings:
-Warning	4269	Failed to parse saved optimizer context: "copy_cost" element not present at offset 631.
+Warning	4269	Failed to parse saved optimizer context: "copy_cost" element not present at offset 623.
 drop table t1;
 drop database db1;

--- a/mysql-test/main/opt_context_store_stats.result
+++ b/mysql-test/main/opt_context_store_stats.result
@@ -52,7 +52,7 @@ count(*)
 # === Tables
 # Tables in the context
 table_name	file_stat_records	index_name	rec_per_key
-db1.t2	30	t2_idx_a	["5"]
+db1.t2	30	t2_idx_a	[5]
 db1.t1	20	NULL	NULL
 # === Range accesses
 index_name	ranges	num_rows	max_index_blocks	max_row_blocks
@@ -83,7 +83,7 @@ a	b	c
 # === Tables
 # Tables in the context
 table_name	file_stat_records	index_name	rec_per_key
-db1.t2	30	t2_idx_a	["5"]
+db1.t2	30	t2_idx_a	[5]
 db1.t1	20	NULL	NULL
 # === Range accesses
 index_name	ranges	num_rows	max_index_blocks	max_row_blocks
@@ -114,7 +114,7 @@ insert into t1 (select t2.a as a, t2.a as b from t2);
 # === Tables
 # Tables in the context
 table_name	file_stat_records	index_name	rec_per_key
-db1.t2	30	t2_idx_a	["5"]
+db1.t2	30	t2_idx_a	[5]
 db1.t1	20	NULL	NULL
 # === Range accesses
 index_name	ranges	num_rows	max_index_blocks	max_row_blocks
@@ -568,7 +568,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 # === Tables
 # Tables in the context
 table_name	file_stat_records	index_name	rec_per_key
-test.t1	3	a	["1"]
+test.t1	3	a	[1]
 # === Range accesses
 index_name	ranges	num_rows	max_index_blocks	max_row_blocks
 # == End of optimizer context

--- a/mysql-test/main/opt_trace.result
+++ b/mysql-test/main/opt_trace.result
@@ -2700,7 +2700,7 @@ select t1.a from t1 left join t2 on t1.a=t2.a	{
                 "table": "t2",
                 "row_may_be_null": true,
                 "map_bit": 1,
-                "depends_on_map_bits": ["0"]
+                "depends_on_map_bits": [0]
               }
             ]
           },
@@ -2856,7 +2856,7 @@ explain select * from t1 left join t2 on t2.a=t1.a	{
                 "table": "t2",
                 "row_may_be_null": true,
                 "map_bit": 1,
-                "depends_on_map_bits": ["0"]
+                "depends_on_map_bits": [0]
               }
             ]
           },
@@ -3090,13 +3090,13 @@ explain select t1.a from t1 left join (t2 join t3 on t2.b=t3.b) on t2.a=t1.a and
                 "table": "t2",
                 "row_may_be_null": true,
                 "map_bit": 1,
-                "depends_on_map_bits": ["0"]
+                "depends_on_map_bits": [0]
               },
               {
                 "table": "t3",
                 "row_may_be_null": true,
                 "map_bit": 2,
-                "depends_on_map_bits": ["0"]
+                "depends_on_map_bits": [0]
               }
             ]
           },

--- a/mysql-test/main/subselect_mat_analyze_json.result
+++ b/mysql-test/main/subselect_mat_analyze_json.result
@@ -853,7 +853,7 @@ ANALYZE
           "r_loops": 1,
           "r_partial_matches": 1,
           "r_partial_match_buffer_size": "REPLACED",
-          "r_partial_match_array_sizes": ["4", "3"],
+          "r_partial_match_array_sizes": [4, 3],
           "query_block": {
             "select_id": 2,
             "cost": "REPLACED",
@@ -1143,7 +1143,7 @@ ANALYZE
           "r_loops": 1,
           "r_partial_matches": 1,
           "r_partial_match_buffer_size": "REPLACED",
-          "r_partial_match_array_sizes": ["4", "3"],
+          "r_partial_match_array_sizes": [4, 3],
           "query_block": {
             "select_id": 2,
             "cost": "REPLACED",
@@ -1206,7 +1206,7 @@ ANALYZE
           "r_loops": 1,
           "r_partial_matches": 1,
           "r_partial_match_buffer_size": "REPLACED",
-          "r_partial_match_array_sizes": ["4", "3"],
+          "r_partial_match_array_sizes": [4, 3],
           "query_block": {
             "select_id": 2,
             "cost": "REPLACED",

--- a/sql/my_json_writer.cc
+++ b/sql/my_json_writer.cc
@@ -259,7 +259,7 @@ void Json_writer::add_unquoted_str(const char* str, size_t len)
 {
   VALIDITY_ASSERT(fmt_helper.is_making_writer_calls() ||
                   got_name == named_item_expected());
-  if (on_add_str(str, len))
+  if (on_add_str(str, len, false))
     return;
 
   if (!element_started)
@@ -269,12 +269,13 @@ void Json_writer::add_unquoted_str(const char* str, size_t len)
   element_started= false;
 }
 
-inline bool Json_writer::on_add_str(const char *str, size_t num_bytes)
+inline bool Json_writer::on_add_str(const char *str, size_t num_bytes,
+                                    bool quoted_str)
 {
 #if !defined(NDEBUG) || defined(JSON_WRITER_UNIT_TEST)
   got_name= false;
 #endif
-  bool helped= fmt_helper.on_add_str(str, num_bytes);
+  bool helped= fmt_helper.on_add_str(str, num_bytes, quoted_str);
   return helped;
 }
 
@@ -327,7 +328,7 @@ void Json_writer::add_escaped_str(const char* str, size_t num_bytes)
 {
   VALIDITY_ASSERT(fmt_helper.is_making_writer_calls() ||
                   got_name == named_item_expected());
-  if (on_add_str(str, num_bytes))
+  if (on_add_str(str, num_bytes, true))
     return;
 
   if (!element_started)
@@ -383,6 +384,7 @@ bool Single_line_formatting_helper::on_add_member(const char *name,
   {
     // remove everything from the array
     buf_ptr= buffer;
+    n_elements= 0;
 
     //append member name to the array
     if (len < MAX_LINE_LEN)
@@ -438,7 +440,8 @@ void Single_line_formatting_helper::on_start_object()
 
 
 bool Single_line_formatting_helper::on_add_str(const char *str,
-                                               size_t len)
+                                               size_t len,
+                                               bool quoted_str)
 {
   if (state == IN_ARRAY)
   {
@@ -448,10 +451,18 @@ bool Single_line_formatting_helper::on_add_str(const char *str,
       return false;
     }
 
-    // New length will be:
-    //  "$string", 
-    //  quote + quote + comma + space = 4
-    if (line_len + len + 4 > MAX_LINE_LEN)
+    /*
+      New length will be:
+        "$string",
+        quote + quote + comma + space = 4
+
+      Each element uses at least 4 bytes of the line length budget, so the
+      line length check alone already guarantees that we never accumulate
+      MAX_ELEMENTS elements. The n_elements check is redundant, but it is
+      kept so that quoted[] cannot be overrun in a release build if the
+      accounting above is ever changed.
+    */
+    if (line_len + len + 4 > MAX_LINE_LEN || n_elements >= MAX_ELEMENTS)
     {
       disable_and_flush();
       return false; // didn't handle the last element
@@ -461,6 +472,7 @@ bool Single_line_formatting_helper::on_add_str(const char *str,
     memcpy(buf_ptr, str, len);
     buf_ptr+=len;
     *(buf_ptr++)= 0;
+    quoted[n_elements++]= quoted_str;
     line_len += (uint)len + 4;
     return true; // handled
   }
@@ -494,9 +506,13 @@ void Single_line_formatting_helper::flush_on_one_line()
     {
       if (nr != 1)
         owner->output.append(STRING_WITH_LEN(", "));
-      owner->output.append('"');
+      /* Only JSON strings are printed inside quotes */
+      bool add_quotes= quoted[nr - 1];
+      if (add_quotes)
+        owner->output.append('"');
       owner->output.append(str);
-      owner->output.append('"');
+      if (add_quotes)
+        owner->output.append('"');
     }
     nr++;
 
@@ -507,6 +523,7 @@ void Single_line_formatting_helper::flush_on_one_line()
   owner->output.append(']');
   /* We've printed out the contents of the buffer, mark it as empty */
   buf_ptr= buffer;
+  n_elements= 0;
 }
 
 
@@ -535,13 +552,22 @@ void Single_line_formatting_helper::disable_and_flush()
     {
       //if (nr == 1)
       //  owner->start_array();
-      owner->add_str(str, len);
+      /*
+        Print the element as it was originally added: strings are quoted,
+        numbers, booleans and nulls are not. Note that strings in the buffer
+        are already escaped, so there is no need to escape them again.
+      */
+      if (quoted[nr - 1])
+        owner->add_escaped_str(str, len);
+      else
+        owner->add_unquoted_str(str, len);
     }
-    
+
     nr++;
     ptr+= len+1;
   }
   buf_ptr= buffer;
+  n_elements= 0;
   state= INACTIVE;
 }
 

--- a/sql/my_json_writer.h
+++ b/sql/my_json_writer.h
@@ -55,17 +55,20 @@ using JOIN_TAB= struct st_join_table;
 
   The idea is to catch arrays that can be printed on one line:
 
-    arrayName : [ "boo", 123, 456 ] 
+    arrayName : [ "boo", 123, 456 ]
 
   and actually print them on one line. Arrays that occupy too much space on
   the line, or have nested members, cannot be printed on one line.
-  
+
   We hook into JSON printing functions and try to detect the pattern. While
   detecting the pattern, we will accumulate "boo", 123, 456 as strings.
+  For each accumulated element we also remember whether it has to be quoted
+  when it is printed: JSON strings are quoted, while numbers, booleans and
+  nulls are not.
 
-  Then, 
-   - either the pattern is broken, and we print the elements out, 
-   - or the pattern lasts till the end of the array, and we print the 
+  Then,
+   - either the pattern is broken, and we print the elements out,
+   - or the pattern lasts till the end of the array, and we print the
      array on one line.
 */
 
@@ -100,15 +103,31 @@ class Single_line_formatting_helper
   */
   enum enum_state state;
   enum { MAX_LINE_LEN= 80 };
+  /*
+    Every accumulated array element takes at least 4 bytes of the line length
+    budget (see on_add_str()), so this is the maximum number of elements we
+    can ever accumulate. on_add_str() also enforces this limit explicitly, so
+    that quoted[] stays in bounds even if the budget accounting is changed.
+  */
+  enum { MAX_ELEMENTS= MAX_LINE_LEN / 4 };
   char buffer[80];
 
   /* The data in the buffer is located between buffer[0] and buf_ptr */
   char *buf_ptr;
   uint line_len;
 
+  /*
+    For each array element accumulated in the buffer, tells whether it is a
+    JSON string (and so has to be printed inside quotes) or not.
+  */
+  bool quoted[MAX_ELEMENTS];
+  /* Number of array elements accumulated in the buffer */
+  uint n_elements;
+
   Json_writer *owner;
 public:
-  Single_line_formatting_helper() : state(INACTIVE), buf_ptr(buffer) {}
+  Single_line_formatting_helper()
+   : state(INACTIVE), buf_ptr(buffer), n_elements(0) {}
 
   void init(Json_writer *owner_arg) { owner= owner_arg; }
 
@@ -119,7 +138,7 @@ public:
   void on_start_object();
   // on_end_object() is not needed.
 
-  bool on_add_str(const char *str, size_t num_bytes);
+  bool on_add_str(const char *str, size_t num_bytes, bool quoted_str);
 
   /*
     Returns true if the helper is flushing its buffer and is probably
@@ -265,7 +284,7 @@ private:
   void add_unquoted_str(const char* val);
   void add_unquoted_str(const char* val, size_t len);
 
-  bool on_add_str(const char *str, size_t num_bytes);
+  bool on_add_str(const char *str, size_t num_bytes, bool quoted_str);
   void on_start_object();
 
 public:
@@ -669,7 +688,7 @@ public:
   {
     DBUG_ASSERT(!closed);
     if (my_writer)
-      context.add_ll(static_cast<longlong>(value));
+      my_writer->add_ull(value);
     return *this;
   }
   Json_writer_array& add(longlong value)
@@ -686,12 +705,18 @@ public:
       context.add_double(value);
     return *this;
   }
+  /*
+    On _WIN64, size_t is the same type as ulonglong, so the overload above
+    already covers it. Everywhere else size_t needs its own overload, which
+    must print unsigned, just like the ulonglong one, so that the output does
+    not depend on the platform.
+  */
   #ifndef _WIN64
   Json_writer_array& add(size_t value)
   {
     DBUG_ASSERT(!closed);
     if (my_writer)
-      context.add_ll(static_cast<longlong>(value));
+      my_writer->add_ull(static_cast<ulonglong>(value));
     return *this;
   }
   #endif

--- a/unittest/sql/my_json_writer-t.cc
+++ b/unittest/sql/my_json_writer-t.cc
@@ -94,7 +94,7 @@ int main(int args, char **argv)
 {
   MY_INIT(argv[0]);
 
-  plan(130);
+  plan(142);
   diag("Testing Json_writer checks");
 
   {
@@ -566,6 +566,156 @@ int main(int args, char **argv)
     ok(!w.invalid_json, "Named string array is valid");
   }
 
+  diag("Testing arrays of primitive types");
+
+  {
+    Json_writer w;
+    w.start_object();
+    w.add_member("arr1");
+    w.start_array();
+    w.add_ll(1);
+    w.add_ll(2);
+    w.add_ll(3);
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"arr1\": [1, 2, 3]\n"
+       "}"),
+       "Named array of integers: numbers are not quoted");
+    ok(!w.invalid_json, "Named array of integers is valid");
+  }
+
+  {
+    Json_writer w;
+    w.start_object();
+    w.add_member("mixed");
+    w.start_array();
+    w.add_str("str");
+    w.add_ll(-42);
+    w.add_ull(ULLONG_MAX);
+    w.add_double(3.14);
+    w.add_bool(true);
+    w.add_bool(false);
+    w.add_null();
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"mixed\": [\"str\", -42, 18446744073709551615, 3.14, true, false, "
+                     "null]\n"
+       "}"),
+       "Named array of mixed types: only strings are quoted");
+    ok(!w.invalid_json, "Named array of mixed types is valid");
+  }
+
+  {
+    /*
+      A memory size is printed as a string, as it can carry a unit suffix.
+    */
+    Json_writer w;
+    w.start_object();
+    w.add_member("sizes");
+    w.start_array();
+    w.add_size(512);
+    w.add_size(2048);
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"sizes\": [\"512\", \"2KiB\"]\n"
+       "}"),
+       "Named array of sizes: sizes are quoted");
+    ok(!w.invalid_json, "Named array of sizes is valid");
+  }
+
+  {
+    /*
+      The array doesn't fit on one line, so it is printed element per line.
+      The numbers must not become strings because of that.
+    */
+    Json_writer w;
+    w.start_object();
+    w.add_member("arr");
+    w.start_array();
+    for (int i= 0; i < 7; i++)
+      w.add_ll(1000000 + i);
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"arr\": [\n"
+       "    1000000,\n"
+       "    1000001,\n"
+       "    1000002,\n"
+       "    1000003,\n"
+       "    1000004,\n"
+       "    1000005,\n"
+       "    1000006\n"
+       "  ]\n"
+       "}"),
+       "Multi-line array of integers: numbers are not quoted");
+    ok(!w.invalid_json, "Multi-line array of integers is valid");
+  }
+
+  {
+    /*
+      A nested object breaks the one-line pattern. The values accumulated
+      before it must keep their types.
+    */
+    Json_writer w;
+    w.start_object();
+    w.add_member("arr");
+    w.start_array();
+    w.add_ll(1);
+    w.add_bool(false);
+    w.start_object();
+    w.add_member("k").add_ll(3);
+    w.end_object();
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"arr\": [\n"
+       "    1,\n"
+       "    false,\n"
+       "    {\n"
+       "      \"k\": 3\n"
+       "    }\n"
+       "  ]\n"
+       "}"),
+       "Values flushed before a nested object keep their types");
+    ok(!w.invalid_json, "Flushed values before nested object stay valid");
+  }
+
+  {
+    /*
+      Strings accumulated by the one-line helper are already escaped, so
+      flushing them must not escape them for the second time.
+    */
+    Json_writer w;
+    w.start_object();
+    w.add_member("arr");
+    w.start_array();
+    w.add_str("a\"b");
+    w.start_object();
+    w.add_member("k").add_ll(1);
+    w.end_object();
+    w.end_array();
+    w.end_object();
+    ok(json_output_eq(w,
+       "{\n"
+       "  \"arr\": [\n"
+       "    \"a\\\"b\",\n"
+       "    {\n"
+       "      \"k\": 1\n"
+       "    }\n"
+       "  ]\n"
+       "}"),
+       "A flushed string is not escaped twice");
+    ok(!w.invalid_json, "Flushed escaped string stays valid");
+  }
+
   {
     Json_writer w;
     w.start_object();
@@ -852,10 +1002,12 @@ int main(int args, char **argv)
     {
       Json_writer_array arr(&w);
       arr.add((ulonglong) 42);
+      arr.add(ULLONG_MAX);
     }
     ok(json_output_eq(w,
        "[\n"
-       "  42\n"
+       "  42,\n"
+       "  18446744073709551615\n"
        "]"),
        "RAII array add(ulonglong) output");
     ok(!w.invalid_json, "RAII array add(ulonglong) valid");


### PR DESCRIPTION
Single_line_formatting_helper accumulates array elements that may fit on one line, and printed all of them quoted when flushing numbers, booleans and nulls thus came out as JSON strings:

  "depends_on_map_bits": ["0"]   instead of   [0]

Solution is to:
==========
Remember per element whether it arrived via add_escaped_str() (a string, quote it) or add_unquoted_str() (a number, boolean or null, don't), in a parallel quoted[] array reset together with the buffer, and honour it in both flush paths. This also fixes disable_and_flush(), which called add_str() and so escaped the buffered strings a second time.

add_size() output stays quoted: it may carry a unit suffix ("2KiB").

While at it:
 - Json_writer_array::add(ulonglong) cast to longlong, printing values above LLONG_MAX as negative. Use add_ull(). add(size_t) had the same bug and is compiled out on _WIN64, so fixing only one would have made the output platform-dependent.
 - on_add_str() now enforces MAX_ELEMENTS instead of only asserting it, so quoted[] cannot be overrun in a release build if the line length accounting ever changes.

opt_context_schema.inc: rec_per_key holds numbers now, not strings. Also fix two syntax errors that left the schema invalid JSON, so it is usable once MDEV-38033 enables the JSON_SCHEMA_VALID() check in run_query_twice_and_compare_stats.inc.