### PR TITLE
MDEV-15066:  Filter geometry parts by bounding box before the scan

### DIFF
--- a/mysql-test/main/gis-precise.result
+++ b/mysql-test/main/gis-precise.result
@@ -947,3 +947,345 @@ set @geom=ST_BUFFER(ST_BUFFER(ST_POLYGONFROMTEXT('POLYGON((0 0, 5 5, 6 6, 0 0))'
 select round(area(@geom), 5);
 round(area(@geom), 5)
 79.16890
+#
+# MDEV-15066 ST_INTERSECTS over a multipolygon with scattered parts
+#
+# A multipolygon meets another geometry when one of its polygons does.
+# Polygons whose bounding box misses the other operand are left out of
+# the scan.  The cases below cover a probe that reaches one polygon, a
+# probe that falls in a gap between polygons while staying inside the
+# bounding box of the whole shape, and a probe that reaches a polygon's
+# bounding box without reaching the polygon itself.
+SET @mp= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                       ((10 10,12 10,12 12,10 12,10 10)),
+                                       ((20 20,22 20,22 22,20 22,20 20)),
+                                       ((30 30,34 30,30 34,30 30)))');
+# probe inside the second polygon -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))'), @mp) a;
+a
+1
+# probe inside the last polygon -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((20.5 20.5,21 20.5,21 21,20.5 21,20.5 20.5))'), @mp) a;
+a
+1
+# probe in a gap, inside the bounding box of the whole shape -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))'), @mp) a;
+a
+0
+# probe outside the bounding box of the whole shape -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((100 100,101 100,101 101,100 101,100 100))'), @mp) a;
+a
+0
+# probe inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))'), @mp) a;
+a
+0
+# probe spanning two polygons, reaching one of them -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((1 1,11 1,11 11,1 11,1 1))'), @mp) a;
+a
+1
+# the multipolygon as the first operand gives the same answers
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))')) a;
+a
+1
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))')) a;
+a
+0
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))')) a;
+a
+0
+# both operands multipolygons, one pair of polygons meeting -> 1
+SELECT ST_Intersects(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                        ((11 11,13 11,13 13,11 13,11 11)))')) a;
+a
+1
+# both operands multipolygons, no pair meeting -> 0
+SELECT ST_Intersects(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                        ((40 40,41 40,41 41,40 41,40 40)))')) a;
+a
+0
+# polygons meeting along an edge and at a single corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((12 10,14 10,14 12,12 12,12 10))'), @mp) a;
+a
+1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((12 12,14 12,14 14,12 14,12 12))'), @mp) a;
+a
+1
+# ST_Disjoint is the complement and keeps the unfiltered path
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))'), @mp) a;
+a
+1
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))'), @mp) a;
+a
+0
+SET @mp= NULL;
+#
+# MDEV-15066 ST_DISJOINT and geometry collections take the same filter
+#
+# ST_Disjoint asks the same question as ST_Intersects and reads the
+# answer the other way round, so it drops the same parts.  A collection
+# keeps a child when the child's bounding box reaches the other operand
+# and the child still holds a shape once its own parts are filtered.
+SET @mp= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                       ((10 10,12 10,12 12,10 12,10 10)),
+                                       ((20 20,22 20,22 22,20 22,20 20)),
+                                       ((30 30,34 30,30 34,30 30)))');
+SET @gc= ST_GeomFromText('GEOMETRYCOLLECTION(
+                            POLYGON((0 0,2 0,2 2,0 2,0 0)),
+                            MULTIPOLYGON(((10 10,12 10,12 12,10 12,10 10)),
+                                         ((20 20,22 20,22 22,20 22,20 20))),
+                            POINT(40 40),
+                            LINESTRING(50 50,52 52))');
+SET @gap= ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))');
+SET @hit= ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))');
+SET @far= ST_GeomFromText('POLYGON((100 100,101 100,101 101,100 101,100 100))');
+# ST_Disjoint over a multipolygon
+# probe in a gap between parts -> 1
+SELECT ST_Disjoint(@gap, @mp) a;
+a
+1
+# probe inside a part -> 0
+SELECT ST_Disjoint(@hit, @mp) a;
+a
+0
+# probe outside the bounding box of the whole shape -> 1
+SELECT ST_Disjoint(@far, @mp) a;
+a
+1
+# probe inside the triangle's bounding box, outside the triangle -> 1
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))'), @mp) a;
+a
+1
+# reversed operand order
+SELECT ST_Disjoint(@mp, @gap) a;
+a
+1
+SELECT ST_Disjoint(@mp, @hit) a;
+a
+0
+# parts sharing an edge are not disjoint -> 0
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((12 10,14 10,14 12,12 12,12 10))'), @mp) a;
+a
+0
+# two multipolygons with no pair meeting -> 1
+SELECT ST_Disjoint(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                      ((40 40,41 40,41 41,40 41,40 40)))')) a;
+a
+1
+# a hole is not part of the shape, a probe inside it is disjoint -> 1
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((4 4,5 4,5 5,4 5,4 4))'),
+ST_GeomFromText('MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(3 3,7 3,7 7,3 7,3 3)))')) a;
+a
+1
+# collections, reaching a child of each kind
+# probe in a gap between children -> 0
+SELECT ST_Intersects(@gap, @gc) a;
+a
+0
+# probe inside a polygon held by the multipolygon child -> 1
+SELECT ST_Intersects(@hit, @gc) a;
+a
+1
+# probe outside the bounding box of the whole collection -> 0
+SELECT ST_Intersects(@far, @gc) a;
+a
+0
+# probe reaching the point child -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((39 39,41 39,41 41,39 41,39 39))'), @gc) a;
+a
+1
+# probe reaching the linestring child -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((50 50,51 50,51 51,50 51,50 50))'), @gc) a;
+a
+1
+# reversed operand order
+SELECT ST_Intersects(@gc, @hit) a;
+a
+1
+# the same collection under ST_Disjoint
+SELECT ST_Disjoint(@gap, @gc) a;
+a
+1
+SELECT ST_Disjoint(@hit, @gc) a;
+a
+0
+# every child filtered out -> 0
+SELECT ST_Intersects(@gap, ST_GeomFromText('GEOMETRYCOLLECTION(
+                                              POLYGON((0 0,2 0,2 2,0 2,0 0)),
+                                              POLYGON((10 10,12 10,12 12,10 12,10 10)))')) a;
+a
+0
+# a multipolygon child whose parts all miss the probe -> 0
+SELECT ST_Intersects(@gap, ST_GeomFromText('GEOMETRYCOLLECTION(
+                                              MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                                           ((10 10,12 10,12 12,10 12,10 10))))')) a;
+a
+0
+SET @mp= NULL;
+SET @gc= NULL;
+SET @gap= NULL;
+SET @hit= NULL;
+SET @far= NULL;
+#
+# MDEV-15066 the same filter over multipoint and multilinestring
+#
+# A multipoint meets another geometry when one of its points does, and
+# a multilinestring when one of its linestrings does.  Parts whose
+# bounding box misses the other operand are left out of the scan.  A
+# point is its own bounding box, so a point survives the filter only
+# where it falls inside the box of the other operand.
+SET @sq= ST_GeomFromText('POLYGON((45 45,55 45,55 55,45 55,45 45))');
+SET @tri= ST_GeomFromText('POLYGON((0 0,100 0,0 100,0 0))');
+SET @two= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                        ((10 10,12 10,12 12,10 12,10 10)))');
+# multipoint, one point inside the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)'), @sq) a;
+a
+1
+# points on either side of the square, none inside -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,100 100)'), @sq) a;
+a
+0
+# a point on the square's corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(45 45)'), @sq) a;
+a
+1
+# a point on the square's edge -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(45 50)'), @sq) a;
+a
+1
+# a point inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(99 99,200 200)'), @tri) a;
+a
+0
+# the same shape with a second point that does reach the triangle -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,99 99)'), @tri) a;
+a
+1
+# points in the gap between the parts of a multipolygon -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(5 5,500 500)'), @two) a;
+a
+0
+# one point in each part -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,11 11)'), @two) a;
+a
+1
+# reversed operand order
+SELECT ST_Intersects(@sq, ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)')) a;
+a
+1
+# multipoint against multipoint
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50)'),
+ST_GeomFromText('MULTIPOINT(50 50,200 200)')) a;
+a
+1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50)'),
+ST_GeomFromText('MULTIPOINT(60 60,200 200)')) a;
+a
+0
+# multilinestring, one part crossing the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 0),(40 40,60 60),
+                                                      (200 200,210 210))'),
+@sq) a;
+a
+1
+# the same shape without the crossing part -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 0),
+                                                      (200 200,210 210))'),
+@sq) a;
+a
+0
+# a part running along the square's edge -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((45 40,45 60))'), @sq) a;
+a
+1
+# a part ending on the square's corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 45,45 45))'), @sq) a;
+a
+1
+# a part inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((90 90,99 99),
+                                                      (300 300,310 310))'),
+@tri) a;
+a
+0
+# a part in the gap between the parts of a multipolygon -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((5 5,6 6),
+                                                      (500 500,501 501))'),
+@two) a;
+a
+0
+# multilinestring against multilinestring
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 10),
+                                                      (50 0,50 100))'),
+ST_GeomFromText('MULTILINESTRING((0 50,100 50),
+                                                      (500 500,510 510))')) a;
+a
+1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 10))'),
+ST_GeomFromText('MULTILINESTRING((0 50,100 50),
+                                                      (500 500,510 510))')) a;
+a
+0
+# multilinestring against multipoint
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 50,100 50))'),
+ST_GeomFromText('MULTIPOINT(50 50,300 300)')) a;
+a
+1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 50,100 50))'),
+ST_GeomFromText('MULTIPOINT(50 51,300 300)')) a;
+a
+0
+# ST_Disjoint takes the same filter
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)'), @sq) a;
+a
+0
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(1 1,100 100)'), @sq) a;
+a
+1
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(99 99,200 200)'), @tri) a;
+a
+1
+SELECT ST_Disjoint(ST_GeomFromText('MULTILINESTRING((0 0,10 0),(40 40,60 60),
+                                                    (200 200,210 210))'),
+@sq) a;
+a
+0
+SELECT ST_Disjoint(ST_GeomFromText('MULTILINESTRING((90 90,99 99),
+                                                    (300 300,310 310))'),
+@tri) a;
+a
+1
+SELECT ST_Disjoint(@sq, ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)')) a;
+a
+0
+# collections reaching a multipoint or multilinestring child
+# the multipoint child holds a point inside the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(1 1,50 50),
+                                        MULTILINESTRING((900 900,901 901)))'),
+@sq) a;
+a
+1
+# no child reaches the square -> 0
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(1 1,2 2),
+                                        MULTILINESTRING((900 900,901 901)))'),
+@sq) a;
+a
+0
+# the multilinestring child holds a part crossing the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTILINESTRING((40 40,60 60),
+                                                        (900 900,901 901)))'),
+@sq) a;
+a
+1
+# a multipoint child whose points all fall in a gap -> 0
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(5 5,6 6))'), @two) a;
+a
+0
+SET @sq= NULL;
+SET @tri= NULL;
+SET @two= NULL;

