### PR TITLE
MDEV-40910: fix mention of old mysql_install_db

### DIFF
--- a/man/mariadb-admin.1
+++ b/man/mariadb-admin.1
@@ -15,7 +15,7 @@
 .\" administration: server
 .\" server administration
 .SH "NAME"
-mariadb-admin \- client for administering a MariaDB server (mariadb-admin is now a symlink to mariadb-admin)
+mariadb-admin \- client for administering a MariaDB server (mysqladmin is now a symlink to mariadb-admin)
 .SH "SYNOPSIS"
 .HP \w'\fBmariadb-admin\ [\fR\fB\fIoptions\fR\fR\fB]\ \fR\fB\fIcommand\fR\fR\fB\ [\fR\fB\fIcommand\-arg\fR\fR\fB]\ [\fR\fB\fIcommand\fR\fR\fB\ [\fR\fB\fIcommand\-arg\fR\fR\fB]]\ \&.\&.\&.\fR\ 'u
 \fBmariadb-admin [\fR\fB\fIoptions\fR\fR\fB] \fR\fB\fIcommand\fR\fR\fB [\fR\fB\fIcommand\-arg\fR\fR\fB] [\fR\fB\fIcommand\fR\fR\fB [\fR\fB\fIcommand\-arg\fR\fR\fB]] \&.\&.\&.\fR

--- a/man/mariadb-install-db.1
+++ b/man/mariadb-install-db.1
@@ -13,7 +13,8 @@
 .\" -----------------------------------------------------------------
 .\" mariadb-install-db
 .SH "NAME"
-mariadb-install-db \- initialize MariaDB data directory (mariadb-install-db is now a symlink to mariadb-install-db)
+mariadb-install-db \- initialize MariaDB data directory
+(mysql_install_db is now a symlink to mariadb-install-db)
 .SH "SYNOPSIS"
 .HP \w'\fBmariadb-install-db\ [\fR\fB\fIoptions\fR\fR\fB]\fR\ 'u
 \fBmariadb-install-db [\fR\fB\fIoptions\fR\fR\fB]\fR


### PR DESCRIPTION
This is apparently a blind replacement of mentions of mysql_install_db with mariadb-install-db, even at a place where the former is meant.