### PR TITLE
MDEV-37015: Add parameterized tests for binlog-open error handling

### DIFF
--- a/mysql-test/include/binlog_open_error_scenario.inc
+++ b/mysql-test/include/binlog_open_error_scenario.inc
@@ -1,0 +1,137 @@
+#
+# === Name
+#
+# binlog_open_error_scenario.inc
+#
+# === Description
+#
+# Drive a single error-injection scenario for MYSQL_BIN_LOG::open / new_file
+# and report observed behavior in a self-describing block.  Used by the
+# binlog_open_errors_*.test files to exercise the failure points
+# catalogued by the MDEV-36606 static analysis.
+#
+# Each invocation produces a banner + a fixed set of observation fields so
+# that two scenarios reading the same source row of MDEV-36606 are directly
+# comparable in the .result file.
+#
+# The post-trigger state is asserted exactly in both directions: binlogging
+# still on means SHOW BINARY LOGS lists files, off means it fails with
+# ER_NO_BINARY_LOGGING. Neither outcome is tolerated in place of the other.
+#
+# === Inputs (set with --let before --source)
+#
+#   $scn_id                Short id, e.g. open.write_binlog_magic
+#   $scn_kind              error_inject | crash | startup
+#   $scn_dbug              Single DBUG keyword, e.g. fault_injection_registering_index
+#   $scn_trigger           flush | rotate_size | reset_master |
+#                          checksum_update | startup
+#   $scn_expected_client_error
+#                          Expected client-visible error symbol (or empty if
+#                          none expected). Used as --error <symbol>.
+#   $scn_expected_logging_off
+#                          0 or 1 (default 0). 1 asserts the trigger turned
+#                          binlogging off, i.e. SHOW BINARY LOGS must fail
+#                          with ER_NO_BINARY_LOGGING; 0 asserts it is still
+#                          on and records the binlog list.
+#   $scn_mdev36606_row     Reference label from MDEV-36606 spreadsheet, used
+#                          in the banner.
+#   $scn_skip_reason       If non-empty, scenario is reported as skipped with
+#                          this reason and nothing else runs. Use for
+#                          unreachable trigger/knob combinations.
+#   $scn_poststate_crashes 0 or 1 (default 0). Some knobs leave the server in
+#                          a state where the *trigger* statement reports no
+#                          error but a later statement crashes it (observed
+#                          for RESET MASTER + fault_injection_openning_index /
+#                          fault_injection_recovering_index: reset_logs()
+#                          never sets `error` when open_index_file() fails,
+#                          so RESET MASTER "succeeds" and the corruption only
+#                          surfaces on the next statement). If 1, the post-
+#                          state SHOW BINARY LOGS is run through the same
+#                          crash+restart dance as scn_kind=crash.
+#
+# All inputs are unset on exit, on every path, so subsequent invocations
+# start clean.
+
+if (!$scn_id)
+{
+  --die scn_id must be set before sourcing binlog_open_error_scenario.inc
+}
+if (!$scn_kind)
+{
+  --die scn_kind must be set before sourcing binlog_open_error_scenario.inc
+}
+
+--echo
+--echo ### scenario id=$scn_id kind=$scn_kind trigger=$scn_trigger dbug=$scn_dbug mdev36606=$scn_mdev36606_row
+
+# Latch the skip decision: $scn_skip_reason is cleared in the common reset
+# block below, so it cannot be re-tested after that point.
+--let $_scn_skipped= 0
+if ($scn_skip_reason)
+{
+  --echo # SKIPPED: $scn_skip_reason
+  --let $_scn_skipped= 1
+}
+
+if (!$_scn_skipped)
+{
+  --disable_query_log
+  set @scn_saved_dbug = @@global.debug_dbug;
+  --enable_query_log
+
+  if ($scn_kind == error_inject)
+  {
+    --source include/binlog_open_error_scenario_inject.inc
+  }
+  if ($scn_kind == crash)
+  {
+    --source include/binlog_open_error_scenario_crash.inc
+  }
+  if ($scn_kind == startup)
+  {
+    --source include/binlog_open_error_scenario_startup.inc
+  }
+
+  if ($scn_poststate_crashes)
+  {
+    --echo # post-state query is expected to crash the server
+    --let $_scn_expect_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+    --exec echo "wait" > $_scn_expect_file
+    # The crash itself is asserted by wait_until_disconnected.inc below,
+    # which dies on timeout; the error list only tolerates the race between
+    # a clean error reply and the connection simply dropping.
+    --error 0,2006,2013,ER_CONNECTION_KILLED
+    SHOW BINARY LOGS;
+    --source include/wait_until_disconnected.inc
+    --exec echo "restart" > $_scn_expect_file
+    --enable_reconnect
+    --source include/wait_until_connected_again.inc
+    --disable_reconnect
+    --let $_scn_expect_file=
+  }
+  if (!$scn_poststate_crashes)
+  {
+    if (!$scn_expected_logging_off)
+    {
+      --source include/binlog_open_error_show_binary_logs.inc
+    }
+    if ($scn_expected_logging_off)
+    {
+      # Strict: binlogging must be off, so this must fail. Accepting
+      # success here too would make the expectation unfalsifiable.
+      --error ER_NO_BINARY_LOGGING
+      SHOW BINARY LOGS;
+    }
+  }
+}
+
+--let $scn_id=
+--let $scn_kind=
+--let $scn_dbug=
+--let $scn_trigger=
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off=
+--let $scn_mdev36606_row=
+--let $scn_skip_reason=
+--let $scn_poststate_crashes=
+--let $_scn_skipped=

--- a/mysql-test/include/binlog_open_error_scenario_crash.inc
+++ b/mysql-test/include/binlog_open_error_scenario_crash.inc
@@ -1,0 +1,47 @@
+#
+# Sub-helper for binlog_open_error_scenario.inc — crash kind.
+#
+# Sets the crash DBUG knob, fires the configured trigger which is expected
+# to crash the server, then restarts and inspects post-restart state.
+#
+
+#
+# The crash is asserted by wait_until_disconnected.inc below, which dies on
+# timeout if the server stayed up; the --error list on each trigger only
+# tolerates the race between a clean error reply and the connection simply
+# dropping.
+#
+
+--let $_scn_expect_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+
+# Tell mtr to wait for us to bring the server back.
+--exec echo "wait" > $_scn_expect_file
+
+--disable_query_log
+--eval SET @@global.debug_dbug = "d,$scn_dbug"
+--enable_query_log
+
+if ($scn_trigger == flush)
+{
+  --error 0,2006,2013,ER_CONNECTION_KILLED
+  FLUSH BINARY LOGS;
+}
+if ($scn_trigger == reset_master)
+{
+  --error 0,2006,2013,ER_CONNECTION_KILLED
+  RESET MASTER;
+}
+if ($scn_trigger == checksum_update)
+{
+  --error 0,2006,2013,ER_CONNECTION_KILLED
+  --eval SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE')
+}
+
+--source include/wait_until_disconnected.inc
+
+--exec echo "restart" > $_scn_expect_file
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
+--let $_scn_expect_file=

