### PR TITLE
MDEV-35154 : dict_sys_t::load_table() is holding exclusive dict_sys.latch for unnecessarily long time

### DIFF
--- a/mysql-test/suite/innodb/r/dict_load_concurrent.result
+++ b/mysql-test/suite/innodb/r/dict_load_concurrent.result
@@ -1,0 +1,83 @@
+#
+# MDEV-35154 dict_sys_t::load_table() is holding exclusive dict_sys.latch for unnecessarily long time
+#
+CREATE TABLE t1(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+CREATE TABLE t2(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(2);
+SET @save_evict= @@GLOBAL.innodb_evict_tables_on_commit_debug;
+SET GLOBAL innodb_evict_tables_on_commit_debug=ON;
+XA START 'x';
+INSERT INTO t1 VALUES(2);
+INSERT INTO t2 VALUES(3);
+XA END 'x';
+XA PREPARE 'x';
+connect con1,localhost,root,,;
+FLUSH TABLES;
+connection default;
+XA COMMIT 'x';
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_evict;
+connection con1;
+SET DEBUG_SYNC = 'dict_load_table_one_no_latch SIGNAL loading WAIT_FOR go TIMEOUT 30';
+SELECT * FROM t1;
+connection default;
+SET DEBUG_SYNC = 'now WAIT_FOR loading TIMEOUT 30';
+SELECT * FROM t2;
+a
+2
+3
+connect con2,localhost,root,,;
+SELECT * FROM t1;
+connection default;
+SET DEBUG_SYNC = 'now SIGNAL go';
+connection con1;
+a
+1
+2
+connection con2;
+a
+1
+2
+connection default;
+SET DEBUG_SYNC = RESET;
+DROP TABLE t1, t2;
+CREATE TABLE parent(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+FOREIGN KEY(a) REFERENCES parent(a))
+STATS_PERSISTENT=0 ENGINE=InnoDB;
+INSERT INTO parent VALUES(1);
+INSERT INTO child VALUES(1);
+SET GLOBAL innodb_evict_tables_on_commit_debug=ON;
+XA START 'y';
+INSERT INTO parent VALUES(2);
+INSERT INTO child VALUES(2);
+XA END 'y';
+XA PREPARE 'y';
+connection con1;
+FLUSH TABLES;
+connection default;
+XA COMMIT 'y';
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_evict;
+connection con1;
+SET DEBUG_SYNC = 'dict_load_table_one_no_latch SIGNAL child_loading WAIT_FOR child_go TIMEOUT 30';
+SELECT * FROM child;
+connection con2;
+SET DEBUG_SYNC = 'now WAIT_FOR child_loading TIMEOUT 30';
+SELECT * FROM parent;
+connection default;
+SET DEBUG_SYNC = 'now SIGNAL child_go';
+connection con1;
+a
+1
+2
+connection con2;
+a
+1
+2
+connection default;
+DELETE FROM parent WHERE a=1;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `child_ibfk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+disconnect con1;
+disconnect con2;
+SET DEBUG_SYNC = RESET;
+DROP TABLE child, parent;

--- a/mysql-test/suite/innodb/t/dict_load_concurrent.test
+++ b/mysql-test/suite/innodb/t/dict_load_concurrent.test
@@ -1,0 +1,140 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--echo #
+--echo # MDEV-35154 dict_sys_t::load_table() is holding exclusive dict_sys.latch for unnecessarily long time
+--echo #
+
+# Loading a table definition into the dictionary cache must not hold
+# the exclusive dict_sys.latch during the I/O phase. A table whose
+# definition is being loaded is published as an incomplete stub;
+# other openers of the same table wait for the load to complete,
+# while any other table can be opened (and loaded) concurrently.
+
+# STATS_PERSISTENT=0 keeps the background statistics thread from
+# reloading the evicted table definitions behind our back.
+CREATE TABLE t1(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+CREATE TABLE t2(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(2);
+
+# Evict t1 and t2 from the dictionary cache: at XA COMMIT, the
+# modified tables are evicted if no table handles are open, which
+# FLUSH TABLES between XA PREPARE and XA COMMIT guarantees. The
+# FLUSH must be issued from another connection, because a session
+# with a prepared XA transaction refuses other statements. The
+# prepared transaction's own table lock protects the tables from
+# LRU eviction until the commit.
+SET @save_evict= @@GLOBAL.innodb_evict_tables_on_commit_debug;
+SET GLOBAL innodb_evict_tables_on_commit_debug=ON;
+XA START 'x';
+INSERT INTO t1 VALUES(2);
+INSERT INTO t2 VALUES(3);
+XA END 'x';
+XA PREPARE 'x';
+
+connect con1,localhost,root,,;
+FLUSH TABLES;
+
+connection default;
+XA COMMIT 'x';
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_evict;
+
+connection con1;
+SET DEBUG_SYNC = 'dict_load_table_one_no_latch SIGNAL loading WAIT_FOR go TIMEOUT 30';
+send SELECT * FROM t1;
+
+connection default;
+SET DEBUG_SYNC = 'now WAIT_FOR loading TIMEOUT 30';
+
+# con1 is parked inside the load of t1 while holding no dict_sys.latch.
+# Loading another table must not block. (Before this change, the
+# following statement would hang until the load of t1 completed.)
+SELECT * FROM t2;
+
+connect con2,localhost,root,,;
+send SELECT * FROM t1;
+
+connection default;
+# con2 must wait for the load of t1 (it observes the loading stub);
+# con1 is parked at the DEBUG_SYNC point (state 'debug sync point:
+# ...'), so exactly one session is waiting in 'Opening tables'.
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = 'Opening tables' AND info = 'SELECT * FROM t1';
+--source include/wait_condition.inc
+
+SET DEBUG_SYNC = 'now SIGNAL go';
+
+connection con1;
+reap;
+connection con2;
+reap;
+connection default;
+SET DEBUG_SYNC = RESET;
+DROP TABLE t1, t2;
+
+#
+# A table must not become visible while a table that is related to
+# it by a FOREIGN KEY constraint is still being loaded by another
+# thread: the constraint would be missing from referenced_set.
+#
+CREATE TABLE parent(a INT PRIMARY KEY) STATS_PERSISTENT=0 ENGINE=InnoDB;
+CREATE TABLE child(a INT PRIMARY KEY,
+                   FOREIGN KEY(a) REFERENCES parent(a))
+STATS_PERSISTENT=0 ENGINE=InnoDB;
+INSERT INTO parent VALUES(1);
+INSERT INTO child VALUES(1);
+
+SET GLOBAL innodb_evict_tables_on_commit_debug=ON;
+XA START 'y';
+INSERT INTO parent VALUES(2);
+INSERT INTO child VALUES(2);
+XA END 'y';
+XA PREPARE 'y';
+
+connection con1;
+FLUSH TABLES;
+
+connection default;
+XA COMMIT 'y';
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_evict;
+
+# Park inside the load of the child table.
+connection con1;
+SET DEBUG_SYNC = 'dict_load_table_one_no_latch SIGNAL child_loading WAIT_FOR child_go TIMEOUT 30';
+send SELECT * FROM child;
+
+connection con2;
+SET DEBUG_SYNC = 'now WAIT_FOR child_loading TIMEOUT 30';
+# Loading the parent finds the constraint in SYS_FOREIGN, but the child
+# is still an incomplete stub, so the constraint cannot be linked yet.
+# The parent must not become visible before the child has been loaded.
+send SELECT * FROM parent;
+
+connection default;
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = 'Opening tables' AND info = 'SELECT * FROM parent';
+--source include/wait_condition.inc
+
+SET DEBUG_SYNC = 'now SIGNAL child_go';
+
+connection con1;
+reap;
+connection con2;
+reap;
+
+connection default;
+# The constraint was linked into parent->referenced_set before the
+# parent became visible.
+--error ER_ROW_IS_REFERENCED_2
+DELETE FROM parent WHERE a=1;
+
+disconnect con1;
+disconnect con2;
+SET DEBUG_SYNC = RESET;
+DROP TABLE child, parent;
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -244,6 +244,14 @@ ATTRIBUTE_COLD bool btr_search_disable()
 	for (table = UT_LIST_GET_FIRST(dict_sys.table_non_LRU); table;
 	     table = UT_LIST_GET_NEXT(table_LRU, table)) {
 
+		if (table->loading) {
+			/* The table definition is being loaded by another
+			thread without dict_sys.latch; walking its indexes
+			would race with that thread. Its indexes cannot have
+			any adaptive hash index references. */
+			continue;
+		}
+
 		btr_search_disable_ref_count(table);
 	}
 

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -603,13 +603,17 @@ dict_table_t *dict_sys_t::find_table(table_id_t id) const noexcept
   return table_id_hash.cell_get(ut_fold_ull(id))->
     find(&dict_table_t::id_hash, [id](const dict_table_t *t)
     {
+      /* A table that is still being loaded is treated as if it
+      were not cached. */
+      if (t->loading)
+        return false;
       ut_ad(!t->is_temporary());
       ut_ad(t->cached);
       return t->id == id;
     });
 }
 
-dict_table_t *dict_sys_t::find_table(const span<const char> &name)
+dict_table_t *dict_sys_t::find_table_any(const span<const char> &name)
   const noexcept
 {
   ut_ad(frozen());
@@ -619,6 +623,32 @@ dict_table_t *dict_sys_t::find_table(const span<const char> &name)
       return strlen(t->name.m_name) == name.size() &&
         !memcmp(t->name.m_name, name.data(), name.size());
     });
+}
+
+dict_table_t *dict_sys_t::find_table(const span<const char> &name)
+  const noexcept
+{
+  dict_table_t *t= find_table_any(name);
+  /* A table whose loading has not completed must not be accessed;
+  treat it as if it were not cached. */
+  return t && t->loading ? nullptr : t;
+}
+
+dict_table_t *dict_sys_t::find_table_fk(const span<const char> &name)
+  const noexcept
+{
+  ut_ad(locked());
+  dict_table_t *t= find_table_any(name);
+  /* A table whose definition is still being loaded (LOADING_DEF) is
+  concurrently modified by its loader without any latch; it must be
+  treated as if it were not cached. A table that is only waiting for
+  its FOREIGN KEY related tables to be loaded (LOADING_FK) has a
+  complete definition, and its foreign_set/referenced_set are only
+  modified under the exclusive latch, which we are holding; linking
+  a constraint into it is safe, and necessary so that two concurrent
+  dict_sys_t::load_table() invocations whose tables reference each
+  other will resolve the constraints between them. */
+  return t && t->loading == dict_table_t::LOADING_DEF ? nullptr : t;
 }
 
 /** Acquire MDL shared for the table name.
@@ -938,6 +968,8 @@ void dict_sys_t::create() noexcept
   temp_id_hash.create(hash_size);
 
   latch.SRW_LOCK_INIT(dict_operation_lock_key);
+  mysql_mutex_init(dict_load_mutex_key, &load_mutex, nullptr);
+  pthread_cond_init(&load_cond, nullptr);
 
   if (!srv_read_only_mode)
   {
@@ -976,6 +1008,34 @@ void dict_sys_t::lock_wait(SRW_LOCK_ARGS(const char *file, unsigned line)) noexc
     ib::warn() << "A long wait (" << waited
                << " seconds) was observed for dict_sys.latch";
   latch.wr_lock(SRW_LOCK_ARGS(file, line));
+}
+
+void dict_sys_t::load_wait() noexcept
+{
+  ut_ad(locked());
+  /* Acquiring load_mutex before releasing the exclusive latch closes
+  the race with load_done(): the loader can only clear
+  dict_table_t::loading or remove the stub while holding the exclusive
+  latch, which it cannot acquire before we release it below, and its
+  subsequent broadcast has to wait for our my_cond_wait() to release
+  load_mutex. Lock order is dict_sys.latch, then load_mutex; the mutex
+  is never held while (re)acquiring the latch. */
+  mysql_mutex_lock(&load_mutex);
+  unlock();
+  /* The timeout is a safety net: should the loader fail to signal us,
+  the caller will observe the stale stub again and simply wait again. */
+  timespec abstime;
+  set_timespec(abstime, 5);
+  my_cond_timedwait(&load_cond, &load_mutex.m_mutex, &abstime);
+  mysql_mutex_unlock(&load_mutex);
+  lock(SRW_LOCK_CALL);
+}
+
+void dict_sys_t::load_done() noexcept
+{
+  mysql_mutex_lock(&load_mutex);
+  pthread_cond_broadcast(&load_cond);
+  mysql_mutex_unlock(&load_mutex);
 }
 
 #ifdef UNIV_PFS_RWLOCK
@@ -1144,7 +1204,10 @@ dict_table_add_system_columns(
 {
 	ut_ad(table->n_def == table->n_cols - DATA_N_SYS_COLS);
 	ut_ad(table->magic_n == DICT_TABLE_MAGIC_N);
-	ut_ad(!table->cached);
+	/* A table that is being loaded by dict_load_table_one() was
+	published in the cache as an incomplete stub before its columns
+	were loaded. */
+	ut_ad(!table->cached || table->is_loader());
 
 	/* NOTE: the system columns MUST be added in the following order
 	(so that they can be indexed by the numerical value of DATA_ROW_ID,
@@ -1191,7 +1254,9 @@ inline void dict_sys_t::add(dict_table_t *table) noexcept
     search(&dict_table_t::name_hash, [name](const dict_table_t *t)
     {
       if (!t) return true;
-      ut_ad(t->cached);
+      /* t may be a stub that another thread is loading; check the
+      atomic flag before the bit-field to avoid a torn read. */
+      ut_ad(t->loading || t->cached);
       ut_a(strcmp(t->name.m_name, name));
       return false;
     });
@@ -1201,7 +1266,7 @@ inline void dict_sys_t::add(dict_table_t *table) noexcept
     search(&dict_table_t::id_hash, [table](const dict_table_t *t)
     {
       if (!t) return true;
-      ut_ad(t->cached);
+      ut_ad(t->loading || t->cached);
       ut_a(t->id != table->id);
       return false;
     });
@@ -1218,6 +1283,11 @@ static bool dict_table_can_be_evicted(dict_table_t *table)
 {
 	ut_ad(dict_sys.locked());
 	ut_a(table->can_be_evicted);
+
+	if (table->loading) {
+		return false;
+	}
+
 	ut_a(table->foreign_set.empty());
 	ut_a(table->referenced_set.empty());
 
@@ -1587,6 +1657,10 @@ dict_table_rename_in_cache(
 							new_name.size()))
 		->node);
 	for (; *after; after = &(*after)->name_hash) {
+		/* The entry may be a stub that another thread is loading;
+		check the atomic flag before the bit-field to avoid a
+		torn read. */
+		//ut_ad((*after)->loading || (*after)->cached);
 		ut_ad((*after)->cached);
 		ut_a(strcmp((*after)->name.m_name, new_name.data()));
 	}
@@ -1983,7 +2057,7 @@ dict_index_add_to_cache(
 	ulint		n_ord;
 	ulint		i;
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || index->table->is_loader());
 	ut_ad(index->n_def == index->n_fields);
 	ut_ad(index->magic_n == DICT_INDEX_MAGIC_N);
 	ut_ad(!dict_index_is_online_ddl(index));
@@ -2193,7 +2267,7 @@ dict_index_find_cols(
 
 	const dict_table_t* table = index->table;
 	ut_ad(table->magic_n == DICT_TABLE_MAGIC_N);
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	for (ulint i = 0; i < index->n_fields; i++) {
 		ulint		j;
@@ -2463,7 +2537,7 @@ dict_index_build_internal_clust(
 	ut_ad(index->is_primary());
 	ut_ad(!index->has_virtual());
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	/* Create a new index object with certainly enough fields */
 	new_index = dict_mem_index_create(index->table, index->name,
@@ -2618,7 +2692,7 @@ dict_index_build_internal_non_clust(
 	ut_ad(table && index);
 	ut_ad(!dict_index_is_clust(index));
 	ut_ad(!dict_index_is_ibuf(index));
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	/* The clustered index should be the first in the list of indexes */
 	clust_index = UT_LIST_GET_FIRST(table->indexes);
@@ -2707,7 +2781,7 @@ dict_index_build_internal_fts(
 	dict_index_t*	new_index;
 
 	ut_ad(index->type & DICT_FTS);
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || index->table->is_loader());
 
 	/* Create a new index */
 	new_index = dict_mem_index_create(index->table, index->name,
@@ -2926,11 +3000,11 @@ dict_foreign_add_to_cache(
 
 	ut_ad(dict_sys.locked());
 
-	for_table = dict_sys.find_table(
+	for_table = dict_sys.find_table_fk(
 		{foreign->foreign_table_name_lookup,
 		 strlen(foreign->foreign_table_name_lookup)});
 
-	ref_table = dict_sys.find_table(
+	ref_table = dict_sys.find_table_fk(
 		{foreign->referenced_table_name_lookup,
 		 strlen(foreign->referenced_table_name_lookup)});
 	ut_a(for_table || ref_table);
@@ -4381,7 +4455,7 @@ dict_fs2utf8(
 @param id_hash dict_sys.table_id_hash or dict_sys.temp_id_hash */
 static void hash_insert(dict_table_t *table, hash_table_t& id_hash) noexcept
 {
-  ut_ad(table->cached);
+  ut_ad(table->loading || table->cached);
   dict_sys.table_hash.cell_get(my_crc32c(0, table->name.m_name,
                                          strlen(table->name.m_name)))->
     append(*table, &dict_table_t::name_hash);
@@ -4446,6 +4520,8 @@ void dict_sys_t::close() noexcept
 
   unlock();
   latch.destroy();
+  pthread_cond_destroy(&load_cond);
+  mysql_mutex_destroy(&load_mutex);
 
   mysql_mutex_destroy(&dict_foreign_err_mutex);
 

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -56,14 +56,21 @@ key constraints are loaded into memory.
 @param[in]	name		Table name in the db/tablename format
 @param[in]	ignore_err	Error to be ignored when loading table
 				and its index definition
+@param[in]	fk_heap		Heap on which the names appended to
+				fk_tables are allocated
 @param[out]	fk_tables	Related table names that must also be
 				loaded to ensure that all foreign key
 				constraints are loaded.
+@param[in]	hold_latch	Whether to hold the exclusive
+				dict_sys.latch for the whole load; see
+				dict_load_hold_latch()
 @return table, possibly with file_unreadable flag set
 @retval nullptr if the table does not exist */
 static dict_table_t *dict_load_table_one(const span<const char> &name,
                                          dict_err_ignore_t ignore_err,
-                                         dict_names_t &fk_tables);
+                                         mem_heap_t *fk_heap,
+                                         dict_names_t &fk_tables,
+                                         bool hold_latch);
 
 /** Load an index definition from a SYS_INDEXES record to dict_index_t.
 @return	error message
@@ -1320,7 +1327,7 @@ static dberr_t dict_load_columns(dict_table_t *table, unsigned use_uncommitted,
 	mtr_t		mtr;
 	ulint		n_skipped = 0;
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	mtr.start();
 
@@ -1449,7 +1456,7 @@ dict_load_virtual_col(dict_table_t *table, bool uncommitted, ulint nth_v_col)
 	btr_pcur_t	pcur;
 	mtr_t		mtr;
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	mtr.start();
 
@@ -1694,7 +1701,7 @@ static dberr_t dict_load_fields(dict_index_t *index, bool uncommitted,
 	btr_pcur_t	pcur;
 	mtr_t		mtr;
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || index->table->is_loader());
 
 	mtr.start();
 
@@ -1951,7 +1958,7 @@ dberr_t dict_load_indexes(dict_table_t *table, bool uncommitted,
 	byte		table_id[8];
 	mtr_t		mtr;
 
-	ut_ad(dict_sys.locked());
+	ut_ad(dict_sys.locked() || table->is_loader());
 
 	mtr.start();
 
@@ -2325,9 +2332,52 @@ key constraints are loaded into memory.
 				constraints are loaded.
 @return table, possibly with file_unreadable flag set
 @retval nullptr if the table does not exist */
+/** Determine whether a table must be loaded without ever releasing
+the exclusive dict_sys.latch, because it may be referenced by InnoDB
+internal SQL. The non-reentrant internal SQL parser is serialized by
+the exclusive dict_sys.latch, which the callers of que_eval_sql() hold
+across parsing and execution; pars_retrieve_table_def() opens the
+referenced tables in the middle of parsing. Releasing the latch there
+(to publish a loading stub, or to wait for one in
+dict_sys_t::load_wait()) would let another thread corrupt the parser
+state. Because every load of such a table holds the latch throughout,
+no loading stub can ever exist for it, and a parse-time lookup can
+never encounter one.
+@param name  table name ("db/table" or an InnoDB system table name)
+@return whether the table must be loaded while holding the latch */
+static bool dict_load_hold_latch(const span<const char> &name)
+{
+	const void*	p = memchr(name.data(), '/', name.size());
+
+	if (!p) {
+		/* InnoDB system tables, such as SYS_FOREIGN, have no
+		database component in their names. */
+		return true;
+	}
+
+	const char*	n = static_cast<const char*>(p) + 1;
+
+	if (name.end() - n > 4
+	    && (n[0] == 'F' || n[0] == 'f')
+	    && (n[1] == 'T' || n[1] == 't')
+	    && (n[2] == 'S' || n[2] == 's')
+	    && n[3] == '_') {
+		/* FULLTEXT INDEX auxiliary tables */
+		return true;
+	}
+
+	/* The persistent statistics tables */
+	return (name.size() == sizeof TABLE_STATS_NAME - 1
+		&& !memcmp(name.data(), TABLE_STATS_NAME, name.size()))
+		|| (name.size() == sizeof INDEX_STATS_NAME - 1
+		    && !memcmp(name.data(), INDEX_STATS_NAME, name.size()));
+}
+
 static dict_table_t *dict_load_table_one(const span<const char> &name,
                                          dict_err_ignore_t ignore_err,
-                                         dict_names_t &fk_tables)
+                                         mem_heap_t *fk_heap,
+                                         dict_names_t &fk_tables,
+                                         bool hold_latch)
 {
 	btr_pcur_t	pcur;
 	mtr_t		mtr;
@@ -2363,7 +2413,20 @@ static dict_table_t *dict_load_table_one(const span<const char> &name,
 	pcur.btr_cur.page_cur.index = sys_index;
 
 	bool uncommitted = false;
+	dict_table_t* table = nullptr;
 reload:
+	/* Phase 1 (exclusive dict_sys.latch): locate the SYS_TABLES
+	record, create the table object, and make it visible in the
+	cache as a non-evictable, incomplete stub (dict_table_t::loading),
+	so that the latch can be released during the I/O below. */
+	if (table) {
+		/* We are retrying after DB_SUCCESS_LOCKED_REC. Discard
+		the previously published stub; a new table object will
+		be created below, possibly with a different table id. */
+		dict_sys.remove(table);
+		table = nullptr;
+	}
+
 	mtr.start();
 	dberr_t err = btr_pcur_open_on_user_rec(&tuple,
 						BTR_SEARCH_LEAF, &pcur, &mtr);
@@ -2372,6 +2435,11 @@ reload:
 		/* Not found */
 err_exit:
 		mtr.commit();
+		if (uncommitted) {
+			/* A stub was removed at reload:; wake up any
+			threads that were waiting for it. */
+			dict_sys.load_done();
+		}
 		DBUG_RETURN(nullptr);
 	}
 
@@ -2383,7 +2451,6 @@ err_exit:
 		goto err_exit;
 	}
 
-	dict_table_t* table;
 	if (const char* err_msg =
 	    dict_load_table_low(&mtr, uncommitted, rec, &table)) {
 		if (err_msg != dict_load_table_flags) {
@@ -2403,6 +2470,27 @@ err_exit:
 
 	mtr.commit();
 
+	/* Publish the incomplete table object. Any other thread that
+	looks it up will observe dict_table_t::loading and either treat
+	the table as not cached (dict_sys_t::find_table()) or wait for
+	the load to complete (dict_sys_t::load_table()). The stub is
+	inserted into table_non_LRU (can_be_evicted=false), so that
+	dict_sys_t::evict_table_LRU() cannot free it. */
+	ut_ad(!table->can_be_evicted);
+	table->loading = dict_table_t::LOADING_DEF;
+	ut_d(table->load_thread = pthread_self());
+	table->add_to_cache();
+
+	if (!hold_latch) {
+		dict_sys.unlock();
+	}
+
+	/* Phase 2 (no dict_sys.latch): open the tablespace and load the
+	columns and indexes. Only this thread may access the table object;
+	the SYS_ tables and their indexes are non-evictable, and any DDL
+	that would modify this table's SYS_ records must first look up the
+	table in the cache, observe the stub, and wait for it. */
+
 	mem_heap_t* heap = mem_heap_create(32000);
 
 	dict_load_tablespace(table, ignore_err);
@@ -2411,8 +2499,10 @@ err_exit:
 	case DB_SUCCESS_LOCKED_REC:
 		ut_ad(!uncommitted);
 		uncommitted = true;
-		dict_mem_table_free(table);
 		mem_heap_free(heap);
+		if (!hold_latch) {
+			dict_sys.lock(SRW_LOCK_CALL);
+		}
 		goto reload;
 	case DB_SUCCESS:
 		if (!dict_load_virtual(table, uncommitted)) {
@@ -2420,15 +2510,16 @@ err_exit:
 		}
 		/* fall through */
 	default:
-		dict_mem_table_free(table);
 		mem_heap_free(heap);
+		if (!hold_latch) {
+			dict_sys.lock(SRW_LOCK_CALL);
+		}
+		dict_sys.remove(table);
+		dict_sys.load_done();
 		DBUG_RETURN(nullptr);
 	}
 
 	dict_table_add_system_columns(table, heap);
-
-	table->can_be_evicted = true;
-	table->add_to_cache();
 
 	mem_heap_empty(heap);
 
@@ -2447,19 +2538,16 @@ err_exit:
 
 	err = dict_load_indexes(table, uncommitted, heap, index_load_err);
 
+	bool evict_stub = false;
+
 	if (err == DB_TABLE_CORRUPT) {
 		/* Refuse to load the table if the table has a corrupted
 		cluster index */
 		ut_ad(index_load_err != DICT_ERR_IGNORE_DROP);
 		ib::error() << "Refusing to load corrupted table "
 			    << table->name;
-evict:
-		dict_sys.remove(table);
-		mem_heap_free(heap);
-		DBUG_RETURN(nullptr);
-	}
-
-	if (err != DB_SUCCESS || !table->is_readable()) {
+		evict_stub = true;
+	} else if (err != DB_SUCCESS || !table->is_readable()) {
 	} else if (dict_index_t* pk = dict_table_get_first_index(table)) {
 		ut_ad(pk->is_primary());
 		if (pk->is_corrupted()
@@ -2500,8 +2588,39 @@ corrupted:
 		ut_ad(ignore_err & DICT_ERR_IGNORE_INDEX);
 		if (ignore_err != DICT_ERR_IGNORE_DROP) {
 			err = DB_CORRUPTION;
-			goto evict;
+			evict_stub = true;
 		}
+	}
+
+	if (!hold_latch) {
+		/* When the definition is loaded by a connection thread,
+		allow tests to run other statements while no
+		dict_sys.latch is held. */
+		DEBUG_SYNC_C("dict_load_table_one_no_latch");
+
+		/* Phase 3 (exclusive dict_sys.latch): complete the
+		definition and load the foreign key constraints. */
+		dict_sys.lock(SRW_LOCK_CALL);
+	}
+
+	dict_sys.allow_eviction(table);
+	/* The definition is complete, but the table stays hidden from
+	dict_sys_t::find_table() until our caller dict_sys_t::load_table()
+	has also loaded the tables that are related to this table by
+	FOREIGN KEY constraints, and makes all of them visible atomically.
+	From this point on, constraints may be linked into this table
+	via dict_sys_t::find_table_fk(): the foreign_set/referenced_set
+	are only modified while holding the exclusive latch. */
+	table->loading = dict_table_t::LOADING_FK;
+
+	if (evict_stub) {
+evict:
+		dict_sys.remove(table);
+		/* Wake up any dict_sys_t::load_wait() callers, so that
+		they can observe that the stub is gone, and retry. */
+		dict_sys.load_done();
+		mem_heap_free(heap);
+		DBUG_RETURN(nullptr);
 	}
 
 	/* We will load the foreign key information only if
@@ -2511,7 +2630,8 @@ corrupted:
 	} else if (err == DB_SUCCESS) {
 		auto i = fk_tables.size();
 		err = dict_load_foreigns(table->name.m_name, nullptr,
-					 0, true, ignore_err, fk_tables);
+					 0, true, ignore_err, fk_heap,
+					 fk_tables);
 
 		if (err != DB_SUCCESS) {
 			fk_tables.erase(fk_tables.begin() + i, fk_tables.end());
@@ -2558,17 +2678,88 @@ corrupted:
 dict_table_t *dict_sys_t::load_table(const span<const char> &name,
                                      dict_err_ignore_t ignore) noexcept
 {
-  if (dict_table_t *table= find_table(name))
-    return table;
+  for (;;)
+  {
+    dict_table_t *table= find_table_any(name);
+    if (!table)
+      break;
+    if (!table->loading)
+      return table;
+    /* Another thread is loading the table definition. Wait for it
+    to complete or fail, and retry the lookup: the stub may have
+    been removed (and freed) by the time we wake up. */
+    ut_ad(!table->is_loader());
+    load_wait();
+  }
+
+  mem_heap_t *fk_heap= mem_heap_create(1000);
   dict_names_t fk_list;
-  dict_table_t *table= dict_load_table_one(name, ignore, fk_list);
+  /* The tables loaded by this invocation. They remain hidden from
+  other threads (dict_table_t::LOADING_FK) until all of them have
+  been loaded, so that no thread can operate on a table whose
+  foreign key constraints are not fully linked yet. Being hidden,
+  they cannot be referenced, dropped or evicted by any other thread
+  (dict_table_can_be_evicted() also skips them), so the pointers
+  remain valid across the latch releases below. */
+  std::vector<dict_table_t*, ut_allocator<dict_table_t*>> loaded;
+  /* Tables that may be referenced by InnoDB internal SQL must be
+  loaded without ever releasing the exclusive latch, because this may
+  be a parse-time table lookup from pars_retrieve_table_def(), and the
+  non-reentrant internal SQL parser is serialized by the latch. Any
+  tables loaded for their FOREIGN KEY constraints inherit this, so
+  that no latch release can occur in the middle of parsing. */
+  const bool hold_latch= dict_load_hold_latch(name);
+  dict_table_t *table= dict_load_table_one(name, ignore, fk_heap, fk_list,
+                                           hold_latch);
+  if (table)
+    loaded.emplace_back(table);
   while (!fk_list.empty())
   {
     const char *f= fk_list.front();
-    const span<const char> name{f, strlen(f)};
-    if (!find_table(name))
-      dict_load_table_one(name, ignore, fk_list);
+    const span<const char> fk_name{f, strlen(f)};
+    if (dict_table_t *t= find_table_any(fk_name))
+    {
+      if (t->loading == dict_table_t::LOADING_DEF && !hold_latch)
+      {
+        /* Another thread is still loading the definition of this
+        table, so its dict_load_foreigns() has not been invoked yet
+        and the constraints between it and the tables that we loaded
+        may still be missing. Wait for it and retry this name, so
+        that we will not publish a table whose referenced_set is
+        incomplete. */
+        ut_ad(!t->is_loader());
+        load_wait();
+        continue;
+      }
+      /* The table has been loaded, or its definition is complete and
+      only the tables related to it are still being loaded
+      (LOADING_FK). In either case its dict_load_foreigns() has
+      already been invoked while holding the exclusive latch, and it
+      was able to see our tables via dict_sys_t::find_table_fk(), so
+      the constraints have been linked. */
+    }
+    else if (dict_table_t *fk_table=
+             dict_load_table_one(fk_name, ignore, fk_heap, fk_list,
+                                 hold_latch || dict_load_hold_latch(fk_name)))
+      loaded.emplace_back(fk_table);
     fk_list.pop_front();
+  }
+  mem_heap_free(fk_heap);
+
+  if (!loaded.empty())
+  {
+    /* All tables related by foreign key constraints have been
+    loaded and linked; make them visible to other threads, and wake
+    up any dict_sys_t::load_wait() callers. They will block on the
+    exclusive latch until our caller releases it, and then retry
+    their lookup. */
+    for (dict_table_t *t : loaded)
+    {
+      ut_ad(t->loading == dict_table_t::LOADING_FK);
+      ut_ad(t->is_loader());
+      t->loading = dict_table_t::NOT_LOADING;
+    }
+    load_done();
   }
 
   return table;
@@ -2591,10 +2782,6 @@ dict_load_table_on_id(
 	mtr_t		mtr;
 
 	ut_ad(dict_sys.locked());
-
-	/* NOTE that the operation of this function is protected by
-	dict_sys.latch, and therefore no deadlocks can occur
-	with other dictionary operations. */
 
 	mtr.start();
 	/*---------------------------------------------------*/
@@ -2632,16 +2819,46 @@ check_rec:
 
 		/* Check if the table id in record is the one searched for */
 		if (table_id == mach_read_from_8(field)) {
+			char name_buf[MAX_FULL_NAME_LEN + 1];
 			field = rec_get_nth_field_old(rec,
 				DICT_FLD__SYS_TABLE_IDS__NAME, &len);
-			table = dict_sys.load_table(
-				{reinterpret_cast<const char*>(field),
-				 len}, ignore_err);
+			if (UNIV_UNLIKELY(len > sizeof name_buf)) {
+				/* corrupted record */
+				goto func_exit;
+			}
+			/* Copy the name and release the page latch before
+			calling load_table(): it releases the exclusive
+			dict_sys.latch during the load, and it may block
+			waiting for a concurrent load of the same table.
+			Waiting while holding a latched SYS_TABLES page
+			could deadlock with a DDL thread that holds the
+			exclusive dict_sys.latch and is waiting for a
+			latch on this page. */
+			memcpy(name_buf, field, len);
+			ut_d(const auto deleted = rec_get_deleted_flag(rec,
+								       0));
+			btr_pcur_store_position(&pcur, &mtr);
+			mtr.commit();
+
+			table = dict_sys.load_table({name_buf, len},
+						    ignore_err);
 			if (table && table->id != table_id) {
-				ut_ad(rec_get_deleted_flag(rec, 0));
+				/* The record was delete-marked, and the
+				name has been reused by another table. */
+				ut_ad(deleted);
 				table = nullptr;
 			}
-			if (!table) {
+			if (table) {
+				ut_free(pcur.old_rec_buf);
+				return table;
+			}
+
+			/* The SYS_TABLE_IDS record may have been stale.
+			Keep scanning for further records with a
+			matching table id. */
+			mtr.start();
+			if (pcur.restore_position(BTR_SEARCH_LEAF, &mtr)
+			    != btr_pcur_t::CORRUPTED) {
 				while (btr_pcur_move_to_next(&pcur, &mtr)) {
 					rec = btr_pcur_get_rec(&pcur);
 
@@ -2653,7 +2870,9 @@ check_rec:
 		}
 	}
 
+func_exit:
 	mtr.commit();
+	ut_free(pcur.old_rec_buf);
 	return table;
 }
 
@@ -2861,6 +3080,9 @@ dict_load_foreign(
 				/*!< in: foreign constraint id */
 	dict_err_ignore_t	ignore_err,
 				/*!< in: error to be ignored */
+	mem_heap_t*		fk_heap,
+				/*!< in: heap for the names appended
+				to fk_tables */
 	dict_names_t&	fk_tables)
 				/*!< out: the foreign key constraint is added
 				to the dictionary cache only if the referenced
@@ -3010,10 +3232,10 @@ err_exit:
 		goto load_error;
 	}
 
-	ref_table = dict_sys.find_table(
+	ref_table = dict_sys.find_table_fk(
 		{foreign->referenced_table_name_lookup,
 		 strlen(foreign->referenced_table_name_lookup)});
-	for_table = dict_sys.find_table(
+	for_table = dict_sys.find_table_fk(
 		{foreign->foreign_table_name_lookup,
 		 strlen(foreign->foreign_table_name_lookup)});
 
@@ -3021,11 +3243,15 @@ err_exit:
 		/* To avoid recursively loading the tables related through
 		the foreign key constraints, the child table name is saved
 		here.  The child table will be loaded later, along with its
-		foreign key constraint. */
+		foreign key constraint. The name is copied to fk_heap,
+		which the caller keeps valid until fk_tables is drained;
+		ref_table->heap would not do, because ref_table may be
+		evicted while dict_sys.load_table() releases the exclusive
+		dict_sys.latch between the drain iterations. */
 
 		ut_a(ref_table != NULL);
 		fk_tables.push_back(
-			mem_heap_strdupl(ref_table->heap,
+			mem_heap_strdupl(fk_heap,
 					 foreign->foreign_table_name_lookup,
 					 foreign_table_name_len));
 load_error:
@@ -3070,6 +3296,9 @@ dict_load_foreigns(
 	bool			check_charsets,	/*!< in: whether to check
 						charset compatibility */
 	dict_err_ignore_t	ignore_err,	/*!< in: error to be ignored */
+	mem_heap_t*		fk_heap,	/*!< in: heap on which the
+						names appended to fk_tables
+						are allocated */
 	dict_names_t&		fk_tables)
 						/*!< out: stack of table
 						names which must be loaded
@@ -3180,7 +3409,8 @@ loop:
 	err = len < sizeof fk_id
 		? dict_load_foreign(table_name, false, col_names, trx_id,
 				    check_recursive, check_charsets,
-				    {fk_id, len}, ignore_err, fk_tables)
+				    {fk_id, len}, ignore_err, fk_heap,
+				    fk_tables)
 		: DB_CORRUPTION;
 
 	switch (err) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -545,6 +545,7 @@ static mysql_pfs_key_t	pending_checkpoint_mutex_key;
 # ifdef UNIV_PFS_MUTEX
 mysql_pfs_key_t	buf_pool_mutex_key;
 mysql_pfs_key_t	dict_foreign_err_mutex_key;
+mysql_pfs_key_t	dict_load_mutex_key;
 mysql_pfs_key_t	fil_system_mutex_key;
 mysql_pfs_key_t	flush_list_mutex_key;
 mysql_pfs_key_t	fts_cache_mutex_key;
@@ -579,6 +580,7 @@ static PSI_mutex_info all_innodb_mutexes[] = {
 	PSI_KEY(pending_checkpoint_mutex),
 	PSI_KEY(buf_pool_mutex),
 	PSI_KEY(dict_foreign_err_mutex),
+	PSI_KEY(dict_load_mutex),
 	PSI_KEY(recalc_pool_mutex),
 	PSI_KEY(fil_system_mutex),
 	PSI_KEY(flush_list_mutex),
@@ -12540,6 +12542,19 @@ create_table_info_t::create_foreign_keys()
 		foreign->referenced_table_name = dict_table_lookup(
 			d, t, &foreign->referenced_table, foreign->heap);
 
+		if (foreign->referenced_table) {
+			/* Prevent the eviction of the referenced table:
+			dict_sys.load_table() for a later constraint in
+			this loop may temporarily release the exclusive
+			dict_sys.latch, and dict_sys_t::remove() would not
+			clear the pointer that was stored above, because
+			`foreign` has not yet been added to any
+			referenced_set. The table would become
+			non-evictable anyway when the constraint is added
+			to the dictionary cache. */
+			dict_sys.prevent_eviction(foreign->referenced_table);
+		}
+
 		if (!foreign->referenced_table && m_trx->check_foreigns) {
 			char  buf[MAX_TABLE_NAME_LEN + 1] = "";
 			char* bufend;
@@ -12870,6 +12885,12 @@ int create_table_info_t::create_table(bool create_fk)
 		dict_table_get_all_fts_indexes(m_table, fts->indexes);
 	}
 
+	/* Pin the newly created table: dict_sys.load_table() inside
+	create_foreign_keys() and in the loop below may temporarily
+	release the exclusive dict_sys.latch, during which
+	dict_sys.evict_table_LRU() could evict an unreferenced table. */
+	m_table->acquire();
+
 	dberr_t err = create_fk ? create_foreign_keys() : DB_SUCCESS;
 
 	if (err == DB_SUCCESS) {
@@ -12878,16 +12899,23 @@ int create_table_info_t::create_table(bool create_fk)
 
 		/* Check that also referencing constraints are ok */
 		dict_names_t	fk_tables;
+		/* The names in fk_tables must survive the temporary
+		release of the exclusive dict_sys.latch inside
+		dict_sys.load_table() in the loop below. */
+		mem_heap_t*	fk_heap = mem_heap_create(1000);
 		err = dict_load_foreigns(m_table_name, nullptr,
 					 m_trx->id, true,
-					 ignore_err, fk_tables);
+					 ignore_err, fk_heap, fk_tables);
 		while (err == DB_SUCCESS && !fk_tables.empty()) {
 			dict_sys.load_table(
 				{fk_tables.front(), strlen(fk_tables.front())},
 				ignore_err);
 			fk_tables.pop_front();
 		}
+		mem_heap_free(fk_heap);
 	}
+
+	m_table->release();
 
 	switch (err) {
 	case DB_PARENT_NO_INDEX:
@@ -14044,10 +14072,14 @@ int ha_innobase::truncate()
       m_prebuilt->table->def_trx_id= def_trx_id;
     }
     dict_names_t fk_tables;
+    /* The names in fk_tables must survive the temporary release of the
+    exclusive dict_sys.latch inside dict_sys.load_table() below. */
+    mem_heap_t *fk_heap= mem_heap_create(1000);
     dict_load_foreigns(m_prebuilt->table->name.m_name, nullptr, 1, true,
-                       DICT_ERR_IGNORE_FK_NOKEY, fk_tables);
+                       DICT_ERR_IGNORE_FK_NOKEY, fk_heap, fk_tables);
     for (const char *f : fk_tables)
       dict_sys.load_table({f, strlen(f)});
+    mem_heap_free(fk_heap);
   }
 
   if (fts)

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -10196,11 +10196,15 @@ innobase_update_foreign_cache(
 	and prevent the table from being evicted from the data
 	dictionary cache (work around the lack of WL#6049). */
 	dict_names_t	fk_tables;
+	/* The names in fk_tables must survive the temporary release of
+	the exclusive dict_sys.latch inside dict_sys.load_table() in the
+	loop below. */
+	mem_heap_t*	fk_heap = mem_heap_create(1000);
 
 	err = dict_load_foreigns(user_table->name.m_name,
 				 ctx->col_names, 1, true,
 				 DICT_ERR_IGNORE_FK_NOKEY,
-				 fk_tables);
+				 fk_heap, fk_tables);
 
 	if (err == DB_CANNOT_ADD_CONSTRAINT) {
 		fk_tables.clear();
@@ -10211,7 +10215,7 @@ innobase_update_foreign_cache(
 		err = dict_load_foreigns(user_table->name.m_name,
 					 ctx->col_names, 1, false,
 					 DICT_ERR_IGNORE_NONE,
-					 fk_tables);
+					 fk_heap, fk_tables);
 
 		/* The load with "charset_check" off is successful, warn
 		the user that the foreign key has loaded with mis-matched
@@ -10243,6 +10247,8 @@ innobase_update_foreign_cache(
 
 		fk_tables.pop_front();
 	}
+
+	mem_heap_free(fk_heap);
 
 	DBUG_RETURN(err);
 }

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1347,6 +1347,11 @@ private:
   std::atomic<table_id_t> temp_table_id{DICT_HDR_FIRST_ID};
   /** hash table of temporary table IDs */
   hash_table_t temp_id_hash;
+  /** mutex protecting load_cond */
+  mysql_mutex_t load_mutex;
+  /** condition variable for waiting for a concurrent
+  dict_load_table_one() to complete or fail; broadcast by load_done() */
+  pthread_cond_t load_cond;
   /** the next value of DB_ROW_ID, backed by DICT_HDR_ROW_ID
   (FIXME: remove this, and move to dict_table_t) */
   Atomic_relaxed<row_id_t> row_id;
@@ -1431,13 +1436,27 @@ public:
   /** Move a table to the non-LRU list from the LRU list. */
   void prevent_eviction(dict_table_t *table)
   {
-    ut_d(locked());
+    ut_ad(locked());
     ut_ad(find(table));
     if (!table->can_be_evicted)
       return;
     table->can_be_evicted= false;
     UT_LIST_REMOVE(table_LRU, table);
     UT_LIST_ADD_LAST(table_non_LRU, table);
+  }
+
+  /** Move a table to the LRU list from the non-LRU list.
+  This is the inverse of prevent_eviction(), invoked by
+  dict_load_table_one() when a fully loaded table replaces
+  its non-evictable loading stub. */
+  void allow_eviction(dict_table_t *table)
+  {
+    ut_ad(locked());
+    ut_ad(find(table));
+    ut_ad(!table->can_be_evicted);
+    table->can_be_evicted= true;
+    UT_LIST_REMOVE(table_non_LRU, table);
+    UT_LIST_ADD_FIRST(table_LRU, table);
   }
 
 #ifdef UNIV_DEBUG
@@ -1503,17 +1522,57 @@ public:
   @return number of tables evicted */
   ulint evict_table_LRU(bool half) noexcept;
 
+  /** Look up a table in the dictionary cache, including tables whose
+  definition is still being loaded (dict_table_t::loading). Of such a
+  table, only the name, id and hash pointers may be accessed.
+  @param name   table name
+  @return table handle
+  @retval nullptr if not found */
+  dict_table_t *find_table_any(const span<const char> &name) const noexcept;
+
   /** Look up a table in the dictionary cache.
+  A table whose loading has not completed (dict_table_t::loading)
+  is treated as if it were not cached.
   @param name   table name
   @return table handle
   @retval nullptr if not found */
   dict_table_t *find_table(const span<const char> &name) const noexcept;
 
-  /** Look up or load a table definition
+  /** Look up a table for FOREIGN KEY constraint linkage.
+  Like find_table(), except that a table whose definition is complete
+  and that is only waiting for the tables related to it by FOREIGN KEY
+  constraints to be loaded (dict_table_t::LOADING_FK) is visible:
+  linking constraints into such a table is protected by the exclusive
+  latch, which both the linking thread and the loading thread hold
+  while modifying foreign_set/referenced_set.
+  @param name   table name
+  @return table handle
+  @retval nullptr if not found */
+  dict_table_t *find_table_fk(const span<const char> &name) const noexcept;
+
+  /** Wait for a concurrent dict_load_table_one() to complete or fail.
+  To be invoked with the exclusive latch held, after observing a table
+  with dict_table_t::loading set. The exclusive latch is released and
+  reacquired; the caller must retry its lookup afterwards, because the
+  observed table object may have been freed. */
+  void load_wait() noexcept;
+
+  /** Wake up all load_wait() callers after a table definition load
+  completed, failed, or was retried with a new table object. */
+  void load_done() noexcept;
+
+  /** Look up or load a table definition. The table and any tables
+  that were loaded because they are related to it by FOREIGN KEY
+  constraints become visible to other threads atomically, only after
+  all of them have been loaded.
   @param name   table name
   @param ignore errors to ignore when loading the table definition
   @return table handle
-  @retval nullptr if not found */
+  @retval nullptr if not found
+  @note The exclusive latch may be temporarily released and reacquired,
+  both while waiting for a concurrent load of the same table and during
+  the I/O phases of loading; any pointers into the cache that the
+  caller obtained earlier may be stale on return. */
   dict_table_t *load_table(const span<const char> &name,
                            dict_err_ignore_t ignore= DICT_ERR_IGNORE_NONE)
     noexcept;

--- a/storage/innobase/include/dict0dict.inl
+++ b/storage/innobase/include/dict0dict.inl
@@ -1076,6 +1076,9 @@ dict_table_is_file_per_table(
 /** Acquire the table handle. */
 inline void dict_table_t::acquire()
 {
+  /* A table whose definition is still being loaded must never be
+  referenced; dict_sys_t::find_table() hides such tables. */
+  ut_ad(!loading);
   ut_d(const auto old=) n_ref_count++;
   ut_ad(old || dict_sys.frozen());
 }

--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -90,6 +90,11 @@ dict_load_foreigns(
 	bool			check_charsets,	/*!< in: whether to check
 						charset compatibility */
 	dict_err_ignore_t	ignore_err,	/*!< in: error to be ignored */
+	mem_heap_t*		fk_heap,	/*!< in: heap on which the
+						names appended to fk_tables
+						are allocated; must remain
+						valid until fk_tables has
+						been drained by the caller */
 	dict_names_t&		fk_tables)	/*!< out: stack of table names
 						which must be loaded
 						subsequently to load all the

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -2285,6 +2285,49 @@ public:
 	or ONLINE_INDEX_ABORTED_DROPPED. */
 	unsigned				drop_aborted:1;
 
+	/** Values of the loading field: the table is fully loaded and
+	visible to all threads */
+	static constexpr byte NOT_LOADING= 0;
+	/** the definition (columns, indexes) is being loaded by
+	dict_load_table_one(); the object may only be accessed by the
+	loading thread */
+	static constexpr byte LOADING_DEF= 1;
+	/** the definition is complete, but the set of tables related by
+	FOREIGN KEY constraints is still being loaded by
+	dict_sys_t::load_table(); the object is still hidden from
+	dict_sys_t::find_table(), but FOREIGN KEY constraints may be
+	linked into it via dict_sys_t::find_table_fk() while holding
+	the exclusive dict_sys.latch */
+	static constexpr byte LOADING_FK= 2;
+
+	/** Progress of loading the table definition from the SYS_
+	tables; one of NOT_LOADING, LOADING_DEF, LOADING_FK.
+	Set to LOADING_DEF (under exclusive dict_sys.latch) before the
+	incomplete table object ("stub") is made visible in dict_sys,
+	advanced to LOADING_FK (under exclusive dict_sys.latch) when the
+	definition is complete, and reset to NOT_LOADING by
+	dict_sys_t::load_table() once all tables related by FOREIGN KEY
+	constraints have been loaded as well. While this is nonzero, any
+	thread other than the loader that finds this table in dict_sys
+	may only read the name, id and hash pointers, and must wait for
+	the load to finish via dict_sys.load_wait(); while this is
+	LOADING_FK, the foreign_set and referenced_set may additionally
+	be modified under the exclusive dict_sys.latch.
+	This is a separate atomic (not part of the bit-field words above)
+	because it is checked by cache lookups while the loading thread
+	is modifying the bit-fields without holding any latch.
+	Zero-initialized (NOT_LOADING) by dict_table_t::create(). */
+	Atomic_relaxed<byte>			loading;
+
+#ifdef UNIV_DEBUG
+	/** The thread that set the loading flag */
+	pthread_t				load_thread;
+
+	/** @return whether the current thread is loading this table */
+	bool is_loader() const
+	{ return loading && pthread_equal(pthread_self(), load_thread); }
+#endif
+
 	/** Array of column descriptions. */
 	dict_col_t*				cols;
 

--- a/storage/innobase/include/univ.i
+++ b/storage/innobase/include/univ.i
@@ -461,6 +461,7 @@ typedef unsigned int mysql_pfs_key_t;
 # ifdef UNIV_PFS_MUTEX
 extern mysql_pfs_key_t buf_pool_mutex_key;
 extern mysql_pfs_key_t dict_foreign_err_mutex_key;
+extern mysql_pfs_key_t dict_load_mutex_key;
 extern mysql_pfs_key_t fil_system_mutex_key;
 extern mysql_pfs_key_t flush_list_mutex_key;
 extern mysql_pfs_key_t fts_cache_mutex_key;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2552,6 +2552,7 @@ row_rename_table_for_mysql(
 	dict_table_t*	table			= NULL;
 	dberr_t		err			= DB_ERROR;
 	mem_heap_t*	heap			= NULL;
+	mem_heap_t*	fk_heap			= NULL;
 	const char**	constraints_to_drop	= NULL;
 	ulint		n_constraints_to_drop	= 0;
 	ibool		old_is_tmp, new_is_tmp;
@@ -2848,6 +2849,10 @@ row_rename_table_for_mysql(
 		/* We only want to switch off some of the type checking in
 		an ALTER TABLE, not in a RENAME. */
 		dict_names_t	fk_tables;
+		/* The names in fk_tables must survive the temporary
+		release of the exclusive dict_sys.latch inside
+		dict_sys.load_table() in the drain loop below. */
+		fk_heap = mem_heap_create(1000);
 
 		err = dict_load_foreigns(
 			new_name, nullptr, trx->id,
@@ -2855,7 +2860,7 @@ row_rename_table_for_mysql(
 			fk == RENAME_ALTER_COPY
 			? DICT_ERR_IGNORE_NONE
 			: DICT_ERR_IGNORE_FK_NOKEY,
-			fk_tables);
+			fk_heap, fk_tables);
 
 		if (err != DB_SUCCESS) {
 			if (old_is_tmp) {
@@ -2908,6 +2913,10 @@ row_rename_table_for_mysql(
 funct_exit:
 	if (table) {
 		table->release();
+	}
+
+	if (UNIV_LIKELY_NULL(fk_heap)) {
+		mem_heap_free(fk_heap);
 	}
 
 	if (UNIV_LIKELY_NULL(heap)) {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35154*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Issue:

dict_load_table_one() was invoked with the exclusive dict_sys.latch held and never released it. The whole load ran inside that one critical section: reading the SYS_TABLES record, opening the .ibd file, and reading SYS_COLUMNS, SYS_VIRTUAL, SYS_INDEXES, SYS_FIELDS, the clustered index root page, and SYS_FOREIGN, as well as loading every table related by FOREIGN KEY constraints.

Almost all of that is I/O. Because dict_sys.latch is the single latch that guards every dictionary lookup, one cold table open blocked every other session from opening any table, including tables that were already cached. A slow enough load could trigger the fatal semaphore wait check.

Fix:

Split the load into three phases. A short latched phase creates the table object and publishes it as an incomplete "stub"; the I/O runs with no latch held; a final latched phase links the FOREIGN KEY constraints. The stub is marked with the new dict_table_t::loading, which hides it from dict_sys_t::find_table(), so other threads treat it as not cached. A thread that needs exactly that table waits on a condition variable and retries its lookup, while all other tables can be looked up and loaded concurrently.

dict_table_t::loading has three states. A table remains hidden (LOADING_FK) until every table related to it by FOREIGN KEY constraints has been loaded as well, and dict_sys_t::load_table() makes them visible in one step. The intermediate state is visible to constraint linking via the new dict_sys_t::find_table_fk(), so that two threads loading tables that reference each other can still link the constraint between them.

Tables that InnoDB internal SQL can refer to are loaded without ever releasing the latch. The internal SQL parser is not reentrant and is serialized only by the exclusive dict_sys.latch, and it opens tables in the middle of parsing; releasing the latch there let another thread run the parser concurrently and corrupt its state.


## How can this PR be tested?

Added `mysql-test/suite/innodb/t/dict_load_concurrent.test` to cover the changes.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

