### PR TITLE
MDEV-40922  Compilation warning "'<anonymous>' may be used uninitialized" in RecordCallback constructor with GCC

### DIFF
--- a/storage/innobase/fts/fts0exec.cc
+++ b/storage/innobase/fts/fts0exec.cc
@@ -652,44 +652,39 @@ bool CommonTableReader::extract_common_fields(
   return true;
 }
 
+/** WHERE predicate for the common tables: every row qualifies. */
+static RecordCompareAction common_accept_all(
+  const dtuple_t *search_tuple, const rec_t *rec,
+  const dict_index_t *index, const rec_offs *offsets)
+{
+  return RecordCompareAction::PROCESS;
+}
+
+RecordProcessor CommonTableReader::make_processor()
+{
+  return [this](const rec_t *rec, const dict_index_t *index,
+                const rec_offs *offsets) -> dberr_t
+  {
+    doc_id_t doc_id;
+    if (!extract_common_fields(rec, index, &doc_id))
+      return DB_CORRUPTION;
+    *static_cast<doc_id_t*>(ib_vector_push(m_doc_ids, nullptr))= doc_id;
+    return DB_SUCCESS;
+  };
+}
+
 /* Both constructors share the same callbacks: extract each
 doc_id and append it to m_doc_ids; the WHERE predicate accepts
 every row.  They differ only in whether m_doc_ids is owned
 or borrowed from the caller */
 CommonTableReader::CommonTableReader()
-  : RecordCallback(
-      [this](const rec_t *rec, const dict_index_t *index,
-             const rec_offs *offsets) -> dberr_t
-      {
-        doc_id_t doc_id;
-        if (!extract_common_fields(rec, index, &doc_id))
-          return DB_CORRUPTION;
-        *static_cast<doc_id_t*>(ib_vector_push(m_doc_ids, nullptr))= doc_id;
-        return DB_SUCCESS;
-      },
-      [](const dtuple_t *search_tuple, const rec_t *rec,
-         const dict_index_t *index, const rec_offs *offsets)
-           -> RecordCompareAction
-      { return RecordCompareAction::PROCESS; }),
+  : RecordCallback(make_processor(), common_accept_all),
     m_heap(mem_heap_create(512)),
     m_doc_ids(ib_vector_create(ib_heap_allocator_create(m_heap),
                                sizeof(doc_id_t), 32)) {}
 
 CommonTableReader::CommonTableReader(ib_vector_t *dest)
-  : RecordCallback(
-      [this](const rec_t *rec, const dict_index_t *index,
-             const rec_offs *offsets) -> dberr_t
-      {
-        doc_id_t doc_id;
-        if (!extract_common_fields(rec, index, &doc_id))
-          return DB_CORRUPTION;
-        *static_cast<doc_id_t*>(ib_vector_push(m_doc_ids, nullptr))= doc_id;
-        return DB_SUCCESS;
-      },
-      [](const dtuple_t *search_tuple, const rec_t *rec,
-         const dict_index_t *index, const rec_offs *offsets)
-           -> RecordCompareAction
-      { return RecordCompareAction::PROCESS; }),
+  : RecordCallback(make_processor(), common_accept_all),
     m_heap(nullptr), m_doc_ids(dest) {}
 
 CommonTableReader::~CommonTableReader()
@@ -712,11 +707,7 @@ ConfigReader::ConfigReader() : RecordCallback(
 
     return DB_SUCCESS;
   },
-  [](const dtuple_t *search_tuple, const rec_t *rec,
-     const dict_index_t *index, const rec_offs *offsets) -> RecordCompareAction
-  {
-    return compare_config_key(search_tuple, rec, index, offsets);
-  }) {}
+  compare_config_key) {}
 
 /** Initial size of nodes in fts_word_t. */
 static const ulint FTS_WORD_NODES_INIT_SIZE= 64;

--- a/storage/innobase/include/fts0exec.h
+++ b/storage/innobase/include/fts0exec.h
@@ -284,6 +284,10 @@ private:
   /** Destination for extracted doc_ids */
   ib_vector_t *m_doc_ids;
 
+  /** Build the row consumer shared by both constructors.
+  @return processor appending each extracted doc_id to m_doc_ids */
+  RecordProcessor make_processor();
+
 public:
   /** Accumulate doc_ids into the vector */
   CommonTableReader();

--- a/storage/innobase/include/row0query.h
+++ b/storage/innobase/include/row0query.h
@@ -27,6 +27,7 @@ Created 2025/10/30
 
 #include "btr0pcur.h"
 #include <functional>
+#include <utility>
 #include "dict0types.h"
 #include "data0types.h"
 #include "db0err.h"
@@ -77,7 +78,8 @@ public:
   RecordCallback(
     RecordProcessor processor,
     RecordComparator comparator= nullptr)
-    : process_record(processor), compare_record(comparator) {}
+    : process_record(std::move(processor)),
+      compare_record(std::move(comparator)) {}
 
   virtual ~RecordCallback()= default;
 


### PR DESCRIPTION
Move the std::function callbacks into the members instead of copying them, and
pass the captureless FTS comparators as plain functions instead of lambdas. This
is to avoid GCC -Wmaybe-uninitialized false positive in RecordCallback