### PR TITLE
MDEV-40924: validate insert_length before memcpy in KEY_OP_ADD_SUFFIX

### DIFF
--- a/storage/maria/ma_key_recover.c
+++ b/storage/maria/ma_key_recover.c
@@ -1059,6 +1059,12 @@ uint _ma_apply_redo_index(MARIA_HA *info,
     {
       uint insert_length= uint2korr(header);
       DBUG_PRINT("redo", ("key_op_add_suffix: %u", insert_length));
+      if (header + 2 + insert_length > header_end ||
+          page_length + insert_length > max_page_size)
+      {
+        result= mark_crashed= 1;
+        goto err;
+      }
       DBUG_ASSERT(page_length + insert_length <= max_page_size);
       memcpy(buff + page_length, header+2, insert_length);
 
@@ -1071,6 +1077,12 @@ uint _ma_apply_redo_index(MARIA_HA *info,
       uint del_length= uint2korr(header);
       header+= 2;
       DBUG_PRINT("redo", ("key_op_del_suffix: %u", del_length));
+      if (header > header_end ||
+          page_length < keypage_header + del_length)
+      {
+        result= mark_crashed= 1;
+        goto err;
+      }
       DBUG_ASSERT(page_length - del_length >= keypage_header);
       page_length-= del_length;
       break;


### PR DESCRIPTION
- [x] The Jira issue number for this PR is MDEV-40924.

## Description

KEY_OP_ADD_SUFFIX copied insert_length bytes into the key page without checking that the source range stayed inside the log record or that the result fit the page. A corrupt or truncated record could therefore read past header_end and write past max_page_size during redo.

Validate both bounds before the memcpy, and apply the matching check to KEY_OP_DEL_SUFFIX, which had the same shape. On failure, return an error and mark the file crashed through the existing error path. Keep the debug assertions.

The September 17 rebase onto 10.11 at `f4a3b69bdf14` preserves the original 12-line patch as one commit.

## How can this PR be tested?

The native Aria build and five CTests were rerun after this rebase on macOS arm64. The standalone recovery and API diagnostic below passed before the rebase; the Aria source is byte-identical.

- Native Aria libraries, tools and relevant test executables build successfully.
- Five relevant CTests pass with `MYTAP_CONFIG=big`, including the 8k pagecache assertions.
- The standalone recovery suite passes: `ALL RECOVERY TESTS OK (zerofilled 56 tables)`.
- A local diagnostic calls the actual `_ma_apply_redo_index` implementation with real pagecache and temporary file I/O. Eight valid, boundary and malformed-record cases pass with the patch. On current 10.11, the four malformed-record expectations fail while the four valid/boundary controls pass. Rejection checks cover the return value, crashed state in memory and on disk, and unchanged page contents.

The diagnostic is not yet integrated into the repository test suite; committed regression coverage remains outstanding. Its log buffers are physically padded while the logical record lengths are truncated. This verifies the bounds checks, but does not establish safety for every truncated allocation: the existing two-byte length reads still precede the new checks. Full debug MTR fault-injection coverage was not run.

## Basing the PR against the correct MariaDB version

- [x] This is a bug fix based on 10.11, as requested in preliminary review.

## Backward compatibility

No on-disk format changes. Valid suffix operations retain their behavior; the added checks reject invalid lengths before the copy or page-length update.

