### PR TITLE
MDEV-35845:  Propagate a constant into an IN predicate

### DIFF
--- a/mysql-test/main/func_in.result
+++ b/mysql-test/main/func_in.result
@@ -1276,3 +1276,133 @@ drop table t1;
 #
 # End of 10.6 tests
 #
+#
+# MDEV-35845 WHERE COL IN (item0, item1, ..., itemN) AND COL = item1
+# Optimization
+#
+create table t1 (v varchar(64), t text, c char(32));
+insert into t1 values ('a','a','a'),('b','b','b');
+explain extended select * from t1 where v in ('a','b') and v = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`t` AS `t`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`v` = 'b'
+explain extended select * from t1 where t in ('a','b') and t = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`t` AS `t`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`t` = 'b'
+explain extended select * from t1 where c in ('a','b') and c = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`t` AS `t`,`test`.`t1`.`c` AS `c` from `test`.`t1` where `test`.`t1`.`c` = 'b'
+explain extended select * from t1 where v not in ('a','b') and v = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`t` AS `t`,`test`.`t1`.`c` AS `c` from `test`.`t1` where 0
+select * from t1 where v in ('a','b') and v = 'b';
+v	t	c
+b	b	b
+select * from t1 where v in ('a','x') and v = 'b';
+v	t	c
+select * from t1 where v not in ('a','b') and v = 'b';
+v	t	c
+drop table t1;
+# The predicant is left alone when the IN predicate and the equality
+# compare with different collations.  Under utf8mb3_german2_ci the
+# o-umlaut row matches 'oe', under utf8mb3_general_ci it does not, so
+# the two predicates ask different questions and neither one answers
+# for the other.
+# Each list holds two values because a one value list is parsed as an
+# equality and never becomes an IN predicate.
+set names utf8mb3 collate utf8mb3_german2_ci;
+create table t1 (a char(10) character set utf8mb3);
+insert into t1 values (_utf8mb3 0xC3B6),('oe');
+explain extended select * from t1
+where a in ('oe','xx') and a = 'oe' collate utf8mb3_german2_ci;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` in ('oe','xx') and `test`.`t1`.`a` = 'oe'
+select hex(a) from t1
+where a in ('oe','xx') and a = 'oe' collate utf8mb3_german2_ci;
+hex(a)
+6F65
+# Only the first value of the next list carries the other collation, so
+# the second value on its own would allow the rewrite.  Refusing the
+# whole predicate shows the check runs per value.
+explain extended select * from t1
+where a in ('oe' collate utf8mb3_german2_ci,'xx') and a = 'oe';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` in (<cache>('oe' collate utf8mb3_german2_ci),'xx') and `test`.`t1`.`a` = 'oe'
+select hex(a) from t1
+where a in ('oe' collate utf8mb3_german2_ci,'xx') and a = 'oe';
+hex(a)
+6F65
+# With one collation throughout, the same rows let the rewrite happen.
+# The equality on its own matches both rows, so keeping the IN above is
+# what holds the o-umlaut row back.
+explain extended select * from t1 where a in ('oe','xx') and a = 'oe';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`a` AS `a` from `test`.`t1` where `test`.`t1`.`a` = 'oe'
+select hex(a) from t1 where a in ('oe','xx') and a = 'oe';
+hex(a)
+6F65
+select hex(a) from t1 where a = 'oe' collate utf8mb3_german2_ci;
+hex(a)
+C3B6
+6F65
+drop table t1;
+set names default;
+# A constant that stands in for another item is refused.  Comparing the
+# literal 1 against a YEAR column turns it into the value the column
+# would hold, 2001, and the value list is converted the same way.  A
+# clone of that constant carries the literal 1, which matches nothing in
+# the converted list, so the predicant keeps the column.
+# The equality is <=> rather than = so that the multiple equality
+# machinery leaves the condition to this rewrite.
+create table t1 (y year);
+insert into t1 values (2001),(2002),(2003);
+explain extended select * from t1 where y in (1,2) and y <=> 1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`y` AS `y` from `test`.`t1` where `test`.`t1`.`y` in (2001,2002) and `test`.`t1`.`y` <=> 2001
+select * from t1 where y in (1,2) and y <=> 1;
+y
+2001
+select * from t1 where y in (1,2) and y <=> 2;
+y
+2002
+select * from t1 where y in (1,2) and y <=> 3;
+y
+drop table t1;
+# A NULL in the list leaves the predicant alone.  A column in the list
+# does not, and the rewritten predicate still answers correctly.
+create table t1 (v varchar(64), w varchar(64));
+insert into t1 values ('a','a'),('b','b');
+explain extended select * from t1 where v in ('a',NULL) and v = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`w` AS `w` from `test`.`t1` where `test`.`t1`.`v` in ('a',NULL) and `test`.`t1`.`v` = 'b'
+select * from t1 where v in ('a',NULL) and v = 'b';
+v	w
+explain extended select * from t1 where v in ('a',w) and v = 'b';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+Warnings:
+Note	1003	select `test`.`t1`.`v` AS `v`,`test`.`t1`.`w` AS `w` from `test`.`t1` where 'b' in ('a',`test`.`t1`.`w`) and `test`.`t1`.`v` = 'b'
+select * from t1 where v in ('a',w) and v = 'b';
+v	w
+b	b
+drop table t1;
+#
+# End of 11.8 tests
+#