--- a/mysql-test/main/gis-precise.test
+++ b/mysql-test/main/gis-precise.test
@@ -540,3 +540,236 @@ SELECT ST_Crosses(ST_GeomFromText('LINESTRING(0 0, 2 2)'),
 set @geom=ST_BUFFER(ST_BUFFER(ST_POLYGONFROMTEXT('POLYGON((0 0, 5 5, 6 6, 0 0))'),1),2);
 select round(area(@geom), 5);
 
+
+--echo #
+--echo # MDEV-15066 ST_INTERSECTS over a multipolygon with scattered parts
+--echo #
+--echo # A multipolygon meets another geometry when one of its polygons does.
+--echo # Polygons whose bounding box misses the other operand are left out of
+--echo # the scan.  The cases below cover a probe that reaches one polygon, a
+--echo # probe that falls in a gap between polygons while staying inside the
+--echo # bounding box of the whole shape, and a probe that reaches a polygon's
+--echo # bounding box without reaching the polygon itself.
+
+SET @mp= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                       ((10 10,12 10,12 12,10 12,10 10)),
+                                       ((20 20,22 20,22 22,20 22,20 20)),
+                                       ((30 30,34 30,30 34,30 30)))');
+
+--echo # probe inside the second polygon -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))'), @mp) a;
+--echo # probe inside the last polygon -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((20.5 20.5,21 20.5,21 21,20.5 21,20.5 20.5))'), @mp) a;
+--echo # probe in a gap, inside the bounding box of the whole shape -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))'), @mp) a;
+--echo # probe outside the bounding box of the whole shape -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((100 100,101 100,101 101,100 101,100 100))'), @mp) a;
+--echo # probe inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))'), @mp) a;
+--echo # probe spanning two polygons, reaching one of them -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((1 1,11 1,11 11,1 11,1 1))'), @mp) a;
+
+--echo # the multipolygon as the first operand gives the same answers
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))')) a;
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))')) a;
+SELECT ST_Intersects(@mp, ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))')) a;
+
+--echo # both operands multipolygons, one pair of polygons meeting -> 1
+SELECT ST_Intersects(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                        ((11 11,13 11,13 13,11 13,11 11)))')) a;
+--echo # both operands multipolygons, no pair meeting -> 0
+SELECT ST_Intersects(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                        ((40 40,41 40,41 41,40 41,40 40)))')) a;
+
+--echo # polygons meeting along an edge and at a single corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((12 10,14 10,14 12,12 12,12 10))'), @mp) a;
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((12 12,14 12,14 14,12 14,12 12))'), @mp) a;
+
+--echo # ST_Disjoint is the complement and keeps the unfiltered path
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))'), @mp) a;
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))'), @mp) a;
+
+SET @mp= NULL;
+
+--echo #
+--echo # MDEV-15066 ST_DISJOINT and geometry collections take the same filter
+--echo #
+--echo # ST_Disjoint asks the same question as ST_Intersects and reads the
+--echo # answer the other way round, so it drops the same parts.  A collection
+--echo # keeps a child when the child's bounding box reaches the other operand
+--echo # and the child still holds a shape once its own parts are filtered.
+
+SET @mp= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                       ((10 10,12 10,12 12,10 12,10 10)),
+                                       ((20 20,22 20,22 22,20 22,20 20)),
+                                       ((30 30,34 30,30 34,30 30)))');
+SET @gc= ST_GeomFromText('GEOMETRYCOLLECTION(
+                            POLYGON((0 0,2 0,2 2,0 2,0 0)),
+                            MULTIPOLYGON(((10 10,12 10,12 12,10 12,10 10)),
+                                         ((20 20,22 20,22 22,20 22,20 20))),
+                            POINT(40 40),
+                            LINESTRING(50 50,52 52))');
+SET @gap= ST_GeomFromText('POLYGON((5 5,6 5,6 6,5 6,5 5))');
+SET @hit= ST_GeomFromText('POLYGON((10.5 10.5,11 10.5,11 11,10.5 11,10.5 10.5))');
+SET @far= ST_GeomFromText('POLYGON((100 100,101 100,101 101,100 101,100 100))');
+
+--echo # ST_Disjoint over a multipolygon
+--echo # probe in a gap between parts -> 1
+SELECT ST_Disjoint(@gap, @mp) a;
+--echo # probe inside a part -> 0
+SELECT ST_Disjoint(@hit, @mp) a;
+--echo # probe outside the bounding box of the whole shape -> 1
+SELECT ST_Disjoint(@far, @mp) a;
+--echo # probe inside the triangle's bounding box, outside the triangle -> 1
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((33 33,33.5 33,33.5 33.5,33 33.5,33 33))'), @mp) a;
+--echo # reversed operand order
+SELECT ST_Disjoint(@mp, @gap) a;
+SELECT ST_Disjoint(@mp, @hit) a;
+--echo # parts sharing an edge are not disjoint -> 0
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((12 10,14 10,14 12,12 12,12 10))'), @mp) a;
+--echo # two multipolygons with no pair meeting -> 1
+SELECT ST_Disjoint(@mp, ST_GeomFromText('MULTIPOLYGON(((5 5,6 5,6 6,5 6,5 5)),
+                                                      ((40 40,41 40,41 41,40 41,40 40)))')) a;
+--echo # a hole is not part of the shape, a probe inside it is disjoint -> 1
+SELECT ST_Disjoint(ST_GeomFromText('POLYGON((4 4,5 4,5 5,4 5,4 4))'),
+                   ST_GeomFromText('MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(3 3,7 3,7 7,3 7,3 3)))')) a;
+
+--echo # collections, reaching a child of each kind
+--echo # probe in a gap between children -> 0
+SELECT ST_Intersects(@gap, @gc) a;
+--echo # probe inside a polygon held by the multipolygon child -> 1
+SELECT ST_Intersects(@hit, @gc) a;
+--echo # probe outside the bounding box of the whole collection -> 0
+SELECT ST_Intersects(@far, @gc) a;
+--echo # probe reaching the point child -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((39 39,41 39,41 41,39 41,39 39))'), @gc) a;
+--echo # probe reaching the linestring child -> 1
+SELECT ST_Intersects(ST_GeomFromText('POLYGON((50 50,51 50,51 51,50 51,50 50))'), @gc) a;
+--echo # reversed operand order
+SELECT ST_Intersects(@gc, @hit) a;
+--echo # the same collection under ST_Disjoint
+SELECT ST_Disjoint(@gap, @gc) a;
+SELECT ST_Disjoint(@hit, @gc) a;
+--echo # every child filtered out -> 0
+SELECT ST_Intersects(@gap, ST_GeomFromText('GEOMETRYCOLLECTION(
+                                              POLYGON((0 0,2 0,2 2,0 2,0 0)),
+                                              POLYGON((10 10,12 10,12 12,10 12,10 10)))')) a;
+--echo # a multipolygon child whose parts all miss the probe -> 0
+SELECT ST_Intersects(@gap, ST_GeomFromText('GEOMETRYCOLLECTION(
+                                              MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                                           ((10 10,12 10,12 12,10 12,10 10))))')) a;
+
+SET @mp= NULL;
+SET @gc= NULL;
+SET @gap= NULL;
+SET @hit= NULL;
+SET @far= NULL;
+
+
+--echo #
+--echo # MDEV-15066 the same filter over multipoint and multilinestring
+--echo #
+--echo # A multipoint meets another geometry when one of its points does, and
+--echo # a multilinestring when one of its linestrings does.  Parts whose
+--echo # bounding box misses the other operand are left out of the scan.  A
+--echo # point is its own bounding box, so a point survives the filter only
+--echo # where it falls inside the box of the other operand.
+
+SET @sq= ST_GeomFromText('POLYGON((45 45,55 45,55 55,45 55,45 45))');
+SET @tri= ST_GeomFromText('POLYGON((0 0,100 0,0 100,0 0))');
+SET @two= ST_GeomFromText('MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),
+                                        ((10 10,12 10,12 12,10 12,10 10)))');
+
+--echo # multipoint, one point inside the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)'), @sq) a;
+--echo # points on either side of the square, none inside -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,100 100)'), @sq) a;
+--echo # a point on the square's corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(45 45)'), @sq) a;
+--echo # a point on the square's edge -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(45 50)'), @sq) a;
+--echo # a point inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(99 99,200 200)'), @tri) a;
+--echo # the same shape with a second point that does reach the triangle -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,99 99)'), @tri) a;
+--echo # points in the gap between the parts of a multipolygon -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(5 5,500 500)'), @two) a;
+--echo # one point in each part -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,11 11)'), @two) a;
+--echo # reversed operand order
+SELECT ST_Intersects(@sq, ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)')) a;
+--echo # multipoint against multipoint
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50)'),
+                     ST_GeomFromText('MULTIPOINT(50 50,200 200)')) a;
+SELECT ST_Intersects(ST_GeomFromText('MULTIPOINT(1 1,50 50)'),
+                     ST_GeomFromText('MULTIPOINT(60 60,200 200)')) a;
+
+--echo # multilinestring, one part crossing the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 0),(40 40,60 60),
+                                                      (200 200,210 210))'),
+                     @sq) a;
+--echo # the same shape without the crossing part -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 0),
+                                                      (200 200,210 210))'),
+                     @sq) a;
+--echo # a part running along the square's edge -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((45 40,45 60))'), @sq) a;
+--echo # a part ending on the square's corner -> 1
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 45,45 45))'), @sq) a;
+--echo # a part inside the triangle's bounding box, outside the triangle -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((90 90,99 99),
+                                                      (300 300,310 310))'),
+                     @tri) a;
+--echo # a part in the gap between the parts of a multipolygon -> 0
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((5 5,6 6),
+                                                      (500 500,501 501))'),
+                     @two) a;
+--echo # multilinestring against multilinestring
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 10),
+                                                      (50 0,50 100))'),
+                     ST_GeomFromText('MULTILINESTRING((0 50,100 50),
+                                                      (500 500,510 510))')) a;
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 0,10 10))'),
+                     ST_GeomFromText('MULTILINESTRING((0 50,100 50),
+                                                      (500 500,510 510))')) a;
+--echo # multilinestring against multipoint
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 50,100 50))'),
+                     ST_GeomFromText('MULTIPOINT(50 50,300 300)')) a;
+SELECT ST_Intersects(ST_GeomFromText('MULTILINESTRING((0 50,100 50))'),
+                     ST_GeomFromText('MULTIPOINT(50 51,300 300)')) a;
+
+--echo # ST_Disjoint takes the same filter
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)'), @sq) a;
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(1 1,100 100)'), @sq) a;
+SELECT ST_Disjoint(ST_GeomFromText('MULTIPOINT(99 99,200 200)'), @tri) a;
+SELECT ST_Disjoint(ST_GeomFromText('MULTILINESTRING((0 0,10 0),(40 40,60 60),
+                                                    (200 200,210 210))'),
+                   @sq) a;
+SELECT ST_Disjoint(ST_GeomFromText('MULTILINESTRING((90 90,99 99),
+                                                    (300 300,310 310))'),
+                   @tri) a;
+SELECT ST_Disjoint(@sq, ST_GeomFromText('MULTIPOINT(1 1,50 50,100 100)')) a;
+
+--echo # collections reaching a multipoint or multilinestring child
+--echo # the multipoint child holds a point inside the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(1 1,50 50),
+                                        MULTILINESTRING((900 900,901 901)))'),
+                     @sq) a;
+--echo # no child reaches the square -> 0
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(1 1,2 2),
+                                        MULTILINESTRING((900 900,901 901)))'),
+                     @sq) a;
+--echo # the multilinestring child holds a part crossing the square -> 1
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTILINESTRING((40 40,60 60),
+                                                        (900 900,901 901)))'),
+                     @sq) a;
+--echo # a multipoint child whose points all fall in a gap -> 0
+SELECT ST_Intersects(ST_GeomFromText('GEOMETRYCOLLECTION(
+                                        MULTIPOINT(5 5,6 6))'), @two) a;
+
+SET @sq= NULL;
+SET @tri= NULL;
+SET @two= NULL;

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1367,6 +1367,11 @@ public:
   }
   int store_shapes(Gcalc_shape_transporter *trn) const
   { return geom->store_shapes(trn); }
