### PR TITLE
MDEV-40867 CONNECT writes unvalidated data from remote filter into fixed-len buffer

### DIFF
--- a/storage/connect/mysql-test/connect/r/tbl.result
+++ b/storage/connect/mysql-test/connect/r/tbl.result
@@ -150,3 +150,34 @@ x int,
 y int
 ) engine=connect table_type=FIX file_name='test.txt' with system versioning;
 ERROR HY000: System-versioned tables do not support CONNECT storage engine
+#
+# MDEV-40867 Stack buffer overflow in TDBTBL::TestFil()
+#
+CREATE TABLE t1 (a INT NOT NULL, message CHAR(10)) ENGINE=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+INSERT INTO t1 VALUES (1, 'hello');
+CREATE TABLE t2 (a INT NOT NULL, message CHAR(10)) ENGINE=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t2.dos
+INSERT INTO t2 VALUES (2, 'world');
+CREATE TABLE total (
+tabname CHAR(8) NOT NULL SPECIAL='TABID',
+ta TINYINT NOT NULL FLAG=1,
+message CHAR(20)
+) ENGINE=CONNECT TABLE_TYPE=TBL TABLE_LIST='t1,t2';
+SELECT * FROM total WHERE tabname = 't1';
+tabname	ta	message
+t1	1	hello
+SELECT * FROM total WHERE tabname = REPEAT('A', 300);
+tabname	ta	message
+SELECT * FROM total WHERE tabname IN (REPEAT('B', 300));
+tabname	ta	message
+SELECT * FROM total WHERE tabname NOT IN (REPEAT('C', 300));
+tabname	ta	message
+t1	1	hello
+t2	2	world
+DROP TABLE total, t1, t2;
+# End of 10.11 tests

--- a/storage/connect/mysql-test/connect/t/tbl.test
+++ b/storage/connect/mysql-test/connect/t/tbl.test
@@ -62,3 +62,28 @@ create table t2 (
   x int,
   y int
 ) engine=connect table_type=FIX file_name='test.txt' with system versioning;
+
+--echo #
+--echo # MDEV-40867 Stack buffer overflow in TDBTBL::TestFil()
+--echo #
+
+CREATE TABLE t1 (a INT NOT NULL, message CHAR(10)) ENGINE=CONNECT;
+INSERT INTO t1 VALUES (1, 'hello');
+
+CREATE TABLE t2 (a INT NOT NULL, message CHAR(10)) ENGINE=CONNECT;
+INSERT INTO t2 VALUES (2, 'world');
+
+CREATE TABLE total (
+  tabname CHAR(8) NOT NULL SPECIAL='TABID',
+  ta TINYINT NOT NULL FLAG=1,
+  message CHAR(20)
+) ENGINE=CONNECT TABLE_TYPE=TBL TABLE_LIST='t1,t2';
+
+SELECT * FROM total WHERE tabname = 't1';
+SELECT * FROM total WHERE tabname = REPEAT('A', 300);
+SELECT * FROM total WHERE tabname IN (REPEAT('B', 300));
+SELECT * FROM total WHERE tabname NOT IN (REPEAT('C', 300));
+
+DROP TABLE total, t1, t2;
+
+--echo # End of 10.11 tests

--- a/storage/connect/tabtbl.cpp
+++ b/storage/connect/tabtbl.cpp
@@ -287,12 +287,20 @@ bool TDBTBL::InitTableList(PGLOBAL g)
   return FALSE;
   } // end of InitTableList
 
