### PR TITLE
MDEV-40946 Two heap blob tests fail with the embedded server

### DIFF
--- a/mysql-test/suite/heap/blob_delayed_insert.test
+++ b/mysql-test/suite/heap/blob_delayed_insert.test
@@ -11,6 +11,11 @@
 # The binary log must be off: with statement binlogging INSERT DELAYED is
 # downgraded to an ordinary write lock and the delayed thread never runs.
 #
+# The embedded server has no delayed insert thread at all: the facility is
+# compiled out there, INSERT DELAYED is an ordinary insert, and no lock
+# cycle takes place.
+#
+--source include/not_embedded.inc
 
 CREATE TABLE t1 (a INT, b BLOB) ENGINE=MEMORY;
 

--- a/mysql-test/suite/heap/blob_online_alter.test
+++ b/mysql-test/suite/heap/blob_online_alter.test
@@ -12,7 +12,12 @@
 # the very statements this test needs to run.  It is released at the
 # post-downgrade point and only made to wait once it is replaying.
 #
+# The embedded server never runs an ALTER online: the online alter log is
+# part of the replication code, which is not built there, so the source
+# lock is not downgraded and the sync points below are never reached.
+#
 --source include/have_debug_sync.inc
+--source include/not_embedded.inc
 
 CREATE TABLE t1 (a INT PRIMARY KEY, b BLOB) ENGINE=MEMORY;
 INSERT INTO t1 VALUES (1, REPEAT('x', 300)), (2, REPEAT('y', 300)),


### PR DESCRIPTION
Fixes [MDEV-40946](https://jira.mariadb.org/browse/MDEV-40946). Base is `bb-blob-main-monty` at `5847c1aab08`, the commit the failures were reported against.

Neither failure is a HEAP blob defect. Each test exercises a server facility that is compiled out of `libmysqld`, so the test cannot run there at all.

`INSERT DELAYED` has no delayed insert thread in an embedded build. The whole `Delayed_insert` facility in `sql/sql_insert.cc` sits inside `#ifndef EMBEDDED_LIBRARY`, including the check that routes a delayed statement away from the ordinary insert path, so the statement is an ordinary insert, no delayed thread runs, and `DELAYED_WRITES` stays at 0. That is the reported `1` -> `0` diff.

`ALTER TABLE ... LOCK=NONE` is never online in an embedded build. In `mysql_alter_table()`, `online` is hard-wired to `false` when `HAVE_REPLICATION` is undefined, and `include/my_global.h` leaves it undefined for `EMBEDDED_LIBRARY`. The MDL downgrade block that carries `DEBUG_SYNC(thd, "alter_table_online_downgraded")` is itself inside `#ifdef HAVE_REPLICATION`, so the sync point is never reached and the test's `WAIT_FOR downgraded` runs out its `debug_sync` timeout, emitting `Warning 1639`. That one test took 300 seconds under the embedded server against 8 ms normally.

Both tests are therefore skipped with `include/not_embedded.inc`, as `main.delayed`, `main.alter_table_online_debug` and `main.vector_debug` already are. No test content is changed and no assertion is weakened; normal runs still exercise both tests in full.

## Verification

Built a dedicated embedded debug tree (`-DWITH_EMBEDDED_SERVER=ON -DCMAKE_BUILD_TYPE=Debug`) and ran test-first:

| Run | Result |
| --- | --- |
| Fix backed out, `--embedded-server` | both tests fail, diffs byte-identical to the ones in the report |
| Fix applied, `--embedded-server --suite=heap` | both `[ skipped ] Not run for embedded server`; 40/40 pass, 8 skipped, 0 failures |
| Fix applied, normal server, `--suite=heap` | 48/48 pass, both tests exercised and passing |

The full-suite embedded run also confirms no other `heap` test is broken under the embedded server.
