### PR TITLE
MDEV-41028 : Galera appliers deadlock on a foreign key referencing a …

### DIFF
--- a/mysql-test/suite/galera/r/galera_fk_char_key.result
+++ b/mysql-test/suite/galera/r/galera_fk_char_key.result
@@ -1,0 +1,37 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE p (id CHAR(5) CHARACTER SET utf8mb4 PRIMARY KEY, v INT) ENGINE=InnoDB;
+CREATE TABLE c (id INT AUTO_INCREMENT PRIMARY KEY,
+p_id CHAR(5) CHARACTER SET utf8mb4 NOT NULL,
+KEY k (p_id),
+FOREIGN KEY (p_id) REFERENCES p (id)) ENGINE=InnoDB;
+INSERT INTO p VALUES (_utf8mb4 0xC3A9, 0);
+connection node_2;
+SET SESSION wsrep_sync_wait = 1;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+connection node_1;
+INSERT INTO c (p_id) VALUES (_utf8mb4 0xC3A9);
+connection node_2;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+connection node_1;
+UPDATE p SET v = v + 1 WHERE id = _utf8mb4 0xC3A9;
+connection node_2;
+SELECT COUNT(*) = 0 AS no_row_modified_in_parallel FROM INFORMATION_SCHEMA.INNODB_TRX WHERE trx_rows_modified > 0;
+no_row_modified_in_parallel
+1
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SELECT v FROM p;
+v
+1
+SELECT COUNT(*) FROM c;
+COUNT(*)
+1
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_1;
+DROP TABLE c, p;

--- a/mysql-test/suite/galera/r/galera_fk_char_key_big.result
+++ b/mysql-test/suite/galera/r/galera_fk_char_key_big.result
@@ -1,0 +1,19 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET GLOBAL wsrep_slave_threads = 2;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+SET SESSION wsrep_sync_wait = 0;
+# Shape 1: CHAR(36) utf8mb4
+# Shape 2: CHAR(36) utf8mb3
+# Shape 3: CHAR(36) utf8mb4, four byte characters
+# Shape 4: CHAR(36) utf8mb4_bin
+# Shape 5: CHAR(36) utf8mb4, ROW_FORMAT=REDUNDANT
+# Shape 6: CHAR(36) utf16
+# Shape 7: CHAR(36) ucs2
+# Shape 8: CHAR(36) latin1
+# Shape 9: CHAR(36) utf8mb4, ASCII value
+# Shape 10: VARCHAR(36) utf8mb4
+connection node_2;
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+disconnect node_2a;