+  int store_shapes_in_mbr(Gcalc_shape_transporter *trn, const MBR *filter,
+                          uint32 n_filtered) const
+  { return geom->store_shapes_in_mbr(trn, filter, n_filtered); }
+  int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const
+  { return geom->count_shapes_in_mbr(filter, n_shapes); }
   int shape_type() const
   { return geom->get_class_info()->m_type_id; }
 };
@@ -1441,6 +1446,87 @@ static void handle_sp_crosses_func_case(Gcalc_function &func,
 }
 
 
+/*
+  Returns false when the bounding boxes intersect, so that no scan is
+  needed, and also on a malformed operand, which null_value tells apart.
+*/
+
+static bool filter_operands_for_intersection(
+                                  Geometry_ptr_with_buffer_and_mbr &g1,
+                                  Geometry_ptr_with_buffer_and_mbr &g2,
+                                  MBR *g2_filter,
+                                  uint32 *n1, uint32 *n2,
+                                  bool &null_value)
+{
+  *g2_filter= g2.mbr;
+
+  if (!g1.mbr.intersects(&g2.mbr))
+    return false;
+
+  /* g1.mbr carries the tolerance already, g2.mbr does not. */
+  g2_filter->buffer(1e-5);
+
+  if ((null_value= g1.count_shapes_in_mbr(g2_filter, n1) ||
+                   g2.count_shapes_in_mbr(&g1.mbr, n2)))
+    return false;
+
+  return *n1 && *n2;
+}
+
+
+/*
+  Returns false when the operands cannot intersect, leaving the caller to
+  answer from the bounding boxes alone.
+*/
+
+static bool build_intersects_scan(Gcalc_function &func,
+                                  Gcalc_operation_transporter &trn,
+                                  Geometry_ptr_with_buffer_and_mbr &g1,
+                                  Geometry_ptr_with_buffer_and_mbr &g2,
+                                  bool &null_value)
+{
+  MBR g2_filter;
+  uint32 n1, n2;
+
+  if (!filter_operands_for_intersection(g1, g2, &g2_filter, &n1, &n2,
+                                        null_value))
+    return false;
+
+  func.add_operation(Gcalc_function::v_find_t |
+                     Gcalc_function::op_intersection, 2);
+  null_value= g1.store_shapes_in_mbr(&trn, &g2_filter, n1) ||
+              g2.store_shapes_in_mbr(&trn, &g1.mbr, n2);
+  return true;
+}
+
+
+/*
+  Returns false when the operands cannot intersect, which makes them
+  disjoint.
+*/
+
+static bool build_disjoint_scan(Gcalc_function &func,
+                                Gcalc_operation_transporter &trn,
+                                Geometry_ptr_with_buffer_and_mbr &g1,
+                                Geometry_ptr_with_buffer_and_mbr &g2,
+                                bool &null_value)
+{
+  MBR g2_filter;
+  uint32 n1, n2;
+
+  if (!filter_operands_for_intersection(g1, g2, &g2_filter, &n1, &n2,
+                                        null_value))
+    return false;
+
+  func.add_operation(Gcalc_function::v_find_f |
+                     Gcalc_function::op_not |
+                     Gcalc_function::op_intersection, 2);
+  null_value= g1.store_shapes_in_mbr(&trn, &g2_filter, n1) ||
+              g2.store_shapes_in_mbr(&trn, &g1.mbr, n2);
+  return true;
+}
+
+
 bool Item_func_spatial_precise_rel::val_bool()
 {
   DBUG_ENTER("Item_func_spatial_precise_rel::val_int");
@@ -1489,17 +1575,15 @@ bool Item_func_spatial_precise_rel::val_bool()
       null_value= g1.store_shapes(&trn) || g2.store_shapes(&trn);
       break;
     case SP_DISJOINT_FUNC:
-      func.add_operation(Gcalc_function::v_find_f |
-                         Gcalc_function::op_not |
-                         Gcalc_function::op_intersection, 2);
-      null_value= g1.store_shapes(&trn) || g2.store_shapes(&trn);
+      if (!build_disjoint_scan(func, trn, g1, g2, null_value))
+      {
+        result= 1;
+        goto exit;
+      }
       break;
     case SP_INTERSECTS_FUNC:
-      if (!g1.mbr.intersects(&g2.mbr))
+      if (!build_intersects_scan(func, trn, g1, g2, null_value))
         goto exit;
-      func.add_operation(Gcalc_function::v_find_t |
-                         Gcalc_function::op_intersection, 2);
-      null_value= g1.store_shapes(&trn) || g2.store_shapes(&trn);
       break;
     case SP_CROSSES_FUNC:
       if (g1.shape_type() == Geometry::wkb_polygon ||

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -2393,6 +2393,80 @@ int Gis_multi_point::store_shapes(Gcalc_shape_transporter *trn) const
 }
 
 
+int Gis_multi_point::count_shapes_in_mbr(const MBR *filter,
+                                         uint32 *n_shapes) const
+{
+  uint32 n_points;
+  uint32 n_matching= 0;
+  Gis_point pt;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_points= uint4korr(data);
+  data+= 4;
+
+  while (n_points--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    pt.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (pt.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+      n_matching++;
+    data+= pt.get_data_size();
+  }
+  *n_shapes= n_matching;
+  return 0;
+}
+
+
+int Gis_multi_point::store_shapes_in_mbr(Gcalc_shape_transporter *trn,
+                                         const MBR *filter,
+                                         uint32 n_filtered) const
+{
+  uint32 n_points;
+  uint32 n_stored= 0;
+  Gis_point pt;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_points= uint4korr(data);
+  data+= 4;
+
+  if (trn->start_collection(n_filtered))
+    return 1;
+
+  while (n_points--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    pt.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (pt.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+    {
+      if (pt.store_shapes(trn))
+        return 1;
+      n_stored++;
+    }
+    data+= pt.get_data_size();
+  }
+  DBUG_ASSERT(n_stored == n_filtered);
+  return 0;
+}
+
+
 const Geometry::Class_info *Gis_multi_point::get_class_info() const
 {
   return &multipoint_class;
@@ -2882,6 +2956,80 @@ int Gis_multi_line_string::store_shapes(Gcalc_shape_transporter *trn) const
 }
 
 
+int Gis_multi_line_string::count_shapes_in_mbr(const MBR *filter,
+                                               uint32 *n_shapes) const
+{
+  uint32 n_lines;
+  uint32 n_matching= 0;
+  Gis_line_string ls;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_lines= uint4korr(data);
+  data+= 4;
+
+  while (n_lines--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    ls.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (ls.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+      n_matching++;
+    data+= ls.get_data_size();
+  }
+  *n_shapes= n_matching;
+  return 0;
+}
+
+
+int Gis_multi_line_string::store_shapes_in_mbr(Gcalc_shape_transporter *trn,
+                                               const MBR *filter,
+                                               uint32 n_filtered) const
+{
+  uint32 n_lines;
+  uint32 n_stored= 0;
+  Gis_line_string ls;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_lines= uint4korr(data);
+  data+= 4;
+
+  if (trn->start_collection(n_filtered))
+    return 1;
+
+  while (n_lines--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    ls.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (ls.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+    {
+      if (ls.store_shapes(trn))
+        return 1;
+      n_stored++;
+    }
+    data+= ls.get_data_size();
+  }
+  DBUG_ASSERT(n_stored == n_filtered);
+  return 0;
+}
+
+
 const Geometry::Class_info *Gis_multi_line_string::get_class_info() const
 {
   return &multilinestring_class;
@@ -3335,6 +3483,80 @@ int Gis_multi_polygon::store_shapes(Gcalc_shape_transporter *trn) const
       return 1;
     data+= p.get_data_size();
   }
+  return 0;
+}
+
+
+int Gis_multi_polygon::count_shapes_in_mbr(const MBR *filter,
+                                           uint32 *n_shapes) const
+{
+  uint32 n_polygons;
+  uint32 n_matching= 0;
+  Gis_polygon p;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_polygons= uint4korr(data);
+  data+= 4;
+
+  while (n_polygons--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    p.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (p.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+      n_matching++;
+    data+= p.get_data_size();
+  }
+  *n_shapes= n_matching;
+  return 0;
+}
+
+
+int Gis_multi_polygon::store_shapes_in_mbr(Gcalc_shape_transporter *trn,
+                                           const MBR *filter,
+                                           uint32 n_filtered) const
+{
+  uint32 n_polygons;
+  uint32 n_stored= 0;
+  Gis_polygon p;
+  const char *data= m_data;
+
+  if (no_data(data, 4))
+    return 1;
+  n_polygons= uint4korr(data);
+  data+= 4;
+
+  if (trn->start_collection(n_filtered))
+    return 1;
+
+  while (n_polygons--)
+  {
+    MBR part_mbr;
+    const char *mbr_end;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    data+= WKB_HEADER_SIZE;
+    p.set_data_ptr(data, (uint32) (m_data_end - data));
+    if (p.get_mbr(&part_mbr, &mbr_end))
+      return 1;
+    if (part_mbr.intersects(filter))
+    {
+      if (p.store_shapes(trn))
+        return 1;
+      n_stored++;
+    }
+    data+= p.get_data_size();
+  }
+  DBUG_ASSERT(n_stored == n_filtered);
   return 0;
 }
 
@@ -3906,6 +4128,115 @@ int Gis_geometry_collection::store_shapes(Gcalc_shape_transporter *trn) const
 
     data+= geom->get_data_size();
   }
+  return 0;
+}
+
+
+/*
+  A child of a collection takes part in the scan when its bounding box
+  reaches the filter and it still holds a shape once its own parts are
+  filtered.  The pass that counts the children and the pass that stores
+  them have to agree on that.
+*/
+
+static int count_child_shapes_in_mbr(Geometry *geom, const MBR *filter,
+                                     uint32 *n_shapes)
+{
+  MBR child_mbr;
+  const char *mbr_end;
+
+  if (geom->get_mbr(&child_mbr, &mbr_end))
+    return 1;
+  if (!child_mbr.intersects(filter))
+  {
+    *n_shapes= 0;
+    return 0;
+  }
+  return geom->count_shapes_in_mbr(filter, n_shapes);
+}
+
+
+int Gis_geometry_collection::count_shapes_in_mbr(const MBR *filter,
+                                                 uint32 *n_shapes) const
+{
+  uint32 n_objects;
+  uint32 n_matching= 0;
+  const char *data= m_data;
+  Geometry_buffer buffer;
+  Geometry *geom;
+
+  if (no_data(data, 4))
+    return 1;
+  n_objects= uint4korr(data);
+  data+= 4;
+
+  while (n_objects--)
+  {
+    uint32 wkb_type;
+    uint32 n_child;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    wkb_type= uint4korr(data + 1);
+    data+= WKB_HEADER_SIZE;
+    if (!(geom= create_by_typeid(&buffer, wkb_type)))
+      return 1;
+    geom->set_data_ptr(data, (uint32) (m_data_end - data));
+    if (count_child_shapes_in_mbr(geom, filter, &n_child))
+      return 1;
+    if (n_child)
+      n_matching++;
+    data+= geom->get_data_size();
+  }
+  *n_shapes= n_matching;
+  return 0;
+}
+
+
+int Gis_geometry_collection::store_shapes_in_mbr(Gcalc_shape_transporter *trn,
+                                                 const MBR *filter,
+                                                 uint32 n_filtered) const
+{
+  uint32 n_objects;
+  uint32 n_stored= 0;
+  const char *data= m_data;
+  Geometry_buffer buffer;
+  Geometry *geom;
+
+  if (no_data(data, 4))
+    return 1;
+  n_objects= uint4korr(data);
+  data+= 4;
+
+  if (!n_filtered)
+    return trn->empty_shape();
+
+  if (trn->start_collection(n_filtered))
+    return 1;
+
+  while (n_objects--)
+  {
+    uint32 wkb_type;
+    uint32 n_child;
+
+    if (no_data(data, WKB_HEADER_SIZE))
+      return 1;
+    wkb_type= uint4korr(data + 1);
+    data+= WKB_HEADER_SIZE;
+    if (!(geom= create_by_typeid(&buffer, wkb_type)))
+      return 1;
+    geom->set_data_ptr(data, (uint32) (m_data_end - data));
+    if (count_child_shapes_in_mbr(geom, filter, &n_child))
+      return 1;
+    if (n_child)
+    {
+      if (geom->store_shapes_in_mbr(trn, filter, n_child))
+        return 1;
+      n_stored++;
+    }
+    data+= geom->get_data_size();
+  }
+  DBUG_ASSERT(n_stored == n_filtered);
   return 0;
 }
 

--- a/sql/spatial.h
+++ b/sql/spatial.h
@@ -313,6 +313,12 @@ public:
   virtual int interior_ring_n(uint32 num, String *result) const { return -1; }
   virtual int geometry_n(uint32 num, String *result) const { return -1; }
   virtual int store_shapes(Gcalc_shape_transporter *trn) const=0;
+  virtual int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const
+  { *n_shapes= 1; return 0; }
+  virtual int store_shapes_in_mbr(Gcalc_shape_transporter *trn,
+                                  const MBR *filter,
+                                  uint32 n_filtered) const
+  { return store_shapes(trn); }
 
 public:
   static Geometry *create_by_typeid(Geometry_buffer *buffer, int type_id);
@@ -568,6 +574,9 @@ public:
     return 0;
   }
   int store_shapes(Gcalc_shape_transporter *trn) const override;
+  int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const override;
+  int store_shapes_in_mbr(Gcalc_shape_transporter *trn, const MBR *filter,
+                          uint32 n_filtered) const override;
   const Class_info *get_class_info() const override;
   int spherical_distance_multipoints(Geometry *g, const double r, double *res,
                                      int *error);
@@ -601,6 +610,9 @@ public:
     return 0;
   }
   int store_shapes(Gcalc_shape_transporter *trn) const override;
+  int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const override;
+  int store_shapes_in_mbr(Gcalc_shape_transporter *trn, const MBR *filter,
+                          uint32 n_filtered) const override;
   const Class_info *get_class_info() const override;
 };
 
