### PR TITLE
MDEV-40955  mysql_client_test needs a resolvable DNS on Linux

### DIFF
--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -20954,6 +20954,7 @@ static MYSQL *proxy_connect_as(const char *client_ip, const char *user,
 */
 static void test_proxy_header_connect_errors_reset()
 {
+#ifndef DBUG_OFF
   const char *client_ip= "192.0.2.50";
   char query[256];
   unsigned int conn_errno= 0;
@@ -20961,6 +20962,13 @@ static void test_proxy_header_connect_errors_reset()
   MYSQL *m;
 
   myheader("test_proxy_header_connect_errors_reset");
+
+  /* Force a deterministic "unresolvable" outcome; see hostname.cc. */
+  rc= mysql_query(mysql, "SET @save_debug_dbug= @@global.debug_dbug");
+  myquery(rc);
+  rc= mysql_query(mysql,
+                  "SET GLOBAL debug_dbug='+d,getnameinfo_error_noname'");
+  myquery(rc);
 
   rc= mysql_query(mysql,
                   "SET @saved_max_connect_errors= @@global.max_connect_errors");
@@ -21010,6 +21018,9 @@ static void test_proxy_header_connect_errors_reset()
   myquery(rc);
   rc= mysql_query(mysql, "FLUSH HOSTS");
   myquery(rc);
+  rc= mysql_query(mysql, "SET GLOBAL debug_dbug= @save_debug_dbug");
+  myquery(rc);
+#endif /* !DBUG_OFF */
 }
 
 /*


### PR DESCRIPTION
## Summary
- test_proxy_header_connect_errors_reset() relies on 192.0.2.50 (RFC 5737) failing reverse DNS lookup permanently; on Linux, an unreachable resolver reports EAI_AGAIN (temporary) instead, which is excluded from connect-error accounting and silently defeats the max_connect_errors check.
- Fixed by forcing the deterministic outcome via the existing getnameinfo_error_noname debug point, same as sibling tests. Debug-only.

## Test plan
- [x] main.mysql_client_test / _comp / _nonblock pass with network intact (Windows + Linux debug build)
- [x] Same suites pass with DNS fully unreachable (Linux, network-namespace isolation)
       `unshare --net --map-root-user bash -c 'ip link set lo up && perl mysql-test-run.pl --suite=main main.mysql_client_test'`
- [x] Confirmed unpatched test passes on Windows with DNS blocked (not affected; Linux/glibc-specific)