### PR TITLE
MDEV-40927 Crash on long unique insert into partition

### DIFF
--- a/mysql-test/main/long_unique_bugs.result
+++ b/mysql-test/main/long_unique_bugs.result
@@ -850,4 +850,18 @@ create table t(c int primary key, c2 blob unique) engine=innodb;
 insert into t values (0, '');
 replace into t values (0, '123');
 drop table t;
+#
+# MDEV-40927 ha_innobase::change_active_index(uint): Assertion
+#            `m_user_thd == ha_thd()' failed
+#
+CREATE TABLE t (a INT AUTO_INCREMENT PRIMARY KEY, b INT, UNIQUE(b) USING HASH)
+ENGINE=InnoDB PARTITION BY HASH(a) PARTITIONS 2;
+connect  con1,localhost,root,,test;
+SELECT * FROM t;
+a	b
+connection default;
+INSERT INTO t PARTITION (p1) VALUES (1,1);
+disconnect con1;
+connection default;
+DROP TABLE t;
 # End of 10.11 tests

--- a/mysql-test/main/long_unique_bugs.test
+++ b/mysql-test/main/long_unique_bugs.test
@@ -776,4 +776,18 @@ insert into t values (0, '');
 replace into t values (0, '123');
 drop table t;
 
+--echo #
+--echo # MDEV-40927 ha_innobase::change_active_index(uint): Assertion
+--echo #            `m_user_thd == ha_thd()' failed
+--echo #
+CREATE TABLE t (a INT AUTO_INCREMENT PRIMARY KEY, b INT, UNIQUE(b) USING HASH)
+ENGINE=InnoDB PARTITION BY HASH(a) PARTITIONS 2;
+--connect (con1,localhost,root,,test)
+SELECT * FROM t;
+--connection default
+INSERT INTO t PARTITION (p1) VALUES (1,1);
+--disconnect con1
+--connection default
+DROP TABLE t;
+
 --echo # End of 10.11 tests

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -4313,6 +4313,8 @@ int ha_partition::external_lock(THD *thd, int lock_type)
 
   if (lock_type == F_UNLCK)
     used_partitions= &m_locked_partitions;
+  else if (lock_type == F_WRLCK && table->s->long_unique_table)
+    used_partitions= &(m_part_info->read_partitions);
   else
     used_partitions= &(m_part_info->lock_partitions);
 


### PR DESCRIPTION
## Description

`INSERT ... PARTITION` into a partitioned table with a long unique key prunes `lock_partitions` to the named partitions, but `check_insert_or_replace_autoincrement()` widens `read_partitions` to all.

The unique hash check then reads a partition that was never external locked for the statement, tripping the assertion.

Lock all `read_partitions` in `ha_partition::external_lock()` for write locks (`F_WRLCK`) on a table with a long unique key, so every partition the check reads is bound to the current statement. `lock_partitions` is left untouched, so the write stays restricted to the selected partitions.

Add a test to `main.long_unique_bugs`.

## Release Notes

N/A

## How can this PR be tested?

Execute the main suite in mysql-test-run in debug mode. 

This commit adds a test in the `long_unique_bugs` test of the main suite (`main.long_unique_bugs`).