+#define OP_SIZE 7
+#define TN_SIZE 192
+#if TN_SIZE != NAME_LEN
+#error "TN_SIZE must equal NAME_LEN"
+#endif
+#define _OP STRINGIFY_ARG(OP_SIZE)
+#define _TN STRINGIFY_ARG(TN_SIZE)
+
 /***********************************************************************/
 /*  Test the tablename against the pseudo "local" filter.              */
 /***********************************************************************/
 bool TDBTBL::TestFil(PGLOBAL g, PCFIL filp, PTABLE tabp)
   {
-  char *body, *fil, op[8], tn[NAME_LEN];
+  char *body, *fil, op[OP_SIZE+1], tn[TN_SIZE+1];
   bool  neg;
 
   if (!filp)
@@ -305,7 +313,7 @@ bool TDBTBL::TestFil(PGLOBAL g, PCFIL filp, PTABLE tabp)
   else
     fil = body + (*body == '(' ? 1 : 0);
 
-  if (sscanf(fil, "TABID %s", op) != 1)
+  if (sscanf(fil, "TABID %" _OP "s", op) != 1)
     return TRUE;               // ignore invalid filter
 
   if ((neg = !strcmp(op, "NOT")))
@@ -313,7 +321,7 @@ bool TDBTBL::TestFil(PGLOBAL g, PCFIL filp, PTABLE tabp)
 
   if (!strcmp(op, "=")) {
     // Temporarily, filter must be "TABID = 'value'" only
-    if (sscanf(fil, "TABID = '%[^']'", tn) != 1)
+    if (sscanf(fil, "TABID = '%" _TN "[^']'", tn) != 1)
       return TRUE;             // ignore invalid filter
 
     return !stricmp(tn, tabp->GetName());
@@ -333,7 +341,7 @@ bool TDBTBL::TestFil(PGLOBAL g, PCFIL filp, PTABLE tabp)
       if ((p = strchr(tnl, ',')))
         *p++ = 0;
 
-      if (sscanf(tnl, "'%[^']'", tn) != 1)
+      if (sscanf(tnl, "'%" _TN "[^']'", tn) != 1)
         return TRUE;           // ignore invalid filter
       else if (!stricmp(tn, tabp->GetName()))
         return !neg;           // Found


### PR DESCRIPTION
## Description

This PR fixes [MDEV-40867](https://jira.mariadb.org/browse/MDEV-40867) where `TDBTBL::TestFil()` in the CONNECT storage engine crashes with SIGSEGV when a `TABLE_TYPE=TBL` table receives an oversized TABID filter value.

`TDBTBL::TestFil()` re-parses condition-pushed filter strings using `sscanf(fil, "TABID = '%[^']'", tn)` where `tn` is a fixed 192-byte stack buffer (`char tn[NAME_LEN]`). Since `%[^']` is unbounded, a filter value exceeding 192 bytes overflows `tn`, corrupts the stack, and crashes `mysqld`.

The fix involves:

1. Adding `%192[^']` width specifier to bound writes into `tn[NAME_LEN]` (192 chars + null = 193 bytes)
2. Adding `%7s` width specifier to bound writes into `op[8]` (7 chars + null = 8 bytes)
3. Applying the same bound to the `IN (...)` loop that parses individual values back into `tn`

## How can this PR be tested?

Run the MTR test:

```
build/mysql-test/mtr connect.tbl_overflow
```

Or manually:

```sql
INSTALL SONAME 'ha_connect';
CREATE TABLE t1 (a INT NOT NULL) ENGINE=CONNECT;
INSERT INTO t1 VALUES (1);
CREATE TABLE t2 (a INT NOT NULL) ENGINE=CONNECT;
INSERT INTO t2 VALUES (2);
CREATE TABLE total (
  tabname CHAR(8) NOT NULL SPECIAL='TABID',
  ta TINYINT NOT NULL FLAG=1
) ENGINE=CONNECT TABLE_TYPE=TBL TABLE_LIST='t1,t2';

-- These should return empty result, not crash:
SELECT * FROM total WHERE tabname = REPEAT('A', 300);
SELECT * FROM total WHERE tabname IN (REPEAT('B', 300));
```

## Results from my testing

1. Before changes

```
MariaDB> SELECT * FROM total WHERE tabname = REPEAT('A', 300);
ERROR 2013 (HY000): Lost connection to server during query

MariaDB> SELECT 1;
ERROR 2002 (HY000): Can't connect to local server through socket '/tmp/mysql.sock' (111)
```

Server crashed with SIGSEGV. Confirmed on MariaDB 10.6.28, 10.11.18, 11.4.12, 11.8.8, and 12.3.2.

2. After changes

```
MariaDB> SELECT * FROM total WHERE tabname = REPEAT('A', 300);
Empty set (0.00 sec)

MariaDB> SELECT * FROM total WHERE tabname IN (REPEAT('B', 300));
Empty set (0.00 sec)

MariaDB> SELECT * FROM total WHERE tabname NOT IN (REPEAT('C', 300));
+---------+----+
| tabname | ta |
+---------+----+
| t1      |  1 |
| t2      |  2 |
+---------+----+

MariaDB> SELECT * FROM total WHERE tabname = 't1';
+---------+----+
| tabname | ta |
+---------+----+
| t1      |  1 |
+---------+----+
```

Server stays alive. Normal TABID filtering works correctly. Existing `connect.tbl` MTR test passes with no regression.

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix and the PR is based against the oldest affected MariaDB version (10.6) branch._

## PR quality check

* [x] I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am fine with the reviewer making the changes themselves.