--- a/mysql-test/main/func_in.test
+++ b/mysql-test/main/func_in.test
@@ -936,3 +936,81 @@ drop table t1;
 --echo #
 --echo # End of 10.6 tests
 --echo #
+
+--echo #
+--echo # MDEV-35845 WHERE COL IN (item0, item1, ..., itemN) AND COL = item1
+--echo # Optimization
+--echo #
+
+create table t1 (v varchar(64), t text, c char(32));
+insert into t1 values ('a','a','a'),('b','b','b');
+explain extended select * from t1 where v in ('a','b') and v = 'b';
+explain extended select * from t1 where t in ('a','b') and t = 'b';
+explain extended select * from t1 where c in ('a','b') and c = 'b';
+explain extended select * from t1 where v not in ('a','b') and v = 'b';
+select * from t1 where v in ('a','b') and v = 'b';
+select * from t1 where v in ('a','x') and v = 'b';
+select * from t1 where v not in ('a','b') and v = 'b';
+drop table t1;
+
+--echo # The predicant is left alone when the IN predicate and the equality
+--echo # compare with different collations.  Under utf8mb3_german2_ci the
+--echo # o-umlaut row matches 'oe', under utf8mb3_general_ci it does not, so
+--echo # the two predicates ask different questions and neither one answers
+--echo # for the other.
+--echo # Each list holds two values because a one value list is parsed as an
+--echo # equality and never becomes an IN predicate.
+
+set names utf8mb3 collate utf8mb3_german2_ci;
+create table t1 (a char(10) character set utf8mb3);
+insert into t1 values (_utf8mb3 0xC3B6),('oe');
+explain extended select * from t1
+  where a in ('oe','xx') and a = 'oe' collate utf8mb3_german2_ci;
+select hex(a) from t1
+  where a in ('oe','xx') and a = 'oe' collate utf8mb3_german2_ci;
+--echo # Only the first value of the next list carries the other collation, so
+--echo # the second value on its own would allow the rewrite.  Refusing the
+--echo # whole predicate shows the check runs per value.
+explain extended select * from t1
+  where a in ('oe' collate utf8mb3_german2_ci,'xx') and a = 'oe';
+select hex(a) from t1
+  where a in ('oe' collate utf8mb3_german2_ci,'xx') and a = 'oe';
+--echo # With one collation throughout, the same rows let the rewrite happen.
+--echo # The equality on its own matches both rows, so keeping the IN above is
+--echo # what holds the o-umlaut row back.
+explain extended select * from t1 where a in ('oe','xx') and a = 'oe';
+select hex(a) from t1 where a in ('oe','xx') and a = 'oe';
+select hex(a) from t1 where a = 'oe' collate utf8mb3_german2_ci;
+drop table t1;
+set names default;
+
+--echo # A constant that stands in for another item is refused.  Comparing the
+--echo # literal 1 against a YEAR column turns it into the value the column
+--echo # would hold, 2001, and the value list is converted the same way.  A
+--echo # clone of that constant carries the literal 1, which matches nothing in
+--echo # the converted list, so the predicant keeps the column.
+--echo # The equality is <=> rather than = so that the multiple equality
+--echo # machinery leaves the condition to this rewrite.
+
+create table t1 (y year);
+insert into t1 values (2001),(2002),(2003);
+explain extended select * from t1 where y in (1,2) and y <=> 1;
+select * from t1 where y in (1,2) and y <=> 1;
+select * from t1 where y in (1,2) and y <=> 2;
+select * from t1 where y in (1,2) and y <=> 3;
+drop table t1;
+
+--echo # A NULL in the list leaves the predicant alone.  A column in the list
+--echo # does not, and the rewritten predicate still answers correctly.
+
+create table t1 (v varchar(64), w varchar(64));
+insert into t1 values ('a','a'),('b','b');
+explain extended select * from t1 where v in ('a',NULL) and v = 'b';
+select * from t1 where v in ('a',NULL) and v = 'b';
+explain extended select * from t1 where v in ('a',w) and v = 'b';
+select * from t1 where v in ('a',w) and v = 'b';
+drop table t1;
+
+--echo #
+--echo # End of 11.8 tests
+--echo #

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -239,6 +239,14 @@ public:
   const Type_handler *fixed_type_handler() const override
   { return &type_handler_bool; }
   CHARSET_INFO *compare_collation() const override { return NULL; }