--- a/mysql-test/suite/galera/t/galera_fk_char_key.test
+++ b/mysql-test/suite/galera/t/galera_fk_char_key.test
@@ -1,0 +1,94 @@
+#
+# A foreign key on a CHAR column of a variable length character set.
+#
+# The key of the child row is built from the MySQL record by
+# wsrep_store_key_val_for_row() and the key of the parent row from the InnoDB
+# record by wsrep_rec_get_foreign_key(). A CHAR is not space padded the same
+# way in the two formats: the MySQL record pads it to n_chars * mbmaxlen
+# bytes, while InnoDB strips that padding down to, but not below, n_chars
+# bytes. As that compares a byte count with a character count, a value that
+# holds a multi byte character and is shorter than the column ended up with a
+# different number of characters on the two paths, the two keys differed, the
+# child INSERT got no dependency on the parent row and the appliers were free
+# to run it in parallel with a change of that very row.
+#
+# The value used below is one two byte character in a five character column,
+# so it is padded, which is what used to make the two encodings diverge. It
+# is written as a hex literal so that the test does not depend on the
+# character set of the client connection.
+#
+# The test parks the applier of the child INSERT and replicates an UPDATE of
+# the parent row after it, then verifies that the UPDATE had to wait.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/galera_have_debug_sync.inc
+
+--connection node_1
+CREATE TABLE p (id CHAR(5) CHARACTER SET utf8mb4 PRIMARY KEY, v INT) ENGINE=InnoDB;
+CREATE TABLE c (id INT AUTO_INCREMENT PRIMARY KEY,
+                p_id CHAR(5) CHARACTER SET utf8mb4 NOT NULL,
+                KEY k (p_id),
+                FOREIGN KEY (p_id) REFERENCES p (id)) ENGINE=InnoDB;
+INSERT INTO p VALUES (_utf8mb4 0xC3A9, 0);
+
+--connection node_2
+# Catch up with node_1 with a causal read before causal reads are turned off.
+SET SESSION wsrep_sync_wait = 1;
+--disable_query_log
+--disable_result_log
+SELECT COUNT(*) FROM p;
+--enable_result_log
+--enable_query_log
+SET SESSION wsrep_sync_wait = 0;
+
+# Two appliers, so that the two writesets below *can* be applied in parallel
+# if certification does not make them depend on each other.
+SET GLOBAL wsrep_slave_threads = 2;
+
+# Park the first applier on entry to the apply monitor, i.e. before the child
+# INSERT is applied and before its FK check locks the parent row.
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+INSERT INTO c (p_id) VALUES (_utf8mb4 0xC3A9);
+
+--connection node_2
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+
+# Clear the sync point, the second applier must run into the real dependency.
+--source include/galera_clear_sync_point.inc
+
+--let $apply_waits = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
+
+--connection node_1
+UPDATE p SET v = v + 1 WHERE id = _utf8mb4 0xC3A9;
+
+--connection node_2
+# Wait until the second applier has blocked in the apply monitor because
+--let $wait_condition = SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_apply_waits') > $apply_waits
+--source include/wait_condition.inc
+
+# the second applier waited instead of applying it in parallel.
+SELECT COUNT(*) = 0 AS no_row_modified_in_parallel FROM INFORMATION_SCHEMA.INNODB_TRX WHERE trx_rows_modified > 0;
+
+# Release the child INSERT
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM c;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT v = 1 FROM p;
+--source include/wait_condition.inc
+
+SELECT v FROM p;
+SELECT COUNT(*) FROM c;
+
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_1
+DROP TABLE c, p;

