### PR TITLE
MDEV-40916: do not materialise rejected MHNSW neighbours

### DIFF
--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1128,6 +1128,12 @@ class VisitedSet
     count++;
     return v;
   }
+  void remember(FVectorNode *node)
+  {
+    // Mark a distance-tested node without materialising a queue entry.
+    insert(node);
+    count++;
+  }
   void insert(const FVectorNode *n)
   {
     nodes[idx++]= n;
@@ -1367,22 +1373,27 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
         }
         else
         {
-          Visited *v= visited.create(links[i],
-                        links[i]->distance_greater_than(target, furthest_best,
-                                                        p->mode, &p->acc));
-          if (v->distance_to_target <= threshold)
-            continue;
-          if (v->distance_to_target < furthest_best)
+          float distance= links[i]->distance_greater_than(target, furthest_best,
+                                                           p->mode, &p->acc);
+          if (distance <= threshold)
           {
+            visited.remember(links[i]);
+            continue;
+          }
+          if (distance < furthest_best)
+          {
+            Visited *v= visited.create(links[i], distance);
             candidates.safe_push(v);
             if (skip_deleted && v->node->deleted)
               continue;
-            if (v->distance_to_target < best.top()->distance_to_target)
+            if (distance < best.top()->distance_to_target)
             {
               best.replace_top(v);
               furthest_best= lenient_furthest(best, p->acc.diameter, leniency);
             }
           }
+          else
+            visited.remember(links[i]);
         }
       }
     }

--- a/sql/vector_mhnsw.cc
+++ b/sql/vector_mhnsw.cc
@@ -1125,17 +1125,11 @@ class VisitedSet
   {
     auto *v= new (root) Visited(node, dist);
     insert(node);
-    count++;
     return v;
-  }
-  void remember(FVectorNode *node)
-  {
-    // Mark a distance-tested node without materialising a queue entry.
-    insert(node);
-    count++;
   }
   void insert(const FVectorNode *n)
   {
+    count++;
     nodes[idx++]= n;
     if (idx == 8) flush();
   }
@@ -1361,10 +1355,14 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
           return err;
         if (!best.is_full())
         {
-          Visited *v= visited.create(links[i], links[i]->distance_to(target));
-          if (v->distance_to_target <= threshold)
+          float distance= links[i]->distance_to(target);
+          if (distance <= threshold)
+          {
+            visited.insert(links[i]);
             continue;
-          p->acc.diameter= std::max(p->acc.diameter, v->distance_to_target);
+          }
+          p->acc.diameter= std::max(p->acc.diameter, distance);
+          Visited *v= visited.create(links[i], distance);
           candidates.safe_push(v);
           if (skip_deleted && v->node->deleted)
             continue;
@@ -1374,26 +1372,21 @@ static int search_layer(MHNSW_param *p, const FVector *target, float threshold,
         else
         {
           float distance= links[i]->distance_greater_than(target, furthest_best,
-                                                           p->mode, &p->acc);
-          if (distance <= threshold)
+                                                          p->mode, &p->acc);
+          if (distance <= threshold || distance >= furthest_best)
           {
-            visited.remember(links[i]);
+            visited.insert(links[i]);
             continue;
           }
-          if (distance < furthest_best)
+          Visited *v= visited.create(links[i], distance);
+          candidates.safe_push(v);
+          if (skip_deleted && v->node->deleted)
+            continue;
+          if (distance < best.top()->distance_to_target)
           {
-            Visited *v= visited.create(links[i], distance);
-            candidates.safe_push(v);
-            if (skip_deleted && v->node->deleted)
-              continue;
-            if (distance < best.top()->distance_to_target)
-            {
-              best.replace_top(v);
-              furthest_best= lenient_furthest(best, p->acc.diameter, leniency);
-            }
+            best.replace_top(v);
+            furthest_best= lenient_furthest(best, p->acc.diameter, leniency);
           }
-          else
-            visited.remember(links[i]);
         }
       }
     }


### PR DESCRIPTION
Add VisitedSet::remember() to mark rejected nodes in the bloom filter and retain the visit count without allocating a queue entry. Delay Visited construction until a neighbour is accepted by the hierarchical search. 