### PR TITLE
MDEV-40917: Rename duckdb filename to allow to use duckdb as schema

### DIFF
--- a/storage/duckdb/mysql-test/duckdb/r/create_database_duckdb.result
+++ b/storage/duckdb/mysql-test/duckdb/r/create_database_duckdb.result
@@ -1,0 +1,12 @@
+CREATE DATABASE IF NOT EXISTS duckdb CHARACTER SET utf8mb4;
+USE duckdb;
+CREATE TABLE t1 (
+id INT PRIMARY KEY,
+name VARCHAR(32)
+) engine=duckdb;
+INSERT INTO t1 VALUES (1, 'one');
+SELECT * FROM t1;
+id	name
+1	one
+DROP TABLE t1;
+DROP DATABASE duckdb;

--- a/storage/duckdb/mysql-test/duckdb/t/create_database_duckdb.test
+++ b/storage/duckdb/mysql-test/duckdb/t/create_database_duckdb.test
@@ -1,0 +1,16 @@
+--source ../include/have_duckdb.inc
+
+CREATE DATABASE IF NOT EXISTS duckdb CHARACTER SET utf8mb4;
+USE duckdb;
+
+CREATE TABLE t1 (
+  id INT PRIMARY KEY,
+  name VARCHAR(32)
+) engine=duckdb;
+
+INSERT INTO t1 VALUES (1, 'one');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--source ../include/cleanup_duckdb.inc
+DROP DATABASE duckdb;

--- a/storage/duckdb/runtime/duckdb_manager.h
+++ b/storage/duckdb/runtime/duckdb_manager.h
@@ -28,7 +28,7 @@
 namespace myduck
 {
 
-constexpr char DUCKDB_FILE_NAME[]= "duckdb.db";
+constexpr char DUCKDB_FILE_NAME[]= "__duckdb.db";
 constexpr char DUCKDB_DEFAULT_TMP_NAME[]= "duckdb_tmp";
 
 class DuckdbManager


### PR DESCRIPTION
Since it is hardcoded name for the catalog, duckdb requires to explicitly define the catalog additional to the schema names. F.e. `duckdb.duckdb.table`.

Suggesting to rename `duckdb` filename, this fixes:
` Ambiguous reference to catalog or schema "duckdb" - use a fully qualified path like '.duckdb'`