@@ -631,6 +643,9 @@ public:
     return 0;
   }
   int store_shapes(Gcalc_shape_transporter *trn) const override;
+  int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const override;
+  int store_shapes_in_mbr(Gcalc_shape_transporter *trn, const MBR *filter,
+                          uint32 n_filtered) const override;
   const Class_info *get_class_info() const override;
   uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
 };
@@ -658,6 +673,9 @@ public:
   int geometry_n(uint32 num, String *result) const override;
   bool dimension(uint32 *dim, const char **end) const override;
   int store_shapes(Gcalc_shape_transporter *trn) const override;
+  int count_shapes_in_mbr(const MBR *filter, uint32 *n_shapes) const override;
+  int store_shapes_in_mbr(Gcalc_shape_transporter *trn, const MBR *filter,
+                          uint32 n_filtered) const override;
   const Class_info *get_class_info() const override;
 };
 


### PR DESCRIPTION
Implements a pre-filtering step to limit the polygons considered by ST_Intersects and ST_Disjoint to those whose bounding box overlaps the other operand.

The probe polygon overlaps the bounding box of seven rows in a table of 239 country outlines.  Four of those rows are multipolygons of 346, 213, 120 and 21 polygons but not one of those 700 polygons overlaps with the probe.  Yet, ST_Intersects stored all 700 into the scan.

A polygon whose bounding box does not overlap the other operand cannot intersect it, yet the cost of the scan grows with the number of polygons considered.  ST_Intersects and ST_Disjoint now leave such polygons out.  Multipoint, multilinestring, multipolygon and geometry collection each count the parts that pass the filter and store only those.  A geometry of one part is unchanged.