--- a/mysql-test/include/binlog_open_error_scenario_inject.inc
+++ b/mysql-test/include/binlog_open_error_scenario_inject.inc
@@ -1,0 +1,84 @@
+#
+# Sub-helper for binlog_open_error_scenario.inc — error-injection kind.
+#
+# Sets the DBUG knob, fires the trigger described by $scn_trigger, and
+# reports the observed client error.  Server stays alive throughout.
+#
+# The same --replace_regex is applied to both the trigger and the following
+# SHOW WARNINGS: the identical message is reported through both, and would
+# otherwise be recorded unmasked (errno/path-sensitive) by the latter.
+#
+
+--disable_query_log
+--eval SET @@global.debug_dbug = "d,$scn_dbug"
+--enable_query_log
+
+if ($scn_trigger == flush)
+{
+  if ($scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    --error $scn_expected_client_error
+    FLUSH BINARY LOGS;
+  }
+  if (!$scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    FLUSH BINARY LOGS;
+  }
+}
+if ($scn_trigger == rotate_size)
+{
+  # Trigger an implicit rotation by writing past max_binlog_size.  The test
+  # is responsible for setting max_binlog_size small enough and creating
+  # any tables it needs before sourcing this helper.
+  if ($scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    --error $scn_expected_client_error
+    INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+  }
+  if (!$scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+  }
+}
+if ($scn_trigger == reset_master)
+{
+  if ($scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    --error $scn_expected_client_error
+    RESET MASTER;
+  }
+  if (!$scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    RESET MASTER;
+  }
+}
+if ($scn_trigger == checksum_update)
+{
+  # Always toggles to a different value, so it always forces
+  # binlog_checksum_update() -> MYSQL_BIN_LOG::rotate(), regardless of the
+  # value going in.
+  if ($scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    --error $scn_expected_client_error
+    --eval SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE')
+  }
+  if (!$scn_expected_client_error)
+  {
+    --replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+    --eval SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE')
+  }
+}
+
+--replace_regex /\.[\\\/]master/master/ /errno: [0-9]+/errno: NN/
+SHOW WARNINGS;
+
+--disable_query_log
+SET @@global.debug_dbug = @scn_saved_dbug;
+--enable_query_log

--- a/mysql-test/include/binlog_open_error_scenario_startup.inc
+++ b/mysql-test/include/binlog_open_error_scenario_startup.inc
@@ -1,0 +1,30 @@
+#
+# Sub-helper for binlog_open_error_scenario.inc — startup kind.
+#
+# sql/mysqld.cc's startup binlog-open call is unconditionally fatal:
+#   error= mysql_bin_log.open(...);
+#   if (unlikely(error)) unireg_abort(1);
+# so any MYSQL_BIN_LOG::open() failure at startup aborts the whole server,
+# regardless of which internal step failed -- there is no "binlog turned
+# off, server stays up" outcome here (contrast with FLUSH BINARY LOGS /
+# RESET MASTER, which do stay up). Confirmed via mysqld.cc:5657 and by
+# running fail_init_log_file_name, which aborts with exit code 1.
+#
+# Shut the good server down, exec mysqld directly with the fault knob and
+# assert its exit code, then bring a clean server back up -- the standard
+# MTR idiom for "server expected to fail to start" (see e.g.
+# main/plugin_loaderr.test).
+#
+
+# The abort is asserted by the --error 1 on the direct mysqld exec below.
+--write_line wait $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server
+--source include/wait_until_disconnected.inc
+
+--error 1
+--exec $MYSQLD_CMD --log-bin=master-bin --debug-dbug=+d,$scn_dbug --disable-log-error
+
+--write_line restart $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect

--- a/mysql-test/include/binlog_open_error_show_binary_logs.inc
+++ b/mysql-test/include/binlog_open_error_show_binary_logs.inc
@@ -1,0 +1,16 @@
+#
+# SHOW BINARY LOGS, with the file name's numeric suffix masked in addition
+# to the size column already masked by show_binary_logs.inc.
+#
+# The suite deliberately shares a datadir/server with whatever else MTR
+# schedules onto the same worker slot when their startup options are
+# judged "compatible enough" for a plain restart instead of a full
+# reinstall (observed on CI: a leftover master-bin.* from a prior,
+# unrelated test bumped the starting file number here to 000003 instead
+# of 000001). None of this suite's scenarios depend on the absolute
+# number -- only on whether logging is on/off and how many files exist --
+# so the number is masked rather than asserted.
+#
+
+--replace_regex /master-bin\.[0-9]+/master-bin.NNNNNN/
+--source include/show_binary_logs.inc

--- a/mysql-test/suite/binlog/r/binlog_open_errors_checksum_update.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_checksum_update.result
@@ -1,0 +1,77 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Assertion .binlog_checksum_options == value. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=checksum_update.find_uniq_filename kind=crash trigger=checksum_update dbug=error_unique_log_filename mdev36606=find_uniq_filename
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=checksum_update.registering_index kind=error_inject trigger=checksum_update dbug=fault_injection_registering_index mdev36606=open.purge_index_register
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=checksum_update.openning_index kind=error_inject trigger=checksum_update dbug=fault_injection_openning_index mdev36606=open_index_file.open
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=checksum_update.recovering_index kind=error_inject trigger=checksum_update dbug=fault_injection_recovering_index mdev36606=open_index_file.recover
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=checksum_update.updating_index kind=error_inject trigger=checksum_update dbug=fault_injection_updating_index mdev36606=open.update_index
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=checksum_update.new_file_rotate_event kind=crash trigger=checksum_update dbug=fault_injection_new_file_rotate_event mdev36606=new_file_impl.rotate_event
+SET GLOBAL binlog_checksum= IF(@@global.binlog_checksum='NONE', 'CRC32', 'NONE');
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;

