### PR TITLE
MDEV-40903 galera.MDEV-38260 fails with ER_BINLOG_IN_USE on RESET MASTER

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-38260.result
+++ b/mysql-test/suite/galera/r/MDEV-38260.result
@@ -42,11 +42,11 @@ RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_3;
-reset master;
+include/reset_master.inc

--- a/mysql-test/suite/galera/t/MDEV-38260.test
+++ b/mysql-test/suite/galera/t/MDEV-38260.test
@@ -86,13 +86,13 @@ SET GLOBAL gtid_slave_pos = "";
 
 --connection node_1
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_3
-reset master;
+--source include/reset_master.inc


### PR DESCRIPTION
The test fails from 12.3 onwards on the final cleanup step:

  mysqltest: At line 98: query 'reset master' failed: ER_BINLOG_IN_USE
  (4243): Cannot execute RESET MASTER as the binlog is in use by a
  connected slave or other RESET MASTER or binlog reader.

The binlog-in-engine work added a use-count guard around RESET MASTER in MYSQL_BIN_LOG::reset_logs(): every binlog reader, a slave dump thread included, registers itself through start_use_binlog(), and RESET MASTER now refuses with ER_BINLOG_IN_USE while the count is non-zero. Earlier versions reset the binlog even with a slave still attached, which is why the test passes on 11.8 and older.

The test's cleanup stops the async slave on node_2 and then immediately runs RESET MASTER on the master node_3. The dump thread on node_3 does not disappear at STOP SLAVE; it lingers until it next notices the closed connection, so it is often still registered when RESET MASTER arrives.

Fix here is to use include/reset_master.inc, which terminates dump threads and retries on ER_BINLOG_IN_USE.