### PR TITLE
MDEV-41021 SET GLOBAL innodb_log_archive ignores read-only mode

### DIFF
--- a/mysql-test/suite/innodb/r/log_archive.result
+++ b/mysql-test/suite/innodb/r/log_archive.result
@@ -50,6 +50,8 @@ ALTER TABLE mysql.innodb_table_stats ROW_FORMAT=COMPACT, ALGORITHM=INPLACE;
 ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Running in read-only mode. Try ALGORITHM=COPY
 TRUNCATE TABLE mysql.innodb_table_stats;
 ERROR HY000: Table 'innodb_table_stats' is read only
+SET GLOBAL innodb_log_archive=!@@GLOBAL.innodb_log_archive;
+ERROR HY000: InnoDB is in read only mode
 # restart: --innodb-log-recovery-start=0 --innodb-log-recovery-target=18446744073705357290
 SELECT variable_name, variable_value FROM information_schema.global_status
 WHERE variable_name LIKE 'INNODB_LSN%';

--- a/mysql-test/suite/innodb/t/log_archive.test
+++ b/mysql-test/suite/innodb/t/log_archive.test
@@ -148,6 +148,8 @@ DROP TABLE mysql.innodb_index_stats;
 ALTER TABLE mysql.innodb_table_stats ROW_FORMAT=COMPACT, ALGORITHM=INPLACE;
 --error ER_OPEN_AS_READONLY
 TRUNCATE TABLE mysql.innodb_table_stats;
+--error ER_INNODB_READ_ONLY
+SET GLOBAL innodb_log_archive=!@@GLOBAL.innodb_log_archive;
 
 --source include/shutdown_mysqld.inc
 --move_file $DATADIR/ib_logfile0 $DATADIR/ib_ffffffffff803000.log

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -767,6 +767,12 @@ void log_t::header_rewrite(my_bool archive) noexcept
 @param thd      SQL connection */
 void log_t::set_archive(my_bool archive, THD *thd) noexcept
 {
+  if (UNIV_UNLIKELY(recv_sys.rpo != 0))
+  {
+    my_error(ER_INNODB_READ_ONLY, MYF(0));
+    return;
+  }
+
   thd_wait_begin(thd, THD_WAIT_DISKIO);
   tpool::tpool_wait_begin();
   lsn_t wait_lsn;


### PR DESCRIPTION
`log_t::set_archive()`: Prevent a crash in `log_t::header_rewrite()` by refusing the operation if the log is read-only.

This fixes up #4405.