### PR TITLE
MDEV-40281 : galera.galera_wsrep_new_cluster test failure

### DIFF
--- a/mysql-test/include/galera_wait_ready.inc
+++ b/mysql-test/include/galera_wait_ready.inc
@@ -2,11 +2,26 @@
 #
 # Waits for galera node to transition to READY state.
 #
+# Parameters
+# ----------
+# $galera_wait_ready_timeout (optional)
+#   Seconds to wait before giving up, 60 by default. Raise it around a
+#   restart which has to wait for a full SST, as that takes considerably
+#   longer than a plain restart and on a loaded machine can exceed the
+#   default. The value is reset here, so it only applies to the next
+#   sourcing of this file.
+#
 
 --enable_reconnect
 --disable_query_log
 --disable_result_log
+
 let $wait_counter = 600;
+if ($galera_wait_ready_timeout)
+{
+  let $wait_counter = $($galera_wait_ready_timeout * 10);
+}
+
 while ($wait_counter)
 {
   --disable_abort_on_error
@@ -25,7 +40,7 @@ while ($wait_counter)
 
 if (!$success)
 {
-  die "Server did not transition to READY state";
+  die "Server did not transition to READY state in $_galera_wait_ready_timeout seconds";
 }
 --disable_reconnect
 --enable_query_log

--- a/mysql-test/suite/galera/r/galera_wsrep_new_cluster.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_new_cluster.result
@@ -1,5 +1,6 @@
 connection node_2;
 connection node_1;
+# Correct Galera library found
 connection node_1;
 connection node_2;
 connection node_2;

--- a/mysql-test/suite/galera/t/galera_wsrep_new_cluster.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_new_cluster.test
@@ -8,6 +8,10 @@
 # This is needed because we use wsrep-new-cluster
 --source include/have_perfschema.inc
 
+# Make sure that the test is operating on the right version of galera library.
+--let $galera_version=26.4.28
+source ../wsrep/include/check_galera_version.inc;
+
 # Save original auto_increment_offset values.
 --let $node_1=node_1
 --let $node_2=node_2
@@ -86,6 +90,11 @@ SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME 
 
 --echo Starting server ...
 --let $start_mysqld_params=
+# Rejoining with an emptied datadir requires a full SST. That is much slower
+# than a plain restart and on a loaded machine it does not finish within the
+# default 60 seconds, which used to abort the test here while the SST was
+# still running.
+--let $galera_wait_ready_timeout=300
 --source include/start_mysqld.inc
 --source include/wait_until_ready.inc
 


### PR DESCRIPTION
Rejoining with an emptied datadir requires a full SST, which on a loaded machine does not finish within the 60 seconds galera_wait_ready.inc allowed, aborting the test while the SST was still running. Let the readiness wait take an optional $galera_wait_ready_timeout and give that restart 300 seconds.