### PR TITLE
MDEV-40903 : query 'reset master' failed: ER_BINLOG_IN_USE (4243) in …

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-28053.result
+++ b/mysql-test/suite/galera/r/MDEV-28053.result
@@ -11,5 +11,4 @@ connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/MDEV-39011.result
+++ b/mysql-test/suite/galera/r/MDEV-39011.result
@@ -4,7 +4,7 @@ connection node_1;
 connection node_2;
 connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
 connection node_3;
-RESET MASTER;
+include/reset_master.inc
 connection node_2;
 SET GLOBAL DEBUG_DBUG = "+d,delay_sql_thread_after_release_run_lock";
 START SLAVE;
@@ -19,7 +19,6 @@ SET GLOBAL DEBUG_DBUG = "";
 STOP SLAVE;
 RESET SLAVE;
 connection node_3;
-include/kill_binlog_dump_threads.inc
 include/reset_master.inc
 disconnect node_3;
 disconnect node_2;

--- a/mysql-test/suite/galera/r/galera_2primary_replica.result
+++ b/mysql-test/suite/galera/r/galera_2primary_replica.result
@@ -86,11 +86,9 @@ Note	1938	SLAVE 'stream1' stopped
 Note	1938	SLAVE 'stream2' stopped
 RESET SLAVE ALL;
 connection primary1;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 connection primary2;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 connection node_1;
 disconnect primary1;
 disconnect primary2;

--- a/mysql-test/suite/galera/r/galera_as_master.result
+++ b/mysql-test/suite/galera/r/galera_as_master.result
@@ -60,6 +60,5 @@ SET GLOBAL gtid_slave_pos = "";
 CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work');
 connection node_1;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_as_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_slave.result
@@ -30,5 +30,4 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
@@ -98,5 +98,4 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_ctas.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_ctas.result
@@ -32,5 +32,4 @@ RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 call mtr.add_suppression("WSREP: unexpected async replication event: 0");
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid.result
@@ -29,14 +29,11 @@ SET GLOBAL gtid_slave_pos = "";
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_auto_engine.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_auto_engine.result
@@ -29,20 +29,17 @@ SET GLOBAL gtid_slave_pos = "";
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 connection node_2;
 CALL mtr.add_suppression("The automatically created table");
 DROP TABLE mysql.gtid_slave_pos_InnoDB;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_myisam.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_myisam.result
@@ -33,14 +33,11 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL WSREP_ON=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 SET GLOBAL WSREP_ON=ON;
 connection node_2;
 SET GLOBAL WSREP_ON=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 SET GLOBAL WSREP_ON=ON;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
@@ -31,5 +31,4 @@ CALL mtr.add_suppression("(Transport endpoint|Socket) is not connected");
 CALL mtr.add_suppression("Slave SQL: Error in Xid_log_event: Commit could not be completed, 'Deadlock found when trying to get lock; try restarting transaction', Error_code: 1213");
 CALL mtr.add_suppression("Slave SQL: Node has dropped from cluster, Error_code: 1047");
 connection node_4;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc

--- a/mysql-test/suite/galera/r/galera_as_slave_replay.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_replay.result
@@ -5,7 +5,7 @@ connection node_1;
 ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
 connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
 connection node_3;
-RESET MASTER;
+include/reset_master.inc
 connection node_2a;
 START SLAVE;
 connection node_3;
@@ -68,7 +68,6 @@ SET GLOBAL gtid_slave_pos = "";
 DROP TABLE t1;
 connection node_3;
 DROP TABLE t1;
-include/kill_binlog_dump_threads.inc
 include/reset_master.inc
 connection node_1;
 disconnect node_2a;

--- a/mysql-test/suite/galera/r/galera_circular_replication.result
+++ b/mysql-test/suite/galera/r/galera_circular_replication.result
@@ -128,8 +128,7 @@ RESET SLAVE ALL;
 connection replica2;
 STOP SLAVE;
 RESET SLAVE ALL;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 connection node_1;
 disconnect primary1;
 disconnect replica1;