### Before the fix
Running `main.long_unique_bugs` (with the added test) fails as below in debug mode:
```
main.long_unique_bugs                    [ fail ]
        Test ended at 2026-08-26 18:09:02
…
mariadbd: /quick-rebuilds/mariadb-server/storage/innobase/handler/ha_innodb.cc:9112: int ha_innobase::change_active_index(uint): Assertion `m_user_thd == ha_thd()' failed.
260826 18:08:57 [ERROR] /quick-rebuilds/build/sql/mariadbd got signal 6 ;
…
Connection ID (thread ID): 5
Status: NOT_KILLED
Query (0x772018014ec0): INSERT INTO t PARTITION (p1) VALUES (1,1)
…
Thread 1 (Thread 0x7f20544416c0 (LWP 28737)):
#0  0x00007f205804f3bc in ?? () from /usr/lib/x86_64-linux-gnu/libc.so.6
#1  0x000055e86bc7e55a in my_write_core (sig=6) at /quick-rebuilds/mariadb-server/mysys/stacktrace.c:424
#2  0x000055e86b3d0fd4 in handle_fatal_signal (sig=6) at /quick-rebuilds/mariadb-server/sql/signal_handler.cc:300
#3  <signal handler called>
#4  0x00007f205804f3bc in ?? () from /usr/lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f2057ff8942 in raise () from /usr/lib/x86_64-linux-gnu/libc.so.6
#6  0x00007f2057fe04ac in abort () from /usr/lib/x86_64-linux-gnu/libc.so.6
#7  0x00007f2057fe0420 in ?? () from /usr/lib/x86_64-linux-gnu/libc.so.6
#8  0x000055e86b733ae1 in ha_innobase::change_active_index (this=0x772004024628, keynr=1) at /quick-rebuilds/mariadb-server/storage/innobase/handler/ha_innodb.cc:9112
#9  0x000055e86b7330be in ha_innobase::index_init (this=0x772004024628, keynr=1) at /quick-rebuilds/mariadb-server/storage/innobase/handler/ha_innodb.cc:8785
#10 0x000055e86ae4c508 in handler::ha_index_init (this=0x772004024628, idx=1, sorted=false) at /quick-rebuilds/mariadb-server/sql/handler.h:3410
#11 0x000055e86b6f8918 in ha_partition::index_init (this=0x772004023d88, inx=1, sorted=false) at /quick-rebuilds/mariadb-server/sql/ha_partition.cc:5818
#12 0x000055e86ae4c508 in handler::ha_index_init (this=0x772004023d88, idx=1, sorted=false) at /quick-rebuilds/mariadb-server/sql/handler.h:3410
#13 0x000055e86b3e5a8a in handler::check_duplicate_long_entry_key (this=0x772004023d88, new_rec=0x772004025628 "\371\001", key_no=1) at /quick-rebuilds/mariadb-server/sql/handler.cc:7523
#14 0x000055e86b3e61ec in handler::ha_check_long_uniques (this=0x772004023d88, old_rec=0x0, new_rec=0x772004025628 "\371\001") at /quick-rebuilds/mariadb-server/sql/handler.cc:7623
#15 0x000055e86b3e5f1e in handler::ha_check_inserver_constraints (this=0x772004023d88, old_data=0x0, new_data=0x772004025628 "\371\001") at /quick-rebuilds/mariadb-server/sql/handler.cc:7597
#16 0x000055e86b3e6fa3 in handler::ha_write_row (this=0x772004023d88, buf=0x772004025628 "\371\001") at /quick-rebuilds/mariadb-server/sql/handler.cc:7848
#17 0x000055e86af5a252 in Write_record::single_insert (this=0x7f205443f870, inserted=0x7f205443f690) at /quick-rebuilds/mariadb-server/sql/sql_insert.cc:2326
#18 0x000055e86af5a426 in Write_record::write_record (this=0x7f205443f870) at /quick-rebuilds/mariadb-server/sql/sql_insert.cc:2368
#19 0x000055e86af56b3a in mysql_insert (thd=0x772018000e38, table_list=0x772018015010, fields=..., values_list=..., update_fields=..., update_values=..., duplic=DUP_ERROR, ignore=false, result=0x0) at /quick-rebuilds/mariadb-server/sql/sql_insert.cc:1216
```

### After the fix

Running `main.long_unique_bugs` (with the added test) succeeds in debug mode:
```
main.long_unique_bugs                    [ pass ]   1932
```

## Basing the PR against the correct MariaDB version

* [x] _This is a bug fix, and the PR is based against the earliest maintained branch on which the bug can be reproduced: 10.11._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.