### PR TITLE
MDEV-32383 Server crashes in Item_func_match::init_search on 2nd execution of PS

### DIFF
--- a/mysql-test/main/fulltext.result
+++ b/mysql-test/main/fulltext.result
@@ -788,3 +788,24 @@ CREATE TEMPORARY TABLE tmp (a TEXT) ENGINE=Aria;
 ALTER TABLE tmp ADD FULLTEXT (a);
 INSERT INTO tmp VALUES ('foo');
 DROP TABLE tmp;
+#
+# MDEV-32383 Server crashes in Item_func_match::init_search on 2nd execution of PS
+#
+CREATE TABLE t (a VARCHAR(255), FULLTEXT(a));
+INSERT INTO t VALUES ('foo'),('bar');
+CREATE VIEW v AS
+SELECT MATCH (a) AGAINST ('MariaDB' IN NATURAL LANGUAGE MODE) AS f
+FROM t
+WHERE MATCH (a) AGAINST ('MariaDB' IN NATURAL LANGUAGE MODE) > 0
+ORDER BY f;
+PREPARE stmt FROM "SELECT f FROM v ORDER BY f";
+EXECUTE stmt;
+f
+EXECUTE stmt;
+f
+DEALLOCATE PREPARE stmt;
+DROP VIEW v;
+DROP TABLE t;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/fulltext.test
+++ b/mysql-test/main/fulltext.test
@@ -736,3 +736,28 @@ CREATE TEMPORARY TABLE tmp (a TEXT) ENGINE=Aria;
 ALTER TABLE tmp ADD FULLTEXT (a);
 INSERT INTO tmp VALUES ('foo');
 DROP TABLE tmp;
+
+--echo #
+--echo # MDEV-32383 Server crashes in Item_func_match::init_search on 2nd execution of PS
+--echo #
+
+CREATE TABLE t (a VARCHAR(255), FULLTEXT(a));
+INSERT INTO t VALUES ('foo'),('bar');
+
+CREATE VIEW v AS
+  SELECT MATCH (a) AGAINST ('MariaDB' IN NATURAL LANGUAGE MODE) AS f
+  FROM t
+  WHERE MATCH (a) AGAINST ('MariaDB' IN NATURAL LANGUAGE MODE) > 0
+  ORDER BY f;
+
+PREPARE stmt FROM "SELECT f FROM v ORDER BY f";
+EXECUTE stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+DROP VIEW v;
+DROP TABLE t;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -3851,6 +3851,7 @@ public:
     ft_handler= 0;
     concat_ws= 0;
     table= 0;           // required by Item_func_match::eq()
+    master= 0;
     DBUG_VOID_RETURN;
   }
   bool is_expensive_processor(void *arg) override { return TRUE; }


### PR DESCRIPTION
`Item_func_match::master` points at an equal MATCH item that owns the shared `ft_handler`. `setup_ftfuncs()` sets it only when it is still unset, and `cleanup()` never reset it.

A mergeable view is merged once. On re-execution `mysql_derived_prepare()` returns early because `TABLE_LIST::merged` is set, so the view's own MATCH item is never re-fixed and keeps the NULL table left by `cleanup()`. `init_ftfuncs()` skips unfixed items in `ftfunc_list`, but `init_search()` follows master without that check and dereferenced the NULL table.

Reset master in `cleanup()`, after the `ft_handler` ownership check that reads it, so the link is rebuilt from scratch on every execution.