### PR TITLE
Run the moxygen test doc generation only on something actually changing

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'include/mysql/**'
   pull_request:
     branches:
       - 'main'
+    paths:
+      - 'include/mysql/**'
 jobs:
   generate-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now test moxygen docs generation triggers on every pull request regardless of what is changed.

There's no need for that.

It's enough to run it only when something in include/mysql changes.