--- a/mysql-test/suite/galera/t/galera_fk_char_key_big.test
+++ b/mysql-test/suite/galera/t/galera_fk_char_key_big.test
@@ -1,0 +1,130 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+ 
+--connection node_2
+SET GLOBAL wsrep_slave_threads = 2;
+ 
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+SET SESSION wsrep_sync_wait = 0;
+ 
+--let $shape = 0
+while ($shape < 10)
+{
+  --inc $shape
+  --let $opt = ENGINE=InnoDB
+ 
+  if ($shape == 1)
+  {
+    --let $name = CHAR(36) utf8mb4
+    --let $col = CHAR(36) CHARACTER SET utf8mb4
+    --let $val = _utf8mb4 0xC3A9C3A9C3A9C3A9C3A9
+  }
+  if ($shape == 2)
+  {
+    --let $name = CHAR(36) utf8mb3
+    --let $col = CHAR(36) CHARACTER SET utf8mb3
+    --let $val = _utf8mb3 0xC3A9C3A9C3A9C3A9C3A9
+  }
+  if ($shape == 3)
+  {
+    --let $name = CHAR(36) utf8mb4, four byte characters
+    --let $col = CHAR(36) CHARACTER SET utf8mb4
+    --let $val = _utf8mb4 0xF09F9880F09F9880F09F9880F09F9880F09F9880
+  }
+  if ($shape == 4)
+  {
+    --let $name = CHAR(36) utf8mb4_bin
+    --let $col = CHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+    --let $val = _utf8mb4 0xC3A9C3A9C3A9C3A9C3A9
+  }
+  if ($shape == 5)
+  {
+    --let $name = CHAR(36) utf8mb4, ROW_FORMAT=REDUNDANT
+    --let $col = CHAR(36) CHARACTER SET utf8mb4
+    --let $val = _utf8mb4 0xC3A9C3A9C3A9C3A9C3A9
+    --let $opt = ENGINE=InnoDB ROW_FORMAT=REDUNDANT
+  }
+  if ($shape == 6)
+  {
+    --let $name = CHAR(36) utf16
+    --let $col = CHAR(36) CHARACTER SET utf16
+    --let $val = _utf16 0x00E900E900E900E900E9
+  }
+  if ($shape == 7)
+  {
+    --let $name = CHAR(36) ucs2
+    --let $col = CHAR(36) CHARACTER SET ucs2
+    --let $val = _ucs2 0x00E900E900E900E900E9
+  }
+  if ($shape == 8)
+  {
+    --let $name = CHAR(36) latin1
+    --let $col = CHAR(36) CHARACTER SET latin1
+    --let $val = _latin1 0xE9E9E9E9E9
+  }
+  if ($shape == 9)
+  {
+    --let $name = CHAR(36) utf8mb4, ASCII value
+    --let $col = CHAR(36) CHARACTER SET utf8mb4
+    --let $val = _utf8mb4 0x6162636465
+  }
+  if ($shape == 10)
+  {
+    --let $name = VARCHAR(36) utf8mb4
+    --let $col = VARCHAR(36) CHARACTER SET utf8mb4
+    --let $val = _utf8mb4 0xC3A9C3A9C3A9C3A9C3A9
+  }
+ 
+  --echo # Shape $shape: $name
+  --disable_connect_log
+  --connection node_1
+  --disable_query_log
+  --eval CREATE TABLE p (id $col PRIMARY KEY, v INT) $opt
+  --eval CREATE TABLE c (id INT AUTO_INCREMENT PRIMARY KEY, p_id $col NOT NULL, KEY k (p_id), FOREIGN KEY (p_id) REFERENCES p (id)) $opt
+  --eval CREATE TABLE f (id INT AUTO_INCREMENT PRIMARY KEY, pad CHAR(255)) $opt
+  --eval INSERT INTO p VALUES ($val, 0)
+  --enable_query_log
+  --enable_connect_log
+
+  --let $i = 0
+  --let $round = 10
+  while ($round)
+  {
+    --inc $i
+    --disable_connect_log
+    --connection node_1
+    --disable_query_log
+    BEGIN;
+    INSERT INTO f (pad) SELECT REPEAT('x',255) FROM seq_1_to_2000;
+    --eval INSERT INTO c (p_id) VALUES ($val)
+    COMMIT;
+    --eval UPDATE p SET v = v + 1 WHERE id = $val
+    --enable_query_log
+
+    --connection node_2a
+    --let $wait_timeout = 30
+    --let $wait_condition = SELECT COUNT(*) = $i FROM c
+    --source include/wait_condition.inc
+    --enable_connect_log
+
+    if (!$success)
+    {
+      SELECT ID, STATE, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+      SELECT trx_id, trx_state, trx_mysql_thread_id, trx_query FROM INFORMATION_SCHEMA.INNODB_TRX;
+      --die Node 2 stopped applying. The two appliers are deadlocked on the foreign key parent row.
+    }
+    --dec $round
+  }
+
+  --disable_connect_log
+  --connection node_1
+  --disable_query_log
+  DROP TABLE c, p, f;
+  --enable_query_log
+  --enable_connect_log
+}
+ 
+--connection node_2
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+--disconnect node_2a

--- a/mysql-test/suite/wsrep/r/wsrep_protocol_versions.result
+++ b/mysql-test/suite/wsrep/r/wsrep_protocol_versions.result
@@ -1,7 +1,7 @@
 # Correct Galera library found
 show status like 'wsrep_protocol%';
 Variable_name	Value
-wsrep_protocol_application	4
+wsrep_protocol_application	5
 wsrep_protocol_gcs	6
 wsrep_protocol_replicator	11
 wsrep_protocol_version	11

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -121,7 +121,9 @@ my_bool wsrep_incremental_data_collection= 0;   // Incremental data collection
 bool wsrep_new_cluster= false;                  // Bootstrap the cluster?
 int wsrep_slave_count_change= 0;                // No. of appliers to stop/start
 int wsrep_to_isolation= 0;                      // No. of active TO isolation threads
-long wsrep_max_protocol_version= 4;             // Maximum protocol version to use
+// 5: CHAR write set key values are normalized to the number of characters
+//    the column holds, see wsrep_store_string_key_val()
+long wsrep_max_protocol_version= 5;             // Maximum protocol version to use
 long int  wsrep_protocol_version= wsrep_max_protocol_version;
 ulong wsrep_trx_fragment_unit= WSREP_FRAG_BYTES;
                                                 // unit for fragment size