--- a/mysql-test/suite/galera/r/galera_forced_binlog_format.result
+++ b/mysql-test/suite/galera/r/galera_forced_binlog_format.result
@@ -2,7 +2,7 @@ connection node_2;
 connection node_1;
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 FLUSH BINARY LOGS;
 SET SESSION binlog_format = 'STATEMENT';

--- a/mysql-test/suite/galera/r/galera_gtid_slave.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave.result
@@ -34,16 +34,13 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 connection node_2;
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
@@ -155,19 +155,16 @@ connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 set global gtid_slave_pos="";
 #Connection 1
 connection node_1;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 #Connection 3
 connection node_3;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 connection node_2;
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/r/galera_log_bin.result
+++ b/mysql-test/suite/galera/r/galera_log_bin.result
@@ -2,11 +2,11 @@ connection node_2;
 connection node_1;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
@@ -77,5 +77,5 @@ DROP TABLE t2;
 #cleanup
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_log_bin_ext.result
+++ b/mysql-test/suite/galera/r/galera_log_bin_ext.result
@@ -4,11 +4,11 @@ connection node_1;
 connection node_2;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
@@ -65,5 +65,5 @@ DROP TABLE t2;
 #cleanup
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_log_bin_ext_mariabackup.result
+++ b/mysql-test/suite/galera/r/galera_log_bin_ext_mariabackup.result
@@ -4,11 +4,11 @@ connection node_1;
 connection node_2;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
@@ -63,5 +63,5 @@ DROP TABLE t2;
 #cleanup
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_log_bin_opt.result
+++ b/mysql-test/suite/galera/r/galera_log_bin_opt.result
@@ -2,11 +2,11 @@ connection node_2;
 connection node_1;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
@@ -77,5 +77,5 @@ DROP TABLE t2;
 #cleanup
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/r/galera_query_cache_invalidate.result
+++ b/mysql-test/suite/galera/r/galera_query_cache_invalidate.result
@@ -113,8 +113,7 @@ Warnings:
 Note	4190	RESET SLAVE is implicitly changing the value of 'Using_Gtid' from 'Current_Pos' to 'Slave_Pos'
 connection node_1;
 SET SESSION WSREP_ON=OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET SESSION WSREP_ON=ON;
 disconnect node_2;
 disconnect node_1;

--- a/mysql-test/suite/galera/r/galera_replica_no_gtid.result
+++ b/mysql-test/suite/galera/r/galera_replica_no_gtid.result
@@ -59,8 +59,7 @@ connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
 connection node_3;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 drop table t1;
 connection node_2;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_restart_replica.result
+++ b/mysql-test/suite/galera/r/galera_restart_replica.result
@@ -161,8 +161,7 @@ connection replica;
 STOP SLAVE;
 RESET SLAVE ALL;
 connection primary;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 connection node_1;
 disconnect primary;
 disconnect replica;

--- a/mysql-test/suite/galera/r/galera_slave_replay.result
+++ b/mysql-test/suite/galera/r/galera_slave_replay.result
@@ -5,7 +5,7 @@ connection node_2a;
 ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
 connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
 connection node_3;
-RESET MASTER;
+include/reset_master.inc
 connection node_2a;
 START SLAVE;
 connection node_3;
@@ -94,8 +94,7 @@ SET DEBUG_SYNC = "RESET";
 DROP TABLE t1;
 connection node_3;
 DROP TABLE t1;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 connection node_1;
 disconnect node_2a;
 disconnect node_3;

--- a/mysql-test/suite/galera/r/galera_var_gtid_domain_id.result
+++ b/mysql-test/suite/galera/r/galera_var_gtid_domain_id.result
@@ -83,11 +83,11 @@ DROP TABLE t1, t2;
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/r/mdev_10518.result
+++ b/mysql-test/suite/galera/r/mdev_10518.result
@@ -83,11 +83,11 @@ DROP TABLE t1, t2;
 #cleanup
 connection node_1;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 set global wsrep_on=OFF;
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_2;
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/r/rpl_row_annotate.result
+++ b/mysql-test/suite/galera/r/rpl_row_annotate.result
@@ -3,12 +3,12 @@ connection node_1;
 # On node_2
 connection node_2;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 # On node_1
 connection node_1;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 CREATE TABLE t1(i INT)ENGINE=INNODB;
 INSERT INTO t1 VALUES(1);

