### PR TITLE
MDEV-40996 Support `--sync_with_master 0, $variable` in mysqltest

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -5340,7 +5340,7 @@ void do_sync_with_master(struct st_command *command)
   long offset= 0;
   char *p= command->first_argument;
   const char *offset_start= p;
-  char *start, *buff= 0;
+  char *start, *buff= 0, *str;
   start= const_cast<char*>("");
 
   if (*offset_start)
@@ -5358,15 +5358,15 @@ void do_sync_with_master(struct st_command *command)
       p++;
       while (*p && my_isspace(charset_info, *p))
         p++;
-      start= buff= (char*)my_malloc(PSI_NOT_INSTRUMENTED, strlen(p)+1,
-                                    MYF(MY_WME|MY_FAE));
-      get_string(&buff, &p, command);
+      str= buff= (char*)my_malloc(PSI_NOT_INSTRUMENTED, strlen(p)+1,
+                                  MYF(MY_WME|MY_FAE));
+      start= get_string(&str, &p, command);
     }
     command->last_argument= p;
   }
   do_sync_with_master2(command, offset, start);
   if (buff)
-    my_free(start);
+    my_free(buff);
   return;
 }
 
@@ -8417,7 +8417,7 @@ void do_get_errcodes(struct st_command *command)
 
 
 /*
-  Get a string;  Return ptr to end of string
+  Get a string;  Return ptr to start of string
   Strings may be surrounded by " or '
 
   If string is a '$variable', return the value of the variable.

--- a/mysql-test/suite/multi_source/simple.result
+++ b/mysql-test/suite/multi_source/simple.result
@@ -453,6 +453,9 @@ Executed_log_entries	7
 Slave_received_heartbeats	0
 Slave_heartbeat_period	60.000
 Gtid_Slave_Pos	
+#
+# MDEV-40996: the connection name may be given as a variable
+#
 stop all slaves;
 Warnings:
 Note	1938	SLAVE 'slave2' stopped

--- a/mysql-test/suite/multi_source/simple.test
+++ b/mysql-test/suite/multi_source/simple.test
@@ -77,6 +77,12 @@ reset slave 'slave1' all;
 --replace_result $SERVER_MYPORT_1 MYPORT_1 $SERVER_MYPORT_2 MYPORT_2 $read_master_log_pos <read_master_log_pos> $relay_log_pos <relay_log_pos> $relay_log_space1 <relay_log_space1> $relay_log_space2 <relay_log_space2>
 query_vertical show all slaves status;
 
+--echo #
+--echo # MDEV-40996: the connection name may be given as a variable
+--echo #
+--let $conn_name= slave2
+--sync_with_master 0,$conn_name
+
 stop all slaves;
 --replace_result $SERVER_MYPORT_1 MYPORT_1 $SERVER_MYPORT_2 MYPORT_2 $read_master_log_pos <read_master_log_pos> $relay_log_pos <relay_log_pos> $relay_log_space1 <relay_log_space1> $relay_log_space2 <relay_log_space2>
 query_vertical show all slaves status;


### PR DESCRIPTION
* Resolves [MDEV-40996](https://jira.mariadb.org/browse/MDEV-40996)

`--sync_with_master` uses `get_string()`, which has `$variable` support, but it only uses the read buffer, which is written with the unexpanded string and not the variable value.