+  /*
+    Specifies which result type the function uses to compare its arguments.
+    This method is used in equal field propagation.  NULL means the function
+    aggregated no comparison data type, which is the case for a function whose
+    arguments are conditions rather than values.  Item_bool_func2,
+    Item_func_opt_neg and Item_equal override it.
+  */
+  virtual const Type_handler *compare_type_handler() const { return NULL; }
   longlong val_int() override final
   {
     DBUG_ASSERT(!is_cond());
@@ -507,11 +515,7 @@ public:
   COND *remove_eq_conds(THD *thd, Item::cond_result *cond_value,
                         bool top_level) override;
   bool count_sargable_conds(void *arg) override;
-  /*
-    Specifies which result type the function uses to compare its arguments.
-    This method is used in equal field propagation.
-  */
-  virtual const Type_handler *compare_type_handler() const
+  const Type_handler *compare_type_handler() const override
   {
     /*
       Have STRING_RESULT by default, which means the function compares
@@ -1076,6 +1080,10 @@ public:
   CHARSET_INFO *compare_collation() const override
   {
     return cmp_collation.collation;
+  }
+  const Type_handler *compare_type_handler() const override
+  {
+    return m_comparator.type_handler();
   }
   Item *propagate_equal_fields(THD *, const Context &,
                                COND_EQUAL *) override= 0;
@@ -3571,7 +3579,8 @@ public:
   bool unmark_as_eliminated_processor(void *arg) override;
   Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override;
   void print(String *str, enum_query_type query_type) override;
-  const Type_handler *compare_type_handler() const { return m_compare_handler; }
+  const Type_handler *compare_type_handler() const override
+  { return m_compare_handler; }
   CHARSET_INFO *compare_collation() const override
   { return m_compare_collation; }
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -19478,7 +19478,7 @@ static void update_const_equal_items(THD *thd, COND *cond, JOIN_TAB *tab,
                         into "target" instead of "expr".
 */
 static bool
-can_change_cond_ref_to_const(Item_bool_func2 *target,
+can_change_cond_ref_to_const(Item_bool_func *target,
                              Item *target_expr, Item *target_value,
                              Item_bool_func2 *source,
                              Item *source_expr, Item *source_const)
@@ -19488,6 +19488,55 @@ can_change_cond_ref_to_const(Item_bool_func2 *target,
          target->compare_type_handler()->
            can_change_cond_ref_to_const(target, target_expr, target_value,
                                         source, source_expr, source_const);
+}
+
+
+/**
+  Check if
+    WHERE expr IN (value1, ..., valueN) AND expr=const
+  can be rewritten as:
+    WHERE const IN (value1, ..., valueN) AND expr=const
+
+  The predicant is compared against every value of the list, so the rewrite
+  is allowed only when it is allowed for each list member separately.
+
+  Only a predicant whose arguments were all aggregated to one comparison
+  data type is considered.  Otherwise the values are compared to the
+  predicant one by one, each through its own comparator.
+
+  The comparison collation and data type of the target are unchanged by the
+  replacement, so the value list built at fix time remains usable.
+  A constant that stands in for another item is refused.
+
+  @param target       - the IN predicate whose predicant will be replaced
+                        to "const".
+  @param source       - the equality that can be used to rewrite the target.
+  @param source_expr  - the source's "expr".  It should be exactly equal to
+                        the target's predicant to make the rewrite possible.
+  @param source_const - the source's "const" argument, it will be inserted
+                        into the target instead of the predicant.
+*/
+static bool
+can_change_in_ref_to_const(Item_func_in *target, Item_bool_func2 *source,
+                           Item *source_expr, Item *source_const)
+{
+  Item **args= target->arguments();
+
+  // Can't change the IN ref to a const.
+  if (!target->arg_types_compatible || args[0]->const_item() ||
+      source_const->real_item() != source_const)
+    return false;
+
+  // Recurse.
+  for (uint i= 1; i < target->argument_count(); i++)
+  {
+    if (!can_change_cond_ref_to_const(target, args[0], args[i],
+                                      source, source_expr, source_const))
+      return false;
+  }
+
+  // OK we can change the IN ref to a const.
+  return true;
 }
 
 
@@ -19513,6 +19562,30 @@ change_cond_ref_to_const(THD *thd, I_List<COND_CMP> *save_list,
 			       field_value_owner, field, value);
     return;
   }
+
+  /*
+    Optimization for
+      WHERE const IN (item0, ..., itemN) AND const = itemX
+    where X is in (0, ..., N).
+  */
+  if (cond->type() == Item::FUNC_ITEM &&
+      ((Item_func*) cond)->functype() == Item_func::IN_FUNC)
+  {
+    Item_func_in *in_func= (Item_func_in*) cond;
+    if (!can_change_in_ref_to_const(in_func, field_value_owner, field, value))
+      return;
+
+    Item *tmp= value->clone_constant(thd);
+    if (!tmp)
+      return;
+
+    Item **args= in_func->arguments();
+    tmp->collation.set(args[0]->collation);
+    thd->change_item_tree(args, tmp);
+    in_func->update_used_tables();
+    return;
+  }
+
   if (cond->eq_cmp_result() == Item::COND_OK)
     return;					// Not a boolean function
 

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -4497,7 +4497,7 @@ set_comparator_func(THD *thd, Arg_comparator *cmp) const
 /*************************************************************************/
 
 bool Type_handler_temporal_result::
-       can_change_cond_ref_to_const(Item_bool_func2 *target,
+       can_change_cond_ref_to_const(Item_bool_func *target,
                                     Item *target_expr, Item *target_value,
                                     Item_bool_func2 *source,
                                     Item *source_expr, Item *source_const)
@@ -4527,7 +4527,7 @@ bool Type_handler_temporal_result::
 
 
 bool Type_handler_string_result::
-       can_change_cond_ref_to_const(Item_bool_func2 *target,
+       can_change_cond_ref_to_const(Item_bool_func *target,
                                     Item *target_expr, Item *target_value,
                                     Item_bool_func2 *source,
                                     Item *source_expr, Item *source_const)
@@ -4573,7 +4573,7 @@ bool Type_handler_string_result::
 
 
 bool Type_handler_numeric::
-       can_change_cond_ref_to_const(Item_bool_func2 *target,
+       can_change_cond_ref_to_const(Item_bool_func *target,
                                     Item *target_expr, Item *target_value,
                                     Item_bool_func2 *source,
                                     Item *source_expr, Item *source_const)

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -52,6 +52,7 @@ class Item_func_hex;
 class Item_hybrid_func;
 class Item_func_min_max;
 class Item_func_hybrid_field_type;
+class Item_bool_func;
 class Item_bool_func2;
 class Item_bool_rowready_func2;
 class Item_func_between;
@@ -4390,7 +4391,7 @@ public:
                           into "target" instead of "expr".
   */
   virtual bool
-  can_change_cond_ref_to_const(Item_bool_func2 *target,
+  can_change_cond_ref_to_const(Item_bool_func *target,
                                Item *target_expr, Item *target_value,
                                Item_bool_func2 *source,
                                Item *source_expr, Item *source_const) const= 0;
@@ -4827,7 +4828,7 @@ public:
     return 1;
   }
   String *print_item_value(THD *thd, Item *item, String *str) const override;
-  bool can_change_cond_ref_to_const(Item_bool_func2 *, Item *, Item *,
+  bool can_change_cond_ref_to_const(Item_bool_func *, Item *, Item *,
                                    Item_bool_func2 *, Item *, Item *)
     const override
   {
@@ -5065,7 +5066,7 @@ public:
                                   MYSQL_TIME *, date_mode_t fuzzydate) const
     override;
   virtual ~Type_handler_numeric() = default;
-  bool can_change_cond_ref_to_const(Item_bool_func2 *target,
+  bool can_change_cond_ref_to_const(Item_bool_func *target,
                                    Item *target_expr, Item *target_value,
                                    Item_bool_func2 *source,
                                    Item *source_expr, Item *source_const) const
@@ -5626,7 +5627,7 @@ public:
                                  const st_value *value) const override;
   uint32 max_display_length(const Item *item) const override;
   uint32 Item_decimal_notation_int_digits(const Item *item) const override;
-  bool can_change_cond_ref_to_const(Item_bool_func2 *target,
+  bool can_change_cond_ref_to_const(Item_bool_func *target,
                                    Item *target_expr, Item *target_value,
                                    Item_bool_func2 *source,
                                    Item *source_expr, Item *source_const)
@@ -5767,7 +5768,7 @@ public:
   {
     return print_item_value_csstr(thd, item, str);
   }
-  bool can_change_cond_ref_to_const(Item_bool_func2 *target,
+  bool can_change_cond_ref_to_const(Item_bool_func *target,
                                    Item *target_expr, Item *target_value,
                                    Item_bool_func2 *source,
                                    Item *source_expr, Item *source_const) const

--- a/sql/sql_type_fixedbin.h
+++ b/sql/sql_type_fixedbin.h
@@ -1505,7 +1505,7 @@ public:
     @param source_const - the source's "const" argument, it will be inserted
                           into "target" instead of "expr".
   */
-  bool can_change_cond_ref_to_const(Item_bool_func2 *target, Item *target_expr,
+  bool can_change_cond_ref_to_const(Item_bool_func *target, Item *target_expr,
                                Item *target_value, Item_bool_func2 *source,
                                Item *source_expr, Item *source_const)
                                const override


### PR DESCRIPTION
SELECT * FROM t1 WHERE v IN ('a','b') AND v = 'b' kept both conjuncts when v is a string column, while the equivalent form written with OR was simplified to v = 'b'.

Two mechanisms can perform a rewrite.  Multiple equalities handle it when check_simple_equality() builds an Item_equal, which it does only if the field's charset allows constant propagation.  Up through 10.5 the default character set was latin1 whose collation handler supports constant propagation.  MDEV-19123 made utf8mb4 the default in 11.6, and the utf8 collation handlers report that they do not support constant propagation.

The other mechanism is propagate_cond_constants(), which rewrote the OR form under every collation.  It descends through change_cond_ref_to_const(), which returns on any node whose eq_cmp_result() is COND_OK.  Item_func_in inherits that value, so the IN predicate was skipped.

Implement an optimization in change_cond_ref_to_const() that replaces the predicant of an IN predicate with the constant from an equality at the same AND level.  The predicant is compared against every value of the list, so the existing per-operand test from MDEV-7152 is applied once for each of them.

Only a predicant whose arguments were all aggregated to one comparison data type is replaced.