### PR TITLE
MDEV-40382 Support --ssl-crl on server builds with WolfSSL

### DIFF
--- a/include/sslopt-case.h
+++ b/include/sslopt-case.h
@@ -29,16 +29,6 @@
       One can disable SSL later by using --skip-ssl or --ssl=0
     */
       opt_use_ssl= 1;
-#if defined (HAVE_WOLFSSL)
-#if defined(MYSQL_SERVER)
-      /* CRL does not work with WolfSSL (server) */
-      opt_ssl_crl= NULL;
-#endif
-#if !defined(_WIN32) || !defined(LIBMARIADB)
-      /* CRL_PATH does not work with WolfSSL (server) and GnuTLS (client) */
-      opt_ssl_crlpath= NULL;
-#endif
-#endif
       break;
 #endif
 #endif /* SSLOPT_CASE_INCLUDED */

--- a/mysql-test/main/ssl_crl.test
+++ b/mysql-test/main/ssl_crl.test
@@ -1,6 +1,6 @@
 # This test should work in embedded server after we fix mysqltest
 --source include/not_embedded.inc
---source include/have_openssl.inc
+--source include/have_ssl_communication.inc
 --source include/not_ssl.inc
 
 --echo # try logging in with a certificate not in the server's --ssl-crl : should succeed
@@ -8,7 +8,8 @@
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/server-new-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/server-new-cert.pem test -e "SHOW STATUS LIKE 'Ssl_version'"
 
 --echo # try logging in with a certificate in the server's --ssl-crl : should fail
-# OpenSSL 1.1.1a and later releases correctly rejects the certificate, but the error message is different
---replace_regex /(ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+|ERROR 2026 \(HY000\): TLS\/SSL error: sslv3 alert certificate revoked)/ERROR 2026 (HY000): TLS\/SSL error: ssl\/tls alert certificate revoked/
+# The exact wording of the rejection differs by SSL library (OpenSSL, WolfSSL,
+# GnuTLS) and some drop the connection outright instead of naming the alert.
+--replace_regex /ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+/ERROR 2026 (HY000): TLS\/SSL error: ssl\/tls alert certificate revoked/ /ERROR 2026 \(HY000\): TLS\/SSL error:[^\r\n]*(?:revoked|10054)[^\r\n]*/ERROR 2026 (HY000): TLS\/SSL error: ssl\/tls alert certificate revoked/i
 --error 1
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_version'" 2>&1

--- a/mysql-test/main/ssl_crl_clients.test
+++ b/mysql-test/main/ssl_crl_clients.test
@@ -1,11 +1,11 @@
 # This test should work in embedded server after we fix mysqltest
 -- source include/not_embedded.inc
+-- source include/have_ssl_communication.inc
 
-if (`SELECT COUNT(*) = 0 FROM information_schema.GLOBAL_VARIABLES
-    WHERE (VARIABLE_NAME ='version_compile_os' AND VARIABLE_VALUE LIKE 'Win%' OR
-    VARIABLE_NAME='have_openssl' AND VARIABLE_VALUE='YES')`)
+# GnuTLS does not support --ssl-crlpath
+if ($CLIENT_TLS_LIBRARY == "GnuTLS")
 {
-  skip Need openssl or Windows;
+  skip Not supported with the GnuTLS client library;
 }
 
 --echo # Test clients with and without CRL lists

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -339,24 +339,18 @@ new_VioSSLFd(const char *key_file, const char *cert_file,
 
   if (crl_file || crl_path)
   {
-#ifdef HAVE_WOLFSSL
-    /* CRL does not work with WolfSSL. */
-    DBUG_ASSERT(0);
-    goto err2;
-#else
     X509_STORE *store= SSL_CTX_get_cert_store(ssl_fd->ssl_context);
     /* Load crls from the trusted ca */
     if (X509_STORE_load_locations(store, crl_file, crl_path) == 0 ||
         X509_STORE_set_flags(store,
-                             X509_V_FLAG_CRL_CHECK | 
-                             X509_V_FLAG_CRL_CHECK_ALL) == 0)
+                             X509_V_FLAG_CRL_CHECK |
+                             X509_V_FLAG_CRL_CHECK_ALL) != 1)
     {
       DBUG_PRINT("warning", ("X509_STORE_load_locations for CRL failed"));
       *error= SSL_INITERR_BAD_PATHS;
       DBUG_PRINT("error", ("%s", sslGetErrString(*error)));
       goto err2;
     }
-#endif
   }
 
   if (vio_set_cert_stuff(ssl_fd->ssl_context, cert_file, key_file,


### PR DESCRIPTION
--ssl-crl was silently discarded on WolfSSL builds (nulled in sslopt-case.h, skipped in new_VioSSLFd()), so a revoked cert could still authenticate a REQUIRE X509 account. 

WolfSSL's OpenSSL-compat layer already supports real CRL enforcement, so this removes both restrictions and fixes a related return-value check bug (WolfSSL can return negative codes on failure, unlike OpenSSL's 0/1).

Enabled CRL tests. main.ssl_crl_clients remains disabled on GNUTLS builds (it relies on ssl-crlpath, ignored in GNUTLS builds)
