### PR TITLE
MDEV-40688: Skip galera tests when wsrep SST prerequisites are missing

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -711,10 +711,23 @@ else # joiner
         SILENT=""
     fi
 
+    # Without uid/gid, rsync run as root drops the per-connection worker
+    # to nobody:nogroup, which can't write into the root-owned datadir.
+    # Only set it when we're actually root: rsync calls setgroups() as
+    # soon as uid/gid is present at all, which fails outright (not a
+    # no-op) for a non-root daemon even when the value matches its own
+    # identity.
+    UID_GID=""
+    if [ "$(id -u)" -eq 0 ]; then
+        UID_GID="uid = 0
+gid = 0"
+    fi
+
 cat << EOF > "$RSYNC_CONF"
 pid file = $RSYNC_PID
 use chroot = no
 read only = no
+$UID_GID
 timeout = 300
 $SILENT
 [$MODULE]


### PR DESCRIPTION
MDEV-40688: rsync SST fails as joiner when SST runs as root

Issue: wsrep_sst_rsync.sh's joiner-side rsync daemon config has no
explicit uid/gid, so when started by root, rsync drops the connection
handler to nobody:nogroup. That user can't write into the root-owned
datadir, so any file/directory that must be freshly created during
SST (not just overwritten) fails with EACCES, sometimes surfacing to
the peer as a misleading ENOENT instead.

Solution: set uid = 0 / gid = 0 in the generated rsync module config
so the daemon keeps its starting privileges. No effect when the
daemon is not started by root, so normal non-root deployments are
unaffected.

