### PR TITLE
MDEV-41055 innodb_encryption_threads=0 hangs indefinitely when rotation IOPS is zero

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-encr-threads.result
+++ b/mysql-test/suite/encryption/r/innodb-encr-threads.result
@@ -5,3 +5,34 @@ insert t1 values (1);
 drop table t1;
 set global innodb_encryption_threads = 0;
 set global innodb_encryption_rotate_key_age = 1;
+#
+# MDEV-41055 innodb_encryption_threads=0 hangs indefinitely
+#		when rotation IOPS is zero
+#
+connect  con1,localhost,root,,,,,;
+connection default;
+SET @old_encrypt_tables= @@GLOBAL.innodb_encrypt_tables;
+SET @old_threads= @@GLOBAL.innodb_encryption_threads;
+SET @old_iops= @@GLOBAL.innodb_encryption_rotation_iops;
+SET GLOBAL innodb_encryption_threads= 0;
+SET GLOBAL innodb_encrypt_tables= OFF;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_encryption_rotation_iops= 0;
+SET GLOBAL innodb_encryption_threads= 1;
+SET GLOBAL innodb_encrypt_tables= ON;
+SELECT COUNT(*) AS rotating
+FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION
+WHERE ROTATING_OR_FLUSHING <> 0;
+rotating
+0
+connection con1;
+SET GLOBAL innodb_encryption_threads= 0;
+connection default;
+SELECT @@GLOBAL.innodb_encryption_threads;
+@@GLOBAL.innodb_encryption_threads
+0
+disconnect con1;
+DROP TABLE t1;
+SET GLOBAL innodb_encryption_rotation_iops= @old_iops;
+SET GLOBAL innodb_encrypt_tables= @old_encrypt_tables;
+SET GLOBAL innodb_encryption_threads= @old_threads;

--- a/mysql-test/suite/encryption/t/innodb-encr-threads.opt
+++ b/mysql-test/suite/encryption/t/innodb-encr-threads.opt
@@ -1,0 +1,1 @@
+--innodb_tablespaces_encryption

--- a/mysql-test/suite/encryption/t/innodb-encr-threads.test
+++ b/mysql-test/suite/encryption/t/innodb-encr-threads.test
@@ -12,3 +12,43 @@ drop table t1;
 set global innodb_encryption_threads = 0;
 set global innodb_encryption_rotate_key_age = 1;
 
+--echo #
+--echo # MDEV-41055 innodb_encryption_threads=0 hangs indefinitely
+--echo #		when rotation IOPS is zero
+--echo #
+--connect (con1,localhost,root,,,,,)
+--connection default
+
+SET @old_encrypt_tables= @@GLOBAL.innodb_encrypt_tables;
+SET @old_threads= @@GLOBAL.innodb_encryption_threads;
+SET @old_iops= @@GLOBAL.innodb_encryption_rotation_iops;
+
+SET GLOBAL innodb_encryption_threads= 0;
+SET GLOBAL innodb_encrypt_tables= OFF;
+
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+SET GLOBAL innodb_encryption_rotation_iops= 0;
+SET GLOBAL innodb_encryption_threads= 1;
+SET GLOBAL innodb_encrypt_tables= ON;
+
+let $wait_condition=
+  SELECT COUNT(*) > 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION
+   WHERE ENCRYPTION_SCHEME = 1 AND MIN_KEY_VERSION = 0;
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS rotating
+  FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION
+ WHERE ROTATING_OR_FLUSHING <> 0;
+
+--connection con1
+SET GLOBAL innodb_encryption_threads= 0;
+
+--connection default
+SELECT @@GLOBAL.innodb_encryption_threads;
+--disconnect con1
+
+DROP TABLE t1;
+SET GLOBAL innodb_encryption_rotation_iops= @old_iops;
+SET GLOBAL innodb_encrypt_tables= @old_encrypt_tables;
+SET GLOBAL innodb_encryption_threads= @old_threads;

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2363,6 +2363,9 @@ void fil_crypt_set_thread_cnt(const uint new_cnt)
 	}
 
 	pthread_cond_broadcast(&fil_crypt_threads_cond);
+	/* Thread waiting on fil_crypt_iops_cond too. They must
+	be woken as well */
+	pthread_cond_broadcast(&fil_crypt_iops_cond);
 
 	while (srv_n_fil_crypt_threads_started != srv_n_fil_crypt_threads) {
 		my_cond_wait(&fil_crypt_cond,


### PR DESCRIPTION
Problem:
=======
  When innodb_encryption_rotation_iops=0, an encryption thread
could be waiting on fil_crypt_iops_cond in fil_crypt_alloc_iops(). fil_crypt_set_thread_cnt() lowers srv_n_fil_crypt_threads and broadcasts only fil_crypt_thread_cond, so that the waiting thread never re-evaluates should_shutdown() and never exits.

Solution:
=========
fil_crypt_set_thread_cnt(): Broadcast fil_crypt_iops_cond as well, so a thread waiting for IOPS wakes up and sees should_shutdown(), exits.