@@ -2001,6 +2003,7 @@ static bool wsrep_prepare_key_for_isolation(const char* db,
   case 2:
   case 3:
   case 4:
+  case 5:
   {
     *key_len= 0;
     if (db)
@@ -2181,6 +2184,7 @@ bool wsrep_prepare_key(const uchar* cache_key, size_t cache_key_len,
     case 2:
     case 3:
     case 4:
+    case 5:
     {
         key[0].ptr= cache_key;
         key[0].len= strlen( (char*)cache_key );

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6212,6 +6212,37 @@ ha_innobase::close()
 /* The following accessor functions should really be inside MySQL code! */
 
 #ifdef WITH_WSREP
+/** Pick the charset struct of a charset number, for the write set key
+encoding. Since the MySQL function get_charset may be slow before Bar
+removes the mutex operation there, we first look at 2 common charsets
+directly.
+@param charset_number	number of the charset
+@return the charset, never NULL */
+static
+CHARSET_INFO*
+wsrep_get_charset(uint charset_number)
+{
+	if (charset_number == default_charset_info->number) {
+		return default_charset_info;
+	}
+
+	if (charset_number == my_charset_latin1.number) {
+		return &my_charset_latin1;
+	}
+
+	CHARSET_INFO* charset = get_charset(charset_number, MYF(MY_WME));
+
+	if (charset == NULL) {
+		sql_print_error("InnoDB needs charset %lu for doing "
+				"a comparison, but MariaDB cannot "
+				"find that charset.",
+				(ulong) charset_number);
+		ut_a(0);
+	}
+
+	return charset;
+}
+
 size_t
 wsrep_normalize_string(
 	int		mysql_type,	/* in: MySQL type */
@@ -6239,28 +6270,7 @@ wsrep_normalize_string(
 	case MYSQL_TYPE_LONG_BLOB:
 	case MYSQL_TYPE_VARCHAR:
 	{
-		CHARSET_INFO* charset;
-
-		/* Use the charset number to pick the right charset struct for
-		the comparison. Since the MySQL function get_charset may be
-		slow before Bar removes the mutex operation there, we first
-		look at 2 common charsets directly. */
-
-		if (charset_number == default_charset_info->number) {
-			charset = default_charset_info;
-		} else if (charset_number == my_charset_latin1.number) {
-			charset = &my_charset_latin1;
-		} else {
-			charset = get_charset(charset_number, MYF(MY_WME));
-
-			if (charset == NULL) {
-				sql_print_error("InnoDB needs charset %lu for doing "
-						"a comparison, but MariaDB cannot "
-						"find that charset.",
-						(ulong) charset_number);
-				ut_a(0);
-			}
-		}
+		CHARSET_INFO* charset = wsrep_get_charset(charset_number);
 
 		if (wsrep_protocol_version < 3) {
 			ret_length = charset->strnxfrm(
@@ -6303,6 +6313,122 @@ wsrep_normalize_string(
 	}
 
 	return ret_length;
+}
+
+/** Store the write set key value of a string column.
+
+Both write set key paths come here, so that one and the same column value
+always produces one and the same key: wsrep_store_key_val_for_row() has the
+value in the MySQL record format and wsrep_rec_get_foreign_key() has it as
+InnoDB stored it, and a CHAR is not padded the same way in the two.
+
+From protocol version 5 on, the MySQL record pads a CHAR to
+n_chars * mbmaxlen bytes, while InnoDB in a compact row format and a
+variable length character set strips that padding down to but not below
+n_chars bytes; as that compares a byte count against a character count, a
+value holding multi byte characters is left with fewer than n_chars
+characters. See row_mysql_store_col_in_innobase_format(). Both forms are
+brought to exactly n_chars characters here, which also makes the key
+independent of the row format. The normalization itself is always done with
+WSREP_MAX_SUPPORTED_KEY_LENGTH as the buffer length, and only the copy into
+out_str is limited by the space the caller has left, because strnxfrm
+truncates to the length it is given and the key of a column must not depend
+on how much room the columns before it happened to leave.
+
+Before protocol version 5 the two paths did neither of those and disagreed
+for a CHAR in a variable length character set. That is kept here so that a
+node still speaking the older protocol produces the same keys as before.
+Note that the old paths did not agree on the strnxfrm buffer length either,
+3072 on one and 3500 on the other; both get WSREP_MAX_SUPPORTED_KEY_LENGTH
+here, which only makes a difference for a value whose normalized form is
+longer than 3072 bytes, where the two never produced the same key anyway.
+
+@param mysql_type	MySQL type of the column
+@param charset_number	number of the charset of the column
+@param n_chars		characters the column holds, 0 if it is not a CHAR
+@param str		column value
+@param str_length	length of str in bytes
+@param out_str		buffer for the key value
+@param out_length	space left in out_str
+@param mysql_format	str is in the MySQL record format, where a CHAR is
+			padded to more characters than the column holds;
+			before protocol 5 that was cut back here
+@return number of bytes written to out_str */
+size_t
+wsrep_store_string_key_val(
+	int			mysql_type,
+	uint			charset_number,
+	size_t			n_chars,
+	const unsigned char*	str,
+	size_t			str_length,
+	unsigned char*		out_str,
+	ulint			out_length,
+	bool			mysql_format)
+{
+	unsigned char	normalized[WSREP_MAX_SUPPORTED_KEY_LENGTH + 1];
+	size_t		len;
+
+	if (wsrep_protocol_version < 5) {
+		CHARSET_INFO* cs = wsrep_get_charset(charset_number);
+
+		if (mysql_format && str_length > 0 && cs->mbmaxlen > 1) {
+			int error;
+
+			str_length = my_well_formed_length(
+				cs, (const char*) str,
+				(const char*) str + str_length,
+				str_length / cs->mbmaxlen, &error);
+		}
+
+		len = wsrep_normalize_string(mysql_type, charset_number, str,
+					     normalized, str_length,
+					     WSREP_MAX_SUPPORTED_KEY_LENGTH);
+	} else {
+		unsigned char padded[REC_VERSION_56_MAX_INDEX_COL_LEN + 1];
+
+		if (n_chars) {
+			CHARSET_INFO* cs = wsrep_get_charset(charset_number);
+			int error;
+
+			/* Cut to at most n_chars characters ... */
+			str_length = my_well_formed_length(
+				cs, (const char*) str,
+				(const char*) str + str_length, n_chars,
+				&error);
+
+			/* ... and pad back up to n_chars where InnoDB had
+			stripped the padding. mbminlen is 1 for every
+			character set whose CHAR padding InnoDB strips, so
+			the pad character is one 0x20. */
+			const size_t chars = cs->numchars(
+				(const char*) str,
+				(const char*) str + str_length);
+
+			if (chars < n_chars) {
+				const size_t pad = n_chars - chars;
+
+				ut_ad(cs->mbminlen == 1);
+				ut_a(str_length + pad <= sizeof padded);
+
+				memcpy(padded, str, str_length);
+				memset(padded + str_length, 0x20, pad);
+				str = padded;
+				str_length += pad;
+			}
+		}
+
+		len = wsrep_normalize_string(mysql_type, charset_number, str,
+					     normalized, str_length,
+					     WSREP_MAX_SUPPORTED_KEY_LENGTH);
+	}
+
+	if (len > out_length) {
+		len = out_length;
+	}
+
+	memcpy(out_str, normalized, len);
+
+	return len;
 }
 #endif /* WITH_WSREP */
 
@@ -6876,38 +7002,26 @@ wsrep_store_key_val_for_row(
 
 				const CHARSET_INFO* cs= field->charset();
 
-				/* For multi byte character sets we need to
-				calculate the true length of the key */
-
-				if (true_len > 0 && cs->mbmaxlen > 1) {
-					int error;
-
-					true_len= my_well_formed_length(cs,
-							(const char *)src_start,
-							(const char *)src_start
-								+ true_len,
-							(true_len / cs->mbmaxlen),
-							&error);
-				}
+				/* Only a whole CHAR column is brought to the
+				number of characters it holds. A prefix key
+				part is not a column value and is never
+				matched against a foreign key. */
+				const size_t n_chars=
+					(mysql_type == MYSQL_TYPE_STRING
+					 && key_part->length
+					    == field->pack_length())
+					? key_part->length / cs->mbmaxlen : 0;
 
 				/* Normalize string if it is not empty string */
 				if (true_len) {
 					ut_ad(src_start);
-					true_len= wsrep_normalize_string(
-						mysql_type, cs->number,
-						src_start, normalized, true_len,
-						REC_VERSION_56_MAX_INDEX_COL_LEN);
+					true_len= wsrep_store_string_key_val(
+						mysql_type, cs->number, n_chars,
+						src_start, true_len,
+						(uchar*) buff, buff_space, true);
 				} else {
 					ut_ad(src_start == nullptr);
 				}
-
-				if (true_len > buff_space) {
-					fprintf (stderr,
-						 "WSREP: key truncated: %s\n",
-						 wsrep_thd_query(thd));
-					true_len   = buff_space;
-				}
-				memcpy(buff, normalized, true_len);
 			} else {
 				/* Copy only if there is data */
 				if (true_len) {

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -154,6 +154,18 @@ size_t wsrep_normalize_string(int mysql_type,
 			      unsigned char* out_str,
 			      ulint str_length,
 			      ulint buf_length);
+
+/** Store the write set key value of a string column. Used by both write set
+key paths, so that one and the same column value always produces one and the
+same key. See the definition in ha_innodb.cc. */
+size_t wsrep_store_string_key_val(int mysql_type,
+				  uint charset_number,
+				  size_t n_chars,
+				  const unsigned char* str,
+				  size_t str_length,
+				  unsigned char* out_str,
+				  ulint out_length,
+				  bool mysql_format);
 #endif /* WITH_WSREP */
 
 /** Get high resolution timestamp for the current query start time.

--- a/storage/innobase/rem/rem0rec.cc
+++ b/storage/innobase/rem/rem0rec.cc
@@ -2763,12 +2763,26 @@ wsrep_rec_get_foreign_key(
 			}
 			case DATA_VARCHAR:
 			case DATA_VARMYSQL:
-			case DATA_CHAR:
-			case DATA_MYSQL:
-				len = wsrep_normalize_string(
+				len = wsrep_store_string_key_val(
 					(int)(col_f->prtype & DATA_MYSQL_TYPE_MASK),
 					dtype_get_charset_coll(col_f->prtype),
-					data, buf, len, *buf_len);
+					0, data, len, buf,
+					*buf_len - key_len, false);
+				break;
+			case DATA_CHAR:
+			case DATA_MYSQL:
+				/* A CHAR is stored with the space padding
+				InnoDB happened to leave on it, which is not
+				what the MySQL record holds. Pass the number
+				of characters the column has so that both
+				forms end up as the same key. */
+				len = wsrep_store_string_key_val(
+					(int)(col_f->prtype & DATA_MYSQL_TYPE_MASK),
+					dtype_get_charset_coll(col_f->prtype),
+					col_f->mbmaxlen
+					  ? col_f->len / col_f->mbmaxlen : 0,
+					data, len, buf,
+					*buf_len - key_len, false);
 				break;
 			case DATA_BLOB:
 			case DATA_BINARY:


### PR DESCRIPTION
…CHAR column in a multi-byte character set

The write set key of a row is built from the MySQL record by wsrep_store_key_val_for_row(), and the key of a foreign key parent row from the InnoDB record by wsrep_rec_get_foreign_key(). A CHAR is not padded the same way in the two formats: the MySQL record pads it to n_chars * mbmaxlen bytes, while InnoDB strips that padding down to, but not below, n_chars bytes. That compares a byte count with a character count, so a value holding a multi byte character and shorter than the column was left with a different number of characters on the two paths, and the keys differed. A child INSERT then had no dependency on its parent row and the appliers ran it in parallel with a change of that very row. The two paths did not agree on the strnxfrm buffer length either, 3072 on one and 3500 on the other.

Both now go through wsrep_store_string_key_val(), which brings a CHAR to exactly the number of characters the column holds and always normalizes with WSREP_MAX_SUPPORTED_KEY_LENGTH, so that the key of a column does not depend on how much room the columns before it happened to leave. Only the copy into the caller's buffer is bounded by the space that is left, which also stops wsrep_rec_get_foreign_key() from writing past its key buffer.

This changes the write set keys, so it is done from protocol version 5 on and the old encoding is kept below that.