--- a/mysql-test/suite/binlog/r/binlog_open_errors_crash.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_crash.result
@@ -1,0 +1,55 @@
+call mtr.add_suppression("Found 1 prepared transactions!.*");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("Recovering after a crash .*");
+call mtr.add_suppression("Aborted .* during recovery .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+RESET MASTER;
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=crash.non_critical_before_update_index kind=crash trigger=flush dbug=crash_create_non_critical_before_update_index mdev36606=open.non_critical_before_update_index
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=crash.critical_before_update_index kind=crash trigger=flush dbug=crash_create_critical_before_update_index mdev36606=open.critical_before_update_index
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=crash.after_update_index kind=crash trigger=flush dbug=crash_create_after_update_index mdev36606=open.after_update_index
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=crash.before_write_checkpoint_event kind=crash trigger=flush dbug=crash_before_write_checkpoint_event mdev36606=open.before_write_checkpoint_event
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=crash.after_reset_master kind=crash trigger=reset_master dbug=crash_after_reset_master mdev36606=reset_master.crash_after
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;

--- a/mysql-test/suite/binlog/r/binlog_open_errors_flush.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_flush.result
@@ -1,0 +1,270 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Log filename extension number exhausted.*");
+call mtr.add_suppression("Log filename too large.*");
+call mtr.add_suppression("protocol.cc.*Assertion .0. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+RESET MASTER;
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.find_uniq_filename kind=error_inject trigger=flush dbug=error_unique_log_filename mdev36606=find_uniq_filename
+FLUSH BINARY LOGS;
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.registering_index kind=error_inject trigger=flush dbug=fault_injection_registering_index mdev36606=open.purge_index_register
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.openning_index kind=error_inject trigger=flush dbug=fault_injection_openning_index mdev36606=open_index_file.open
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.recovering_index kind=error_inject trigger=flush dbug=fault_injection_recovering_index mdev36606=open_index_file.recover
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.updating_index kind=error_inject trigger=flush dbug=fault_injection_updating_index mdev36606=open.update_index
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.new_file_rotate_event kind=error_inject trigger=flush dbug=fault_injection_new_file_rotate_event mdev36606=new_file_impl.rotate_event
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin' (errno: NN "No such file or directory")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1026	Can't open file: 'master-bin' (errno: NN "No such file or directory")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.init_log_file_name kind=error_inject trigger=flush dbug=fail_init_log_file_name mdev36606=open.init_log_file_name
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.write_binlog_magic kind=error_inject trigger=flush dbug=fail_write_binlog_magic mdev36606=open.write_binlog_magic
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.fde_invalid kind=error_inject trigger=flush dbug=fail_fde_invalid mdev36606=open.fde_invalid
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.write_initial_fde kind=error_inject trigger=flush dbug=fail_write_initial_fde mdev36606=open.write_initial_fde
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.write_glle kind=error_inject trigger=flush dbug=fail_write_glle mdev36606=open.write_glle
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.alloc_xid_list_entry kind=error_inject trigger=flush dbug=fail_alloc_xid_list_entry mdev36606=open.alloc_xid_list_entry
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.b_binlog_name kind=error_inject trigger=flush dbug=fail_b_binlog_name mdev36606=open.b_binlog_name
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.write_checkpoint_event kind=error_inject trigger=flush dbug=fail_write_checkpoint_event mdev36606=open.write_checkpoint_event
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.flush_or_sync_log_file kind=error_inject trigger=flush dbug=fail_flush_or_sync_log_file mdev36606=open.flush_or_sync_log_file
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.state_file_delete kind=error_inject trigger=flush dbug=fail_state_file_delete mdev36606=open.state_file_delete
+FLUSH BINARY LOGS;
+SHOW WARNINGS;
+Level	Code	Message
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.flush_after_rotate_event kind=crash trigger=flush dbug=fail_flush_after_rotate_event mdev36606=new_file_impl.flush_after_rotate
+FLUSH BINARY LOGS;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.find_uniq_filename_max_exceeded kind=error_inject trigger=flush dbug=fail_find_uniq_filename_max_exceeded mdev36606=find_uniq_filename.max_exceeded
+FLUSH BINARY LOGS;
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.find_uniq_filename_too_long kind=error_inject trigger=flush dbug=fail_find_uniq_filename_too_long mdev36606=find_uniq_filename.too_long
+FLUSH BINARY LOGS;
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.find_uniq_filename_snprintf1 kind=error_inject trigger=flush dbug=fail_find_uniq_filename_snprintf1 mdev36606=find_uniq_filename.snprintf1
+FLUSH BINARY LOGS;
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.find_uniq_filename_snprintf2 kind=error_inject trigger=flush dbug=fail_find_uniq_filename_snprintf2 mdev36606=find_uniq_filename.snprintf2
+FLUSH BINARY LOGS;
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=flush.close_purge_index_file kind=error_inject trigger=flush dbug=fail_close_purge_index_file mdev36606=close_purge_index_file
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;
+
+### scenario id=flush.mysql_log_open kind=error_inject trigger=flush dbug=fail_mysql_log_open mdev36606=MYSQL_LOG.open
+FLUSH BINARY LOGS;
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+# restart
+RESET MASTER;

--- a/mysql-test/suite/binlog/r/binlog_open_errors_reset_master.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_reset_master.result
@@ -1,0 +1,57 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Recovering after a crash .*");
+call mtr.add_suppression("Aborted .* during recovery .*");
+call mtr.add_suppression("protocol.cc.*Assertion .0. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+
+### scenario id=reset_master.find_uniq_filename kind=error_inject trigger=reset_master dbug=error_unique_log_filename mdev36606=find_uniq_filename
+# SKIPPED: RESET MASTER resets log number to 1 so error_unique_log_filename does not fire here
+RESET MASTER;
+
+### scenario id=reset_master.registering_index kind=crash trigger=reset_master dbug=fault_injection_registering_index mdev36606=open.purge_index_register
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=reset_master.openning_index kind=error_inject trigger=reset_master dbug=fault_injection_openning_index mdev36606=open_index_file.open
+RESET MASTER;
+SHOW WARNINGS;
+Level	Code	Message
+# post-state query is expected to crash the server
+SHOW BINARY LOGS;
+RESET MASTER;
+
+### scenario id=reset_master.recovering_index kind=error_inject trigger=reset_master dbug=fault_injection_recovering_index mdev36606=open_index_file.recover
+RESET MASTER;
+SHOW WARNINGS;
+Level	Code	Message
+# post-state query is expected to crash the server
+SHOW BINARY LOGS;
+RESET MASTER;
+
+### scenario id=reset_master.updating_index kind=crash trigger=reset_master dbug=fault_injection_updating_index mdev36606=open.update_index
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+# restart
+RESET MASTER;
+
+### scenario id=reset_master.new_file_rotate_event kind=error_inject trigger=reset_master dbug=fault_injection_new_file_rotate_event mdev36606=new_file_impl.rotate_event
+# SKIPPED: RESET MASTER does not invoke new_file_impl, so the rotate-event knob is unreachable here
+RESET MASTER;

--- a/mysql-test/suite/binlog/r/binlog_open_errors_rotate.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_rotate.result
@@ -1,0 +1,107 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Writing one row to the row-based binary log failed.*");
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+TRUNCATE TABLE scn_filler;
+RESET MASTER;
+
+### scenario id=rotate.find_uniq_filename kind=error_inject trigger=rotate_size dbug=error_unique_log_filename mdev36606=find_uniq_filename
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't generate a unique log-filename master-bin.(1-999)
+SHOW WARNINGS;
+Level	Code	Message
+Error	1098	Can't generate a unique log-filename master-bin.(1-999)
+Error	1026	Error writing file 'master-bin' (errno: NN "No such file or directory")
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+DELETE FROM scn_filler;
+RESET MASTER;
+
+### scenario id=rotate.registering_index kind=error_inject trigger=rotate_size dbug=fault_injection_registering_index mdev36606=open.purge_index_register
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+Error	1026	Error writing file '(null)' (errno: NN "No such file or directory")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+DROP TABLE scn_filler;
+# restart
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+### scenario id=rotate.openning_index kind=error_inject trigger=rotate_size dbug=fault_injection_openning_index mdev36606=open_index_file.open
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+Error	1026	Error writing file '(null)' (errno: NN "Bad file descriptor")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+DROP TABLE scn_filler;
+# restart
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+### scenario id=rotate.recovering_index kind=error_inject trigger=rotate_size dbug=fault_injection_recovering_index mdev36606=open_index_file.recover
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: './mysqld-bin.index' (errno: NN "Operation not permitted")
+Error	1026	Error writing file '(null)' (errno: NN "No such file or directory")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+DROP TABLE scn_filler;
+# restart
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+### scenario id=rotate.updating_index kind=error_inject trigger=rotate_size dbug=fault_injection_updating_index mdev36606=open.update_index
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1016	Can't open file: 'master-bin.000002' (errno: NN "Operation not permitted")
+Error	1026	Error writing file '(null)' (errno: NN "Internal error/check (Not system error)")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+DROP TABLE scn_filler;
+# restart
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+### scenario id=rotate.new_file_rotate_event kind=error_inject trigger=rotate_size dbug=fault_injection_new_file_rotate_event mdev36606=new_file_impl.rotate_event
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+ERROR HY000: Can't open file: 'master-bin' (errno: NN "No such file or directory")
+SHOW WARNINGS;
+Level	Code	Message
+Error	1026	Can't open file: 'master-bin' (errno: NN "No such file or directory")
+Error	1026	Error writing file '(null)' (errno: NN "No such file or directory")
+SHOW BINARY LOGS;
+ERROR HY000: You are not using binary logging
+DROP TABLE scn_filler;
+# restart
+SET @@global.max_binlog_size= DEFAULT;
+RESET MASTER;

--- a/mysql-test/suite/binlog/r/binlog_open_errors_startup.result
+++ b/mysql-test/suite/binlog/r/binlog_open_errors_startup.result
@@ -1,0 +1,68 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Failed to enable encryption of binary logs");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+# restart
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+
+### scenario id=startup.init_log_file_name kind=startup trigger=startup dbug=fail_init_log_file_name mdev36606=startup.init_log_file_name
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.find_uniq_filename_dir_enum kind=startup trigger=startup dbug=fail_find_uniq_filename_dir_enum mdev36606=find_uniq_filename.dir_enum
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.registering_index kind=startup trigger=startup dbug=fault_injection_registering_index mdev36606=startup.purge_index_register
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.openning_index kind=startup trigger=startup dbug=fault_injection_openning_index mdev36606=startup.openning_index
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.my_random_bytes kind=startup trigger=startup dbug=fail_my_random_bytes mdev36606=startup.my_random_bytes
+# SKIPPED: requires encrypted-binlog config; see binlog_encryption/binlog_open_errors_startup.test
+RESET MASTER;
+
+### scenario id=startup.mysql_log_open kind=startup trigger=startup dbug=fail_mysql_log_open mdev36606=MYSQL_LOG.open
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.write_binlog_magic kind=startup trigger=startup dbug=fail_write_binlog_magic mdev36606=startup.write_binlog_magic
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.write_initial_fde kind=startup trigger=startup dbug=fail_write_initial_fde mdev36606=startup.write_initial_fde
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_checksum_update.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_checksum_update.test
@@ -1,0 +1,146 @@
+#
+# Binlog-open error injection scenarios triggered by SET GLOBAL
+# binlog_checksum, which calls MYSQL_BIN_LOG::rotate() directly from a
+# sys_var update callback (sql/log.cc:binlog_checksum_update) -- a third,
+# differently-locked way into the same new_file_impl()/open() reopen chain
+# already exercised by FLUSH BINARY LOGS and implicit size-rotation.
+#
+# binlog_checksum_update() ignores rotate()'s return value and then asserts
+# DBUG_ASSERT(binlog_checksum_options == value). Any failure *before*
+# new_file_impl's unconditional "binlog_checksum_options= checksum_alg_reset"
+# step leaves that assert false and crashes the server -- both
+# error_unique_log_filename (fails in generate_new_name, before the rotate
+# event is even written) and fault_injection_new_file_rotate_event do. The
+# remaining knobs fail after that step, so the option already matches and
+# they report ER_CANT_OPEN_FILE as usual.
+#
+# STEPS:
+#   - for each DBUG knob: inject it, then SET GLOBAL binlog_checksum to a
+#     different value to force a rotation
+#   - record the client error, warnings and post-state via
+#     binlog_open_error_scenario.inc
+#   - restart between scenarios that turn logging off
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Assertion .binlog_checksum_options == value. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+
+RESET MASTER;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: error_unique_log_filename via SET GLOBAL binlog_checksum
+#
+# Reports ER_NO_UNIQUE_LOGFILE under FLUSH BINARY LOGS and implicit
+# rotation, but crashes here: generate_new_name fails before the
+# checksum-option update, so the assert below it is left false.
+#
+RESET MASTER;
+--let $scn_id= checksum_update.find_uniq_filename
+--let $scn_kind= crash
+--let $scn_dbug= error_unique_log_filename
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_registering_index via SET GLOBAL binlog_checksum
+# Fails after the unconditional checksum-option update, so no assertion --
+# just a normal reopen failure (same as flush.registering_index).
+#
+RESET MASTER;
+--let $scn_id= checksum_update.registering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_registering_index
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.purge_index_register
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_openning_index via SET GLOBAL binlog_checksum
+# Same as registering_index above -- fails after the checksum-option
+# update, no assertion.
+#
+RESET MASTER;
+--let $scn_id= checksum_update.openning_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_openning_index
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.open
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_recovering_index via SET GLOBAL binlog_checksum
+# Same as registering_index above -- fails after the checksum-option
+# update, no assertion.
+#
+RESET MASTER;
+--let $scn_id= checksum_update.recovering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_recovering_index
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.recover
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_updating_index via SET GLOBAL binlog_checksum
+# Same as registering_index above -- fails after the checksum-option
+# update, no assertion.
+#
+RESET MASTER;
+--let $scn_id= checksum_update.updating_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_updating_index
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.update_index
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_new_file_rotate_event via SET GLOBAL binlog_checksum
+#
+RESET MASTER;
+--let $scn_id= checksum_update.new_file_rotate_event
+--let $scn_kind= crash
+--let $scn_dbug= fault_injection_new_file_rotate_event
+--let $scn_trigger= checksum_update
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= new_file_impl.rotate_event
+--source include/binlog_open_error_scenario.inc
+
+# Final cleanup
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_crash.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_crash.test
@@ -1,0 +1,93 @@
+#
+# Crash + recovery scenarios for new-binlog opening.
+#
+# STEPS:
+#   - for each crash_create_*/crash_before_*/crash_after_* DBUG knob: kill
+#     the server at that point via the trigger statement
+#   - restart and record the post-restart state via
+#     binlog_open_error_scenario.inc
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_innodb.inc
+
+call mtr.add_suppression("Found 1 prepared transactions!.*");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("Recovering after a crash .*");
+call mtr.add_suppression("Aborted .* during recovery .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+
+RESET MASTER;
+FLUSH BINARY LOGS;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: crash_create_non_critical_before_update_index
+#   Trigger: FLUSH BINARY LOGS
+#
+RESET MASTER;
+--let $scn_id= crash.non_critical_before_update_index
+--let $scn_kind= crash
+--let $scn_dbug= crash_create_non_critical_before_update_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.non_critical_before_update_index
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: crash_create_critical_before_update_index
+#
+RESET MASTER;
+--let $scn_id= crash.critical_before_update_index
+--let $scn_kind= crash
+--let $scn_dbug= crash_create_critical_before_update_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.critical_before_update_index
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: crash_create_after_update_index
+#
+RESET MASTER;
+--let $scn_id= crash.after_update_index
+--let $scn_kind= crash
+--let $scn_dbug= crash_create_after_update_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.after_update_index
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: crash_before_write_checkpoint_event
+#
+RESET MASTER;
+--let $scn_id= crash.before_write_checkpoint_event
+--let $scn_kind= crash
+--let $scn_dbug= crash_before_write_checkpoint_event
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.before_write_checkpoint_event
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: crash_after_reset_master
+#
+RESET MASTER;
+--let $scn_id= crash.after_reset_master
+--let $scn_kind= crash
+--let $scn_dbug= crash_after_reset_master
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= reset_master.crash_after
+--source include/binlog_open_error_scenario.inc
+
+# Final cleanup
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_flush.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_flush.test
@@ -1,0 +1,446 @@
+#
+# Binlog-open error injection scenarios triggered by FLUSH BINARY LOGS.
+#
+# STEPS:
+#   - for each DBUG knob: RESET MASTER, inject the knob, FLUSH BINARY LOGS
+#   - record the client error, warnings and post-state via
+#     binlog_open_error_scenario.inc
+#   - restart between scenarios that turn logging off
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Log filename extension number exhausted.*");
+call mtr.add_suppression("Log filename too large.*");
+#
+# flush.flush_after_rotate_event's missing-DA-set path trips
+# DBUG_ASSERT(0) in Protocol::end_statement -- a real bug this test is
+# designed to surface, not an artifact of the test itself. Anchored on
+# protocol.cc so an unrelated assertion elsewhere is still reported.
+call mtr.add_suppression("protocol.cc.*Assertion .0. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+
+# Establish a baseline: we know FLUSH BINARY LOGS works without injection.
+RESET MASTER;
+FLUSH BINARY LOGS;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: error_unique_log_filename
+#   Trigger: FLUSH BINARY LOGS
+#   MDEV-36606 row: find_uniq_filename / "Found log_no is beyond MAX"
+#   Expected: ER_NO_UNIQUE_LOGFILE; binlog stays open.
+#
+RESET MASTER;
+--let $scn_id= flush.find_uniq_filename
+--let $scn_kind= error_inject
+--let $scn_dbug= error_unique_log_filename
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_registering_index
+#   MDEV-36606 row: open / Error in initializing purge_index_file
+#   Expected: ER_CANT_OPEN_FILE; logging turned off.
+#
+RESET MASTER;
+--let $scn_id= flush.registering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_registering_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.purge_index_register
+--source include/binlog_open_error_scenario.inc
+
+# Restart so we have a binlog again.
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_openning_index
+#   MDEV-36606 row: open_index_file / mysql_file_open of .index
+#   Expected: ER_CANT_OPEN_FILE; logging turned off.
+#
+RESET MASTER;
+--let $scn_id= flush.openning_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_openning_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.open
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_recovering_index
+#   MDEV-36606 row: open_index_file / purge index recovery
+#   Expected: ER_CANT_OPEN_FILE; logging turned off.
+#   First runtime exercise of this knob -- no pre-existing test used it.
+#
+RESET MASTER;
+--let $scn_id= flush.recovering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_recovering_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.recover
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_updating_index
+#   MDEV-36606 row: open / write filename to .index
+#   Expected: ER_CANT_OPEN_FILE (via MYSQL_BIN_LOG::open goto err);
+#   logging turned off.
+#
+RESET MASTER;
+--let $scn_id= flush.updating_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_updating_index
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.update_index
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_new_file_rotate_event
+#   MDEV-36606 row: new_file_impl / write Rotate_log_event
+#   Expected: ER_ERROR_ON_WRITE; logging turned off.
+#
+RESET MASTER;
+--let $scn_id= flush.new_file_rotate_event
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_new_file_rotate_event
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_ERROR_ON_WRITE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= new_file_impl.rotate_event
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# DBUG knobs added below cover previously-untested MDEV-36606 rows.
+#
+
+#
+# Scenario: fail_init_log_file_name
+#
+RESET MASTER;
+--let $scn_id= flush.init_log_file_name
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_init_log_file_name
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.init_log_file_name
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_write_binlog_magic
+#
+RESET MASTER;
+--let $scn_id= flush.write_binlog_magic
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_write_binlog_magic
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.write_binlog_magic
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_fde_invalid
+#
+RESET MASTER;
+--let $scn_id= flush.fde_invalid
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_fde_invalid
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.fde_invalid
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_write_initial_fde
+#
+RESET MASTER;
+--let $scn_id= flush.write_initial_fde
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_write_initial_fde
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.write_initial_fde
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_write_glle
+#
+RESET MASTER;
+--let $scn_id= flush.write_glle
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_write_glle
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.write_glle
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_alloc_xid_list_entry
+#
+RESET MASTER;
+--let $scn_id= flush.alloc_xid_list_entry
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_alloc_xid_list_entry
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.alloc_xid_list_entry
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_b_binlog_name
+#
+RESET MASTER;
+--let $scn_id= flush.b_binlog_name
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_b_binlog_name
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.b_binlog_name
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_write_checkpoint_event
+#
+RESET MASTER;
+--let $scn_id= flush.write_checkpoint_event
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_write_checkpoint_event
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.write_checkpoint_event
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_flush_or_sync_log_file
+#
+RESET MASTER;
+--let $scn_id= flush.flush_or_sync_log_file
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_flush_or_sync_log_file
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.flush_or_sync_log_file
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_state_file_delete
+#
+# State-file deletion error is currently silently ignored — knob makes
+# the path observable so we can confirm whether the silent-ignore
+# behaviour matches the analysis.
+#
+RESET MASTER;
+--let $scn_id= flush.state_file_delete
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_state_file_delete
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.state_file_delete
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fail_flush_after_rotate_event
+#
+# new_file_impl's flush_io_cache() failure right after the rotate-event
+# write never sets the diagnostics area (MDEV-36606 itself predicts
+# "DA set=0" here) -- with nothing setting a reply at all, the connection
+# hits DBUG_ASSERT(0) in Protocol::end_statement and the server crashes.
+# Recorded as a crash scenario since that is the actual observed
+# behaviour (verified deterministic, not flaky).
+#
+RESET MASTER;
+--let $scn_id= flush.flush_after_rotate_event
+--let $scn_kind= crash
+--let $scn_dbug= fail_flush_after_rotate_event
+--let $scn_trigger= flush
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= new_file_impl.flush_after_rotate
+--source include/binlog_open_error_scenario.inc
+
+#
+# new_file_impl's post-rotate reopen calls open_index_file()/open() directly
+# (log.cc), the same functions exercised by flush.openning_index,
+# flush.registering_index and flush.updating_index above -- FLUSH BINARY
+# LOGS always goes through this reopen path, so no separate "after rotate"
+# knob is needed; those three scenarios already cover it.
+#
+
+#
+# Scenario: fail_find_uniq_filename_max_exceeded
+#
+RESET MASTER;
+--let $scn_id= flush.find_uniq_filename_max_exceeded
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_find_uniq_filename_max_exceeded
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename.max_exceeded
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fail_find_uniq_filename_too_long
+#
+RESET MASTER;
+--let $scn_id= flush.find_uniq_filename_too_long
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_find_uniq_filename_too_long
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename.too_long
+--source include/binlog_open_error_scenario.inc
+
+#
+# fail_find_uniq_filename_dir_enum (my_dir() fails) is NOT reachable here:
+# RESET MASTER's own internal reopen already caches last_used_log_number
+# to a nonzero value (sql/log.cc, find_uniq_filename), so find_uniq_filename's
+# `else` branch (the one that calls my_dir()) never runs again for any
+# FLUSH BINARY LOGS / rotation that follows a RESET MASTER. It's only
+# reachable on the very first-ever open() call, i.e. at server startup --
+# see startup.find_uniq_filename_dir_enum in binlog_open_errors_startup.test.
+#
+
+#
+# Scenario: fail_find_uniq_filename_snprintf1 (extension snprintf fails)
+#
+RESET MASTER;
+--let $scn_id= flush.find_uniq_filename_snprintf1
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_find_uniq_filename_snprintf1
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename.snprintf1
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fail_find_uniq_filename_snprintf2 (final name snprintf fails)
+#
+RESET MASTER;
+--let $scn_id= flush.find_uniq_filename_snprintf2
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_find_uniq_filename_snprintf2
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename.snprintf2
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fail_close_purge_index_file (close_purge_index_file's own
+# my_close() failure).
+#
+# close_purge_index_file() has seven call sites (log.cc:3927, 4035, 4346,
+# 4361, 5149, 5181, 10741) but only two check its return value (3927 and
+# 10741). FLUSH BINARY LOGS's rotate reaches the checked 3927 site
+# (open_index_file()'s index-recovery step) first, so this knob behaves
+# like fault_injection_recovering_index (ER_CANT_OPEN_FILE, binlog off),
+# NOT a silent MISSING-CHECK. The five unchecked sites are not reachable
+# in isolation from this trigger.
+#
+RESET MASTER;
+--let $scn_id= flush.close_purge_index_file
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_close_purge_index_file
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= close_purge_index_file
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fail_mysql_log_open (MYSQL_LOG::open's own mysql_file_open()
+# call, distinct from every write/alloc knob above which assume this
+# inner open already succeeded)
+#
+RESET MASTER;
+--let $scn_id= flush.mysql_log_open
+--let $scn_kind= error_inject
+--let $scn_dbug= fail_mysql_log_open
+--let $scn_trigger= flush
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= MYSQL_LOG.open
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+# Final cleanup
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_reset_master.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_reset_master.test
@@ -1,0 +1,145 @@
+#
+# Binlog-open error injection scenarios triggered by RESET MASTER, which
+# deletes all logs and re-creates #1 + index.
+#
+# STEPS:
+#   - for each DBUG knob: inject it, then RESET MASTER
+#   - record the client error, warnings and post-state via
+#     binlog_open_error_scenario.inc
+#   - restart between scenarios that turn logging off
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Recovering after a crash .*");
+call mtr.add_suppression("Aborted .* during recovery .*");
+#
+# RESET MASTER's error path never calls my_error() on these knobs (see
+# scenario comments below), which trips DBUG_ASSERT(0) in
+# Protocol::end_statement -- a real bug this test is designed to surface,
+# not an artifact of the test itself.
+call mtr.add_suppression("protocol.cc.*Assertion .0. failed");
+call mtr.add_suppression("got signal 6");
+call mtr.add_suppression("Attempting backtrace");
+
+# Sanity baseline.
+RESET MASTER;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: error_unique_log_filename via RESET MASTER
+#
+# RESET MASTER takes the binlog number back to 1 so the unique-filename
+# generator does not normally trip.  This scenario is included for
+# completeness but is expected to be a no-op trigger; we still check that
+# the server stays consistent.
+#
+--let $scn_id= reset_master.find_uniq_filename
+--let $scn_kind= error_inject
+--let $scn_dbug= error_unique_log_filename
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename
+--let $scn_skip_reason= RESET MASTER resets log number to 1 so error_unique_log_filename does not fire here
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_registering_index via RESET MASTER
+#
+# reset_master() (sql_repl.cc) returns reset_logs()'s raw error code
+# without ever calling my_error() -- sql_reload.cc even comments "NOTE:
+# my_error() has been already called by reset_master()", but it hasn't
+# been for this path. No error reaches the client and the missing
+# diagnostics-area report trips DBUG_ASSERT(0) in Protocol::end_statement,
+# crashing the server. Recorded here as a crash scenario since that is
+# the actual observed behaviour.
+#
+RESET MASTER;
+--let $scn_id= reset_master.registering_index
+--let $scn_kind= crash
+--let $scn_dbug= fault_injection_registering_index
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.purge_index_register
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_openning_index via RESET MASTER
+#
+# reset_logs()'s "if (create_new_log && !open_index_file(...)) if
+# (unlikely(error= open(...))) goto err;" never sets `error` when
+# open_index_file() itself fails (the outer condition is simply false) --
+# RESET MASTER reports success though the log was never reopened.
+#
+RESET MASTER;
+--let $scn_id= reset_master.openning_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_openning_index
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_poststate_crashes= 1
+--let $scn_mdev36606_row= open_index_file.open
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_recovering_index via RESET MASTER
+# Same unchecked-open_index_file() path as openning_index above.
+#
+RESET MASTER;
+--let $scn_id= reset_master.recovering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_recovering_index
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_poststate_crashes= 1
+--let $scn_mdev36606_row= open_index_file.recover
+--source include/binlog_open_error_scenario.inc
+
+#
+# Scenario: fault_injection_updating_index via RESET MASTER
+# Fails inside open() itself (like registering_index above), so the same
+# missing-my_error() crash is expected.
+#
+RESET MASTER;
+--let $scn_id= reset_master.updating_index
+--let $scn_kind= crash
+--let $scn_dbug= fault_injection_updating_index
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= open.update_index
+--source include/binlog_open_error_scenario.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+#
+# Scenario: fault_injection_new_file_rotate_event via RESET MASTER
+# RESET MASTER does not call new_file_impl, so this knob does not fire.
+#
+RESET MASTER;
+--let $scn_id= reset_master.new_file_rotate_event
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_new_file_rotate_event
+--let $scn_trigger= reset_master
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= new_file_impl.rotate_event
+--let $scn_skip_reason= RESET MASTER does not invoke new_file_impl, so the rotate-event knob is unreachable here
+--source include/binlog_open_error_scenario.inc
+
+# Final cleanup
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_rotate.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_rotate.test
@@ -1,0 +1,156 @@
+#
+# Binlog-open error injection scenarios triggered by size-based
+# auto-rotation (max_binlog_size), the implicit-rotation counterpart to
+# binlog_open_errors_flush.test.
+#
+# STEPS:
+#   - for each DBUG knob: inject it, then INSERT past max_binlog_size to
+#     force an implicit rotation
+#   - record the client error, warnings and post-state via
+#     binlog_open_error_scenario.inc
+#   - restart between scenarios that turn logging off
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_innodb.inc
+# The rotation trigger below relies on row-format events being sized by
+# the row data; under statement/mixed format the short INSERT text never
+# reaches max_binlog_size.
+--source include/have_binlog_format_row.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+call mtr.add_suppression("Writing one row to the row-based binary log failed.*");
+
+# Force rotation early.
+SET @@global.max_binlog_size= 4096;
+
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+# Sanity: an unblocked insert beyond max_binlog_size triggers rotation.
+INSERT INTO scn_filler VALUES (REPEAT('x', 6000));
+--source include/binlog_open_error_show_binary_logs.inc
+TRUNCATE TABLE scn_filler;
+RESET MASTER;
+
+#
+# Scenario: error_unique_log_filename via implicit rotation
+#
+--let $scn_id= rotate.find_uniq_filename
+--let $scn_kind= error_inject
+--let $scn_dbug= error_unique_log_filename
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_NO_UNIQUE_LOGFILE
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename
+--source include/binlog_open_error_scenario.inc
+
+DELETE FROM scn_filler;
+RESET MASTER;
+
+#
+# Scenario: fault_injection_registering_index via implicit rotation
+#
+--let $scn_id= rotate.registering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_registering_index
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.purge_index_register
+--source include/binlog_open_error_scenario.inc
+
+# After logging-off we need a restart to re-enable binlog.
+DROP TABLE scn_filler;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+#
+# Scenario: fault_injection_openning_index via implicit rotation
+#
+--let $scn_id= rotate.openning_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_openning_index
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.open
+--source include/binlog_open_error_scenario.inc
+
+DROP TABLE scn_filler;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+#
+# Scenario: fault_injection_recovering_index via implicit rotation
+#
+--let $scn_id= rotate.recovering_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_recovering_index
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open_index_file.recover
+--source include/binlog_open_error_scenario.inc
+
+DROP TABLE scn_filler;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+#
+# Scenario: fault_injection_updating_index via implicit rotation
+#
+--let $scn_id= rotate.updating_index
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_updating_index
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_CANT_OPEN_FILE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= open.update_index
+--source include/binlog_open_error_scenario.inc
+
+DROP TABLE scn_filler;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+SET @@global.max_binlog_size= 4096;
+CREATE TABLE scn_filler (a VARCHAR(8192)) ENGINE=InnoDB;
+RESET MASTER;
+
+#
+# Scenario: fault_injection_new_file_rotate_event via implicit rotation
+#
+--let $scn_id= rotate.new_file_rotate_event
+--let $scn_kind= error_inject
+--let $scn_dbug= fault_injection_new_file_rotate_event
+--let $scn_trigger= rotate_size
+--let $scn_expected_client_error= ER_ERROR_ON_WRITE
+--let $scn_expected_logging_off= 1
+--let $scn_mdev36606_row= new_file_impl.rotate_event
+--source include/binlog_open_error_scenario.inc
+
+DROP TABLE scn_filler;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+# Final cleanup. Reset to DEFAULT rather than saving/restoring the original
+# in a user variable: those are reconnect-local and would not survive the
+# restarts above.
+SET @@global.max_binlog_size= DEFAULT;
+RESET MASTER;

--- a/mysql-test/suite/binlog/t/binlog_open_errors_startup.test
+++ b/mysql-test/suite/binlog/t/binlog_open_errors_startup.test
@@ -1,0 +1,153 @@
+#
+# Server-startup binlog-open error injection scenarios.
+#
+# STEPS:
+#   - restart with --debug-dbug=+d,<knob> so the failure hits the
+#     server's first MYSQL_BIN_LOG::open call
+#   - record the post-startup state via binlog_open_error_scenario.inc
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Failed to enable encryption of binary logs");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+
+# Baseline: confirm a clean restart works and binlogging is on.
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+RESET MASTER;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: fail_init_log_file_name at startup
+#
+# mysqld.cc's startup path treats any MYSQL_BIN_LOG::open() failure as
+# fatal (unireg_abort), unlike FLUSH BINARY LOGS / RESET MASTER which just
+# disable logging and stay up. Confirmed: the server aborts entirely
+# rather than starting with binlog off.
+#
+--let $scn_id= startup.init_log_file_name
+--let $scn_kind= startup
+--let $scn_dbug= fail_init_log_file_name
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.init_log_file_name
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_find_uniq_filename_dir_enum at startup
+#
+# Only reachable here, not via FLUSH BINARY LOGS / rotation: this is the
+# `else` branch of find_uniq_filename (the one that calls my_dir()), which
+# only runs while last_used_log_number is still 0 -- true at the server's
+# very first open() call, but RESET MASTER's own internal reopen caches it
+# to a nonzero value for every subsequent call. Same unconditional-abort
+# path as init_log_file_name above.
+#
+--let $scn_id= startup.find_uniq_filename_dir_enum
+--let $scn_kind= startup
+--let $scn_dbug= fail_find_uniq_filename_dir_enum
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= find_uniq_filename.dir_enum
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fault_injection_registering_index at startup
+# Same unconditional-abort path as init_log_file_name above.
+#
+--let $scn_id= startup.registering_index
+--let $scn_kind= startup
+--let $scn_dbug= fault_injection_registering_index
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.purge_index_register
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fault_injection_openning_index at startup
+# Same unconditional-abort path as init_log_file_name above.
+#
+--let $scn_id= startup.openning_index
+--let $scn_kind= startup
+--let $scn_dbug= fault_injection_openning_index
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.openning_index
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_my_random_bytes at startup — original MDEV-24625 trigger
+#
+# Unreachable without encrypt-binlog, so skipped here; kept as a row so
+# the matrix stays aligned with the gap report. Actually exercised by
+# binlog_encryption/binlog_open_errors_startup.test.
+#
+--let $scn_id= startup.my_random_bytes
+--let $scn_kind= startup
+--let $scn_dbug= fail_my_random_bytes
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.my_random_bytes
+--let $scn_skip_reason= requires encrypted-binlog config; see binlog_encryption/binlog_open_errors_startup.test
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_mysql_log_open at startup
+# Same unconditional-abort path as init_log_file_name above.
+#
+--let $scn_id= startup.mysql_log_open
+--let $scn_kind= startup
+--let $scn_dbug= fail_mysql_log_open
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= MYSQL_LOG.open
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_write_binlog_magic at startup
+# Same unconditional-abort path as init_log_file_name above.
+#
+--let $scn_id= startup.write_binlog_magic
+--let $scn_kind= startup
+--let $scn_dbug= fail_write_binlog_magic
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.write_binlog_magic
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_write_initial_fde at startup
+# Same unconditional-abort path as init_log_file_name above.
+#
+--let $scn_id= startup.write_initial_fde
+--let $scn_kind= startup
+--let $scn_dbug= fail_write_initial_fde
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.write_initial_fde
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;

--- a/mysql-test/suite/binlog_encryption/binlog_open_errors_startup.result
+++ b/mysql-test/suite/binlog_encryption/binlog_open_errors_startup.result
@@ -1,0 +1,46 @@
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Failed to enable encryption of binary logs");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+# restart
+SELECT @@global.encrypt_binlog AS encrypt_binlog_baseline;
+encrypt_binlog_baseline
+1
+RESET MASTER;
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+
+### scenario id=startup.my_random_bytes kind=startup trigger=startup dbug=fail_my_random_bytes mdev36606=startup.my_random_bytes
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.encryption_key_lookup kind=startup trigger=startup dbug=fail_encryption_key_lookup mdev36606=write_description_event.encryption_key_lookup
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.write_sele kind=startup trigger=startup dbug=fail_write_sele mdev36606=write_description_event.write_sele
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;
+
+### scenario id=startup.crypto_init kind=startup trigger=startup dbug=fail_crypto_init mdev36606=write_description_event.crypto_init
+show binary logs;
+Log_name	File_size
+master-bin.NNNNNN	#
+master-bin.NNNNNN	#
+RESET MASTER;

--- a/mysql-test/suite/binlog_encryption/binlog_open_errors_startup.test
+++ b/mysql-test/suite/binlog_encryption/binlog_open_errors_startup.test
@@ -1,0 +1,90 @@
+#
+# Server-startup binlog-open error injection scenarios that only fire with
+# binlog encryption enabled (this suite's default config: encrypt-binlog +
+# file_key_management). Counterpart to
+# suite/binlog/t/binlog_open_errors_startup.test, which cannot reach any of
+# these since it runs without encryption.
+#
+# STEPS:
+#   - restart with --debug-dbug=+d,<knob> so the failure hits the
+#     server's first MYSQL_BIN_LOG::open call, inside its
+#     "if (encrypt_binlog) { ... }" block
+#   - record the post-startup state via binlog_open_error_scenario.inc
+#
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("Can't generate a unique log-filename");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open_index_file failed to sync the index file.");
+call mtr.add_suppression("MYSQL_BIN_LOG::open failed to generate new file name.");
+call mtr.add_suppression("Could not use .*");
+call mtr.add_suppression("Could not open .* for logging.*");
+call mtr.add_suppression("Failed to enable encryption of binary logs");
+call mtr.add_suppression("Failed to switch from old to new log file.*");
+call mtr.add_suppression("Error writing file .*");
+call mtr.add_suppression("Turning logging off for the whole duration.*");
+
+# Baseline: confirm a clean restart works with encryption on.
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+SELECT @@global.encrypt_binlog AS encrypt_binlog_baseline;
+RESET MASTER;
+--source include/binlog_open_error_show_binary_logs.inc
+
+#
+# Scenario: fail_my_random_bytes at startup -- the original MDEV-24625
+# trigger. Same unconditional-abort path as every other startup knob
+# (mysqld.cc's `if (unlikely(error)) unireg_abort(1);`).
+#
+--let $scn_id= startup.my_random_bytes
+--let $scn_kind= startup
+--let $scn_dbug= fail_my_random_bytes
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= startup.my_random_bytes
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_encryption_key_lookup at startup
+# Same unconditional-abort path as fail_my_random_bytes above.
+#
+--let $scn_id= startup.encryption_key_lookup
+--let $scn_kind= startup
+--let $scn_dbug= fail_encryption_key_lookup
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= write_description_event.encryption_key_lookup
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_write_sele at startup
+# Same unconditional-abort path as fail_my_random_bytes above.
+#
+--let $scn_id= startup.write_sele
+--let $scn_kind= startup
+--let $scn_dbug= fail_write_sele
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= write_description_event.write_sele
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;
+
+#
+# Scenario: fail_crypto_init at startup
+# Same unconditional-abort path as fail_my_random_bytes above.
+#
+--let $scn_id= startup.crypto_init
+--let $scn_kind= startup
+--let $scn_dbug= fail_crypto_init
+--let $scn_trigger= startup
+--let $scn_expected_client_error=
+--let $scn_expected_logging_off= 0
+--let $scn_mdev36606_row= write_description_event.crypto_init
+--source include/binlog_open_error_scenario.inc
+RESET MASTER;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2969,7 +2969,10 @@ static int find_uniq_filename(char *name, size_t name_size,
     max_found= *last_used_log_number;
   else
   {
-    if (unlikely(!(dir_info= my_dir(buff, MYF(MY_DONT_SORT)))))
+    dir_info= my_dir(buff, MYF(MY_DONT_SORT));
+    DBUG_EXECUTE_IF("fail_find_uniq_filename_dir_enum",
+                    if (dir_info) { my_dirend(dir_info); dir_info= NULL; });
+    if (unlikely(!dir_info))
     {						// This shouldn't happen
       strmov(end,".1");				// use name+1
       DBUG_RETURN(1);
@@ -2988,7 +2991,8 @@ static int find_uniq_filename(char *name, size_t name_size,
   }
 
   /* check if reached the maximum possible extension number */
-  if (max_found >= MAX_LOG_UNIQUE_FN_EXT)
+  if (max_found >= MAX_LOG_UNIQUE_FN_EXT ||
+      DBUG_IF("fail_find_uniq_filename_max_exceeded"))
   {
     sql_print_error("Log filename extension number exhausted: %06lu. \
 Please fix this by archiving old logs and \
@@ -2998,7 +3002,8 @@ updating the index files.", max_found);
   }
 
   next= max_found + 1;
-  if (snprintf(ext_buf, sizeof(ext_buf), "%06lu", next)<0)
+  if (snprintf(ext_buf, sizeof(ext_buf), "%06lu", next)<0 ||
+      DBUG_IF("fail_find_uniq_filename_snprintf1"))
   {
     error= 1;
     goto end;
@@ -3010,7 +3015,8 @@ updating the index files.", max_found);
     buffer size used. If one did not check this, then the filename might be
     truncated, resulting in error.
    */
-  if (((strlen(ext_buf) + (end - name)) >= FN_REFLEN))
+  if (((strlen(ext_buf) + (end - name)) >= FN_REFLEN) ||
+      DBUG_IF("fail_find_uniq_filename_too_long"))
   {
     sql_print_error("Log filename too large: %s%s (%zu). \
 Please fix this by archiving old logs and updating the \
@@ -3019,7 +3025,8 @@ index files.", name, ext_buf, (strlen(ext_buf) + (end - name)));
     goto end;
   }
 
-  if (snprintf(end, name + name_size - end, "%06lu", next)<0)
+  if (snprintf(end, name + name_size - end, "%06lu", next)<0 ||
+      DBUG_IF("fail_find_uniq_filename_snprintf2"))
   {
     error= 1;
     goto end;
@@ -3043,6 +3050,10 @@ bool MYSQL_LOG::init_and_set_log_file_name(const char *log_name,
                                            enum_log_type log_type_arg,
                                            enum cache_type io_cache_type_arg)
 {
+  /* Binlog only: this function also serves the slow and general query logs. */
+  if (log_type_arg == LOG_BIN)
+    DBUG_EXECUTE_IF("fail_init_log_file_name", return TRUE;);
+
   log_type= log_type_arg;
   io_cache_type= io_cache_type_arg;
 
@@ -3134,7 +3145,8 @@ bool MYSQL_LOG::open(
 #endif
 
   if ((file= mysql_file_open(log_file_key, log_file_name, open_flags,
-                             MYF(MY_WME))) < 0)
+                             MYF(MY_WME))) < 0 ||
+      DBUG_IF("fail_mysql_log_open"))
     goto err;
 
   if (is_fifo)
@@ -4045,7 +4057,8 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
 	In this case we write a standard header to it.
       */
       if (my_b_safe_write(&log_file, BINLOG_MAGIC,
-			  BIN_LOG_HEADER_SIZE))
+			  BIN_LOG_HEADER_SIZE) ||
+          DBUG_IF("fail_write_binlog_magic"))
         goto err;
       bytes_written+= BIN_LOG_HEADER_SIZE;
       write_file_name_to_index_file= 1;
@@ -4078,16 +4091,18 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
 
       crypto.scheme = 0;
       DBUG_ASSERT(s.checksum_alg != BINLOG_CHECKSUM_ALG_UNDEF);
-      if (!s.is_valid())
+      if (!s.is_valid() || DBUG_IF("fail_fde_invalid"))
         goto err;
       s.dont_set_created= null_created_arg;
-      if (write_event(&s))
+      if (write_event(&s) || DBUG_IF("fail_write_initial_fde"))
         goto err;
       bytes_written+= s.data_written;
 
       if (encrypt_binlog)
       {
         uint key_version= encryption_key_get_latest_version(ENCRYPTION_KEY_SYSTEM_DATA);
+        DBUG_EXECUTE_IF("fail_encryption_key_lookup",
+                        key_version= ENCRYPTION_KEY_VERSION_INVALID;);
         if (key_version == ENCRYPTION_KEY_VERSION_INVALID)
         {
           sql_print_error("Failed to enable encryption of binary logs");
@@ -4096,16 +4111,18 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
 
         if (key_version != ENCRYPTION_KEY_NOT_ENCRYPTED)
         {
-          if (my_random_bytes(crypto.nonce, sizeof(crypto.nonce)))
+          if (my_random_bytes(crypto.nonce, sizeof(crypto.nonce)) ||
+              DBUG_IF("fail_my_random_bytes"))
             goto err;
 
           Start_encryption_log_event sele(1, key_version, crypto.nonce);
           sele.checksum_alg= s.checksum_alg;
-          if (write_event(&sele))
+          if (write_event(&sele) || DBUG_IF("fail_write_sele"))
             goto err;
 
           // Start_encryption_log_event is written, enable the encryption
-          if (crypto.init(sele.crypto_scheme, key_version))
+          if (crypto.init(sele.crypto_scheme, key_version) ||
+              DBUG_IF("fail_crypto_init"))
             goto err;
         }
       }
@@ -4149,7 +4166,7 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
         */
 
         Gtid_list_log_event gl_ev(&rpl_global_gtid_binlog_state, 0);
-        if (write_event(&gl_ev))
+        if (write_event(&gl_ev) || DBUG_IF("fail_write_glle"))
           goto err;
 
         /* Output a binlog checkpoint event at the start of the binlog file. */
@@ -4168,6 +4185,8 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
         size_t off= dirname_length(log_file_name);
         uint len= static_cast<uint>(strlen(log_file_name) - off);
         new_xid_list_entry= new xid_count_per_binlog(log_file_name+off, len);
+        DBUG_EXECUTE_IF("fail_alloc_xid_list_entry",
+                        { delete new_xid_list_entry; new_xid_list_entry= NULL; });
         if (!new_xid_list_entry)
           goto err;
 
@@ -4186,7 +4205,7 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
         mysql_mutex_unlock(&LOCK_xid_list);
         if (!b)
           b= new_xid_list_entry;
-        if (b->binlog_name)
+        if (b->binlog_name && !DBUG_IF("fail_b_binlog_name"))
           strmake(buf, b->binlog_name, b->binlog_name_len);
         else
           goto err;
@@ -4195,7 +4214,7 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
                         flush_io_cache(&log_file);
                         mysql_file_sync(log_file.file, MYF(MY_WME));
                         DBUG_SUICIDE(););
-        if (write_event(&ev))
+        if (write_event(&ev) || DBUG_IF("fail_write_checkpoint_event"))
           goto err;
         bytes_written+= ev.data_written;
       }
@@ -4232,7 +4251,8 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
       bytes_written+= description_event_for_queue->data_written;
     }
     if (flush_io_cache(&log_file) ||
-        mysql_file_sync(log_file.file, MYF(MY_WME)))
+        mysql_file_sync(log_file.file, MYF(MY_WME)) ||
+        DBUG_IF("fail_flush_or_sync_log_file"))
       goto err;
 
     my_off_t offset= my_b_tell(&log_file);
@@ -4316,6 +4336,8 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
       char buf[FN_REFLEN];
       fn_format(buf, opt_bin_logname, mysql_data_home, ".state",
                 MY_UNPACK_FILENAME);
+      DBUG_EXECUTE_IF("fail_state_file_delete",
+                      strmov(buf, "/nonexistent-dir/mdev37015.state"););
       my_delete(buf, MY_SYNC_DIR);
       state_file_deleted= true;
     }
@@ -5187,6 +5209,7 @@ int MYSQL_BIN_LOG::close_purge_index_file()
   {
     end_io_cache(&purge_index_file);
     error= my_close(purge_index_file.file, MYF(0));
+    DBUG_EXECUTE_IF("fail_close_purge_index_file", error= 1;);
   }
   my_delete(purge_index_file_name, MYF(0));
   bzero((char*) &purge_index_file, sizeof(purge_index_file));
@@ -5703,7 +5726,9 @@ int MYSQL_BIN_LOG::new_file_impl()
     log rotation should give the waiting thread a signal to
     discover EOF and move on to the next log.
   */
-  if (unlikely((error= flush_io_cache(&log_file))))
+  error= flush_io_cache(&log_file);
+  DBUG_EXECUTE_IF("fail_flush_after_rotate_event", error= 1;);
+  if (unlikely(error))
   {
     close_on_error= TRUE;
     goto end;


### PR DESCRIPTION
Issue: several binlog-open error paths crash the server or silently report success instead of failing. RESET MASTER and SET GLOBAL binlog_checksum can each crash on certain reopen failures, and RESET MASTER can report success without ever having reopened the binlog.

Solution: add parameterized fault-injection tests across the open paths and trigger contexts to reproduce these and other inconsistencies, with strict assertions, and write up the findings in a gap report.