--- a/mysql-test/suite/galera/t/MDEV-28053.test
+++ b/mysql-test/suite/galera/t/MDEV-28053.test
@@ -59,5 +59,4 @@ STOP SLAVE;
 RESET SLAVE ALL;
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/MDEV-39011.test
+++ b/mysql-test/suite/galera/t/MDEV-39011.test
@@ -16,7 +16,7 @@
 # node 3 is a native MariaDB server operating as async replication master
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
-RESET MASTER;
+--source include/reset_master.inc
 
 # nodes 1 and 2 form a Galera cluster, node 2 operates as a slave for the
 # native MariaDB master in node 3
@@ -48,7 +48,6 @@ RESET SLAVE;
 --source include/restart_mysqld.inc
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
 --source include/reset_master.inc
 --disconnect node_3
 

--- a/mysql-test/suite/galera/t/galera_2primary_replica.test
+++ b/mysql-test/suite/galera/t/galera_2primary_replica.test
@@ -157,11 +157,9 @@ STOP ALL SLAVES;
 RESET SLAVE ALL;
 
 --connection primary1
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 --connection primary2
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 
 --source include/auto_increment_offset_restore.inc
 

--- a/mysql-test/suite/galera/t/galera_as_master.test
+++ b/mysql-test/suite/galera/t/galera_as_master.test
@@ -76,6 +76,5 @@ CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work
 
 --connection node_1
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -64,5 +64,4 @@ RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -83,5 +83,4 @@ RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_ctas.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_ctas.test
@@ -76,5 +76,4 @@ SET GLOBAL gtid_slave_pos = "";
 call mtr.add_suppression("WSREP: unexpected async replication event: 0");
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid.inc
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid.inc
@@ -83,16 +83,13 @@ SET GLOBAL gtid_slave_pos = "";
 --echo #cleanup
 --connection node_1
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_auto_engine.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_auto_engine.test
@@ -18,5 +18,5 @@ DROP TABLE mysql.gtid_slave_pos_InnoDB;
 # binlog state here, that leftover (e.g. 0-2-2) survives into the next
 # test iteration and breaks the gtid_binlog_state comparison in the .inc.
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_myisam.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_myisam.test
@@ -74,16 +74,13 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL WSREP_ON=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 SET GLOBAL WSREP_ON=ON;
 
 --connection node_2
 SET GLOBAL WSREP_ON=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 SET GLOBAL WSREP_ON=ON;
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
@@ -89,5 +89,4 @@ CALL mtr.add_suppression("Slave SQL: Error in Xid_log_event: Commit could not be
 CALL mtr.add_suppression("Slave SQL: Node has dropped from cluster, Error_code: 1047");
 
 --connection node_4
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_replay.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_replay.test
@@ -25,7 +25,7 @@ ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
 #
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
-RESET MASTER;
+--source include/reset_master.inc
 
 --connection node_2a
 #
@@ -146,7 +146,6 @@ DROP TABLE t1;
 
 --connection node_3
 DROP TABLE t1;
---source include/kill_binlog_dump_threads.inc
 --source include/reset_master.inc
 
 --connection node_1

--- a/mysql-test/suite/galera/t/galera_circular_replication.test
+++ b/mysql-test/suite/galera/t/galera_circular_replication.test
@@ -221,8 +221,7 @@ RESET SLAVE ALL;
 --connection replica2
 STOP SLAVE;
 RESET SLAVE ALL;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 
 --source include/auto_increment_offset_restore.inc
 

--- a/mysql-test/suite/galera/t/galera_forced_binlog_format.test
+++ b/mysql-test/suite/galera/t/galera_forced_binlog_format.test
@@ -8,7 +8,7 @@
 
 --connection node_1
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 FLUSH BINARY LOGS;
 

--- a/mysql-test/suite/galera/t/galera_gtid_slave.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave.test
@@ -87,19 +87,16 @@ STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL gtid_slave_pos = "";
 SET GLOBAL wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 
 --connection node_1
 SET GLOBAL wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 
 --connection node_2
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
@@ -202,8 +202,7 @@ DROP TABLE t2,t1;
 STOP SLAVE;
 RESET SLAVE ALL;
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --disable_warnings
@@ -213,14 +212,12 @@ set global gtid_slave_pos="";
 --echo #Connection 1
 --connection node_1
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --echo #Connection 3
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 
 --connection node_2
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera/t/galera_log_bin.inc
+++ b/mysql-test/suite/galera/t/galera_log_bin.inc
@@ -3,11 +3,11 @@
 
 --connection node_2
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_1
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 #
@@ -42,5 +42,5 @@ DROP TABLE t2;
 --echo #cleanup
 --connection node_1
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_log_bin_sst.inc
+++ b/mysql-test/suite/galera/t/galera_log_bin_sst.inc
@@ -8,11 +8,11 @@
 
 --connection node_2
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_1
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 #
@@ -88,7 +88,7 @@ DROP TABLE t2;
 --echo #cleanup
 --connection node_1
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 
 # Restore original auto_increment_offset values.

--- a/mysql-test/suite/galera/t/galera_query_cache_invalidate.test
+++ b/mysql-test/suite/galera/t/galera_query_cache_invalidate.test
@@ -114,8 +114,7 @@ RESET SLAVE ALL;
 
 --connection node_1
 SET SESSION WSREP_ON=OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET SESSION WSREP_ON=ON;
 
 --source include/galera_end.inc

--- a/mysql-test/suite/galera/t/galera_replica_no_gtid.test
+++ b/mysql-test/suite/galera/t/galera_replica_no_gtid.test
@@ -106,8 +106,7 @@ STOP SLAVE;
 RESET SLAVE ALL;
 
 --connection node_3
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 drop table t1;
 
 --connection node_2

--- a/mysql-test/suite/galera/t/galera_restart_replica.test
+++ b/mysql-test/suite/galera/t/galera_restart_replica.test
@@ -274,8 +274,7 @@ STOP SLAVE;
 RESET SLAVE ALL;
 
 --connection primary
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 
 --source include/auto_increment_offset_restore.inc
 

--- a/mysql-test/suite/galera/t/galera_slave_replay.test
+++ b/mysql-test/suite/galera/t/galera_slave_replay.test
@@ -23,7 +23,7 @@ ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
 #
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
-RESET MASTER;
+--source include/reset_master.inc
 
 --connection node_2a
 #
@@ -199,8 +199,7 @@ DROP TABLE t1;
 
 --connection node_3
 DROP TABLE t1;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 
 --connection node_1
 --disconnect node_2a

--- a/mysql-test/suite/galera/t/galera_var_gtid_domain_id.test
+++ b/mysql-test/suite/galera/t/galera_var_gtid_domain_id.test
@@ -56,12 +56,12 @@ DROP TABLE t1, t2;
 --echo #cleanup
 --connection node_1
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2

--- a/mysql-test/suite/galera/t/mdev_10518.test
+++ b/mysql-test/suite/galera/t/mdev_10518.test
@@ -56,12 +56,12 @@ DROP TABLE t1, t2;
 --echo #cleanup
 --connection node_1
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2
 set global wsrep_on=OFF;
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 
 --connection node_2

--- a/mysql-test/suite/galera/t/rpl_row_annotate.test
+++ b/mysql-test/suite/galera/t/rpl_row_annotate.test
@@ -4,13 +4,13 @@
 --echo # On node_2
 --connection node_2
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 
 --echo # On node_1
 --connection node_1
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 CREATE TABLE t1(i INT)ENGINE=INNODB;
 INSERT INTO t1 VALUES(1);

--- a/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
@@ -75,34 +75,28 @@ RESET SLAVE;
 Warnings:
 Note	4190	RESET SLAVE is implicitly changing the value of 'Using_Gtid' from 'Current_Pos' to 'Slave_Pos'
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 SET GLOBAL GTID_SLAVE_POS="";
 connection node_1;
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 connection node_2;
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 connection node_3;
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 connection node_5;
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 connection node_6;
 SET GLOBAL wsrep_on = OFF;
-include/kill_binlog_dump_threads.inc
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 connection node_1;
 CALL mtr.add_suppression("Ignoring server id .* for non bootstrap node");

--- a/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
@@ -235,37 +235,31 @@ cluster 1 node 1
 connection node_1;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 cluster 2 node 1
 connection node_4;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 connection node_2;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_3;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_5;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_6;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_1;
 --- ignore_server_ids=(12,13)
@@ -454,8 +448,7 @@ drop table t1;
 stop slave;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 cluster 2 node 1
@@ -463,27 +456,22 @@ connection node_4;
 stop slave;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 connection node_2;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_3;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_5;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;
 connection node_6;
 set global wsrep_on=OFF;
-include/kill_binlog_dump_threads.inc
-reset master;
+include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
@@ -138,8 +138,7 @@ DROP TABLE t1;
 STOP SLAVE;
 RESET SLAVE;
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 SET GLOBAL GTID_SLAVE_POS="";
@@ -147,40 +146,35 @@ SET GLOBAL GTID_SLAVE_POS="";
 --connection node_1
 
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 
 --connection node_2
 
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 
 --connection node_3
 
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 
 --connection node_5
 
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 
 --connection node_6
 
 SET GLOBAL wsrep_on = OFF;
---source include/kill_binlog_dump_threads.inc
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on = ON;
 --source include/wait_until_ready.inc
 

--- a/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
@@ -203,8 +203,7 @@ reset slave;
 --connection node_1
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 --sleep 2
@@ -213,30 +212,25 @@ set global GTID_SLAVE_POS="";
 --connection node_4
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 
 --connection node_2
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_3
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_5
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_6
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 #--enable_parsing
 #
@@ -404,8 +398,7 @@ drop table t1;
 stop slave;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 
@@ -414,28 +407,23 @@ set global GTID_SLAVE_POS="";
 stop slave;
 change master to master_use_gtid=no, ignore_server_ids=();
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 set global GTID_SLAVE_POS="";
 
 --connection node_2
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_3
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_5
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;
 --connection node_6
 set global wsrep_on=OFF;
---source include/kill_binlog_dump_threads.inc
-reset master;
+--source include/reset_master.inc
 set global wsrep_on=ON;

--- a/mysql-test/suite/galera_sr/r/galera_sr_log_bin.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_log_bin.result
@@ -11,14 +11,14 @@ INSERT INTO t1 VALUES (1);
 connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1a;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t2 VALUES (1);
 connection node_2;
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 SET AUTOCOMMIT=OFF;
 SET SESSION wsrep_trx_fragment_size = 1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_log_bin.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_log_bin.test
@@ -17,7 +17,7 @@ INSERT INTO t1 VALUES (1);
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connection node_1a
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
@@ -25,7 +25,7 @@ INSERT INTO t2 VALUES (1);
 
 --connection node_2
 SET GLOBAL wsrep_on=OFF;
-RESET MASTER;
+--source include/reset_master.inc
 SET GLOBAL wsrep_on=ON;
 SET AUTOCOMMIT=OFF;
 SET SESSION wsrep_trx_fragment_size = 1;


### PR DESCRIPTION
…Galera tests

RESET MASTER fails with ER_BINLOG_IN_USE when a binlog dump thread is still lingering after a slave disconnects, causing sporadic failures.

Replace direct RESET MASTER in galera, galera_sr and galera_3nodes tests with include/reset_master.inc, which kills leftover dump threads and retries the RESET MASTER. Redundant preceding calls to include/kill_binlog_dump_threads.inc are removed, as reset_master.inc already does that itself.

Note that all of affected test cases are not vulnerable of failure, they are here modified for completeness.