### PR TITLE
MDEV-41022 Wildcard term returns no rows when combined with a phrase in boolean mode search

### DIFF
--- a/mysql-test/suite/innodb_fts/r/fulltext.result
+++ b/mysql-test/suite/innodb_fts/r/fulltext.result
@@ -835,5 +835,18 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE
 DROP TABLE t1, t2;
 #
+# MDEV-41022 Wildcard term returns no rows when combined with a
+#		phrase in boolean search
+#
+CREATE TABLE t1(f1 TEXT, FULLTEXT(f1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES ('auth code out');
+SELECT * FROM t1 WHERE MATCH(f1) AGAINST('"zzzz" aut*' IN BOOLEAN MODE);
+f1
+auth code out
+SELECT * FROM t1 WHERE MATCH(f1) AGAINST('"zzzz yyyy" @3 aut*' IN BOOLEAN MODE);
+f1
+auth code out
+DROP TABLE t1;
+#
 # End of 10.11 tests
 #

--- a/mysql-test/suite/innodb_fts/t/fulltext.test
+++ b/mysql-test/suite/innodb_fts/t/fulltext.test
@@ -850,6 +850,16 @@ WHERE EXISTS (
 DROP TABLE t1, t2;
 
 --echo #
+--echo # MDEV-41022 Wildcard term returns no rows when combined with a
+--echo #		phrase in boolean search
+--echo #
+CREATE TABLE t1(f1 TEXT, FULLTEXT(f1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES ('auth code out');
+SELECT * FROM t1 WHERE MATCH(f1) AGAINST('"zzzz" aut*' IN BOOLEAN MODE);
+SELECT * FROM t1 WHERE MATCH(f1) AGAINST('"zzzz yyyy" @3 aut*' IN BOOLEAN MODE);
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.11 tests
 --echo #
 

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -2890,8 +2890,12 @@ fts_query_phrase_search(
 func_exit:
 	mem_heap_free(heap);
 
-	/* Don't need it anymore. */
+	/* Don't need it anymore.
+	Reset the phrase/proximity flag to avoid the subsequent
+	wildcard term in the same boolean query would take the
+	exact word lookup path in fts_query_cache() */
 	query->matched = NULL;
+	query->flags = 0;
 
 	return(query->error);
 }


### PR DESCRIPTION
Problem:
========
MATCH(..) AGAINST('"zzzz" aut*' IN BOOLEAN MODE) fails to return the rows which match the wildcard term when the matching word is still in the FTS cache. fts_query_phrase_search() sets query->flags to FTS_PHRASE or FTS_PROXIMITY, but never resets it before returning. The subsequent wildcard term of the same query then finds the stale flag in fts_query_cache() and fts_query_difference(), takes the exact word lookup path instead of fts_cache_find_wildcard() and misses the words present in the cache.

Solution:
=========
- Reset query->flags in fts_query_phrase_search() before returning, so that the phrase or proximity state doesn't leak into the terms evaluated later in the same query.